### PR TITLE
Grant table privileges to authenticated role on hangar.*

### DIFF
--- a/hangar.sql
+++ b/hangar.sql
@@ -83,3 +83,12 @@ create policy "Users read own assets"
       select id from hangar.character where user_id = (select auth.uid())
     )
   );
+
+-- Explicit grants on the tables we just created. `alter default privileges`
+-- above only applies to tables created by the role that ran the statement,
+-- so this belt-and-suspenders grant ensures PostgREST's `authenticated` /
+-- `anon` / `service_role` roles can actually reach these tables. Re-runnable.
+grant select, insert, update, delete on hangar.character to authenticated;
+grant select, insert, update, delete on hangar.token     to authenticated;
+grant select                          on hangar.asset    to authenticated;
+grant all on hangar.character, hangar.token, hangar.asset to service_role;


### PR DESCRIPTION
## Summary

Production callback is failing with Postgres `42501` (insufficient_privilege) on the character upsert, confirmed via Vercel runtime logs. `alter default privileges` only grants on tables created by the matching role, which doesn't reliably line up when running through the Supabase SQL editor — so the explicit privileges never landed on `hangar.character` / `hangar.token` / `hangar.asset`.

Adds explicit `GRANT`s on the existing tables. Re-runnable.

## Deploy steps

Apply the new GRANT block from `hangar.sql` against the Supabase database (re-running the whole file is safe — `create schema if not exists`, `create table` will error on existing tables but the grants at the bottom are idempotent; easiest is to just copy/paste the four `grant` lines).

```sql
grant select, insert, update, delete on hangar.character to authenticated;
grant select, insert, update, delete on hangar.token     to authenticated;
grant select                          on hangar.asset    to authenticated;
grant all on hangar.character, hangar.token, hangar.asset to service_role;
```

## Test plan

- [ ] Apply grants
- [ ] Click "Add Character", complete EVE SSO
- [ ] Confirm row appears on `/character` and in `hangar.character` / `hangar.token`


---
_Generated by [Claude Code](https://claude.ai/code/session_01FguvfrBxzzDQh2QNYo8qNe)_