### PR TITLE
Isolate character/token/asset into a hangar schema

### DIFF
--- a/hangar.sql
+++ b/hangar.sql
@@ -1,0 +1,85 @@
+-- eve-hangar's own schema, isolated from any other app on the shared Supabase
+-- project. Apply with `psql ... -f hangar.sql` (or paste into the SQL editor),
+-- then add "hangar" to Settings → API → Exposed schemas in the Supabase
+-- dashboard so PostgREST will route `.schema('hangar')` queries to it.
+
+create schema if not exists hangar;
+
+grant usage on schema hangar to anon, authenticated, service_role;
+alter default privileges in schema hangar
+  grant all on tables to anon, authenticated, service_role;
+alter default privileges in schema hangar
+  grant all on sequences to anon, authenticated, service_role;
+alter default privileges in schema hangar
+  grant all on functions to anon, authenticated, service_role;
+
+create table hangar.character (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  owner text not null,
+  name text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (user_id, owner)
+);
+create index character_user_id_idx on hangar.character (user_id);
+
+alter table hangar.character enable row level security;
+
+create policy "Users manage own characters"
+  on hangar.character
+  for all
+  to authenticated
+  using (user_id = (select auth.uid()))
+  with check (user_id = (select auth.uid()));
+
+create table hangar.token (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  character_id uuid not null references hangar.character(id) on delete cascade,
+  access_token text not null,
+  refresh_token text not null,
+  issued_at timestamptz not null,
+  expires_at timestamptz not null,
+  scope text[] not null default '{}',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (character_id, scope)
+);
+create index token_character_id_idx on hangar.token (character_id);
+create index token_user_id_idx on hangar.token (user_id);
+
+alter table hangar.token enable row level security;
+
+create policy "Users manage own tokens"
+  on hangar.token
+  for all
+  to authenticated
+  using (user_id = (select auth.uid()))
+  with check (user_id = (select auth.uid()));
+
+create table hangar.asset (
+  item_id bigint primary key,
+  character_id uuid not null references hangar.character(id) on delete cascade,
+  type_id bigint not null,
+  location_id bigint,
+  location_flag text,
+  location_type text,
+  quantity bigint,
+  is_singleton boolean,
+  is_blueprint_copy boolean,
+  updated_at timestamptz not null default now()
+);
+create index asset_character_id_idx on hangar.asset (character_id);
+
+alter table hangar.asset enable row level security;
+
+create policy "Users read own assets"
+  on hangar.asset
+  for select
+  to authenticated
+  using (
+    character_id in (
+      select id from hangar.character where user_id = (select auth.uid())
+    )
+  );

--- a/src/app/character/callback/route.ts
+++ b/src/app/character/callback/route.ts
@@ -9,7 +9,11 @@ import { sso } from '../sso'
 
 const upsertCharacter =
   (supabase: SupabaseClient) => async (columns: { user_id: string; owner: string; name: string }) => {
-    const response = await supabase.from('character').upsert(columns, { onConflict: 'owner' }).select()
+    const response = await supabase
+      .schema('hangar')
+      .from('character')
+      .upsert(columns, { onConflict: 'user_id, owner' })
+      .select()
     if (response.error) console.error(response.error)
     return response.data?.[0]?.id
   }
@@ -25,7 +29,11 @@ const upsertToken =
     expires_at: string
     scope: string[]
   }) => {
-    const response = await supabase.from('token').upsert(columns, { onConflict: 'character_id, scope' }).select()
+    const response = await supabase
+      .schema('hangar')
+      .from('token')
+      .upsert(columns, { onConflict: 'character_id, scope' })
+      .select()
     if (response.error) console.error(response.error)
     return response.data?.[0]?.id
   }

--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -11,7 +11,7 @@ const CharacterPage = async () => {
     redirect('/')
   }
 
-  const { data: characters, status, statusText, error } = await supabase.from('character').select()
+  const { data: characters, status, statusText, error } = await supabase.schema('hangar').from('character').select()
 
   return (
     <>

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -26,12 +26,17 @@ export const authenticate = async () => {
 }
 
 export const upsertCharacter = async (columns) => {
-  const response = await supabase.from('character').upsert(columns, { onConflict: 'owner' }).select()
+  const response = await supabase
+    .schema('hangar')
+    .from('character')
+    .upsert(columns, { onConflict: 'user_id, owner' })
+    .select()
   return response.data?.[0]?.id
 }
 
 export const upsertToken = async (columns) => {
   const response = await supabase
+    .schema('hangar')
     .from('token')
     .upsert(columns, { onConflict: ['character_id', 'scope'] })
     .select()
@@ -41,6 +46,7 @@ export const upsertToken = async (columns) => {
 
 export const upsertAssets = async (assets) => {
   const response = await supabase
+    .schema('hangar')
     .from('asset')
     .upsert(assets, { onConflict: ['item_id'] })
     .select()
@@ -48,7 +54,7 @@ export const upsertAssets = async (assets) => {
 }
 
 export const selectCharacters = async (columns, owner) => {
-  let query = supabase.from('character').select(columns)
+  let query = supabase.schema('hangar').from('character').select(columns)
   if (owner !== undefined) query = query.eq('owner', owner)
   const response = await query
   return response?.data?.map((r) => r.id)
@@ -56,6 +62,7 @@ export const selectCharacters = async (columns, owner) => {
 
 export const selectToken = async (character_id, scope = []) => {
   const response = await supabase
+    .schema('hangar')
     .from('token')
     .select('refresh_token, scope')
     .eq('character_id', character_id)


### PR DESCRIPTION
## Summary

The Supabase project is shared with edencom-pds, so `public.character` and `public.token` were colliding across apps. An existing row with the same `owner` hash under a different `user_id` was blocking the eve-hangar upsert via RLS — silently producing no row for the eve-hangar user, which is why "Add Character" appeared to stop working.

This PR moves the app's data into its own `hangar` schema with user-scoped RLS, and points every PostgREST call at `.schema('hangar')`. The character uniqueness widens from `owner` to `(user_id, owner)` so two different Supabase users can each legitimately own a row for the same EVE character.

## Changes

- New `hangar.sql` with the schema, RLS policies, and grants for `character`, `token`, and `asset`
- `src/app/character/page.tsx`, `src/app/character/callback/route.ts`, `src/supabase.js` updated to use `.schema('hangar')`
- `onConflict` widened to `user_id, owner` for character upserts

## Deploy steps

1. Run `hangar.sql` against the Supabase database (SQL editor or `psql`)
2. Add `hangar` to **Settings → API → Exposed schemas** in the Supabase dashboard so PostgREST will serve it
3. Deploy

## Test plan

- [ ] Apply `hangar.sql` to the database
- [ ] Add `hangar` to exposed schemas
- [ ] Log in, click "Add Character", complete EVE SSO
- [ ] Verify the character now shows on `/character`
- [ ] Verify a row appears in `hangar.character` and `hangar.token`


---
_Generated by [Claude Code](https://claude.ai/code/session_01FguvfrBxzzDQh2QNYo8qNe)_