### PR TITLE
feat(structures): pull corp wallet journal and list last 7 days

### DIFF
--- a/.github/workflows/structures.yml
+++ b/.github/workflows/structures.yml
@@ -3,7 +3,7 @@ name: Structures
 on:
   workflow_dispatch:
   schedule:
-    - cron: '17 */6 * * *'
+    - cron: '17 * * * *'
 
 jobs:
   refresh:

--- a/hangar.sql
+++ b/hangar.sql
@@ -284,3 +284,51 @@ create policy "Users read structures for own corps"
 
 grant select on hangar.corp_structure to authenticated;
 grant all    on hangar.corp_structure to service_role;
+
+create table if not exists hangar.corp_wallet_journal (
+  corporation_id bigint not null,
+  division smallint not null,
+  entry_id bigint not null,
+  date timestamptz not null,
+  ref_type text not null,
+  amount numeric(20, 2),
+  balance numeric(20, 2),
+  reason text,
+  description text,
+  first_party_id bigint,
+  second_party_id bigint,
+  context_id bigint,
+  context_id_type text,
+  tax numeric(20, 2),
+  tax_receiver_id bigint,
+  seen_at timestamptz not null default now(),
+  primary key (corporation_id, division, entry_id)
+);
+create index if not exists corp_wallet_journal_corp_date_idx
+  on hangar.corp_wallet_journal (corporation_id, date desc);
+
+alter table hangar.corp_wallet_journal enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'hangar'
+      and tablename = 'corp_wallet_journal'
+      and policyname = 'Users read journal for own corps'
+  ) then
+    create policy "Users read journal for own corps"
+      on hangar.corp_wallet_journal
+      for select
+      to authenticated
+      using (
+        corporation_id in (
+          select corporation_id from hangar.character
+          where user_id = (select auth.uid()) and corporation_id is not null
+        )
+      );
+  end if;
+end $$;
+
+grant select on hangar.corp_wallet_journal to authenticated;
+grant all    on hangar.corp_wallet_journal to service_role;

--- a/src/app/character/sso.ts
+++ b/src/app/character/sso.ts
@@ -11,6 +11,7 @@ export const scopes = [
   'esi-industry.read_character_jobs.v1',
   'esi-markets.read_character_orders.v1',
   'esi-corporations.read_structures.v1',
+  'esi-wallet.read_corporation_wallets.v1',
   // 'esi-characters.read_blueprints.v1',
 ]
 

--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -15,6 +15,24 @@ type Structure = {
   last_seen_at: string
 }
 
+type JournalEntry = {
+  corporation_id: number
+  division: number
+  entry_id: string | number
+  date: string
+  ref_type: string
+  amount: string | number | null
+  balance: string | number | null
+  description: string | null
+  reason: string | null
+}
+
+const formatIsk = (raw: string | number | null) => {
+  if (raw === null) return '—'
+  const n = Number(raw)
+  return n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+
 const StructuresPage = async () => {
   const supabase = await createClient()
 
@@ -33,6 +51,17 @@ const StructuresPage = async () => {
     .order('structure_id', { ascending: true })
 
   const list = (structures ?? []) as Structure[]
+
+  // eslint-disable-next-line react-hooks/purity
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
+  const { data: journal } = await supabase
+    .schema('hangar')
+    .from('corp_wallet_journal')
+    .select('corporation_id, division, entry_id, date, ref_type, amount, balance, description, reason')
+    .gte('date', sevenDaysAgo)
+    .order('date', { ascending: false })
+
+  const journalEntries = (journal ?? []) as JournalEntry[]
 
   return (
     <>
@@ -75,6 +104,38 @@ const StructuresPage = async () => {
           No structures visible. Re-link a director character on the <a href="/character">Characters</a> page so the
           hourly job can fetch them.
         </p>
+      )}
+
+      <h2>Corp Wallet (last 7 days)</h2>
+      {journalEntries.length > 0 ? (
+        <table>
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Corp ID</th>
+              <th>Div</th>
+              <th>Ref Type</th>
+              <th>Amount</th>
+              <th>Balance</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {journalEntries.map((e) => (
+              <tr key={`journal-${e.corporation_id}-${e.division}-${e.entry_id}`}>
+                <td>{e.date}</td>
+                <td>{e.corporation_id}</td>
+                <td>{e.division}</td>
+                <td>{e.ref_type}</td>
+                <td>{formatIsk(e.amount)}</td>
+                <td>{formatIsk(e.balance)}</td>
+                <td>{e.description ?? '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p>No corp wallet activity in the last 7 days.</p>
       )}
     </>
   )

--- a/src/esi.js
+++ b/src/esi.js
@@ -122,6 +122,31 @@ export const corpStructures = async (access_token, corporationID, page = 1) => {
   return [data, pages]
 }
 
+export const corpWalletJournal = async (access_token, corporationID, division, page = 1) => {
+  const response = await fetch(
+    `https://esi.evetech.net/latest/corporations/${corporationID}/wallets/${division}/journal/?` +
+      new URLSearchParams({
+        token: access_token,
+        page,
+      }),
+    {
+      method: 'GET',
+      headers: {
+        'User-Agent': userAgent,
+      },
+    }
+  )
+  if (!response.ok) {
+    const body = await response.text().catch(() => '')
+    throw new Error(
+      `corpWalletJournal ${corporationID} div=${division} page=${page}: ${response.status} ${response.statusText} body=${body.slice(0, 500)}`
+    )
+  }
+  const pages = response.headers.get('x-pages')
+  const data = await response.json()
+  return [data, pages]
+}
+
 export const assetNames = async (access_token, characterID, ids) => {
   const params = new URLSearchParams({
     token: access_token,

--- a/src/structures.js
+++ b/src/structures.js
@@ -1,4 +1,4 @@
-import { character as fetchCharacter, corpStructures, userAgent } from './esi.js'
+import { character as fetchCharacter, corpStructures, corpWalletJournal, userAgent } from './esi.js'
 import SingleSignOn from './sso.js'
 import { sudoSupabase } from './supabase.js'
 
@@ -7,6 +7,9 @@ const EVE_SECRET_KEY = process.env.EVE_SECRET_KEY
 const EVE_CALLBACK_URL = process.env.EVE_CALLBACK_URL
 
 const STRUCTURES_SCOPE = 'esi-corporations.read_structures.v1'
+const WALLET_SCOPE = 'esi-wallet.read_corporation_wallets.v1'
+const JOURNAL_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000
+const WALLET_DIVISIONS = [1, 2, 3, 4, 5, 6, 7]
 
 const sso = new SingleSignOn(EVE_CLIENT_ID, EVE_SECRET_KEY, EVE_CALLBACK_URL, { userAgent })
 
@@ -147,6 +150,56 @@ const execute = async () => {
 
       const dt = Date.now() - t0
       console.log(`[structures] ${ctx}: done corp ${corporation_id} ${rows.length} fetched in ${dt}ms`)
+
+      if (scope.includes(WALLET_SCOPE)) {
+        const cutoff = Date.now() - JOURNAL_LOOKBACK_MS
+        for (const division of WALLET_DIVISIONS) {
+          const journalRows = []
+          try {
+            for (let page = 1; ; page++) {
+              const [entries, pagesHeader] = await corpWalletJournal(access_token, corporation_id, division, page)
+              if (!Array.isArray(entries) || entries.length === 0) break
+              let oldestMs = Infinity
+              for (const e of entries) {
+                const ms = new Date(e.date).getTime()
+                if (ms < oldestMs) oldestMs = ms
+                if (ms < cutoff) continue
+                journalRows.push({
+                  corporation_id,
+                  division,
+                  entry_id: e.id,
+                  date: e.date,
+                  ref_type: e.ref_type,
+                  amount: e.amount ?? null,
+                  balance: e.balance ?? null,
+                  reason: e.reason ?? null,
+                  description: e.description ?? null,
+                  first_party_id: e.first_party_id ?? null,
+                  second_party_id: e.second_party_id ?? null,
+                  context_id: e.context_id ?? null,
+                  context_id_type: e.context_id_type ?? null,
+                  tax: e.tax ?? null,
+                  tax_receiver_id: e.tax_receiver_id ?? null,
+                })
+              }
+              const totalPages = Math.max(1, Number.parseInt(pagesHeader, 10) || 1)
+              if (oldestMs < cutoff || page >= totalPages) break
+            }
+            if (journalRows.length > 0) {
+              const { error: jErr } = await sudoSupabase
+                .schema('hangar')
+                .from('corp_wallet_journal')
+                .upsert(journalRows, { onConflict: 'corporation_id,division,entry_id', ignoreDuplicates: true })
+              if (jErr) throw jErr
+            }
+            console.log(`[corp-wallet] ${ctx}: corp ${corporation_id} div ${division} ${journalRows.length} entries`)
+          } catch (jErr) {
+            console.error(
+              `[corp-wallet] ${ctx}: corp ${corporation_id} div ${division} FAILED message=${jErr?.message}`
+            )
+          }
+        }
+      }
     } catch (e) {
       const dt = Date.now() - t0
       console.error(`[structures] ${ctx}: FAILED after ${dt}ms name=${e?.name} message=${e?.message}\n${e?.stack ?? e}`)


### PR DESCRIPTION
## Summary
- Adds `esi-wallet.read_corporation_wallets.v1` to the SSO login scopes so director characters can grant corp wallet access.
- New `hangar.corp_wallet_journal` table (PK on corporation_id+division+entry_id) with an RLS policy that only lets a user read journal rows for corps they have a character in. Matches the `corp_structure` pattern.
- `src/structures.js` (which already iterates director-scope tokens, refreshes them, and resolves their `corporation_id`) now also walks each of the seven wallet divisions for tokens that carry the wallet scope. Pagination stops once the oldest entry on a page falls outside the 7-day window, so steady-state runs are one page per division. Per-division errors (e.g. 403 from a non-Accountant token) are caught so they don't abort the run.
- The Structures workflow cron bumps from `*/6h` to hourly so journal data refreshes promptly.
- `/structures` now renders a "Corp Wallet (last 7 days)" table below the existing structures list, ordered by date desc.

## Test plan
- [ ] `psql -f hangar.sql` against the dev DB and confirm the new table + policy land cleanly.
- [ ] Re-link the director character on `/character` and confirm the EVE consent screen now lists "Read your corporation wallets".
- [ ] Trigger `Structures` via workflow_dispatch and confirm the `[corp-wallet]` log lines report non-zero entries for at least one division.
- [ ] Visit `/structures` and confirm corp wallet entries render below the structures list, with `amount`/`balance` formatted as ISK.
- [ ] Visit `/structures` as a non-director user and confirm the wallet section is empty (RLS).

https://claude.ai/code/session_01YZpaa8APhRvadzmdLP76VY

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZpaa8APhRvadzmdLP76VY)_