### PR TITLE
feat(market): record and show recent character sales

### DIFF
--- a/hangar.sql
+++ b/hangar.sql
@@ -158,3 +158,35 @@ begin
     alter table hangar.token add constraint token_character_id_key unique (character_id);
   end if;
 end $$;
+
+create table if not exists hangar.market_transaction (
+  transaction_id bigint primary key,
+  character_id uuid not null references hangar.character(id) on delete cascade,
+  date timestamptz not null,
+  type_id bigint not null,
+  quantity bigint not null,
+  unit_price numeric(20, 2) not null,
+  is_buy boolean not null,
+  is_personal boolean not null,
+  client_id bigint not null,
+  location_id bigint not null,
+  journal_ref_id bigint not null,
+  seen_at timestamptz not null default now()
+);
+create index if not exists market_transaction_character_id_date_idx
+  on hangar.market_transaction (character_id, date desc);
+
+alter table hangar.market_transaction enable row level security;
+
+create policy "Users read own transactions"
+  on hangar.market_transaction
+  for select
+  to authenticated
+  using (
+    character_id in (
+      select id from hangar.character where user_id = (select auth.uid())
+    )
+  );
+
+grant select on hangar.market_transaction to authenticated;
+grant all    on hangar.market_transaction to service_role;

--- a/src/app/character/character.module.css
+++ b/src/app/character/character.module.css
@@ -53,3 +53,32 @@
   color: #999;
   margin-right: 4pt;
 }
+
+.sales {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 10pt;
+  margin: 12pt 0;
+}
+
+.sales th,
+.sales td {
+  border-bottom: 1px solid #eee;
+  padding: 6pt 8pt;
+  text-align: left;
+}
+
+.sales th {
+  background: #fafafa;
+  font-weight: bold;
+}
+
+.sales td:nth-child(3),
+.sales td:nth-child(4),
+.sales td:nth-child(5),
+.sales th:nth-child(3),
+.sales th:nth-child(4),
+.sales th:nth-child(5) {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}

--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -24,8 +24,21 @@ const CharacterPage = async () => {
   for (const w of wallets ?? []) {
     if (!latestBalance.has(w.character_id)) latestBalance.set(w.character_id, w.balance)
   }
-  const formatIsk = (raw: string) =>
+  const formatIsk = (raw: string | number) =>
     new Intl.NumberFormat('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(Number(raw))
+
+  // eslint-disable-next-line react-hooks/purity
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
+  const { data: sales } = await supabase
+    .schema('hangar')
+    .from('market_transaction')
+    .select('transaction_id, character_id, date, type_id, quantity, unit_price, seen_at')
+    .eq('is_buy', false)
+    .gte('date', sevenDaysAgo)
+    .order('date', { ascending: false })
+
+  const characterName = new Map<string, string>(characters?.map((c) => [c.id, c.name]) ?? [])
+  const formatDate = (iso: string) => new Date(iso).toLocaleString()
 
   return (
     <>
@@ -59,6 +72,37 @@ const CharacterPage = async () => {
           </li>
         ))}
       </ul>
+      <h2>Recent Sales (last 7 days)</h2>
+      {sales && sales.length > 0 ? (
+        <table className={styles.sales}>
+          <thead>
+            <tr>
+              <th>Character</th>
+              <th>Type ID</th>
+              <th>Qty</th>
+              <th>Unit Price</th>
+              <th>Total</th>
+              <th>Sold</th>
+              <th>Seen</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sales.map((s) => (
+              <tr key={`sale-${s.transaction_id}`}>
+                <td>{characterName.get(s.character_id) ?? '—'}</td>
+                <td>{s.type_id}</td>
+                <td>{s.quantity}</td>
+                <td>{formatIsk(s.unit_price)}</td>
+                <td>{formatIsk(Number(s.unit_price) * Number(s.quantity))}</td>
+                <td>{formatDate(s.date)}</td>
+                <td>{formatDate(s.seen_at)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p>No sales in the last 7 days.</p>
+      )}
       {error && (
         <>
           <strong>

--- a/src/esi.js
+++ b/src/esi.js
@@ -19,6 +19,25 @@ export const assets = async (access_token, characterID, page = 1) => {
   return [data, pages]
 }
 
+export const transactions = async (access_token, characterID) => {
+  const response = await fetch(
+    `https://esi.evetech.net/latest/characters/${characterID}/wallet/transactions/?` +
+      new URLSearchParams({
+        token: access_token,
+      }),
+    {
+      method: 'GET',
+      headers: {
+        'User-Agent': userAgent,
+      },
+    }
+  )
+  if (!response.ok) {
+    throw new Error(`transactions ${characterID}: ${response.status} ${response.statusText}`)
+  }
+  return await response.json()
+}
+
 export const wallet = async (access_token, characterID) => {
   const response = await fetch(
     `https://esi.evetech.net/latest/characters/${characterID}/wallet/?` +

--- a/src/hourly.js
+++ b/src/hourly.js
@@ -1,4 +1,4 @@
-import { userAgent, wallet } from './esi.js'
+import { transactions, userAgent, wallet } from './esi.js'
 import SingleSignOn from './sso.js'
 import { sudoSupabase } from './supabase.js'
 
@@ -52,8 +52,31 @@ const execute = async () => {
         .insert({ character_id: tokenRow.character_id, balance })
       if (insertError) throw insertError
       console.log(`wallet ${tokenRow.character_id} (${characterID}): ${balance}`)
+
+      const txns = await transactions(access_token, characterID)
+      if (txns.length > 0) {
+        const rows = txns.map((t) => ({
+          transaction_id: t.transaction_id,
+          character_id: tokenRow.character_id,
+          date: t.date,
+          type_id: t.type_id,
+          quantity: t.quantity,
+          unit_price: t.unit_price,
+          is_buy: t.is_buy,
+          is_personal: t.is_personal,
+          client_id: t.client_id,
+          location_id: t.location_id,
+          journal_ref_id: t.journal_ref_id,
+        }))
+        const { error: txError } = await sudoSupabase
+          .schema('hangar')
+          .from('market_transaction')
+          .upsert(rows, { onConflict: 'transaction_id', ignoreDuplicates: true })
+        if (txError) throw txError
+        console.log(`transactions ${tokenRow.character_id} (${characterID}): ${txns.length} fetched`)
+      }
     } catch (e) {
-      console.error(`wallet refresh failed for ${tokenRow.character_id}:`, e)
+      console.error(`refresh failed for ${tokenRow.character_id}:`, e)
     }
   }
 }


### PR DESCRIPTION
## Summary

- New `hangar.market_transaction` table keyed on ESI's globally-unique `transaction_id`, with a `seen_at timestamptz default now()` column capturing first observation.
- New `transactions()` helper in `src/esi.js` for `/characters/{id}/wallet/transactions/`. Uses the existing `esi-wallet.read_character_wallet.v1` scope — no new SSO permission needed.
- `hourly.js` now fetches transactions for every wallet-scoped character and bulk-inserts with `ignoreDuplicates: true`, so `seen_at` reflects when our job first saw a transaction (not when it was reported by ESI).
- `/character` renders a table of sells (`is_buy = false`) from the last 7 days below the character list, showing character, type ID, qty, unit price, total, sold date, and seen date.

## Test plan

- [ ] Apply the new `hangar.market_transaction` block from `hangar.sql` to Supabase (table, index, RLS, policy, grants).
- [ ] Trigger Hourly → confirm new rows appear in `hangar.market_transaction` and that running it again does not duplicate rows or change `seen_at` on existing ones.
- [ ] Load `/character` and confirm the "Recent Sales" table shows only sells from the last 7 days, sorted newest first.
- [ ] Character without recent sales: confirm "No sales in the last 7 days." copy renders.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ftj6n74ZQYd97GPE7JaX8m)_