### PR TITLE
feat(proxy): rewrite build-calculator API through same origin to dodge CORS

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,13 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  async rewrites() {
+    return [
+      {
+        source: '/api/build-calculator/:path*',
+        destination: 'https://eve-build-calculator.philihp.com/api/:path*',
+      },
+    ]
+  },
+}
 
 export default nextConfig

--- a/src/app/character/typeName.tsx
+++ b/src/app/character/typeName.tsx
@@ -7,7 +7,7 @@ const cache = new Map<number, Promise<string | null>>()
 const lookupName = (typeID: number): Promise<string | null> => {
   const cached = cache.get(typeID)
   if (cached) return cached
-  const promise = fetch(`https://eve-build-calculator.philihp.com/api/type/${typeID}`)
+  const promise = fetch(`/api/build-calculator/type/${typeID}`)
     .then((res) => (res.ok ? res.json() : null))
     .then((type: { name?: { en?: string } | string } | null) => {
       if (!type) return null


### PR DESCRIPTION
## Summary
`eve-build-calculator.philihp.com` doesn't send `Access-Control-Allow-Origin`, so the browser blocks the direct cross-origin call from `eve-hangar.philihp.com` when `<TypeName>` tries to resolve a typeID.

Fix from this end without touching the calculator app: proxy through Next.js. Add a `rewrites()` entry that maps `/api/build-calculator/:path*` → `https://eve-build-calculator.philihp.com/api/:path*`, then hit that same-origin path from the client component. No CORS preflight, no header changes needed upstream.

## Test plan
- [ ] On the preview, the `Type` column in Recent Sales resolves to names instead of `#<id>`.
- [ ] DevTools network shows `/api/build-calculator/type/<id>` returning the upstream JSON, no CORS error.
- [ ] Unknown typeID still falls back to `#<id>`.

https://claude.ai/code/session_015u1xgKQDoRyXbpHVPoc7qD

---
_Generated by [Claude Code](https://claude.ai/code/session_015u1xgKQDoRyXbpHVPoc7qD)_