### PR TITLE
docs: add CLAUDE.md with rebase-before-commit workflow note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Workflow
+
+- Before committing to a new feature branch, check what branch it branched from and rebase onto the latest upstream of that base (typically `origin/main`) first. This avoids opening PRs that include changes already merged on the base.


### PR DESCRIPTION
## Summary
Adds `CLAUDE.md` documenting the workflow rule: before committing on a new feature branch, check the branch's base and rebase onto the latest upstream of that base first — so PRs don't include changes already merged.

https://claude.ai/code/session_015u1xgKQDoRyXbpHVPoc7qD

---
_Generated by [Claude Code](https://claude.ai/code/session_015u1xgKQDoRyXbpHVPoc7qD)_