### PR TITLE
feat(industry): list active industry jobs on /industry

### DIFF
--- a/src/app/industry/activeJobs.tsx
+++ b/src/app/industry/activeJobs.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { TypeName } from '../market/typeName'
+import { usePersist } from '../market/usePersist'
+import styles from './industry.module.css'
+
+export type Job = {
+  job_id: number | string
+  character_id: string
+  activity_id: number
+  blueprint_type_id: number | string
+  product_type_id: number | string | null
+  runs: number
+  status: string
+  start_date: string
+  end_date: string
+}
+
+type Character = {
+  id: string
+  name: string
+}
+
+type ActiveJobsProps = {
+  jobs: Job[]
+  characters: Character[]
+  initialNow: number
+}
+
+const ACTIVITY_NAMES: Record<number, string> = {
+  1: 'Manufacturing',
+  3: 'TE Research',
+  4: 'ME Research',
+  5: 'Copying',
+  7: 'Reverse Engineering',
+  8: 'Invention',
+  9: 'Reactions',
+}
+
+const CHARACTER_STORAGE_KEY = 'industry.activeJobs.characterId'
+const ALL_CHARACTERS = ''
+
+const formatDate = (iso: string) =>
+  new Intl.DateTimeFormat('sv-SE', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(new Date(iso))
+
+const formatRemaining = (endIso: string, now: number) => {
+  const ms = new Date(endIso).getTime() - now
+  if (ms <= 0) return 'ready'
+  const totalSeconds = Math.floor(ms / 1000)
+  const days = Math.floor(totalSeconds / 86400)
+  const hours = Math.floor((totalSeconds % 86400) / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  if (days > 0) return `${days}d ${hours}h`
+  if (hours > 0) return `${hours}h ${minutes}m`
+  return `${minutes}m`
+}
+
+export const ActiveJobs = ({ jobs, characters, initialNow }: ActiveJobsProps) => {
+  const characterName: Record<string, string> = Object.fromEntries(characters.map((c) => [c.id, c.name]))
+
+  const [characterId, setCharacterId] = usePersist<string>(CHARACTER_STORAGE_KEY, ALL_CHARACTERS, (raw) =>
+    raw === ALL_CHARACTERS || characters.some((c) => c.id === raw) ? raw : undefined,
+  )
+
+  const filtered = jobs.filter((j) => characterId === ALL_CHARACTERS || j.character_id === characterId)
+
+  const [now, setNow] = useState<number>(initialNow)
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 60_000)
+    return () => clearInterval(id)
+  }, [])
+
+  return (
+    <section>
+      <div className={styles.jobsHeader}>
+        <h2>Active Jobs</h2>
+        <div className={styles.jobsFilters}>
+          <label className={styles.jobsFilter}>
+            Character:&nbsp;
+            <select value={characterId} onChange={(e) => setCharacterId(e.target.value)}>
+              <option value={ALL_CHARACTERS}>All characters</option>
+              {characters.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </div>
+      {filtered.length > 0 ? (
+        <table className={styles.jobs}>
+          <thead>
+            <tr>
+              <th>Character</th>
+              <th>Activity</th>
+              <th>Blueprint</th>
+              <th>Product</th>
+              <th>Runs</th>
+              <th>Start</th>
+              <th>End</th>
+              <th>Remaining</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((j) => (
+              <tr key={`job-${j.job_id}`}>
+                <td>{characterName[j.character_id] ?? '—'}</td>
+                <td>{ACTIVITY_NAMES[j.activity_id] ?? `#${j.activity_id}`}</td>
+                <td>
+                  <TypeName typeID={Number(j.blueprint_type_id)} />
+                </td>
+                <td>
+                  {j.product_type_id != null ? <TypeName typeID={Number(j.product_type_id)} /> : '—'}
+                </td>
+                <td>{j.runs}</td>
+                <td>{formatDate(j.start_date)}</td>
+                <td>{formatDate(j.end_date)}</td>
+                <td>{formatRemaining(j.end_date, now)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p>No active industry jobs.</p>
+      )}
+    </section>
+  )
+}

--- a/src/app/industry/industry.module.css
+++ b/src/app/industry/industry.module.css
@@ -1,0 +1,56 @@
+.jobsHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12pt;
+  margin-top: 16pt;
+}
+
+.jobsHeader h2 {
+  margin: 0;
+}
+
+.jobsFilters {
+  display: flex;
+  align-items: center;
+  gap: 12pt;
+}
+
+.jobsFilter {
+  font-size: 10pt;
+  color: #555;
+}
+
+.jobs {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 10pt;
+  margin: 12pt 0;
+}
+
+.jobs th,
+.jobs td {
+  border-bottom: 1px solid #eee;
+  padding: 6pt 8pt;
+  text-align: left;
+}
+
+.jobs th {
+  background: #fafafa;
+  font-weight: bold;
+}
+
+.jobs td:nth-child(5),
+.jobs th:nth-child(5) {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.jobs td:nth-child(6),
+.jobs td:nth-child(7),
+.jobs td:nth-child(8),
+.jobs th:nth-child(6),
+.jobs th:nth-child(7),
+.jobs th:nth-child(8) {
+  font-variant-numeric: tabular-nums;
+}

--- a/src/app/industry/page.tsx
+++ b/src/app/industry/page.tsx
@@ -1,15 +1,37 @@
 import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
+import { ActiveJobs, type Job } from './activeJobs'
 
 const IndustryPage = async () => {
   const supabase = await createClient()
 
-  const { data, error } = await supabase.auth.getUser()
-  if (error || !data?.user) {
+  const { data, error: authError } = await supabase.auth.getUser()
+  if (authError || !data?.user) {
     redirect('/')
   }
 
-  return <h1>Industry</h1>
+  const { data: characters } = await supabase.schema('hangar').from('character').select('id, name')
+
+  const { data: jobs } = await supabase
+    .schema('hangar')
+    .from('industry_job')
+    .select(
+      'job_id, character_id, activity_id, blueprint_type_id, product_type_id, runs, status, start_date, end_date',
+    )
+    .eq('status', 'active')
+    .order('end_date', { ascending: true })
+
+  const sortedCharacters = [...(characters ?? [])].sort((a, b) => a.name.localeCompare(b.name))
+
+  // eslint-disable-next-line react-hooks/purity
+  const initialNow = Date.now()
+
+  return (
+    <>
+      <h1>Industry</h1>
+      <ActiveJobs jobs={(jobs ?? []) as Job[]} characters={sortedCharacters} initialNow={initialNow} />
+    </>
+  )
 }
 export default IndustryPage


### PR DESCRIPTION
## Summary
- The hourly cron already fetches each character's industry jobs (PR #296); this surfaces the rows whose `status = 'active'` on the previously stubbed `/industry` page.
- Adds a per-character filter (persisted in localStorage, matching `/market`) and a live "Remaining" column that re-renders every minute.
- Reuses `TypeName` and `usePersist` from the market module.

## Test plan
- [ ] Sign in with a character that has the `esi-industry.read_character_jobs.v1` scope, run `npm run hourly`, then visit `/industry` and confirm active jobs appear.
- [ ] Confirm the character filter persists across reloads.
- [ ] Confirm the Remaining column counts down (or shows `ready` when past the end date).

https://claude.ai/code/session_01YZpaa8APhRvadzmdLP76VY

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZpaa8APhRvadzmdLP76VY)_