### PR TITLE
perf(typeNames): stream type-name lookups via Suspense

### DIFF
--- a/src/app/industry/activeJobs.tsx
+++ b/src/app/industry/activeJobs.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react'
 import { DateTime } from '../DateTime'
 import { usePersist } from '../market/usePersist'
 import retro from '../retro.module.css'
+import { TypeName } from '../typeName'
 import styles from './industry.module.css'
 import { ACTIVITY_NAMES } from './jobFields'
 
@@ -31,7 +32,7 @@ type ActiveJobsProps = {
   jobs: Job[]
   characters: Character[]
   initialNow: number
-  typeNames: Record<number, string>
+  typeNamesPromise: Promise<Record<number, string>>
   stationNames: Record<string, string>
 }
 
@@ -50,7 +51,7 @@ const formatRemaining = (endIso: string, now: number) => {
   return `${minutes}m`
 }
 
-export const ActiveJobs = ({ jobs, characters, initialNow, typeNames, stationNames }: ActiveJobsProps) => {
+export const ActiveJobs = ({ jobs, characters, initialNow, typeNamesPromise, stationNames }: ActiveJobsProps) => {
   const characterName: Record<string, string> = Object.fromEntries(characters.map((c) => [c.id, c.name]))
 
   const [characterId, setCharacterId] = usePersist<string>(CHARACTER_STORAGE_KEY, ALL_CHARACTERS, (raw) =>
@@ -104,9 +105,11 @@ export const ActiveJobs = ({ jobs, characters, initialNow, typeNames, stationNam
                   <td className="serif">{characterName[j.character_id] ?? '—'}</td>
                   <td>{ACTIVITY_NAMES[j.activity_id] ?? `#${j.activity_id}`}</td>
                   <td className="serif">
-                    {j.product_type_id != null
-                      ? (typeNames[Number(j.product_type_id)] ?? `#${j.product_type_id}`)
-                      : '—'}
+                    {j.product_type_id != null ? (
+                      <TypeName id={Number(j.product_type_id)} promise={typeNamesPromise} />
+                    ) : (
+                      '—'
+                    )}
                   </td>
                   <td className={retro.num}>{j.runs}</td>
                   <td>

--- a/src/app/industry/page.tsx
+++ b/src/app/industry/page.tsx
@@ -34,12 +34,8 @@ const IndustryPage = async () => {
   )
 
   const jobRows = (jobs ?? []) as Job[]
-  const typeNames = await fetchTypeNames(
-    jobRows.flatMap((j) => {
-      const ids = [Number(j.blueprint_type_id)]
-      if (j.product_type_id != null) ids.push(Number(j.product_type_id))
-      return ids
-    })
+  const typeNamesPromise = fetchTypeNames(
+    jobRows.flatMap((j) => (j.product_type_id != null ? [Number(j.product_type_id)] : []))
   )
 
   // eslint-disable-next-line react-hooks/purity
@@ -52,7 +48,7 @@ const IndustryPage = async () => {
         jobs={jobRows}
         characters={sortedCharacters}
         initialNow={initialNow}
-        typeNames={typeNames}
+        typeNamesPromise={typeNamesPromise}
         stationNames={stationNames}
       />
     </>

--- a/src/app/market/page.tsx
+++ b/src/app/market/page.tsx
@@ -26,12 +26,12 @@ const MarketPage = async () => {
 
   const sortedCharacters = [...(characters ?? [])].sort((a, b) => a.name.localeCompare(b.name))
 
-  const typeNames = await fetchTypeNames((sales ?? []).map((s) => Number(s.type_id)))
+  const typeNamesPromise = fetchTypeNames((sales ?? []).map((s) => Number(s.type_id)))
 
   return (
     <>
       <h1>Market</h1>
-      <RecentSales sales={sales ?? []} characters={sortedCharacters} typeNames={typeNames} />
+      <RecentSales sales={sales ?? []} characters={sortedCharacters} typeNamesPromise={typeNamesPromise} />
     </>
   )
 }

--- a/src/app/market/recentSales.tsx
+++ b/src/app/market/recentSales.tsx
@@ -2,6 +2,7 @@
 
 import { DateTime } from '../DateTime'
 import { formatMisk } from '../isk'
+import { TypeName } from '../typeName'
 import styles from './market.module.css'
 import { usePersist } from './usePersist'
 
@@ -23,7 +24,7 @@ type Character = {
 type RecentSalesProps = {
   sales: Sale[]
   characters: Character[]
-  typeNames: Record<number, string>
+  typeNamesPromise: Promise<Record<number, string>>
 }
 
 const THRESHOLDS: Array<{ label: string; value: number }> = [
@@ -38,7 +39,7 @@ const THRESHOLD_STORAGE_KEY = 'market.recentSales.threshold'
 const CHARACTER_STORAGE_KEY = 'market.recentSales.characterId'
 const ALL_CHARACTERS = ''
 
-export const RecentSales = ({ sales, characters, typeNames }: RecentSalesProps) => {
+export const RecentSales = ({ sales, characters, typeNamesPromise }: RecentSalesProps) => {
   const characterName: Record<string, string> = Object.fromEntries(characters.map((c) => [c.id, c.name]))
 
   const [threshold, setThreshold] = usePersist(THRESHOLD_STORAGE_KEY, 0, (raw) => {
@@ -101,7 +102,9 @@ export const RecentSales = ({ sales, characters, typeNames }: RecentSalesProps) 
             {filtered.map((s) => (
               <tr key={`sale-${s.transaction_id}`}>
                 <td className="serif">{characterName[s.character_id] ?? '—'}</td>
-                <td className="serif">{typeNames[Number(s.type_id)] ?? `#${s.type_id}`}</td>
+                <td className="serif">
+                  <TypeName id={Number(s.type_id)} promise={typeNamesPromise} />
+                </td>
                 <td>{s.quantity}</td>
                 <td>{formatMisk(s.unit_price)}</td>
                 <td>{formatMisk(Number(s.unit_price) * Number(s.quantity))}</td>

--- a/src/app/typeName.tsx
+++ b/src/app/typeName.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { Suspense, use } from 'react'
+
+type TypeNameProps = {
+  id: number
+  promise: Promise<Record<number, string>>
+}
+
+const Resolved = ({ id, promise }: TypeNameProps) => {
+  const names = use(promise)
+  return <>{names[id] ?? `#${id}`}</>
+}
+
+export const TypeName = ({ id, promise }: TypeNameProps) => (
+  <Suspense fallback={`#${id}`}>
+    <Resolved id={id} promise={promise} />
+  </Suspense>
+)


### PR DESCRIPTION
## Summary
- The industry and market pages used to `await fetchTypeNames(...)` before returning, which blocked the initial response on the external EVE type-name API.
- Now the page hands the unresolved promise to the client component, and a tiny `<TypeName>` client component resolves it via `use()` inside per-cell `<Suspense>` boundaries.
- The table renders immediately with `#id` placeholders and the names stream in when the API responds. The existing module-level promise cache in `typeNames.ts` still dedupes lookups, so behavior on warm caches is unchanged.

## Test plan
- [ ] Visit `/industry` with active jobs and confirm the table appears immediately, with blueprint/product cells showing `#id` then flipping to names.
- [ ] Visit `/market` with recent sales and confirm the type column behaves the same way.
- [ ] Reload after a warm cache and confirm names appear without a visible placeholder flash.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCkJhn6BqF87vcHSqPkA29)_