### PR TITLE
fix(blueprint): type filtersUsed args as number, drop `as any`

### DIFF
--- a/src/app/blueprint/[typeID]/filters.ts
+++ b/src/app/blueprint/[typeID]/filters.ts
@@ -108,10 +108,10 @@ export const groupsWithFilter = reduce(
   toPairs(filters) as [id: string, attr: FilterAttrs][]
 )
 
-export const filtersUsed = (groupID: string, categoryID: string) => {
+export const filtersUsed = (groupID: number, categoryID: number) => {
   const allFiltersUsed = [
-    ...filter(([thisGroupID]) => (groupID as any) === (thisGroupID as any), groupsWithFilter),
-    ...filter(([thisCategoryID]) => (categoryID as any) === (thisCategoryID as any), categoriesWithFilter),
+    ...filter(([thisGroupID]) => groupID === thisGroupID, groupsWithFilter),
+    ...filter(([thisCategoryID]) => categoryID === thisCategoryID, categoriesWithFilter),
   ]
   return map(([groupID, filterID]) => filterID, allFiltersUsed)
 }


### PR DESCRIPTION
## Summary
`filtersUsed` was typed `(groupID: string, categoryID: string)` even though the only caller (`blueprint/[typeID]/page.tsx`) passes the numeric `groupID`/`categoryID` it reads from `invTypes` / `invGroups`. The mismatch was hidden by `as any` casts on both sides of the equality check. Typing the params as `number` lets the comparison run as plain `===` and removes the escape hatch.

## Test plan
- [ ] `tsc --noEmit` / `next build` clean.
- [ ] Load a blueprint page (e.g. `/blueprint/<typeID>/<productTypeID>`) and confirm the rigs list still renders.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBZg9SoCmwUBDBz5pbmeov)_