### PR TITLE
fix(refresh): guard empty characters list before indexing

### DIFF
--- a/src/refresh.js
+++ b/src/refresh.js
@@ -48,6 +48,10 @@ const execute = async () => {
     //'fTWbcvorPidXBXybfbo/JpND0Qc=' // international blue
   )
 
+  if (!characters?.length) {
+    console.error('no character found for owner')
+    process.exit(1)
+  }
   const character_id = characters[0]
   const [refresh_token, characterID] = await accessToken(character_id)
 


### PR DESCRIPTION
## Summary
`selectCharacters` can legitimately return an empty array when no row matches the hard-coded owner. The script then took `characters[0]` (= `undefined`) and called `accessToken(undefined)`, which failed downstream inside a Supabase query with an opaque error. Bail out up front with a clear message instead.

## Test plan
- [ ] Run `refresh.js` with an owner that doesn't exist in `hangar.character` → expect the new "no character found for owner" message and exit 1.
- [ ] Run with a valid owner → unchanged behavior.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBZg9SoCmwUBDBz5pbmeov)_