### PR TITLE
feat(character): request industry-jobs scope at login

### DIFF
--- a/src/app/character/sso.ts
+++ b/src/app/character/sso.ts
@@ -8,6 +8,7 @@ export const scopes = [
   'publicData',
   'esi-wallet.read_character_wallet.v1',
   'esi-assets.read_assets.v1',
+  'esi-industry.read_character_jobs.v1',
   'esi-markets.read_character_orders.v1',
   'esi-corporations.read_structures.v1',
   // 'esi-characters.read_blueprints.v1',


### PR DESCRIPTION
## Summary
- The hourly cron filters tokens with `.contains('scope', ['esi-industry.read_character_jobs.v1'])` before fetching industry jobs (src/hourly.js:88), but the character SSO login flow never requested that scope — so no token had it and the industry loop was a silent no-op, leaving `/industry` empty.
- Adds the scope to the login scope list so newly-linked (or re-linked) characters grant it.

## Test plan
- [ ] Visit `/character`, re-link a character, and confirm the EVE consent screen now lists "Read your industry jobs".
- [ ] Run `npm run hourly` and confirm the `industry <character>:` log line reports a non-zero job count.
- [ ] Visit `/industry` and confirm active jobs render.

https://claude.ai/code/session_01YZpaa8APhRvadzmdLP76VY

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZpaa8APhRvadzmdLP76VY)_