### PR TITLE
feat(character): TypeName client component for typeID -> name lookup

### DIFF
--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation'
 import { createClient } from '@/utils/supabase/server'
 import { register } from './actions'
 import styles from './character.module.css'
+import { TypeName } from './typeName'
 
 const CharacterPage = async () => {
   const supabase = await createClient()
@@ -78,7 +79,7 @@ const CharacterPage = async () => {
           <thead>
             <tr>
               <th>Character</th>
-              <th>Type ID</th>
+              <th>Type</th>
               <th>Qty</th>
               <th>Unit Price</th>
               <th>Total</th>
@@ -90,7 +91,9 @@ const CharacterPage = async () => {
             {sales.map((s) => (
               <tr key={`sale-${s.transaction_id}`}>
                 <td>{characterName.get(s.character_id) ?? '—'}</td>
-                <td>{s.type_id}</td>
+                <td>
+                  <TypeName typeID={Number(s.type_id)} />
+                </td>
                 <td>{s.quantity}</td>
                 <td>{formatIsk(s.unit_price)}</td>
                 <td>{formatIsk(Number(s.unit_price) * Number(s.quantity))}</td>

--- a/src/app/character/typeName.tsx
+++ b/src/app/character/typeName.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+const cache = new Map<number, Promise<string | null>>()
+
+const lookupName = (typeID: number): Promise<string | null> => {
+  const cached = cache.get(typeID)
+  if (cached) return cached
+  const promise = fetch(`https://eve-build-calculator.philihp.com/api/type/${typeID}`)
+    .then((res) => (res.ok ? res.json() : null))
+    .then((type: { name?: { en?: string } | string } | null) => {
+      if (!type) return null
+      return typeof type.name === 'string' ? type.name : (type.name?.en ?? null)
+    })
+    .catch(() => null)
+  cache.set(typeID, promise)
+  return promise
+}
+
+type TypeNameProps = {
+  typeID: number
+  fallback?: string
+}
+
+export const TypeName = ({ typeID, fallback }: TypeNameProps) => {
+  const [name, setName] = useState<string | null>(null)
+
+  useEffect(() => {
+    let active = true
+    lookupName(typeID).then((value) => {
+      if (active) setName(value)
+    })
+    return () => {
+      active = false
+    }
+  }, [typeID])
+
+  return <>{name ?? fallback ?? `#${typeID}`}</>
+}


### PR DESCRIPTION
## Summary
Adds a reusable client component `<TypeName typeID={...} />` that asynchronously resolves an EVE `typeID` to a human-readable name by calling `https://eve-build-calculator.philihp.com/api/type/{typeID}` and reading `name.en` — the method documented in the [eve-build-calculator README](https://github.com/philihp/eve-build-calculator).

- Promise-level cache dedupes concurrent lookups for the same `typeID`.
- Falls back to `fallback` prop or `#<typeID>` while loading / on 404.
- Ready to drop into the character page's recent-transactions list once that data is wired up.

## Test plan
- [ ] `<TypeName typeID={671} />` renders `Erebus` after mount.
- [ ] Unknown typeID renders the `#<id>` fallback (or supplied `fallback`).
- [ ] Same typeID used twice on a page fires only one network request.

https://claude.ai/code/session_015u1xgKQDoRyXbpHVPoc7qD

---
_Generated by [Claude Code](https://claude.ai/code/session_015u1xgKQDoRyXbpHVPoc7qD)_