### PR TITLE
feat(market): filter Recent Sales by character

### DIFF
--- a/src/app/market/market.module.css
+++ b/src/app/market/market.module.css
@@ -10,6 +10,12 @@
   margin: 0;
 }
 
+.salesFilters {
+  display: flex;
+  align-items: center;
+  gap: 12pt;
+}
+
 .salesFilter {
   font-size: 10pt;
   color: #555;

--- a/src/app/market/page.tsx
+++ b/src/app/market/page.tsx
@@ -23,12 +23,12 @@ const MarketPage = async () => {
     .gte('date', sevenDaysAgo)
     .order('date', { ascending: false })
 
-  const characterName: Record<string, string> = Object.fromEntries(characters?.map((c) => [c.id, c.name]) ?? [])
+  const sortedCharacters = [...(characters ?? [])].sort((a, b) => a.name.localeCompare(b.name))
 
   return (
     <>
       <h1>Market</h1>
-      <RecentSales sales={sales ?? []} characterName={characterName} />
+      <RecentSales sales={sales ?? []} characters={sortedCharacters} />
     </>
   )
 }

--- a/src/app/market/recentSales.tsx
+++ b/src/app/market/recentSales.tsx
@@ -14,9 +14,14 @@ export type Sale = {
   seen_at: string
 }
 
+type Character = {
+  id: string
+  name: string
+}
+
 type RecentSalesProps = {
   sales: Sale[]
-  characterName: Record<string, string>
+  characters: Character[]
 }
 
 const THRESHOLDS: Array<{ label: string; value: number }> = [
@@ -28,6 +33,8 @@ const THRESHOLDS: Array<{ label: string; value: number }> = [
 ]
 
 const THRESHOLD_STORAGE_KEY = 'market.recentSales.threshold'
+const CHARACTER_STORAGE_KEY = 'market.recentSales.characterId'
+const ALL_CHARACTERS = ''
 
 const iskTier = (n: number) => {
   const abs = Math.abs(n)
@@ -59,28 +66,51 @@ const formatDate = (iso: string) =>
     hour12: false,
   }).format(new Date(iso))
 
-export const RecentSales = ({ sales, characterName }: RecentSalesProps) => {
+export const RecentSales = ({ sales, characters }: RecentSalesProps) => {
+  const characterName: Record<string, string> = Object.fromEntries(characters.map((c) => [c.id, c.name]))
+
   const [threshold, setThreshold] = usePersist(THRESHOLD_STORAGE_KEY, 0, (raw) => {
     const parsed = Number(raw)
     return THRESHOLDS.some((t) => t.value === parsed) ? parsed : undefined
   })
 
-  const filtered = sales.filter((s) => Number(s.unit_price) * Number(s.quantity) >= threshold)
+  const [characterId, setCharacterId] = usePersist<string>(CHARACTER_STORAGE_KEY, ALL_CHARACTERS, (raw) =>
+    raw === ALL_CHARACTERS || characters.some((c) => c.id === raw) ? raw : undefined,
+  )
+
+  const filtered = sales.filter(
+    (s) =>
+      Number(s.unit_price) * Number(s.quantity) >= threshold &&
+      (characterId === ALL_CHARACTERS || s.character_id === characterId),
+  )
 
   return (
     <section>
       <div className={styles.salesHeader}>
         <h2>Recent Sales (last 7 days)</h2>
-        <label className={styles.salesFilter}>
-          Filter:&nbsp;
-          <select value={threshold} onChange={(e) => setThreshold(Number(e.target.value))}>
-            {THRESHOLDS.map((t) => (
-              <option key={t.value} value={t.value}>
-                {t.label}
-              </option>
-            ))}
-          </select>
-        </label>
+        <div className={styles.salesFilters}>
+          <label className={styles.salesFilter}>
+            Character:&nbsp;
+            <select value={characterId} onChange={(e) => setCharacterId(e.target.value)}>
+              <option value={ALL_CHARACTERS}>All characters</option>
+              {characters.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className={styles.salesFilter}>
+            Filter:&nbsp;
+            <select value={threshold} onChange={(e) => setThreshold(Number(e.target.value))}>
+              {THRESHOLDS.map((t) => (
+                <option key={t.value} value={t.value}>
+                  {t.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
       </div>
       {filtered.length > 0 ? (
         <table className={styles.sales}>

--- a/src/app/market/usePersist.ts
+++ b/src/app/market/usePersist.ts
@@ -1,20 +1,19 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 export const usePersist = <T>(
   key: string,
   initial: T,
   parse: (raw: string) => T | undefined,
 ): [T, (value: T) => void] => {
-  const [value, setValue] = useState<T>(initial)
-
-  useEffect(() => {
+  const [value, setValue] = useState<T>(() => {
+    if (typeof window === 'undefined') return initial
     const saved = window.localStorage.getItem(key)
-    if (saved === null) return
+    if (saved === null) return initial
     const parsed = parse(saved)
-    if (parsed !== undefined) setValue(parsed)
-  }, [key])
+    return parsed !== undefined ? parsed : initial
+  })
 
   const set = (next: T) => {
     setValue(next)


### PR DESCRIPTION
## Summary

- Add a **Character** dropdown to the Market tab next to the existing price-threshold filter, listing every character the current user owns (sorted by name) plus an **All characters** option that preserves today's aggregated view.
- Persist the selection in `localStorage` (`market.recentSales.characterId`) via the existing `usePersist` hook.
- Refactor `usePersist` to a lazy `useState` initializer so it no longer trips `react-hooks/set-state-in-effect` in CI.

## Test plan

- [ ] Sign in and visit `/market` — confirm the new dropdown renders next to the price filter and lists every owned character plus "All characters".
- [ ] Pick a single character — only that character's sales remain in the table; combining with the price filter still works.
- [ ] Switch back to "All characters" — every row returns.
- [ ] Reload the page — the previously-selected character is restored from `localStorage`.
- [ ] `pnpm lint` reports 0 errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3qaiGZg3w6cbH7sfsv9Pw)_