### PR TITLE
feat(structures): split director-character corp structures pull into its own workflow with debug logging

### DIFF
--- a/.github/workflows/structures.yml
+++ b/.github/workflows/structures.yml
@@ -1,0 +1,25 @@
+name: Structures
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 */6 * * *'
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm install
+      - run: npm run structures
+        env:
+          EVE_CLIENT_ID: ${{ vars.EVE_CLIENT_ID }}
+          EVE_SECRET_KEY: ${{ secrets.EVE_SECRET_KEY }}
+          SUPABASE_URL: ${{ vars.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "dev": "next dev",
     "heartbeat": "node src/heartbeat.js",
     "hourly": "node src/hourly.js",
+    "structures": "node src/structures.js",
     "refresh": "node src/refresh.js",
     "lint": "eslint .",
     "ping": "node src/ping-db.js",

--- a/src/esi.js
+++ b/src/esi.js
@@ -91,7 +91,8 @@ export const character = async (access_token, characterID) => {
     }
   )
   if (!response.ok) {
-    throw new Error(`character ${characterID}: ${response.status} ${response.statusText}`)
+    const body = await response.text().catch(() => '')
+    throw new Error(`character ${characterID}: ${response.status} ${response.statusText} body=${body.slice(0, 500)}`)
   }
   return await response.json()
 }
@@ -111,7 +112,10 @@ export const corpStructures = async (access_token, corporationID, page = 1) => {
     }
   )
   if (!response.ok) {
-    throw new Error(`corpStructures ${corporationID}: ${response.status} ${response.statusText}`)
+    const body = await response.text().catch(() => '')
+    throw new Error(
+      `corpStructures ${corporationID} page=${page}: ${response.status} ${response.statusText} body=${body.slice(0, 500)}`
+    )
   }
   const pages = response.headers.get('x-pages')
   const data = await response.json()

--- a/src/hourly.js
+++ b/src/hourly.js
@@ -1,4 +1,4 @@
-import { character as fetchCharacter, corpStructures, industryJobs, transactions, userAgent, wallet } from './esi.js'
+import { industryJobs, transactions, userAgent, wallet } from './esi.js'
 import SingleSignOn from './sso.js'
 import { sudoSupabase } from './supabase.js'
 
@@ -8,7 +8,6 @@ const EVE_CALLBACK_URL = process.env.EVE_CALLBACK_URL
 
 const WALLET_SCOPE = 'esi-wallet.read_character_wallet.v1'
 const INDUSTRY_SCOPE = 'esi-industry.read_character_jobs.v1'
-const STRUCTURES_SCOPE = 'esi-corporations.read_structures.v1'
 
 const sso = new SingleSignOn(EVE_CLIENT_ID, EVE_SECRET_KEY, EVE_CALLBACK_URL, { userAgent })
 
@@ -132,75 +131,6 @@ const execute = async () => {
       console.log(`industry ${tokenRow.character_id} (${characterID}): ${jobs.length} jobs`)
     } catch (e) {
       console.error(`industry refresh failed for ${tokenRow.character_id}:`, e)
-    }
-  }
-
-  const { data: structureTokens, error: structureErr } = await sudoSupabase
-    .schema('hangar')
-    .from('token')
-    .select('id, character_id, refresh_token')
-    .contains('scope', [STRUCTURES_SCOPE])
-
-  if (structureErr) {
-    console.error(structureErr)
-    return
-  }
-
-  const seenCorps = new Set()
-  for (const tokenRow of structureTokens ?? []) {
-    try {
-      const { access_token, characterID } = await refreshToken(tokenRow)
-      const info = await fetchCharacter(access_token, characterID)
-      const corporation_id = info.corporation_id
-
-      await sudoSupabase
-        .schema('hangar')
-        .from('character')
-        .update({ corporation_id })
-        .eq('id', tokenRow.character_id)
-
-      if (seenCorps.has(corporation_id)) continue
-      seenCorps.add(corporation_id)
-
-      const all = []
-      const [firstPage, pagesHeader] = await corpStructures(access_token, corporation_id, 1)
-      all.push(...firstPage)
-      const totalPages = Math.max(1, Number.parseInt(pagesHeader, 10) || 1)
-      for (let page = 2; page <= totalPages; page++) {
-        const [more] = await corpStructures(access_token, corporation_id, page)
-        all.push(...more)
-      }
-
-      const now = new Date().toISOString()
-      const rows = all.map((s) => ({
-        structure_id: s.structure_id,
-        corporation_id: s.corporation_id,
-        type_id: s.type_id,
-        system_id: s.system_id,
-        profile_id: s.profile_id ?? null,
-        name: s.name ?? null,
-        state: s.state ?? null,
-        fuel_expires: s.fuel_expires ?? null,
-        unanchors_at: s.unanchors_at ?? null,
-        reinforce_hour: s.reinforce_hour ?? null,
-        next_reinforce_hour: s.next_reinforce_hour ?? null,
-        next_reinforce_apply: s.next_reinforce_apply ?? null,
-        next_reinforce_weekday: s.next_reinforce_weekday ?? null,
-        services: s.services ?? null,
-        last_seen_at: now,
-        updated_at: now,
-      }))
-
-      if (rows.length > 0) {
-        const { error: upsertErr } = await sudoSupabase
-          .schema('hangar')
-          .from('corp_structure')
-          .upsert(rows, { onConflict: 'structure_id' })
-        if (upsertErr) throw upsertErr
-      }
-      console.log(`structures corp ${corporation_id} via ${characterID}: ${rows.length} fetched`)
-    } catch (e) {
-      console.error(`structures failed for ${tokenRow.character_id}:`, e)
     }
   }
 }

--- a/src/structures.js
+++ b/src/structures.js
@@ -1,0 +1,157 @@
+import { character as fetchCharacter, corpStructures, userAgent } from './esi.js'
+import SingleSignOn from './sso.js'
+import { sudoSupabase } from './supabase.js'
+
+const EVE_CLIENT_ID = process.env.EVE_CLIENT_ID
+const EVE_SECRET_KEY = process.env.EVE_SECRET_KEY
+const EVE_CALLBACK_URL = process.env.EVE_CALLBACK_URL
+
+const STRUCTURES_SCOPE = 'esi-corporations.read_structures.v1'
+
+const sso = new SingleSignOn(EVE_CLIENT_ID, EVE_SECRET_KEY, EVE_CALLBACK_URL, { userAgent })
+
+const tail = (s) => (typeof s === 'string' && s.length > 4 ? s.slice(-4) : '????')
+
+const refreshToken = async (tokenRow) => {
+  const refreshed = await sso.getAccessToken(tokenRow.refresh_token, true)
+  const { access_token, refresh_token } = refreshed
+  const { sub, scp = [], iat, exp } = refreshed.decoded_access_token
+  const characterID = sub.split(':')[2]
+  const scope = [scp].flat()
+  const issued_at = new Date(iat * 1000).toISOString()
+  const expires_at = new Date(exp * 1000).toISOString()
+  await sudoSupabase
+    .schema('hangar')
+    .from('token')
+    .update({ access_token, refresh_token, issued_at, expires_at, scope })
+    .eq('id', tokenRow.id)
+  return { access_token, characterID, scope, issued_at, expires_at }
+}
+
+const execute = async () => {
+  const { data: tokens, error } = await sudoSupabase
+    .schema('hangar')
+    .from('token')
+    .select('id, character_id, refresh_token')
+    .contains('scope', [STRUCTURES_SCOPE])
+
+  if (error) {
+    console.error('[structures] token lookup failed:', error)
+    process.exit(1)
+  }
+
+  console.log(`[structures] found ${tokens?.length ?? 0} token(s) with ${STRUCTURES_SCOPE}`)
+  for (const t of tokens ?? []) {
+    console.log(`[structures]   token ${t.id} character ${t.character_id} refresh ...${tail(t.refresh_token)}`)
+  }
+
+  const seenCorps = new Set()
+  for (const tokenRow of tokens ?? []) {
+    const t0 = Date.now()
+    const ctx = `character=${tokenRow.character_id} token=${tokenRow.id}`
+    try {
+      console.log(`[structures] ${ctx}: refreshing token (refresh ...${tail(tokenRow.refresh_token)})`)
+      const { access_token, characterID, scope, issued_at, expires_at } = await refreshToken(tokenRow)
+      console.log(
+        `[structures] ${ctx}: refreshed characterID=${characterID} issued=${issued_at} expires=${expires_at} scope=${JSON.stringify(scope)}`
+      )
+      if (!scope.includes(STRUCTURES_SCOPE)) {
+        console.error(
+          `[structures] ${ctx}: refreshed token NO LONGER has ${STRUCTURES_SCOPE} (scope=${JSON.stringify(scope)}) — skipping`
+        )
+        continue
+      }
+
+      console.log(`[structures] ${ctx}: fetching character info`)
+      const info = await fetchCharacter(access_token, characterID)
+      const corporation_id = info?.corporation_id
+      const alliance_id = info?.alliance_id ?? null
+      console.log(`[structures] ${ctx}: character corporation_id=${corporation_id} alliance_id=${alliance_id}`)
+      if (!corporation_id) {
+        console.error(`[structures] ${ctx}: character payload missing corporation_id, raw=${JSON.stringify(info)}`)
+        continue
+      }
+
+      const { error: charUpdateErr, status: charUpdateStatus } = await sudoSupabase
+        .schema('hangar')
+        .from('character')
+        .update({ corporation_id })
+        .eq('id', tokenRow.character_id)
+      if (charUpdateErr) {
+        console.error(
+          `[structures] ${ctx}: character.corporation_id update failed status=${charUpdateStatus} code=${charUpdateErr.code} message=${charUpdateErr.message} details=${charUpdateErr.details} hint=${charUpdateErr.hint}`
+        )
+      } else {
+        console.log(`[structures] ${ctx}: character.corporation_id updated (status=${charUpdateStatus})`)
+      }
+
+      if (seenCorps.has(corporation_id)) {
+        console.log(`[structures] ${ctx}: corp ${corporation_id} already pulled this run, skipping structures fetch`)
+        continue
+      }
+      seenCorps.add(corporation_id)
+
+      const all = []
+      console.log(`[structures] ${ctx}: fetching corp ${corporation_id} structures page 1`)
+      const [firstPage, pagesHeader] = await corpStructures(access_token, corporation_id, 1)
+      console.log(
+        `[structures] ${ctx}: corp ${corporation_id} page 1 returned ${firstPage?.length ?? 0} rows, x-pages=${pagesHeader}`
+      )
+      all.push(...firstPage)
+      const totalPages = Math.max(1, Number.parseInt(pagesHeader, 10) || 1)
+      for (let page = 2; page <= totalPages; page++) {
+        console.log(`[structures] ${ctx}: fetching corp ${corporation_id} structures page ${page}/${totalPages}`)
+        const [more] = await corpStructures(access_token, corporation_id, page)
+        console.log(`[structures] ${ctx}: corp ${corporation_id} page ${page} returned ${more?.length ?? 0} rows`)
+        all.push(...more)
+      }
+
+      const now = new Date().toISOString()
+      const rows = all.map((s) => ({
+        structure_id: s.structure_id,
+        corporation_id: s.corporation_id,
+        type_id: s.type_id,
+        system_id: s.system_id,
+        profile_id: s.profile_id ?? null,
+        name: s.name ?? null,
+        state: s.state ?? null,
+        fuel_expires: s.fuel_expires ?? null,
+        unanchors_at: s.unanchors_at ?? null,
+        reinforce_hour: s.reinforce_hour ?? null,
+        next_reinforce_hour: s.next_reinforce_hour ?? null,
+        next_reinforce_apply: s.next_reinforce_apply ?? null,
+        next_reinforce_weekday: s.next_reinforce_weekday ?? null,
+        services: s.services ?? null,
+        last_seen_at: now,
+        updated_at: now,
+      }))
+
+      if (rows.length > 0) {
+        console.log(
+          `[structures] ${ctx}: upserting ${rows.length} structure row(s) for corp ${corporation_id} sample=${JSON.stringify(rows[0])}`
+        )
+        const { error: upsertErr, status: upsertStatus } = await sudoSupabase
+          .schema('hangar')
+          .from('corp_structure')
+          .upsert(rows, { onConflict: 'structure_id' })
+        if (upsertErr) {
+          console.error(
+            `[structures] ${ctx}: upsert failed status=${upsertStatus} code=${upsertErr.code} message=${upsertErr.message} details=${upsertErr.details} hint=${upsertErr.hint}`
+          )
+          throw upsertErr
+        }
+        console.log(`[structures] ${ctx}: upsert ok (status=${upsertStatus})`)
+      } else {
+        console.log(`[structures] ${ctx}: corp ${corporation_id} returned zero structures, nothing to upsert`)
+      }
+
+      const dt = Date.now() - t0
+      console.log(`[structures] ${ctx}: done corp ${corporation_id} ${rows.length} fetched in ${dt}ms`)
+    } catch (e) {
+      const dt = Date.now() - t0
+      console.error(`[structures] ${ctx}: FAILED after ${dt}ms name=${e?.name} message=${e?.message}\n${e?.stack ?? e}`)
+    }
+  }
+}
+
+execute()


### PR DESCRIPTION
## Summary

The hourly corporation-structures pull (which requires a director-level character) has been failing, and the existing `console.error('structures failed for ${character_id}:', e)` doesn't tell us which step or why.

- Lift the structures task out of `src/hourly.js` into its own entrypoint `src/structures.js` and a new `Structures` GitHub Actions workflow (`.github/workflows/structures.yml`) scheduled every 6 hours at `:17` (offset from the existing hourly `:44` so they don't pile onto ESI together). `workflow_dispatch` is enabled for manual debugging.
- Wrap the structures path in verbose, prefixed logs (`[structures] ...`): token list at start, per-token refresh + scope, character `corporation_id` / `alliance_id`, supabase update result with full PostgrestError shape (`code` / `message` / `details` / `hint`), each ESI page request and row count, upsert row count + sample row, per-token timing, and full `err.stack` on catch.
- Extend `corpStructures` and `character` in `src/esi.js` to include the truncated ESI response body in the thrown error, so messages like "Character is not a director" or "Token is not valid for the requested scope" actually surface in the log.
- Remove the structures block (and now-unused imports/constant) from `src/hourly.js`. Wallet + industry jobs continue to run on the existing hourly schedule, unchanged.

## Test plan

- [ ] Manually trigger the new `Structures` workflow via `workflow_dispatch` (after merge, or via the branch selector from Actions) and confirm the per-step `[structures] ...` log lines appear.
- [ ] On the failing director character, confirm the new logs identify which step throws and surface the ESI response body / supabase error code.
- [ ] Confirm the existing `Hourly` workflow still completes green (wallet + industry pulls, no structures-related log lines).
- [ ] Confirm `hangar.corp_structure` rows continue to be upserted by the new workflow on a successful run.

Once the root cause is identified and fixed, the debug verbosity can be trimmed in a follow-up PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TWyLTwD21fDkmgoBdxvwLK)_