### PR TITLE
feat(character): show sales dates in 24h YYYY-MM-DD HH:MM:SS

### DIFF
--- a/src/app/character/recentSales.tsx
+++ b/src/app/character/recentSales.tsx
@@ -36,7 +36,16 @@ const formatIsk = (raw: string | number) => {
   return n.toPrecision(4)
 }
 
-const formatDate = (iso: string) => new Date(iso).toLocaleString()
+const formatDate = (iso: string) =>
+  new Intl.DateTimeFormat('sv-SE', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).format(new Date(iso))
 
 export const RecentSales = ({ sales, characterName }: RecentSalesProps) => {
   const [threshold, setThreshold] = useState(0)


### PR DESCRIPTION
## Summary
Switches the "Sold" and "Seen" columns of Recent Sales from the locale default (12-hour AM/PM, M/D/Y) to ISO-style `YYYY-MM-DD HH:MM:SS` 24-hour clock using `Intl.DateTimeFormat('sv-SE', ...)`.

## Test plan
- [ ] Sales rows show timestamps like `2026-05-26 14:30:45`.

https://claude.ai/code/session_015u1xgKQDoRyXbpHVPoc7qD

---
_Generated by [Claude Code](https://claude.ai/code/session_015u1xgKQDoRyXbpHVPoc7qD)_