### PR TITLE
feat(hourly): fetch each character's industry jobs

### DIFF
--- a/hangar.sql
+++ b/hangar.sql
@@ -190,3 +190,57 @@ create policy "Users read own transactions"
 
 grant select on hangar.market_transaction to authenticated;
 grant all    on hangar.market_transaction to service_role;
+
+create table if not exists hangar.industry_job (
+  job_id bigint primary key,
+  character_id uuid not null references hangar.character(id) on delete cascade,
+  installer_id bigint not null,
+  facility_id bigint not null,
+  station_id bigint,
+  activity_id smallint not null,
+  blueprint_id bigint not null,
+  blueprint_type_id bigint not null,
+  blueprint_location_id bigint not null,
+  output_location_id bigint not null,
+  product_type_id bigint,
+  runs integer not null,
+  cost numeric(20, 2),
+  licensed_runs integer,
+  probability real,
+  status text not null,
+  duration integer not null,
+  start_date timestamptz not null,
+  end_date timestamptz not null,
+  pause_date timestamptz,
+  completed_date timestamptz,
+  completed_character_id bigint,
+  successful_runs integer,
+  seen_at timestamptz not null default now()
+);
+create index if not exists industry_job_character_id_end_date_idx
+  on hangar.industry_job (character_id, end_date desc);
+
+alter table hangar.industry_job enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'hangar'
+      and tablename = 'industry_job'
+      and policyname = 'Users read own industry jobs'
+  ) then
+    create policy "Users read own industry jobs"
+      on hangar.industry_job
+      for select
+      to authenticated
+      using (
+        character_id in (
+          select id from hangar.character where user_id = (select auth.uid())
+        )
+      );
+  end if;
+end $$;
+
+grant select on hangar.industry_job to authenticated;
+grant all    on hangar.industry_job to service_role;

--- a/src/esi.js
+++ b/src/esi.js
@@ -38,6 +38,26 @@ export const transactions = async (access_token, characterID) => {
   return await response.json()
 }
 
+export const industryJobs = async (access_token, characterID) => {
+  const response = await fetch(
+    `https://esi.evetech.net/latest/characters/${characterID}/industry/jobs/?` +
+      new URLSearchParams({
+        token: access_token,
+        include_completed: 'true',
+      }),
+    {
+      method: 'GET',
+      headers: {
+        'User-Agent': userAgent,
+      },
+    }
+  )
+  if (!response.ok) {
+    throw new Error(`industry jobs ${characterID}: ${response.status} ${response.statusText}`)
+  }
+  return await response.json()
+}
+
 export const wallet = async (access_token, characterID) => {
   const response = await fetch(
     `https://esi.evetech.net/latest/characters/${characterID}/wallet/?` +

--- a/src/hourly.js
+++ b/src/hourly.js
@@ -1,4 +1,4 @@
-import { transactions, userAgent, wallet } from './esi.js'
+import { industryJobs, transactions, userAgent, wallet } from './esi.js'
 import SingleSignOn from './sso.js'
 import { sudoSupabase } from './supabase.js'
 
@@ -7,6 +7,7 @@ const EVE_SECRET_KEY = process.env.EVE_SECRET_KEY
 const EVE_CALLBACK_URL = process.env.EVE_CALLBACK_URL
 
 const WALLET_SCOPE = 'esi-wallet.read_character_wallet.v1'
+const INDUSTRY_SCOPE = 'esi-industry.read_character_jobs.v1'
 
 const sso = new SingleSignOn(EVE_CLIENT_ID, EVE_SECRET_KEY, EVE_CALLBACK_URL, { userAgent })
 
@@ -77,6 +78,59 @@ const execute = async () => {
       }
     } catch (e) {
       console.error(`refresh failed for ${tokenRow.character_id}:`, e)
+    }
+  }
+
+  const { data: industryTokens, error: industryTokensError } = await sudoSupabase
+    .schema('hangar')
+    .from('token')
+    .select('id, character_id, refresh_token')
+    .contains('scope', [INDUSTRY_SCOPE])
+
+  if (industryTokensError) {
+    console.error(industryTokensError)
+    process.exit(1)
+  }
+
+  for (const tokenRow of industryTokens ?? []) {
+    try {
+      const { access_token, characterID } = await refreshToken(tokenRow)
+      const jobs = await industryJobs(access_token, characterID)
+      if (jobs.length > 0) {
+        const rows = jobs.map((j) => ({
+          job_id: j.job_id,
+          character_id: tokenRow.character_id,
+          installer_id: j.installer_id,
+          facility_id: j.facility_id,
+          station_id: j.station_id ?? null,
+          activity_id: j.activity_id,
+          blueprint_id: j.blueprint_id,
+          blueprint_type_id: j.blueprint_type_id,
+          blueprint_location_id: j.blueprint_location_id,
+          output_location_id: j.output_location_id,
+          product_type_id: j.product_type_id ?? null,
+          runs: j.runs,
+          cost: j.cost ?? null,
+          licensed_runs: j.licensed_runs ?? null,
+          probability: j.probability ?? null,
+          status: j.status,
+          duration: j.duration,
+          start_date: j.start_date,
+          end_date: j.end_date,
+          pause_date: j.pause_date ?? null,
+          completed_date: j.completed_date ?? null,
+          completed_character_id: j.completed_character_id ?? null,
+          successful_runs: j.successful_runs ?? null,
+        }))
+        const { error: jobError } = await sudoSupabase
+          .schema('hangar')
+          .from('industry_job')
+          .upsert(rows, { onConflict: 'job_id' })
+        if (jobError) throw jobError
+      }
+      console.log(`industry ${tokenRow.character_id} (${characterID}): ${jobs.length} jobs`)
+    } catch (e) {
+      console.error(`industry refresh failed for ${tokenRow.character_id}:`, e)
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds `industryJobs` ESI helper in `src/esi.js` (calls `/characters/{id}/industry/jobs/?include_completed=true`).
- Adds a second pass in `src/hourly.js` that selects tokens with the `esi-industry.read_character_jobs.v1` scope and upserts each character's jobs into a new `hangar.industry_job` table. The existing wallet/transactions loop is left alone — future PRs will tighten its scope handling.
- Adds the `hangar.industry_job` schema, index, RLS policy, and grants to `hangar.sql`.

Note: characters that authorized both wallet and industry scopes will refresh their token twice per hourly run. Acceptable for now; a follow-up can restructure the loop to refresh once and dispatch per-scope.

## Test plan

- [ ] Apply `hangar.sql` to Supabase and confirm `hangar.industry_job` exists with the read policy attached.
- [ ] Run `npm run hourly` locally with `.env` populated; expect `industry <uuid> (<eveID>): N jobs` lines for characters that granted the industry scope.
- [ ] `select count(*), status from hangar.industry_job group by status;` to confirm rows landed.
- [ ] Verify wallet + transactions still log normally on the next hourly run (no regression in the untouched loop).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkF3SmTPVNGuhSC13ojK2s)_