### PR TITLE
Limit Recent Sales to what ESI would currently return

### DIFF
--- a/src/app/market/page.tsx
+++ b/src/app/market/page.tsx
@@ -1,7 +1,9 @@
 import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
-import { RecentSales } from './recentSales'
+import { RecentSales, type Sale } from './recentSales'
+
+const ESI_TRANSACTION_LIMIT = 2500
 
 const MarketPage = async () => {
   const supabase = await createClient()
@@ -13,22 +15,30 @@ const MarketPage = async () => {
 
   const { data: characters } = await supabase.schema('hangar').from('character').select('id, name')
 
-  // eslint-disable-next-line react-hooks/purity
-  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
-  const { data: sales } = await supabase
-    .schema('hangar')
-    .from('market_transaction')
-    .select('transaction_id, character_id, date, type_id, quantity, unit_price, seen_at')
-    .eq('is_buy', false)
-    .gte('date', sevenDaysAgo)
-    .order('date', { ascending: false })
+  const perCharacterSales = await Promise.all(
+    (characters ?? []).map(async (c) => {
+      const { data: rows } = await supabase
+        .schema('hangar')
+        .from('market_transaction')
+        .select('transaction_id, character_id, date, type_id, quantity, unit_price, seen_at, is_buy')
+        .eq('character_id', c.id)
+        .order('date', { ascending: false })
+        .limit(ESI_TRANSACTION_LIMIT)
+      return rows ?? []
+    })
+  )
+
+  const sales: Sale[] = perCharacterSales
+    .flat()
+    .filter((s) => !s.is_buy)
+    .sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0))
 
   const characterName: Record<string, string> = Object.fromEntries(characters?.map((c) => [c.id, c.name]) ?? [])
 
   return (
     <>
       <h1>Market</h1>
-      <RecentSales sales={sales ?? []} characterName={characterName} />
+      <RecentSales sales={sales} characterName={characterName} />
     </>
   )
 }

--- a/src/app/market/recentSales.tsx
+++ b/src/app/market/recentSales.tsx
@@ -66,6 +66,7 @@ export const RecentSales = ({ sales, characterName }: RecentSalesProps) => {
     const saved = window.localStorage.getItem(THRESHOLD_STORAGE_KEY)
     if (saved === null) return
     const parsed = Number(saved)
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- hydration-safe restore from localStorage
     if (THRESHOLDS.some((t) => t.value === parsed)) setThreshold(parsed)
   }, [])
 
@@ -79,7 +80,7 @@ export const RecentSales = ({ sales, characterName }: RecentSalesProps) => {
   return (
     <section>
       <div className={styles.salesHeader}>
-        <h2>Recent Sales (last 7 days)</h2>
+        <h2>Recent Sales</h2>
         <label className={styles.salesFilter}>
           Filter:&nbsp;
           <select value={threshold} onChange={(e) => handleThresholdChange(Number(e.target.value))}>


### PR DESCRIPTION
## Summary

Previously the Recent Sales page filtered by a fixed 7-day window, which both hid older sales a character can still see via ESI (for low-volume characters) and showed accumulated history beyond what ESI currently returns (for high-volume characters).

ESI's `GET /characters/{character_id}/wallet/transactions/` returns the **latest 2500 transactions per character** with no time window. This change mirrors that behavior: for each of the user's characters, fetch the most recent 2500 transactions ordered by date, then keep the sales (`is_buy = false`).

## Changes

- `src/app/market/page.tsx`: query per-character with `.limit(2500)` instead of a 7-day filter
- `src/app/market/recentSales.tsx`: drop the now-inaccurate "(last 7 days)" from the heading

## Test plan

- [ ] Visit `/market` with a character that has had wallet activity recently — sales appear, sorted by date descending
- [ ] Confirm sales older than 7 days still appear (so long as they're within the most recent 2500 transactions for that character)
- [ ] Confirm the threshold filter still works

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnzHakBUF4Gpma1ySCJ2qQ)_