### PR TITLE
feat(character): color-coded magnitude pill on ISK prices

### DIFF
--- a/src/app/character/character.module.css
+++ b/src/app/character/character.module.css
@@ -99,3 +99,36 @@
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
+
+.suffix {
+  display: inline-block;
+  width: 1.4em;
+  height: 1.4em;
+  line-height: 1.4em;
+  border-radius: 50%;
+  text-align: center;
+  font-size: 0.8em;
+  font-weight: bold;
+  text-transform: lowercase;
+  margin-left: 5pt;
+  vertical-align: middle;
+}
+
+.suffixNone {
+  background: #fef0d9;
+}
+
+.suffixK {
+  background: #fdcc8a;
+  color: #5a3a00;
+}
+
+.suffixM {
+  background: #fc8d59;
+  color: #fff;
+}
+
+.suffixB {
+  background: #d7301f;
+  color: #fff;
+}

--- a/src/app/character/recentSales.tsx
+++ b/src/app/character/recentSales.tsx
@@ -27,13 +27,23 @@ const THRESHOLDS: Array<{ label: string; value: number }> = [
   { label: '≥ 1B ISK', value: 1_000_000_000 },
 ]
 
-const formatIsk = (raw: string | number) => {
-  const n = Number(raw)
+const iskTier = (n: number) => {
   const abs = Math.abs(n)
-  if (abs >= 1_000_000_000) return `${(n / 1_000_000_000).toPrecision(4)}b`
-  if (abs >= 1_000_000) return `${(n / 1_000_000).toPrecision(4)}m`
-  if (abs >= 1_000) return `${(n / 1_000).toPrecision(4)}k`
-  return n.toPrecision(4)
+  if (abs >= 1_000_000_000) return { value: n / 1_000_000_000, suffix: 'b', className: styles.suffixB }
+  if (abs >= 1_000_000) return { value: n / 1_000_000, suffix: 'm', className: styles.suffixM }
+  if (abs >= 1_000) return { value: n / 1_000, suffix: 'k', className: styles.suffixK }
+  return { value: n, suffix: '', className: styles.suffixNone }
+}
+
+const IskPrice = ({ raw }: { raw: string | number }) => {
+  const n = Number(raw)
+  const { value, suffix, className } = iskTier(n)
+  return (
+    <>
+      {value.toPrecision(4)}
+      <span className={`${styles.suffix} ${className}`}>{suffix}</span>
+    </>
+  )
 }
 
 const formatDate = (iso: string) => new Date(iso).toLocaleString()
@@ -79,8 +89,12 @@ export const RecentSales = ({ sales, characterName }: RecentSalesProps) => {
                   <TypeName typeID={Number(s.type_id)} />
                 </td>
                 <td>{s.quantity}</td>
-                <td>{formatIsk(s.unit_price)}</td>
-                <td>{formatIsk(Number(s.unit_price) * Number(s.quantity))}</td>
+                <td>
+                  <IskPrice raw={s.unit_price} />
+                </td>
+                <td>
+                  <IskPrice raw={Number(s.unit_price) * Number(s.quantity)} />
+                </td>
                 <td>{formatDate(s.date)}</td>
                 <td>{formatDate(s.seen_at)}</td>
               </tr>


### PR DESCRIPTION
## Summary
Replaces the plain `k`/`m`/`b` suffix on Recent Sales prices with a small color-coded circular badge (ColorBrewer YlOrRd):

- no suffix → `#fef0d9` (empty cream circle)
- `k` → `#fdcc8a`
- `m` → `#fc8d59`
- `b` → `#d7301f`

Text color picked per swatch for legibility (dark on the two light shades, white on the two darker ones).

Branched off `main` (independent of open PR #285).

## Test plan
- [ ] A 1.234b ISK total renders the number followed by a small red circle containing `b`.
- [ ] A 12.34m sale shows the orange circle with `m`.
- [ ] A sub-1000 ISK value shows an empty cream circle.
- [ ] Pill sits flush right in the right-aligned price columns.

https://claude.ai/code/session_015u1xgKQDoRyXbpHVPoc7qD

---
_Generated by [Claude Code](https://claude.ai/code/session_015u1xgKQDoRyXbpHVPoc7qD)_