### PR TITLE
refactor(token): one token row per character

### DIFF
--- a/hangar.sql
+++ b/hangar.sql
@@ -45,7 +45,7 @@ create table hangar.token (
   scope text[] not null default '{}',
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
-  unique (character_id, scope)
+  unique (character_id)
 );
 create index token_character_id_idx on hangar.token (character_id);
 create index token_user_id_idx on hangar.token (user_id);
@@ -130,3 +130,31 @@ create policy "Users read own wallets"
 
 grant select on hangar.wallet to authenticated;
 grant all    on hangar.wallet to service_role;
+
+-- Collapse hangar.token so there is at most one row per character, keeping the
+-- row with the most scopes (ties broken by most recently updated).
+delete from hangar.token
+where id in (
+  select id from (
+    select id,
+      row_number() over (
+        partition by character_id
+        order by coalesce(array_length(scope, 1), 0) desc, updated_at desc
+      ) as rn
+    from hangar.token
+  ) ranked
+  where rn > 1
+);
+
+alter table hangar.token drop constraint if exists token_character_id_scope_key;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'token_character_id_key'
+      and conrelid = 'hangar.token'::regclass
+  ) then
+    alter table hangar.token add constraint token_character_id_key unique (character_id);
+  end if;
+end $$;

--- a/src/app/character/callback/route.ts
+++ b/src/app/character/callback/route.ts
@@ -34,7 +34,7 @@ const upsertToken =
     const response = await supabase
       .schema('hangar')
       .from('token')
-      .upsert(columns, { onConflict: 'character_id, scope' })
+      .upsert(columns, { onConflict: 'character_id' })
       .select()
     if (response.error) throw new Error(`upsert token failed: ${JSON.stringify(response.error)}`)
     if (!response.data?.[0]?.id) throw new Error(`upsert token returned no row: ${JSON.stringify(response)}`)

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -38,7 +38,7 @@ export const upsertToken = async (columns) => {
   const response = await supabase
     .schema('hangar')
     .from('token')
-    .upsert(columns, { onConflict: ['character_id', 'scope'] })
+    .upsert(columns, { onConflict: ['character_id'] })
     .select()
   if (response.error) console.error(response.error)
   return response.data?.[0]?.id


### PR DESCRIPTION
## Summary

- `hangar.token` had `unique (character_id, scope)`, so a single character could accumulate multiple token rows with different scope arrays. The hourly job then queried ESI once per row, fetching the same character's wallet multiple times.
- This PR drops that constraint, replaces it with `unique (character_id)`, and ships a one-time migration block that collapses existing duplicates — keeping the row with the most scopes (ties broken by most recently updated).
- Callback and `upsertToken` helper now upsert with `onConflict: 'character_id'`, so a reconnect replaces the existing token in place instead of inserting a new row.

## Test plan

- [ ] Apply the new migration block at the bottom of `hangar.sql` to Supabase.
- [ ] Verify `select character_id, count(*) from hangar.token group by 1 having count(*) > 1;` returns no rows.
- [ ] Trigger Hourly → confirm exactly one wallet row per character is inserted per run.
- [ ] Reconnect an existing character → confirm the same row is updated (no new row inserted).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ftj6n74ZQYd97GPE7JaX8m)_