### PR TITLE
refactor(sso): extract shared refreshAccessToken helper

### DIFF
--- a/src/hourly.js
+++ b/src/hourly.js
@@ -1,35 +1,9 @@
-import { industryJobs, transactions, userAgent, wallet } from './esi.js'
-import SingleSignOn from 'eve-sso'
+import { industryJobs, transactions, wallet } from './esi.js'
 import { sudoSupabase } from './supabase.js'
-
-const EVE_CLIENT_ID = process.env.EVE_CLIENT_ID
-const EVE_SECRET_KEY = process.env.EVE_SECRET_KEY
-const EVE_CALLBACK_URL = process.env.EVE_CALLBACK_URL
+import { refreshAccessToken } from './tokenRefresh.js'
 
 const WALLET_SCOPE = 'esi-wallet.read_character_wallet.v1'
 const INDUSTRY_SCOPE = 'esi-industry.read_character_jobs.v1'
-
-const sso = new SingleSignOn(EVE_CLIENT_ID, EVE_SECRET_KEY, EVE_CALLBACK_URL, userAgent)
-
-const refreshToken = async (tokenRow) => {
-  const refreshed = await sso.getAccessToken(tokenRow.refresh_token, true)
-  const { access_token, refresh_token } = refreshed
-  const { sub, scp = [], iat, exp } = refreshed.decoded_access_token
-  const characterID = sub.split(':')[2]
-  const scope = [scp].flat()
-  await sudoSupabase
-    .schema('hangar')
-    .from('token')
-    .update({
-      access_token,
-      refresh_token,
-      issued_at: new Date(iat * 1000).toISOString(),
-      expires_at: new Date(exp * 1000).toISOString(),
-      scope,
-    })
-    .eq('id', tokenRow.id)
-  return { access_token, characterID, scope }
-}
 
 const execute = async () => {
   const { data: tokens, error } = await sudoSupabase
@@ -45,7 +19,7 @@ const execute = async () => {
 
   for (const tokenRow of tokens ?? []) {
     try {
-      const { access_token, characterID } = await refreshToken(tokenRow)
+      const { access_token, characterID } = await refreshAccessToken(tokenRow)
       const balance = await wallet(access_token, characterID)
       const { error: insertError } = await sudoSupabase
         .schema('hangar')
@@ -94,7 +68,7 @@ const execute = async () => {
 
   for (const tokenRow of industryTokens ?? []) {
     try {
-      const { access_token, characterID } = await refreshToken(tokenRow)
+      const { access_token, characterID } = await refreshAccessToken(tokenRow)
       const jobs = await industryJobs(access_token, characterID)
       if (jobs.length > 0) {
         const rows = jobs.map((j) => ({

--- a/src/structures.js
+++ b/src/structures.js
@@ -1,11 +1,7 @@
-import SingleSignOn from 'eve-sso'
 import { pullCorpWalletJournals } from './corpWalletJournal.js'
-import { character as fetchCharacter, corpAssets, corpStructures, corpWalletJournal, userAgent } from './esi.js'
+import { character as fetchCharacter, corpAssets, corpStructures, corpWalletJournal } from './esi.js'
 import { sudoSupabase } from './supabase.js'
-
-const EVE_CLIENT_ID = process.env.EVE_CLIENT_ID
-const EVE_SECRET_KEY = process.env.EVE_SECRET_KEY
-const EVE_CALLBACK_URL = process.env.EVE_CALLBACK_URL
+import { refreshAccessToken } from './tokenRefresh.js'
 
 const STRUCTURES_SCOPE = 'esi-corporations.read_structures.v1'
 const WALLET_SCOPE = 'esi-wallet.read_corporation_wallets.v1'
@@ -15,25 +11,7 @@ const ASSETS_SCOPE = 'esi-assets.read_corporation_assets.v1'
 // equal to the structure_id and a RigSlotN location_flag.
 const isRigSlot = (flag) => typeof flag === 'string' && flag.startsWith('RigSlot')
 
-const sso = new SingleSignOn(EVE_CLIENT_ID, EVE_SECRET_KEY, EVE_CALLBACK_URL, userAgent)
-
 const tail = (s) => (typeof s === 'string' && s.length > 4 ? s.slice(-4) : '????')
-
-const refreshToken = async (tokenRow) => {
-  const refreshed = await sso.getAccessToken(tokenRow.refresh_token, true)
-  const { access_token, refresh_token } = refreshed
-  const { sub, scp = [], iat, exp } = refreshed.decoded_access_token
-  const characterID = sub.split(':')[2]
-  const scope = [scp].flat()
-  const issued_at = new Date(iat * 1000).toISOString()
-  const expires_at = new Date(exp * 1000).toISOString()
-  await sudoSupabase
-    .schema('hangar')
-    .from('token')
-    .update({ access_token, refresh_token, issued_at, expires_at, scope })
-    .eq('id', tokenRow.id)
-  return { access_token, characterID, scope, issued_at, expires_at }
-}
 
 const execute = async () => {
   const { data: tokens, error } = await sudoSupabase
@@ -60,7 +38,7 @@ const execute = async () => {
     const ctx = `character=${tokenRow.character_id} token=${tokenRow.id}`
     try {
       console.log(`[structures] ${ctx}: refreshing token (refresh ...${tail(tokenRow.refresh_token)})`)
-      const { access_token, characterID, scope, issued_at, expires_at } = await refreshToken(tokenRow)
+      const { access_token, characterID, scope, issued_at, expires_at } = await refreshAccessToken(tokenRow)
       console.log(
         `[structures] ${ctx}: refreshed characterID=${characterID} issued=${issued_at} expires=${expires_at} scope=${JSON.stringify(scope)}`
       )

--- a/src/tokenRefresh.js
+++ b/src/tokenRefresh.js
@@ -1,0 +1,27 @@
+import SingleSignOn from 'eve-sso'
+
+import { userAgent } from './esi.js'
+import { sudoSupabase } from './supabase.js'
+
+const sso = new SingleSignOn(
+  process.env.EVE_CLIENT_ID,
+  process.env.EVE_SECRET_KEY,
+  process.env.EVE_CALLBACK_URL,
+  userAgent
+)
+
+export const refreshAccessToken = async (tokenRow) => {
+  const refreshed = await sso.getAccessToken(tokenRow.refresh_token, true)
+  const { access_token, refresh_token } = refreshed
+  const { sub, scp = [], iat, exp } = refreshed.decoded_access_token
+  const characterID = sub.split(':')[2]
+  const scope = [scp].flat()
+  const issued_at = new Date(iat * 1000).toISOString()
+  const expires_at = new Date(exp * 1000).toISOString()
+  await sudoSupabase
+    .schema('hangar')
+    .from('token')
+    .update({ access_token, refresh_token, issued_at, expires_at, scope })
+    .eq('id', tokenRow.id)
+  return { access_token, characterID, scope, issued_at, expires_at }
+}


### PR DESCRIPTION
## Summary
`hourly.js` and `structures.js` each carried an identical ~15-line `refreshToken` implementation: instantiate `SingleSignOn` from the `EVE_*` env vars, exchange the refresh token, decode the JWT, split `sub` for `characterID`, flatten the scope, then `UPDATE hangar.token` by id. Lift it into `src/tokenRefresh.js` so both scripts (and any future cron jobs) share one definition.

(`refresh.js` uses a different upsert path via `supabase.js` helpers and a different — debug — invocation pattern, so it's left alone for a follow-up.)

## Test plan
- [ ] `npm run hourly` (or however it's invoked): wallet/transactions/industry pull for at least one character; verify `hangar.token` row's `access_token` updates.
- [ ] `npm run structures`: structures + corp wallet journal pull; verify `hangar.token` row updates.
- [ ] Confirm `EVE_CLIENT_ID` / `EVE_SECRET_KEY` / `EVE_CALLBACK_URL` env vars are still picked up (they're now read in `tokenRefresh.js`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBZg9SoCmwUBDBz5pbmeov)_