### PR TITLE
feat(industry, structures): show station IDs in glorious 1996 Netscape style

### DIFF
--- a/src/app/industry/activeJobs.tsx
+++ b/src/app/industry/activeJobs.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 
 import { usePersist } from '../market/usePersist'
+import retro from '../retro.module.css'
 import styles from './industry.module.css'
 
 export type Job = {
@@ -15,6 +16,8 @@ export type Job = {
   status: string
   start_date: string
   end_date: string
+  station_id: number | string | null
+  facility_id: number | string | null
 }
 
 type Character = {
@@ -68,7 +71,7 @@ export const ActiveJobs = ({ jobs, characters, initialNow, typeNames }: ActiveJo
   const characterName: Record<string, string> = Object.fromEntries(characters.map((c) => [c.id, c.name]))
 
   const [characterId, setCharacterId] = usePersist<string>(CHARACTER_STORAGE_KEY, ALL_CHARACTERS, (raw) =>
-    raw === ALL_CHARACTERS || characters.some((c) => c.id === raw) ? raw : undefined,
+    raw === ALL_CHARACTERS || characters.some((c) => c.id === raw) ? raw : undefined
   )
 
   const filtered = jobs.filter((j) => characterId === ALL_CHARACTERS || j.character_id === characterId)
@@ -98,38 +101,46 @@ export const ActiveJobs = ({ jobs, characters, initialNow, typeNames }: ActiveJo
         </div>
       </div>
       {filtered.length > 0 ? (
-        <table className={styles.jobs}>
-          <thead>
-            <tr>
-              <th>Character</th>
-              <th>Activity</th>
-              <th>Blueprint</th>
-              <th>Product</th>
-              <th>Runs</th>
-              <th>Start</th>
-              <th>End</th>
-              <th>Remaining</th>
-            </tr>
-          </thead>
-          <tbody>
-            {filtered.map((j) => (
-              <tr key={`job-${j.job_id}`}>
-                <td>{characterName[j.character_id] ?? '—'}</td>
-                <td>{ACTIVITY_NAMES[j.activity_id] ?? `#${j.activity_id}`}</td>
-                <td>{typeNames[Number(j.blueprint_type_id)] ?? `#${j.blueprint_type_id}`}</td>
-                <td>
-                  {j.product_type_id != null
-                    ? (typeNames[Number(j.product_type_id)] ?? `#${j.product_type_id}`)
-                    : '—'}
-                </td>
-                <td>{j.runs}</td>
-                <td>{formatDate(j.start_date)}</td>
-                <td>{formatDate(j.end_date)}</td>
-                <td>{formatRemaining(j.end_date, now)}</td>
+        <>
+          <table className={retro.retro} border={3} cellPadding={4} cellSpacing={2}>
+            <caption>~*~ Active Industry Jobs ~*~</caption>
+            <thead>
+              <tr>
+                <th>Character</th>
+                <th>Activity</th>
+                <th>Blueprint</th>
+                <th>Product</th>
+                <th>Runs</th>
+                <th>Station ID</th>
+                <th>Start</th>
+                <th>End</th>
+                <th>Remaining</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {filtered.map((j) => (
+                <tr key={`job-${j.job_id}`}>
+                  <td>{characterName[j.character_id] ?? '—'}</td>
+                  <td>{ACTIVITY_NAMES[j.activity_id] ?? `#${j.activity_id}`}</td>
+                  <td>{typeNames[Number(j.blueprint_type_id)] ?? `#${j.blueprint_type_id}`}</td>
+                  <td>
+                    {j.product_type_id != null
+                      ? (typeNames[Number(j.product_type_id)] ?? `#${j.product_type_id}`)
+                      : '—'}
+                  </td>
+                  <td>{j.runs}</td>
+                  <td className={retro.id}>
+                    {(j.station_id ?? j.facility_id) != null ? String(j.station_id ?? j.facility_id) : '—'}
+                  </td>
+                  <td>{formatDate(j.start_date)}</td>
+                  <td>{formatDate(j.end_date)}</td>
+                  <td>{formatRemaining(j.end_date, now)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p className={retro.bestViewedIn}>Best viewed in Netscape Navigator 3.0 at 800&times;600</p>
+        </>
       ) : (
         <p>No active industry jobs.</p>
       )}

--- a/src/app/industry/page.tsx
+++ b/src/app/industry/page.tsx
@@ -18,7 +18,7 @@ const IndustryPage = async () => {
     .schema('hangar')
     .from('industry_job')
     .select(
-      'job_id, character_id, activity_id, blueprint_type_id, product_type_id, runs, status, start_date, end_date',
+      'job_id, character_id, activity_id, blueprint_type_id, product_type_id, runs, status, start_date, end_date, station_id, facility_id'
     )
     .eq('status', 'active')
     .order('end_date', { ascending: true })
@@ -31,7 +31,7 @@ const IndustryPage = async () => {
       const ids = [Number(j.blueprint_type_id)]
       if (j.product_type_id != null) ids.push(Number(j.product_type_id))
       return ids
-    }),
+    })
   )
 
   // eslint-disable-next-line react-hooks/purity

--- a/src/app/retro.module.css
+++ b/src/app/retro.module.css
@@ -1,0 +1,60 @@
+/*
+ * Retro "HTML 3.2 / Netscape Navigator" table styling.
+ * Replicates the beveled, silver-and-navy look of a table hand-written
+ * in 1996 — back when <FONT> tags roamed the earth and every page was
+ * "Best viewed in Netscape Navigator 3.0 at 800x600".
+ */
+
+.retro {
+  font-family: 'Times New Roman', Times, serif;
+  font-size: 12pt;
+  background: #c0c0c0;
+  color: #000080;
+  border: 4px outset #c0c0c0;
+  border-spacing: 2px;
+  margin: 12pt 0;
+}
+
+.retro caption {
+  font-family: 'Comic Sans MS', 'Times New Roman', cursive, serif;
+  font-weight: bold;
+  font-size: 14pt;
+  color: #ff0000;
+  background: #ffff00;
+  border: 3px ridge #808080;
+  padding: 4pt;
+  margin-bottom: 4pt;
+}
+
+.retro th {
+  font-family: Arial, Helvetica, sans-serif;
+  background: #000080;
+  color: #ffff00;
+  border: 3px outset #c0c0c0;
+  padding: 3pt 8pt;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.retro td {
+  background: #ffffff;
+  color: #000000;
+  border: 2px inset #c0c0c0;
+  padding: 2pt 8pt;
+  text-align: left;
+}
+
+/* Station / structure IDs get the classic green terminal monospace look. */
+.id {
+  font-family: 'Courier New', Courier, monospace;
+  font-weight: bold;
+  color: #008000;
+}
+
+/* The obligatory <BLINK>-flavored "best viewed in Netscape" disclaimer. */
+.bestViewedIn {
+  font-family: 'Comic Sans MS', 'Times New Roman', cursive, serif;
+  font-size: 9pt;
+  color: #808080;
+  margin: 4pt 0 16pt;
+}

--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
+import retro from '../retro.module.css'
 
 type Structure = {
   structure_id: number
@@ -45,7 +46,7 @@ const StructuresPage = async () => {
     .schema('hangar')
     .from('corp_structure')
     .select(
-      'structure_id, corporation_id, type_id, system_id, name, state, fuel_expires, unanchors_at, services, last_seen_at',
+      'structure_id, corporation_id, type_id, system_id, name, state, fuel_expires, unanchors_at, services, last_seen_at'
     )
     .order('corporation_id', { ascending: true })
     .order('structure_id', { ascending: true })
@@ -67,38 +68,45 @@ const StructuresPage = async () => {
     <>
       <h1>Structures</h1>
       {list.length > 0 ? (
-        <table>
-          <thead>
-            <tr>
-              <th>Structure ID</th>
-              <th>Name</th>
-              <th>Corp ID</th>
-              <th>Type ID</th>
-              <th>System ID</th>
-              <th>State</th>
-              <th>Fuel Expires</th>
-              <th>Unanchors At</th>
-              <th>Services</th>
-              <th>Last Seen</th>
-            </tr>
-          </thead>
-          <tbody>
-            {list.map((s) => (
-              <tr key={`structure-${s.structure_id}`}>
-                <td>{s.structure_id}</td>
-                <td>{s.name ?? '—'}</td>
-                <td>{s.corporation_id}</td>
-                <td>{s.type_id}</td>
-                <td>{s.system_id}</td>
-                <td>{s.state ?? '—'}</td>
-                <td>{s.fuel_expires ?? '—'}</td>
-                <td>{s.unanchors_at ?? '—'}</td>
-                <td>{s.services?.map((svc) => svc.name).join(', ') ?? '—'}</td>
-                <td>{s.last_seen_at}</td>
+        <>
+          <table className={retro.retro} border={3} cellPadding={4} cellSpacing={2}>
+            <caption>~*~ Corporation Structures ~*~</caption>
+            <thead>
+              <tr>
+                <th>Structure ID</th>
+                <th>Station ID</th>
+                <th>Name</th>
+                <th>Corp ID</th>
+                <th>Type ID</th>
+                <th>System ID</th>
+                <th>State</th>
+                <th>Fuel Expires</th>
+                <th>Unanchors At</th>
+                <th>Services</th>
+                <th>Last Seen</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {list.map((s) => (
+                <tr key={`structure-${s.structure_id}`}>
+                  <td className={retro.id}>{s.structure_id}</td>
+                  {/* Upwell structures share their structure_id with the station/facility id industry jobs run at. */}
+                  <td className={retro.id}>{s.structure_id}</td>
+                  <td>{s.name ?? '—'}</td>
+                  <td>{s.corporation_id}</td>
+                  <td>{s.type_id}</td>
+                  <td>{s.system_id}</td>
+                  <td>{s.state ?? '—'}</td>
+                  <td>{s.fuel_expires ?? '—'}</td>
+                  <td>{s.unanchors_at ?? '—'}</td>
+                  <td>{s.services?.map((svc) => svc.name).join(', ') ?? '—'}</td>
+                  <td>{s.last_seen_at}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p className={retro.bestViewedIn}>Best viewed in Netscape Navigator 3.0 at 800&times;600</p>
+        </>
       ) : (
         <p>
           No structures visible. Re-link a director character on the <a href="/character">Characters</a> page so the
@@ -108,7 +116,8 @@ const StructuresPage = async () => {
 
       <h2>Corp Wallet (last 30 days)</h2>
       {journalEntries.length > 0 ? (
-        <table>
+        <table className={retro.retro} border={3} cellPadding={4} cellSpacing={2}>
+          <caption>~*~ Corp Wallet ~*~</caption>
           <thead>
             <tr>
               <th>Date</th>


### PR DESCRIPTION
## What

Surfaces the **station ID** where things are happening, then dresses the tables up like it's 1996 and you're browsing on Netscape Navigator.

### Industry page
- Added a **Station ID** column to the Active Jobs table.
- Pulls `station_id` from `industry_job`, falling back to `facility_id` for jobs running in player-owned structures (ESI leaves `station_id` null in that case, so `facility_id` is the actual place the job runs).

### Structures page
- Added a **Station ID** column. For Upwell structures the `structure_id` *is* the station/facility id (the same value industry jobs run at), so the two pages now line up.

### The 90s, baby
- New shared `src/app/retro.module.css` giving every table the beveled silver-and-navy HTML 3.2 look — `border` / `cellPadding` / `cellSpacing`, Times New Roman body text, navy headers with yellow text, Courier-green monospace IDs, a `~*~ caption ~*~`, and the obligatory "Best viewed in Netscape Navigator 3.0 at 800×600" disclaimer.
- Applied to the industry jobs, structures, and corp wallet tables.

## Notes
- Stuck to type-safe markup: real deprecated table attributes (`border`/`cellPadding`/`cellSpacing`) plus CSS for the look, avoiding `<font>`/`<marquee>`/`<center>` which aren't in the React 19 type defs.
- `npx tsc --noEmit` and `eslint` both clean on the changed files.

https://claude.ai/code/session_018QzbGxQ2G7jZj54kDvibwm

---
_Generated by [Claude Code](https://claude.ai/code/session_018QzbGxQ2G7jZj54kDvibwm)_