### PR TITLE
Enlarge ISK suffix dots and show letter in white

### DIFF
--- a/src/app/market/market.module.css
+++ b/src/app/market/market.module.css
@@ -45,34 +45,40 @@
 }
 
 .suffix {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border-radius: 50%;
   margin-left: 5pt;
   vertical-align: middle;
-  overflow: hidden;
   box-sizing: content-box;
+  color: #fff;
+  font-size: 7px;
+  font-weight: 700;
+  line-height: 1;
+  text-transform: lowercase;
 }
 
 .suffixNone {
-  width: 4px;
-  height: 4px;
+  width: 8px;
+  height: 8px;
   background: #fef0d9;
 }
 
 .suffixK {
-  width: 6px;
-  height: 6px;
+  width: 12px;
+  height: 12px;
   background: #fdcc8a;
 }
 
 .suffixM {
-  width: 8px;
-  height: 8px;
+  width: 14px;
+  height: 14px;
   background: #fc8d59;
 }
 
 .suffixB {
-  width: 10px;
-  height: 10px;
+  width: 16px;
+  height: 16px;
   background: #d7301f;
 }


### PR DESCRIPTION
Exaggerates the size of the ISK magnitude dots in the market suffix pills (`k`/`m`/`b`) and renders the letter centered inside in small white text so it reads clearly on the dark background.

- Dots grow from 4/6/8/10px to 8/12/14/16px
- Letter is now visible (flex-centered, 7px, bold, white) instead of clipped via `overflow: hidden`

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnzHakBUF4Gpma1ySCJ2qQ)_