### PR TITLE
feat(character): filter Recent Sales by total ISK threshold

### DIFF
--- a/src/app/character/character.module.css
+++ b/src/app/character/character.module.css
@@ -54,6 +54,23 @@
   margin-right: 4pt;
 }
 
+.salesHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12pt;
+  margin-top: 16pt;
+}
+
+.salesHeader h2 {
+  margin: 0;
+}
+
+.salesFilter {
+  font-size: 10pt;
+  color: #555;
+}
+
 .sales {
   width: 100%;
   border-collapse: collapse;

--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -3,7 +3,7 @@ import { redirect } from 'next/navigation'
 import { createClient } from '@/utils/supabase/server'
 import { register } from './actions'
 import styles from './character.module.css'
-import { TypeName } from './typeName'
+import { RecentSales } from './recentSales'
 
 const CharacterPage = async () => {
   const supabase = await createClient()
@@ -38,8 +38,7 @@ const CharacterPage = async () => {
     .gte('date', sevenDaysAgo)
     .order('date', { ascending: false })
 
-  const characterName = new Map<string, string>(characters?.map((c) => [c.id, c.name]) ?? [])
-  const formatDate = (iso: string) => new Date(iso).toLocaleString()
+  const characterName: Record<string, string> = Object.fromEntries(characters?.map((c) => [c.id, c.name]) ?? [])
 
   return (
     <>
@@ -73,39 +72,7 @@ const CharacterPage = async () => {
           </li>
         ))}
       </ul>
-      <h2>Recent Sales (last 7 days)</h2>
-      {sales && sales.length > 0 ? (
-        <table className={styles.sales}>
-          <thead>
-            <tr>
-              <th>Character</th>
-              <th>Type</th>
-              <th>Qty</th>
-              <th>Unit Price</th>
-              <th>Total</th>
-              <th>Sold</th>
-              <th>Seen</th>
-            </tr>
-          </thead>
-          <tbody>
-            {sales.map((s) => (
-              <tr key={`sale-${s.transaction_id}`}>
-                <td>{characterName.get(s.character_id) ?? '—'}</td>
-                <td>
-                  <TypeName typeID={Number(s.type_id)} />
-                </td>
-                <td>{s.quantity}</td>
-                <td>{formatIsk(s.unit_price)}</td>
-                <td>{formatIsk(Number(s.unit_price) * Number(s.quantity))}</td>
-                <td>{formatDate(s.date)}</td>
-                <td>{formatDate(s.seen_at)}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      ) : (
-        <p>No sales in the last 7 days.</p>
-      )}
+      <RecentSales sales={sales ?? []} characterName={characterName} />
       {error && (
         <>
           <strong>

--- a/src/app/character/recentSales.tsx
+++ b/src/app/character/recentSales.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { useState } from 'react'
+import styles from './character.module.css'
+import { TypeName } from './typeName'
+
+export type Sale = {
+  transaction_id: string | number
+  character_id: string
+  date: string
+  type_id: number | string
+  quantity: number | string
+  unit_price: number | string
+  seen_at: string
+}
+
+type RecentSalesProps = {
+  sales: Sale[]
+  characterName: Record<string, string>
+}
+
+const THRESHOLDS: Array<{ label: string; value: number }> = [
+  { label: 'All', value: 0 },
+  { label: '≥ 1M ISK', value: 1_000_000 },
+  { label: '≥ 10M ISK', value: 10_000_000 },
+  { label: '≥ 100M ISK', value: 100_000_000 },
+  { label: '≥ 1B ISK', value: 1_000_000_000 },
+]
+
+const formatIsk = (raw: string | number) =>
+  new Intl.NumberFormat('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(Number(raw))
+
+const formatDate = (iso: string) => new Date(iso).toLocaleString()
+
+export const RecentSales = ({ sales, characterName }: RecentSalesProps) => {
+  const [threshold, setThreshold] = useState(0)
+
+  const filtered = sales.filter((s) => Number(s.unit_price) * Number(s.quantity) >= threshold)
+
+  return (
+    <section>
+      <div className={styles.salesHeader}>
+        <h2>Recent Sales (last 7 days)</h2>
+        <label className={styles.salesFilter}>
+          Filter:&nbsp;
+          <select value={threshold} onChange={(e) => setThreshold(Number(e.target.value))}>
+            {THRESHOLDS.map((t) => (
+              <option key={t.value} value={t.value}>
+                {t.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      {filtered.length > 0 ? (
+        <table className={styles.sales}>
+          <thead>
+            <tr>
+              <th>Character</th>
+              <th>Type</th>
+              <th>Qty</th>
+              <th>Unit Price</th>
+              <th>Total</th>
+              <th>Sold</th>
+              <th>Seen</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((s) => (
+              <tr key={`sale-${s.transaction_id}`}>
+                <td>{characterName[s.character_id] ?? '—'}</td>
+                <td>
+                  <TypeName typeID={Number(s.type_id)} />
+                </td>
+                <td>{s.quantity}</td>
+                <td>{formatIsk(s.unit_price)}</td>
+                <td>{formatIsk(Number(s.unit_price) * Number(s.quantity))}</td>
+                <td>{formatDate(s.date)}</td>
+                <td>{formatDate(s.seen_at)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p>No sales matching this filter.</p>
+      )}
+    </section>
+  )
+}

--- a/src/app/character/recentSales.tsx
+++ b/src/app/character/recentSales.tsx
@@ -27,8 +27,14 @@ const THRESHOLDS: Array<{ label: string; value: number }> = [
   { label: '≥ 1B ISK', value: 1_000_000_000 },
 ]
 
-const formatIsk = (raw: string | number) =>
-  new Intl.NumberFormat('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(Number(raw))
+const formatIsk = (raw: string | number) => {
+  const n = Number(raw)
+  const abs = Math.abs(n)
+  if (abs >= 1_000_000_000) return `${(n / 1_000_000_000).toPrecision(4)}b`
+  if (abs >= 1_000_000) return `${(n / 1_000_000).toPrecision(4)}m`
+  if (abs >= 1_000) return `${(n / 1_000).toPrecision(4)}k`
+  return n.toPrecision(4)
+}
 
 const formatDate = (iso: string) => new Date(iso).toLocaleString()
 


### PR DESCRIPTION
## Summary
Adds a filter dropdown floated to the right of the "Recent Sales (last 7 days)" heading on the character page. Options: **All**, **≥ 1M ISK**, **≥ 10M ISK**, **≥ 100M ISK**, **≥ 1B ISK** — filtering rows whose `unit_price × quantity` is at least the threshold.

Extracted the sales table into a new client component `<RecentSales>` so the dropdown can manage filter state without an extra round-trip; the server still does the 7-day fetch.

## Test plan
- [ ] Default view ("All") shows the same rows as before.
- [ ] Picking ≥ 1B ISK hides everything below 1,000,000,000 ISK total.
- [ ] Empty filtered result renders "No sales matching this filter."
- [ ] Dropdown sits to the right of the heading and aligns on the same baseline.

https://claude.ai/code/session_015u1xgKQDoRyXbpHVPoc7qD

---
_Generated by [Claude Code](https://claude.ai/code/session_015u1xgKQDoRyXbpHVPoc7qD)_