### PR TITLE
fix(market): only show transactions for the user's own characters

### DIFF
--- a/src/app/market/page.tsx
+++ b/src/app/market/page.tsx
@@ -12,6 +12,7 @@ const MarketPage = async () => {
   }
 
   const { data: characters } = await supabase.schema('hangar').from('character').select('id, name')
+  const characterIds = characters?.map((c) => c.id) ?? []
 
   // eslint-disable-next-line react-hooks/purity
   const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
@@ -19,6 +20,7 @@ const MarketPage = async () => {
     .schema('hangar')
     .from('market_transaction')
     .select('transaction_id, character_id, date, type_id, quantity, unit_price, seen_at')
+    .in('character_id', characterIds)
     .eq('is_buy', false)
     .gte('date', sevenDaysAgo)
     .order('date', { ascending: false })


### PR DESCRIPTION
## Summary
- The Recent Sales query now filters `market_transaction` by `character_id in (the user's characters)`, in addition to whatever RLS already enforces.

## Test plan
- [ ] Logged-in user with characters: sees only their own sales
- [ ] User with no characters: empty list (no error)

https://claude.ai/code/session_01DNaCE9d3DvUsFYRDEQ7jf3

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNaCE9d3DvUsFYRDEQ7jf3)_