### PR TITLE
Shrink ISK suffix indicators to colored dots

### DIFF
--- a/src/app/character/character.module.css
+++ b/src/app/character/character.module.css
@@ -105,8 +105,8 @@
   border-radius: 50%;
   margin-left: 5pt;
   vertical-align: middle;
-  font-size: 0;
-  color: transparent;
+  overflow: hidden;
+  box-sizing: content-box;
 }
 
 .suffixNone {

--- a/src/app/character/character.module.css
+++ b/src/app/character/character.module.css
@@ -102,33 +102,33 @@
 
 .suffix {
   display: inline-block;
-  width: 1.4em;
-  height: 1.4em;
-  line-height: 1.4em;
   border-radius: 50%;
-  text-align: center;
-  font-size: 0.8em;
-  font-weight: bold;
-  text-transform: lowercase;
   margin-left: 5pt;
   vertical-align: middle;
+  font-size: 0;
+  color: transparent;
 }
 
 .suffixNone {
+  width: 4px;
+  height: 4px;
   background: #fef0d9;
 }
 
 .suffixK {
+  width: 6px;
+  height: 6px;
   background: #fdcc8a;
-  color: #5a3a00;
 }
 
 .suffixM {
+  width: 8px;
+  height: 8px;
   background: #fc8d59;
-  color: #fff;
 }
 
 .suffixB {
+  width: 10px;
+  height: 10px;
   background: #d7301f;
-  color: #fff;
 }


### PR DESCRIPTION
Resizes the ISK price suffix badges to small colored dots:

- `b` → 10px diameter
- `m` → 8px diameter
- `k` → 6px diameter
- (none) → 4px diameter

The letter glyphs are hidden (font-size: 0) since the dots are too small to legibly contain text; the color alone now communicates the magnitude.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HspwkmmVthKzNAuXGRPsHv)_