### PR TITLE
Remove duplicate SingleSignOn import in structures.js

### DIFF
--- a/src/structures.js
+++ b/src/structures.js
@@ -1,7 +1,6 @@
 import SingleSignOn from 'eve-sso'
 import { pullCorpWalletJournals } from './corpWalletJournal.js'
 import { character as fetchCharacter, corpStructures, corpWalletJournal, userAgent } from './esi.js'
-import SingleSignOn from './sso.js'
 import { sudoSupabase } from './supabase.js'
 
 const EVE_CLIENT_ID = process.env.EVE_CLIENT_ID


### PR DESCRIPTION
## Summary
Removes a duplicate import statement for `SingleSignOn` that was causing a conflict in `src/structures.js`.

## Key Changes
- Removed duplicate `import SingleSignOn from './sso.js'` statement (line 4)
- Kept the correct import `import SingleSignOn from 'eve-sso'` from the npm package (line 1)

## Details
The file had two imports for `SingleSignOn` - one from the external `eve-sso` package and one from a local `./sso.js` file. The local import was redundant and would have caused the second import to override the first, breaking the intended dependency on the npm package.

https://claude.ai/code/session_01V2gsk74cfetqNWw3rCDw1b