### PR TITLE
refactor(market): extract usePersist hook for localStorage-backed state

### DIFF
--- a/src/app/market/recentSales.tsx
+++ b/src/app/market/recentSales.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useEffect, useState } from 'react'
 import styles from './market.module.css'
 import { TypeName } from './typeName'
+import { usePersist } from './usePersist'
 
 export type Sale = {
   transaction_id: string | number
@@ -60,19 +60,10 @@ const formatDate = (iso: string) =>
   }).format(new Date(iso))
 
 export const RecentSales = ({ sales, characterName }: RecentSalesProps) => {
-  const [threshold, setThreshold] = useState(0)
-
-  useEffect(() => {
-    const saved = window.localStorage.getItem(THRESHOLD_STORAGE_KEY)
-    if (saved === null) return
-    const parsed = Number(saved)
-    if (THRESHOLDS.some((t) => t.value === parsed)) setThreshold(parsed)
-  }, [])
-
-  const handleThresholdChange = (value: number) => {
-    setThreshold(value)
-    window.localStorage.setItem(THRESHOLD_STORAGE_KEY, String(value))
-  }
+  const [threshold, setThreshold] = usePersist(THRESHOLD_STORAGE_KEY, 0, (raw) => {
+    const parsed = Number(raw)
+    return THRESHOLDS.some((t) => t.value === parsed) ? parsed : undefined
+  })
 
   const filtered = sales.filter((s) => Number(s.unit_price) * Number(s.quantity) >= threshold)
 
@@ -82,7 +73,7 @@ export const RecentSales = ({ sales, characterName }: RecentSalesProps) => {
         <h2>Recent Sales (last 7 days)</h2>
         <label className={styles.salesFilter}>
           Filter:&nbsp;
-          <select value={threshold} onChange={(e) => handleThresholdChange(Number(e.target.value))}>
+          <select value={threshold} onChange={(e) => setThreshold(Number(e.target.value))}>
             {THRESHOLDS.map((t) => (
               <option key={t.value} value={t.value}>
                 {t.label}

--- a/src/app/market/usePersist.ts
+++ b/src/app/market/usePersist.ts
@@ -1,0 +1,25 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export const usePersist = <T>(
+  key: string,
+  initial: T,
+  parse: (raw: string) => T | undefined,
+): [T, (value: T) => void] => {
+  const [value, setValue] = useState<T>(initial)
+
+  useEffect(() => {
+    const saved = window.localStorage.getItem(key)
+    if (saved === null) return
+    const parsed = parse(saved)
+    if (parsed !== undefined) setValue(parsed)
+  }, [key])
+
+  const set = (next: T) => {
+    setValue(next)
+    window.localStorage.setItem(key, String(next))
+  }
+
+  return [value, set]
+}


### PR DESCRIPTION
## Summary
- Extract the localStorage read/write logic out of `RecentSales` into a generic `usePersist(key, initial, parse)` hook
- `RecentSales` now just declares the parse/validate rule for its threshold

## Test plan
- [ ] `/market`: change filter dropdown, reload — selection still persists
- [ ] Invalid value in localStorage — falls back to default

https://claude.ai/code/session_01DNaCE9d3DvUsFYRDEQ7jf3

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNaCE9d3DvUsFYRDEQ7jf3)_