### PR TITLE
feat(structures): per-structure detail page at /structures/[id]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 - Before committing to a new feature branch, check what branch it branched from and rebase onto the latest upstream of that base (typically `origin/main`) first. This avoids opening PRs that include changes already merged on the base.
 
+# Data sources
+
+- NEVER query the `evesde` SDE schema in the database. That data is out of date and must not be used for any work. Resolve type/name lookups via the external API helper in `src/app/typeNames.ts` (`fetchTypeNames`) instead. If a needed lookup has no non-SDE source, show the raw ID rather than reading the SDE.
+
 # Architecture
 
 - Data from ESI flows into the database (typically via the hourly cron job in `src/hourly.js`). The UI then reads from the database. The UI/Next.js server components must never call ESI directly.

--- a/src/app/industry/activeJobs.tsx
+++ b/src/app/industry/activeJobs.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react'
 import { usePersist } from '../market/usePersist'
 import retro from '../retro.module.css'
 import styles from './industry.module.css'
+import { ACTIVITY_NAMES, formatDate } from './jobFields'
 
 export type Job = {
   job_id: number | string
@@ -32,28 +33,8 @@ type ActiveJobsProps = {
   typeNames: Record<number, string>
 }
 
-const ACTIVITY_NAMES: Record<number, string> = {
-  1: 'Manufacturing',
-  3: 'TE Research',
-  4: 'ME Research',
-  5: 'Copying',
-  7: 'Reverse Engineering',
-  8: 'Invention',
-  9: 'Reactions',
-}
-
 const CHARACTER_STORAGE_KEY = 'industry.activeJobs.characterId'
 const ALL_CHARACTERS = ''
-
-const formatDate = (iso: string) =>
-  new Intl.DateTimeFormat('sv-SE', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  }).format(new Date(iso))
 
 const formatRemaining = (endIso: string, now: number) => {
   const ms = new Date(endIso).getTime() - now

--- a/src/app/industry/jobFields.ts
+++ b/src/app/industry/jobFields.ts
@@ -1,0 +1,19 @@
+export const ACTIVITY_NAMES: Record<number, string> = {
+  1: 'Manufacturing',
+  3: 'TE Research',
+  4: 'ME Research',
+  5: 'Copying',
+  7: 'Reverse Engineering',
+  8: 'Invention',
+  9: 'Reactions',
+}
+
+export const formatDate = (iso: string) =>
+  new Intl.DateTimeFormat('sv-SE', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(new Date(iso))

--- a/src/app/structures/[structureId]/page.tsx
+++ b/src/app/structures/[structureId]/page.tsx
@@ -1,0 +1,235 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+
+import { createClient } from '@/utils/supabase/server'
+import { ACTIVITY_NAMES, formatDate } from '../../industry/jobFields'
+import { fetchTypeNames } from '../../typeNames'
+import retro from '../../retro.module.css'
+
+type Structure = {
+  structure_id: number
+  corporation_id: number
+  type_id: number
+  system_id: number
+  profile_id: number | null
+  name: string | null
+  state: string | null
+  fuel_expires: string | null
+  unanchors_at: string | null
+  reinforce_hour: number | null
+  next_reinforce_hour: number | null
+  next_reinforce_apply: string | null
+  next_reinforce_weekday: number | null
+  services: Array<{ name: string; state: string }> | null
+  last_seen_at: string
+  updated_at: string | null
+}
+
+type Job = {
+  job_id: number | string
+  character_id: string
+  activity_id: number
+  blueprint_type_id: number | string
+  product_type_id: number | string | null
+  runs: number
+  status: string
+  start_date: string
+  end_date: string
+  station_id: number | string | null
+  facility_id: number | string | null
+}
+
+type StructureParams = {
+  params: Promise<{
+    structureId: string
+  }>
+}
+
+const show = (value: string | number | null | undefined) => (value === null || value === undefined ? '—' : value)
+
+const StructurePage = async ({ params }: StructureParams) => {
+  const { structureId } = await params
+  const supabase = await createClient()
+
+  const { data: auth, error: authError } = await supabase.auth.getUser()
+  if (authError || !auth?.user) {
+    redirect('/')
+  }
+
+  // structure ids are bigints; only digits are valid, and validating guards the .or() filter below.
+  const validId = /^\d+$/.test(structureId)
+
+  const { data: structure } = validId
+    ? await supabase
+        .schema('hangar')
+        .from('corp_structure')
+        .select(
+          'structure_id, corporation_id, type_id, system_id, profile_id, name, state, fuel_expires, unanchors_at, reinforce_hour, next_reinforce_hour, next_reinforce_apply, next_reinforce_weekday, services, last_seen_at, updated_at'
+        )
+        .eq('structure_id', structureId)
+        .maybeSingle()
+    : { data: null }
+
+  if (!structure) {
+    return (
+      <>
+        <h1>Structure not found</h1>
+        <p>
+          No structure <span className={retro.id}>{structureId}</span> is visible. It may not exist, or you may need to
+          re-link a director character on the <a href="/character">Characters</a> page. Back to{' '}
+          <Link href="/structures">Structures</Link>.
+        </p>
+      </>
+    )
+  }
+
+  const s = structure as Structure
+
+  const { data: jobsData } = await supabase
+    .schema('hangar')
+    .from('industry_job')
+    .select(
+      'job_id, character_id, activity_id, blueprint_type_id, product_type_id, runs, status, start_date, end_date, station_id, facility_id'
+    )
+    .or(`station_id.eq.${structureId},facility_id.eq.${structureId}`)
+    .order('end_date', { ascending: true })
+
+  const jobs = (jobsData ?? []) as Job[]
+
+  const { data: characters } = await supabase.schema('hangar').from('character').select('id, name')
+  const characterName: Record<string, string> = Object.fromEntries((characters ?? []).map((c) => [c.id, c.name]))
+
+  const typeNames = await fetchTypeNames([
+    Number(s.type_id),
+    ...jobs.flatMap((j) => {
+      const ids = [Number(j.blueprint_type_id)]
+      if (j.product_type_id != null) ids.push(Number(j.product_type_id))
+      return ids
+    }),
+  ])
+
+  const typeName = typeNames[Number(s.type_id)]
+
+  return (
+    <>
+      <h1>{s.name ?? `Structure #${s.structure_id}`}</h1>
+      <p>
+        <Link href="/structures">&laquo; Back to Structures</Link>
+      </p>
+
+      <table className={retro.retro} border={3} cellPadding={4} cellSpacing={2}>
+        <caption>~*~ Structure Attributes ~*~</caption>
+        <tbody>
+          <tr>
+            <th>Structure ID</th>
+            <td className={retro.id}>{s.structure_id}</td>
+          </tr>
+          <tr>
+            <th>Name</th>
+            <td>{show(s.name)}</td>
+          </tr>
+          <tr>
+            <th>Type</th>
+            <td>
+              {typeName ? `${typeName} ` : ''}
+              <span className={retro.id}>#{s.type_id}</span>
+            </td>
+          </tr>
+          <tr>
+            <th>System ID</th>
+            <td className={retro.id}>{s.system_id}</td>
+          </tr>
+          <tr>
+            <th>Corp ID</th>
+            <td className={retro.id}>{s.corporation_id}</td>
+          </tr>
+          <tr>
+            <th>Profile ID</th>
+            <td className={retro.id}>{show(s.profile_id)}</td>
+          </tr>
+          <tr>
+            <th>State</th>
+            <td>{show(s.state)}</td>
+          </tr>
+          <tr>
+            <th>Fuel Expires</th>
+            <td>{show(s.fuel_expires)}</td>
+          </tr>
+          <tr>
+            <th>Unanchors At</th>
+            <td>{show(s.unanchors_at)}</td>
+          </tr>
+          <tr>
+            <th>Reinforce Hour</th>
+            <td>{show(s.reinforce_hour)}</td>
+          </tr>
+          <tr>
+            <th>Next Reinforce Hour</th>
+            <td>{show(s.next_reinforce_hour)}</td>
+          </tr>
+          <tr>
+            <th>Next Reinforce Weekday</th>
+            <td>{show(s.next_reinforce_weekday)}</td>
+          </tr>
+          <tr>
+            <th>Next Reinforce Apply</th>
+            <td>{show(s.next_reinforce_apply)}</td>
+          </tr>
+          <tr>
+            <th>Services</th>
+            <td>{s.services?.map((svc) => `${svc.name} (${svc.state})`).join(', ') ?? '—'}</td>
+          </tr>
+          <tr>
+            <th>Last Seen</th>
+            <td>{s.last_seen_at}</td>
+          </tr>
+          <tr>
+            <th>Updated At</th>
+            <td>{show(s.updated_at)}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Industry Jobs</h2>
+      {jobs.length > 0 ? (
+        <table className={retro.retro} border={3} cellPadding={4} cellSpacing={2}>
+          <caption>~*~ Jobs Running Here ~*~</caption>
+          <thead>
+            <tr>
+              <th>Character</th>
+              <th>Activity</th>
+              <th>Blueprint</th>
+              <th>Product</th>
+              <th>Runs</th>
+              <th>Status</th>
+              <th>Start</th>
+              <th>End</th>
+            </tr>
+          </thead>
+          <tbody>
+            {jobs.map((j) => (
+              <tr key={`job-${j.job_id}`}>
+                <td>{characterName[j.character_id] ?? '—'}</td>
+                <td>{ACTIVITY_NAMES[j.activity_id] ?? `#${j.activity_id}`}</td>
+                <td>{typeNames[Number(j.blueprint_type_id)] ?? `#${j.blueprint_type_id}`}</td>
+                <td>
+                  {j.product_type_id != null ? (typeNames[Number(j.product_type_id)] ?? `#${j.product_type_id}`) : '—'}
+                </td>
+                <td>{j.runs}</td>
+                <td>{j.status}</td>
+                <td>{formatDate(j.start_date)}</td>
+                <td>{formatDate(j.end_date)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p>No industry jobs known at this structure.</p>
+      )}
+
+      <p className={retro.bestViewedIn}>Best viewed in Netscape Navigator 3.0 at 800&times;600</p>
+    </>
+  )
+}
+
+export default StructurePage

--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -89,7 +89,9 @@ const StructuresPage = async () => {
             <tbody>
               {list.map((s) => (
                 <tr key={`structure-${s.structure_id}`}>
-                  <td className={retro.id}>{s.structure_id}</td>
+                  <td className={retro.id}>
+                    <a href={`/structures/${s.structure_id}`}>{s.structure_id}</a>
+                  </td>
                   {/* Upwell structures share their structure_id with the station/facility id industry jobs run at. */}
                   <td className={retro.id}>{s.structure_id}</td>
                   <td>{s.name ?? '—'}</td>


### PR DESCRIPTION
## What

Each Structure ID in the structures list now links to its own detail page at `/structures/<structureId>`. The detail page shows everything we know about that structure plus all the industry jobs running in it.

### Structure list (`src/app/structures/page.tsx`)
- The Structure ID cell is now a link to `/structures/<id>`.

### New detail page (`src/app/structures/[structureId]/page.tsx`)
- Async server component, same Next 16 `params`-as-Promise pattern as `blueprint/[typeID]`, and the same auth-redirect guard as the list page.
- **Attributes table** — every known `hangar.corp_structure` column: name, type, system, corp, profile, state, fuel/unanchor timers, all four reinforce fields, services (name + state), last seen, updated at.
- **Industry jobs table** — every job we know of running at the structure, matched on `station_id` OR `facility_id` equal to the `structure_id` (an Upwell structure's id is the facility/station id jobs store). Shows all statuses with a Status column.
- Both tables use the existing retro Netscape styling. Missing/invisible structures (incl. non-numeric ids) get a friendly not-found message instead of crashing.

### Refactor
- Extracted `ACTIVITY_NAMES` and `formatDate` out of the `'use client'` `activeJobs.tsx` into a new plain module `src/app/industry/jobFields.ts` so the server detail page can reuse them.

## Data-source constraints
- **No `evesde` SDE database queries.** Type and blueprint/product names are resolved via the existing `fetchTypeNames` helper, which hits an external HTTP API (not the SDE). System is shown as a raw id (no non-SDE name source). Character names come from `hangar.character`.
- Documented in `CLAUDE.md` that the `evesde` schema in the database must never be queried (it's out of date).

## Verification
- `npx tsc --noEmit` clean.
- `npx eslint src/app/structures src/app/industry` clean (no new warnings).
- Prettier-formatted; pre-commit husky lint passed.

https://claude.ai/code/session_018QzbGxQ2G7jZj54kDvibwm

---
_Generated by [Claude Code](https://claude.ai/code/session_018QzbGxQ2G7jZj54kDvibwm)_