### PR TITLE
refactor: split getAccessToken into two more semantic requests

### DIFF
--- a/src/app/character/callback/route.ts
+++ b/src/app/character/callback/route.ts
@@ -51,7 +51,7 @@ export const GET = async (request: NextRequest) => {
 
   const { searchParams } = new URL(request.url)
   const code = searchParams.get('code')
-  const { access_token, refresh_token, ...info } = await sso.getAccessToken(code)
+  const { access_token, refresh_token, ...info } = await sso.exchangeAuthCode(code)
   const {
     decoded_access_token: { name, owner, sub, scp = [], iat, exp },
   } = info
@@ -59,8 +59,7 @@ export const GET = async (request: NextRequest) => {
   const expires_at = new Date(exp * 1000).toISOString()
   const eve_character_id = Number(sub.split(':')[2])
 
-  // why are we doing this, again? can this be deleted?
-  await sso.getAccessToken(refresh_token, true)
+  await sso.refreshAccessToken(refresh_token)
 
   const character_id = await upsertCharacter(supabase)({ user_id, owner, name, character_id: eve_character_id })
   const token_id = await upsertToken(supabase)({

--- a/src/hourly.js
+++ b/src/hourly.js
@@ -12,7 +12,7 @@ const INDUSTRY_SCOPE = 'esi-industry.read_character_jobs.v1'
 const sso = new SingleSignOn(EVE_CLIENT_ID, EVE_SECRET_KEY, EVE_CALLBACK_URL, { userAgent })
 
 const refreshToken = async (tokenRow) => {
-  const refreshed = await sso.getAccessToken(tokenRow.refresh_token, true)
+  const refreshed = await sso.getAccessToken(tokenRow.refresh_token)
   const { access_token, refresh_token } = refreshed
   const { sub, scp = [], iat, exp } = refreshed.decoded_access_token
   const characterID = sub.split(':')[2]

--- a/src/refresh.js
+++ b/src/refresh.js
@@ -26,7 +26,7 @@ const accessToken = async (character_id) => {
     access_token,
     refresh_token,
     decoded_access_token: { scp = [], iat, exp, sub },
-  } = await sso.getAccessToken(old_token, true)
+  } = await sso.refreshAccessToken(old_token)
   const characterID = sub.split(':')[2]
   await upsertToken({
     character_id,

--- a/src/sso.js
+++ b/src/sso.js
@@ -47,16 +47,7 @@ class SingleSignOn {
     })
     return `${this.endpoint}/v2/oauth/authorize?${search.toString()}`
   }
-  async getAccessToken(code, isRefreshToken = false) {
-    const payload = !isRefreshToken
-      ? {
-          grant_type: 'authorization_code',
-          code,
-        }
-      : {
-          grant_type: 'refresh_token',
-          refresh_token: code,
-        }
+  async getToken(payload) {
     const response = await fetch(`${this.endpoint}/v2/oauth/token`, {
       method: 'POST',
       body: formUrlEncoded(payload),
@@ -85,6 +76,14 @@ class SingleSignOn {
       )
     })
     return data
+  }
+  async exchangeAuthCode(code) {
+    const grant_type = 'authorization_code'
+    return this.getToken({ grant_type, code })
+  }
+  async refreshAccessToken(refresh_token) {
+    const grant_type = 'refresh_tokene'
+    return this.getToken({ grant_type, refresh_token })
   }
   getKey(header, callback) {
     this.#jwks.getSigningKey(header.kid, (err, key) => {

--- a/src/structures.js
+++ b/src/structures.js
@@ -16,7 +16,7 @@ const sso = new SingleSignOn(EVE_CLIENT_ID, EVE_SECRET_KEY, EVE_CALLBACK_URL, { 
 const tail = (s) => (typeof s === 'string' && s.length > 4 ? s.slice(-4) : '????')
 
 const refreshToken = async (tokenRow) => {
-  const refreshed = await sso.getAccessToken(tokenRow.refresh_token, true)
+  const refreshed = await sso.refreshAccessToken(tokenRow.refresh_token)
   const { access_token, refresh_token } = refreshed
   const { sub, scp = [], iat, exp } = refreshed.decoded_access_token
   const characterID = sub.split(':')[2]


### PR DESCRIPTION
almost broke this in #303, renamed methods so we have a more descriptive interface