### PR TITLE
fix(callback): drop redundant SSO token refresh

### DIFF
--- a/src/app/character/callback/route.ts
+++ b/src/app/character/callback/route.ts
@@ -59,9 +59,6 @@ export const GET = async (request: NextRequest) => {
   const expires_at = new Date(exp * 1000).toISOString()
   const eve_character_id = Number(sub.split(':')[2])
 
-  // why are we doing this, again? can this be deleted?
-  await sso.getAccessToken(refresh_token, true)
-
   const character_id = await upsertCharacter(supabase)({ user_id, owner, name, character_id: eve_character_id })
   const token_id = await upsertToken(supabase)({
     user_id,


### PR DESCRIPTION
## Summary
The `/character/callback` handler called `sso.getAccessToken` twice — once to exchange the auth code, and a second time on the just-issued refresh token. The in-file comment already flagged it (`// why are we doing this, again? can this be deleted?`). The persisted `access_token` / `refresh_token` come from the first call, so the second is pure overhead.

## Test plan
- [ ] Log in with a fresh / re-linked character; verify `hangar.token` row is upserted with valid `access_token` and `refresh_token`.
- [ ] Confirm subsequent ESI calls (wallet, etc.) authenticate using the stored token.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBZg9SoCmwUBDBz5pbmeov)_