### PR TITLE
refactor(structures): split corp wallet journal pull into its own module

### DIFF
--- a/src/corpWalletJournal.js
+++ b/src/corpWalletJournal.js
@@ -1,0 +1,58 @@
+import { corpWalletJournal } from './esi.js'
+import { sudoSupabase } from './supabase.js'
+
+const JOURNAL_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000
+const WALLET_DIVISIONS = [1, 2, 3, 4, 5, 6, 7]
+
+const fetchDivision = async (access_token, corporation_id, division, cutoff) => {
+  const rows = []
+  for (let page = 1; ; page++) {
+    const [entries, pagesHeader] = await corpWalletJournal(access_token, corporation_id, division, page)
+    if (!Array.isArray(entries) || entries.length === 0) break
+    let oldestMs = Infinity
+    for (const e of entries) {
+      const ms = new Date(e.date).getTime()
+      if (ms < oldestMs) oldestMs = ms
+      if (ms < cutoff) continue
+      rows.push({
+        corporation_id,
+        division,
+        entry_id: e.id,
+        date: e.date,
+        ref_type: e.ref_type,
+        amount: e.amount ?? null,
+        balance: e.balance ?? null,
+        reason: e.reason ?? null,
+        description: e.description ?? null,
+        first_party_id: e.first_party_id ?? null,
+        second_party_id: e.second_party_id ?? null,
+        context_id: e.context_id ?? null,
+        context_id_type: e.context_id_type ?? null,
+        tax: e.tax ?? null,
+        tax_receiver_id: e.tax_receiver_id ?? null,
+      })
+    }
+    const totalPages = Math.max(1, Number.parseInt(pagesHeader, 10) || 1)
+    if (oldestMs < cutoff || page >= totalPages) break
+  }
+  return rows
+}
+
+export const pullCorpWalletJournals = async ({ access_token, corporation_id, ctx }) => {
+  const cutoff = Date.now() - JOURNAL_LOOKBACK_MS
+  for (const division of WALLET_DIVISIONS) {
+    try {
+      const rows = await fetchDivision(access_token, corporation_id, division, cutoff)
+      if (rows.length > 0) {
+        const { error } = await sudoSupabase
+          .schema('hangar')
+          .from('corp_wallet_journal')
+          .upsert(rows, { onConflict: 'corporation_id,division,entry_id', ignoreDuplicates: true })
+        if (error) throw error
+      }
+      console.log(`[corp-wallet] ${ctx}: corp ${corporation_id} div ${division} ${rows.length} entries`)
+    } catch (e) {
+      console.error(`[corp-wallet] ${ctx}: corp ${corporation_id} div ${division} FAILED message=${e?.message}`)
+    }
+  }
+}

--- a/src/structures.js
+++ b/src/structures.js
@@ -1,4 +1,5 @@
-import { character as fetchCharacter, corpStructures, corpWalletJournal, userAgent } from './esi.js'
+import { pullCorpWalletJournals } from './corpWalletJournal.js'
+import { character as fetchCharacter, corpStructures, userAgent } from './esi.js'
 import SingleSignOn from './sso.js'
 import { sudoSupabase } from './supabase.js'
 
@@ -8,8 +9,6 @@ const EVE_CALLBACK_URL = process.env.EVE_CALLBACK_URL
 
 const STRUCTURES_SCOPE = 'esi-corporations.read_structures.v1'
 const WALLET_SCOPE = 'esi-wallet.read_corporation_wallets.v1'
-const JOURNAL_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000
-const WALLET_DIVISIONS = [1, 2, 3, 4, 5, 6, 7]
 
 const sso = new SingleSignOn(EVE_CLIENT_ID, EVE_SECRET_KEY, EVE_CALLBACK_URL, { userAgent })
 
@@ -152,53 +151,7 @@ const execute = async () => {
       console.log(`[structures] ${ctx}: done corp ${corporation_id} ${rows.length} fetched in ${dt}ms`)
 
       if (scope.includes(WALLET_SCOPE)) {
-        const cutoff = Date.now() - JOURNAL_LOOKBACK_MS
-        for (const division of WALLET_DIVISIONS) {
-          const journalRows = []
-          try {
-            for (let page = 1; ; page++) {
-              const [entries, pagesHeader] = await corpWalletJournal(access_token, corporation_id, division, page)
-              if (!Array.isArray(entries) || entries.length === 0) break
-              let oldestMs = Infinity
-              for (const e of entries) {
-                const ms = new Date(e.date).getTime()
-                if (ms < oldestMs) oldestMs = ms
-                if (ms < cutoff) continue
-                journalRows.push({
-                  corporation_id,
-                  division,
-                  entry_id: e.id,
-                  date: e.date,
-                  ref_type: e.ref_type,
-                  amount: e.amount ?? null,
-                  balance: e.balance ?? null,
-                  reason: e.reason ?? null,
-                  description: e.description ?? null,
-                  first_party_id: e.first_party_id ?? null,
-                  second_party_id: e.second_party_id ?? null,
-                  context_id: e.context_id ?? null,
-                  context_id_type: e.context_id_type ?? null,
-                  tax: e.tax ?? null,
-                  tax_receiver_id: e.tax_receiver_id ?? null,
-                })
-              }
-              const totalPages = Math.max(1, Number.parseInt(pagesHeader, 10) || 1)
-              if (oldestMs < cutoff || page >= totalPages) break
-            }
-            if (journalRows.length > 0) {
-              const { error: jErr } = await sudoSupabase
-                .schema('hangar')
-                .from('corp_wallet_journal')
-                .upsert(journalRows, { onConflict: 'corporation_id,division,entry_id', ignoreDuplicates: true })
-              if (jErr) throw jErr
-            }
-            console.log(`[corp-wallet] ${ctx}: corp ${corporation_id} div ${division} ${journalRows.length} entries`)
-          } catch (jErr) {
-            console.error(
-              `[corp-wallet] ${ctx}: corp ${corporation_id} div ${division} FAILED message=${jErr?.message}`
-            )
-          }
-        }
+        await pullCorpWalletJournals({ access_token, corporation_id, ctx })
       }
     } catch (e) {
       const dt = Date.now() - t0


### PR DESCRIPTION
## Summary
`structures.js` had quietly accumulated two distinct concerns: pulling/upserting corp structures (its name) and pulling/upserting seven divisions of corp wallet journal (the trailing ~50 lines added in #301). Move the journal code to `src/corpWalletJournal.js` behind `pullCorpWalletJournals({ access_token, corporation_id, ctx })`. `structures.js` just calls it when the refreshed token has the wallet scope. Same behavior, same logging, same error semantics (per-division try/catch with a `[corp-wallet]`-prefixed log).

## Test plan
- [ ] Run `structures.js` with a director token that has both `read_structures.v1` and `read_corporation_wallets.v1`. Verify both `hangar.corp_structure` and `hangar.corp_wallet_journal` are upserted.
- [ ] Run with a token that has structures scope but NOT wallet scope. Verify the journal step is skipped (no `[corp-wallet]` logs) and structures still upsert.
- [ ] Confirm pagination still terminates at the 7-day lookback cutoff per division.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBZg9SoCmwUBDBz5pbmeov)_