### PR TITLE
feat(character): show EVE portrait on character page

### DIFF
--- a/hangar.sql
+++ b/hangar.sql
@@ -18,6 +18,7 @@ create table hangar.character (
   user_id uuid not null references auth.users(id) on delete cascade,
   owner text not null,
   name text not null,
+  character_id bigint,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
   unique (user_id, owner)
@@ -103,6 +104,8 @@ create index if not exists heartbeat_ran_at_idx
 
 alter table hangar.heartbeat enable row level security;
 grant all on hangar.heartbeat to service_role;
+
+alter table hangar.character add column if not exists character_id bigint;
 
 create table if not exists hangar.wallet (
   id uuid primary key default gen_random_uuid(),

--- a/src/app/character/callback/route.ts
+++ b/src/app/character/callback/route.ts
@@ -8,7 +8,8 @@ import { createClient } from '@/utils/supabase/server'
 import { sso } from '../sso'
 
 const upsertCharacter =
-  (supabase: SupabaseClient) => async (columns: { user_id: string; owner: string; name: string }) => {
+  (supabase: SupabaseClient) =>
+  async (columns: { user_id: string; owner: string; name: string; character_id: number }) => {
     const response = await supabase
       .schema('hangar')
       .from('character')
@@ -56,11 +57,12 @@ export const GET = async (request: NextRequest) => {
   } = info
   const issued_at = new Date(iat * 1000).toISOString()
   const expires_at = new Date(exp * 1000).toISOString()
+  const eve_character_id = Number(sub.split(':')[2])
 
   // why are we doing this, again? can this be deleted?
   await sso.getAccessToken(refresh_token, true)
 
-  const character_id = await upsertCharacter(supabase)({ user_id, owner, name })
+  const character_id = await upsertCharacter(supabase)({ user_id, owner, name, character_id: eve_character_id })
   const token_id = await upsertToken(supabase)({
     user_id,
     character_id,

--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -33,7 +33,16 @@ const CharacterPage = async () => {
       <ul className={styles.grid}>
         {characters?.map((c) => (
           <li key={`character-${c.id}`} className={styles.tile}>
-            <div className={styles.avatar} aria-hidden="true" />
+            {c.character_id ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                className={styles.avatar}
+                src={`https://images.evetech.net/characters/${c.character_id}/portrait?size=128`}
+                alt={c.name}
+              />
+            ) : (
+              <div className={styles.avatar} aria-hidden="true" />
+            )}
             <div className={styles.body}>
               <div className={styles.name}>{c.name}</div>
               <div className={styles.meta}>


### PR DESCRIPTION
## Summary

- Adds a nullable `character_id bigint` column to `hangar.character` and a matching `alter table … add column if not exists` so the existing table picks it up.
- Extracts the numeric EVE character ID from the JWT `sub` claim in the SSO callback and stores it on the character row.
- Renders the official portrait from `images.evetech.net/characters/{id}/portrait?size=128` on `/character`. Characters with no `character_id` yet (existing rows pre-migration) keep the gray placeholder.

## Test plan

- [ ] Apply the `alter table` line from `hangar.sql` to Supabase.
- [ ] Reconnect at least one existing character → confirm `character_id` populates and the portrait appears on `/character`.
- [ ] Newly added characters get the portrait immediately.
- [ ] Characters without a populated `character_id` still render the placeholder, not a broken image.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ftj6n74ZQYd97GPE7JaX8m)_