### PR TITLE
Surface character/token upsert errors in /character/callback

### DIFF
--- a/src/app/character/callback/route.ts
+++ b/src/app/character/callback/route.ts
@@ -14,8 +14,9 @@ const upsertCharacter =
       .from('character')
       .upsert(columns, { onConflict: 'user_id, owner' })
       .select()
-    if (response.error) console.error(response.error)
-    return response.data?.[0]?.id
+    if (response.error) throw new Error(`upsert character failed: ${JSON.stringify(response.error)}`)
+    if (!response.data?.[0]?.id) throw new Error(`upsert character returned no row: ${JSON.stringify(response)}`)
+    return response.data[0].id
   }
 
 const upsertToken =
@@ -34,8 +35,9 @@ const upsertToken =
       .from('token')
       .upsert(columns, { onConflict: 'character_id, scope' })
       .select()
-    if (response.error) console.error(response.error)
-    return response.data?.[0]?.id
+    if (response.error) throw new Error(`upsert token failed: ${JSON.stringify(response.error)}`)
+    if (!response.data?.[0]?.id) throw new Error(`upsert token returned no row: ${JSON.stringify(response)}`)
+    return response.data[0].id
   }
 
 export const GET = async (request: NextRequest) => {
@@ -43,7 +45,8 @@ export const GET = async (request: NextRequest) => {
   const {
     data: { user },
   } = await supabase.auth.getUser()
-  const user_id = user?.id ?? ''
+  if (!user?.id) throw new Error('no authenticated supabase user on /character/callback')
+  const user_id = user.id
 
   const { searchParams } = new URL(request.url)
   const code = searchParams.get('code')


### PR DESCRIPTION
## Summary

Character creation is still failing after the hangar-schema move, but the callback silently `console.error`'s upsert failures and redirects to `/character` anyway, so we can't tell what's actually wrong. This patch throws on:

- missing authenticated supabase user
- upsert returning an error
- upsert returning no row (RLS silent-no-op)

After deploying, retry the EVE SSO flow and the Next error page (or Vercel logs) will show the real failure — PostgREST 404, RLS denial, NOT NULL violation, etc. — so we can fix the actual root cause.

## Test plan

- [ ] Merge & deploy
- [ ] Click "Add Character", complete EVE SSO
- [ ] Capture the error message from the resulting error page / server logs


---
_Generated by [Claude Code](https://claude.ai/code/session_01FguvfrBxzzDQh2QNYo8qNe)_