### PR TITLE
feat(sso): request market orders scope from ESI

### DIFF
--- a/src/app/character/sso.ts
+++ b/src/app/character/sso.ts
@@ -8,6 +8,7 @@ export const scopes = [
   'publicData',
   'esi-wallet.read_character_wallet.v1',
   'esi-assets.read_assets.v1',
+  'esi-markets.read_character_orders.v1',
   // 'esi-characters.read_blueprints.v1',
 ]
 


### PR DESCRIPTION
## Summary
- Adds `esi-markets.read_character_orders.v1` to the OAuth scopes requested when a character connects, so we can fetch recent market sales/orders history.
- The scope is already used by `src/refresh.js:17`; this aligns the connect-time request with what downstream jobs need.

## Notes
- Existing characters connected before this change will need to reconnect to grant the new scope.

## Test plan
- [ ] Connect a new character via SSO and confirm EVE's consent screen lists the market orders permission
- [ ] Verify the issued token's `scp` claim includes `esi-markets.read_character_orders.v1`
- [ ] Confirm an existing token without the new scope still works for assets/wallet (no regression)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ftj6n74ZQYd97GPE7JaX8m)_