### PR TITLE
docs: prefer eve-build-calculator over evesde schema for new work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,4 @@
 # Architecture
 
 - Data from ESI flows into the database (typically via the hourly cron job in `src/hourly.js`). The UI then reads from the database. The UI/Next.js server components must never call ESI directly.
+- Avoid using the `evesde` schema in the database for new work — it can be out of date. Instead, query [eve-build-calculator](https://eve-build-calculator.philihp.com) (e.g. the `https://eve-build-calculator.philihp.com/api/type/${typeID}` pattern in `src/app/typeNames.ts`). It downloads the full SDE but only saves/exposes a curated subset. If the data you need isn't exposed there yet, prefer adding it to eve-build-calculator rather than reaching into the `evesde` schema.


### PR DESCRIPTION
## Summary

Adds guidance to `CLAUDE.md` steering new work away from the `evesde` database schema, which can be out of date.

The new note recommends:
- Querying [eve-build-calculator](https://eve-build-calculator.philihp.com) instead (per the `/api/type/${typeID}` pattern already used in `src/app/typeNames.ts`).
- Adding any missing data to eve-build-calculator rather than reaching into the `evesde` schema. eve-build-calculator downloads the full SDE but only saves/exposes a curated subset.

https://claude.ai/code/session_01MMcu1aV76x68jaUkx11hAx

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMcu1aV76x68jaUkx11hAx)_