### PR TITLE
fix(auth): reset Turnstile widget after each form submission

### DIFF
--- a/src/app/account/login/page.tsx
+++ b/src/app/account/login/page.tsx
@@ -1,17 +1,20 @@
 'use client'
 
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { redirect } from 'next/navigation'
-import { Turnstile } from '@marsidev/react-turnstile'
+import { Turnstile, type TurnstileInstance } from '@marsidev/react-turnstile'
 
 import { login } from './actions'
 
 const Login = () => {
   const [response, setResponse] = useState<string>('')
   const [captchaToken, setCaptchaToken] = useState<string>('')
+  const turnstileRef = useRef<TurnstileInstance>(undefined)
 
   const loginAndReturn = async (formData: FormData) => {
     const error = await login(formData, captchaToken)
+    setCaptchaToken('')
+    turnstileRef.current?.reset()
     if (error) {
       setResponse(error)
       return
@@ -45,6 +48,7 @@ const Login = () => {
           <a href="reset">Forgot Password</a>
         </div>
         <Turnstile
+          ref={turnstileRef}
           siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? ''}
           onSuccess={setCaptchaToken}
           options={{

--- a/src/app/account/register/page.tsx
+++ b/src/app/account/register/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState } from 'react'
-import { Turnstile } from '@marsidev/react-turnstile'
+import { useRef, useState } from 'react'
+import { Turnstile, type TurnstileInstance } from '@marsidev/react-turnstile'
 
 import { register } from './actions'
 
@@ -10,8 +10,11 @@ const RegisterPage = () => {
   const [color, setColor] = useState('#000000')
   const [response, setResponse] = useState('')
   const [captchaToken, setCaptchaToken] = useState<string>('')
+  const turnstileRef = useRef<TurnstileInstance>(undefined)
   const signupAndReturn = async (formData: FormData) => {
     const { error } = await register(formData, captchaToken)
+    setCaptchaToken('')
+    turnstileRef.current?.reset()
     if (error?.message) {
       setDisabled(false)
       setResponse(error?.message)
@@ -56,6 +59,7 @@ const RegisterPage = () => {
         </>
       )}
       <Turnstile
+        ref={turnstileRef}
         siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? ''}
         onSuccess={setCaptchaToken}
         options={{

--- a/src/app/account/reset/page.tsx
+++ b/src/app/account/reset/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState } from 'react'
-import { Turnstile } from '@marsidev/react-turnstile'
+import { useRef, useState } from 'react'
+import { Turnstile, type TurnstileInstance } from '@marsidev/react-turnstile'
 
 import { reset } from './actions'
 
@@ -9,9 +9,12 @@ const ResetPage = () => {
   const [disabled, setDisabled] = useState(false)
   const [emailSent, setEmailSent] = useState(false)
   const [captchaToken, setCaptchaToken] = useState<string>('')
+  const turnstileRef = useRef<TurnstileInstance>(undefined)
 
   const resetAndReturn = async (formData: FormData) => {
     await reset(formData, captchaToken)
+    setCaptchaToken('')
+    turnstileRef.current?.reset()
     setEmailSent(true)
   }
 
@@ -44,6 +47,7 @@ const ResetPage = () => {
         </>
       )}
       <Turnstile
+        ref={turnstileRef}
         siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? ''}
         onSuccess={setCaptchaToken}
         options={{


### PR DESCRIPTION
## Summary

Fixes the captcha bug where a second submission attempt fails with "invalid captcha token".

Cloudflare Turnstile tokens are **single-use**. After a failed login (e.g. wrong password), the consumed token was still attached to the form. The next submission would send the same stale token, and Supabase would reject it as invalid — masking the real error.

## Fix

After every submission in `login`, `register`, and `reset` pages:
- Clear the local `captchaToken` state
- Call `reset()` on the `<Turnstile>` widget via ref so it issues a fresh token

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [ ] Manual: log in with wrong password, get "invalid credentials", fix password, submit again → should log in (not "invalid captcha token")
- [ ] Manual: same flow on `/account/register` and `/account/reset`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ftj6n74ZQYd97GPE7JaX8m)_