### PR TITLE
feat(wallet): track and display per-character ISK balance

### DIFF
--- a/hangar.sql
+++ b/hangar.sql
@@ -103,3 +103,27 @@ create index if not exists heartbeat_ran_at_idx
 
 alter table hangar.heartbeat enable row level security;
 grant all on hangar.heartbeat to service_role;
+
+create table if not exists hangar.wallet (
+  id uuid primary key default gen_random_uuid(),
+  character_id uuid not null references hangar.character(id) on delete cascade,
+  balance numeric(20, 2) not null,
+  recorded_at timestamptz not null default now()
+);
+create index if not exists wallet_character_id_recorded_at_idx
+  on hangar.wallet (character_id, recorded_at desc);
+
+alter table hangar.wallet enable row level security;
+
+create policy "Users read own wallets"
+  on hangar.wallet
+  for select
+  to authenticated
+  using (
+    character_id in (
+      select id from hangar.character where user_id = (select auth.uid())
+    )
+  );
+
+grant select on hangar.wallet to authenticated;
+grant all    on hangar.wallet to service_role;

--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -14,6 +14,19 @@ const CharacterPage = async () => {
 
   const { data: characters, status, statusText, error } = await supabase.schema('hangar').from('character').select()
 
+  const { data: wallets } = await supabase
+    .schema('hangar')
+    .from('wallet')
+    .select('character_id, balance, recorded_at')
+    .order('recorded_at', { ascending: false })
+
+  const latestBalance = new Map<string, string>()
+  for (const w of wallets ?? []) {
+    if (!latestBalance.has(w.character_id)) latestBalance.set(w.character_id, w.balance)
+  }
+  const formatIsk = (raw: string) =>
+    new Intl.NumberFormat('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(Number(raw))
+
   return (
     <>
       <h1>Characters</h1>
@@ -23,6 +36,10 @@ const CharacterPage = async () => {
             <div className={styles.avatar} aria-hidden="true" />
             <div className={styles.body}>
               <div className={styles.name}>{c.name}</div>
+              <div className={styles.meta}>
+                <span className={styles.metaLabel}>ISK:</span>
+                {latestBalance.has(c.id) ? `${formatIsk(latestBalance.get(c.id)!)} ISK` : '—'}
+              </div>
               <div className={styles.meta}>
                 <span className={styles.metaLabel}>Location:</span>
               </div>

--- a/src/esi.js
+++ b/src/esi.js
@@ -19,6 +19,25 @@ export const assets = async (access_token, characterID, page = 1) => {
   return [data, pages]
 }
 
+export const wallet = async (access_token, characterID) => {
+  const response = await fetch(
+    `https://esi.evetech.net/latest/characters/${characterID}/wallet/?` +
+      new URLSearchParams({
+        token: access_token,
+      }),
+    {
+      method: 'GET',
+      headers: {
+        'User-Agent': userAgent,
+      },
+    }
+  )
+  if (!response.ok) {
+    throw new Error(`wallet ${characterID}: ${response.status} ${response.statusText}`)
+  }
+  return await response.json()
+}
+
 export const assetNames = async (access_token, characterID, ids) => {
   const params = new URLSearchParams({
     token: access_token,

--- a/src/hourly.js
+++ b/src/hourly.js
@@ -1,9 +1,61 @@
-import { authenticate, sudoSupabase } from './supabase.js'
+import { userAgent, wallet } from './esi.js'
+import SingleSignOn from './sso.js'
+import { sudoSupabase } from './supabase.js'
+
+const EVE_CLIENT_ID = process.env.EVE_CLIENT_ID
+const EVE_SECRET_KEY = process.env.EVE_SECRET_KEY
+const EVE_CALLBACK_URL = process.env.EVE_CALLBACK_URL
+
+const WALLET_SCOPE = 'esi-wallet.read_character_wallet.v1'
+
+const sso = new SingleSignOn(EVE_CLIENT_ID, EVE_SECRET_KEY, EVE_CALLBACK_URL, { userAgent })
+
+const refreshToken = async (tokenRow) => {
+  const refreshed = await sso.getAccessToken(tokenRow.refresh_token, true)
+  const { access_token, refresh_token } = refreshed
+  const { sub, scp = [], iat, exp } = refreshed.decoded_access_token
+  const characterID = sub.split(':')[2]
+  const scope = [scp].flat()
+  await sudoSupabase
+    .schema('hangar')
+    .from('token')
+    .update({
+      access_token,
+      refresh_token,
+      issued_at: new Date(iat * 1000).toISOString(),
+      expires_at: new Date(exp * 1000).toISOString(),
+      scope,
+    })
+    .eq('id', tokenRow.id)
+  return { access_token, characterID, scope }
+}
 
 const execute = async () => {
-  await authenticate()
-  const res = await sudoSupabase.from('character_token').select(`id, name`)
-  console.log(res)
+  const { data: tokens, error } = await sudoSupabase
+    .schema('hangar')
+    .from('token')
+    .select('id, character_id, refresh_token')
+    .contains('scope', [WALLET_SCOPE])
+
+  if (error) {
+    console.error(error)
+    process.exit(1)
+  }
+
+  for (const tokenRow of tokens ?? []) {
+    try {
+      const { access_token, characterID } = await refreshToken(tokenRow)
+      const balance = await wallet(access_token, characterID)
+      const { error: insertError } = await sudoSupabase
+        .schema('hangar')
+        .from('wallet')
+        .insert({ character_id: tokenRow.character_id, balance })
+      if (insertError) throw insertError
+      console.log(`wallet ${tokenRow.character_id} (${characterID}): ${balance}`)
+    } catch (e) {
+      console.error(`wallet refresh failed for ${tokenRow.character_id}:`, e)
+    }
+  }
 }
 
 execute()


### PR DESCRIPTION
## Summary

- Adds a `hangar.wallet` history table (one row per balance snapshot per character, with RLS so users only read their own).
- Adds `wallet(access_token, characterID)` to `src/esi.js` to call `/characters/{character_id}/wallet/`.
- Rewrites `src/hourly.js` to refresh the access token for every wallet-scoped token row, fetch the current balance, and insert a `hangar.wallet` row. Tokens get persisted back so subsequent refreshes use the latest refresh_token.
- Surfaces the most recent balance per character on `/character`, formatted with thousands separators.

## Test plan

- [ ] Apply the new `hangar.wallet` block in `hangar.sql` to Supabase (RLS, policy, grants all included).
- [ ] Manually trigger the **Hourly** workflow → confirm one new row per wallet-scoped character appears in `hangar.wallet`.
- [ ] Load `/character` and confirm the ISK line shows the latest balance for each character (and `—` for characters with no wallet rows yet).
- [ ] Verify that errors fetching one character's wallet don't abort the job for the rest (logged, continue).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ftj6n74ZQYd97GPE7JaX8m)_