### PR TITLE
feat(structures): extend corp wallet window to last 30 days

### DIFF
--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -53,12 +53,12 @@ const StructuresPage = async () => {
   const list = (structures ?? []) as Structure[]
 
   // eslint-disable-next-line react-hooks/purity
-  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
   const { data: journal } = await supabase
     .schema('hangar')
     .from('corp_wallet_journal')
     .select('corporation_id, division, entry_id, date, ref_type, amount, balance, description, reason')
-    .gte('date', sevenDaysAgo)
+    .gte('date', thirtyDaysAgo)
     .order('date', { ascending: false })
 
   const journalEntries = (journal ?? []) as JournalEntry[]
@@ -106,7 +106,7 @@ const StructuresPage = async () => {
         </p>
       )}
 
-      <h2>Corp Wallet (last 7 days)</h2>
+      <h2>Corp Wallet (last 30 days)</h2>
       {journalEntries.length > 0 ? (
         <table>
           <thead>
@@ -135,7 +135,7 @@ const StructuresPage = async () => {
           </tbody>
         </table>
       ) : (
-        <p>No corp wallet activity in the last 7 days.</p>
+        <p>No corp wallet activity in the last 30 days.</p>
       )}
     </>
   )

--- a/src/structures.js
+++ b/src/structures.js
@@ -8,7 +8,7 @@ const EVE_CALLBACK_URL = process.env.EVE_CALLBACK_URL
 
 const STRUCTURES_SCOPE = 'esi-corporations.read_structures.v1'
 const WALLET_SCOPE = 'esi-wallet.read_corporation_wallets.v1'
-const JOURNAL_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000
+const JOURNAL_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000
 const WALLET_DIVISIONS = [1, 2, 3, 4, 5, 6, 7]
 
 const sso = new SingleSignOn(EVE_CLIENT_ID, EVE_SECRET_KEY, EVE_CALLBACK_URL, { userAgent })


### PR DESCRIPTION
## Summary

- Bump the corp wallet journal lookback from 7 days to 30 days in
  `src/structures.js` so the hourly cron pulls a full month of ESI
  entries on each run.
- Update the `/structures` page query to read the last 30 days of
  `corp_wallet_journal` instead of 7.
- Update the section heading and empty-state copy on `/structures`
  accordingly.

## Test plan

- [ ] `npm run lint` — passes (only pre-existing warnings).
- [ ] `npm run build` — passes.
- [ ] Load `/structures` and confirm the Corp Wallet section heading
      reads "Corp Wallet (last 30 days)" and the table includes entries
      older than 7 days (after the next hourly run has backfilled them).
- [ ] Confirm the empty-state copy reads "No corp wallet activity in
      the last 30 days." when no rows match.

https://claude.ai/code/session_01QvzJ9iTWBwuEcW6bixyynA

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvzJ9iTWBwuEcW6bixyynA)_