### PR TITLE
style(retro): remove colors and bevels, use default text

### DIFF
--- a/src/app/industry/activeJobs.tsx
+++ b/src/app/industry/activeJobs.tsx
@@ -110,9 +110,7 @@ export const ActiveJobs = ({ jobs, characters, initialNow, typeNames }: ActiveJo
                       : '—'}
                   </td>
                   <td>{j.runs}</td>
-                  <td className={retro.id}>
-                    {(j.station_id ?? j.facility_id) != null ? String(j.station_id ?? j.facility_id) : '—'}
-                  </td>
+                  <td>{(j.station_id ?? j.facility_id) != null ? String(j.station_id ?? j.facility_id) : '—'}</td>
                   <td>{formatDate(j.start_date)}</td>
                   <td>{formatDate(j.end_date)}</td>
                   <td>{formatRemaining(j.end_date, now)}</td>

--- a/src/app/retro.module.css
+++ b/src/app/retro.module.css
@@ -1,37 +1,30 @@
 /*
- * Subtle retro table styling — beveled borders reminiscent of an old
- * HTML table, but with default text and no loud color fills.
+ * Plain table styling — thin solid borders, default text, no colors.
  */
 
 .retro {
-  border: 2px outset #c0c0c0;
+  border: 2px solid;
   border-spacing: 2px;
   margin: 12pt 0;
 }
 
 .retro caption {
-  font-weight: bold;
-  border: 1.5px ridge #808080;
+  border: 1.5px solid;
   padding: 4pt;
   margin-bottom: 4pt;
 }
 
 .retro th {
-  border: 1.5px outset #c0c0c0;
+  border: 1.5px solid;
   padding: 3pt 8pt;
   text-align: left;
   white-space: nowrap;
 }
 
 .retro td {
-  border: 1px inset #c0c0c0;
+  border: 1px solid;
   padding: 2pt 8pt;
   text-align: left;
-}
-
-/* IDs keep a bolder weight to stand out. */
-.id {
-  font-weight: bold;
 }
 
 .bestViewedIn {

--- a/src/app/structures/[structureId]/page.tsx
+++ b/src/app/structures/[structureId]/page.tsx
@@ -75,9 +75,8 @@ const StructurePage = async ({ params }: StructureParams) => {
       <>
         <h1>Structure not found</h1>
         <p>
-          No structure <span className={retro.id}>{structureId}</span> is visible. It may not exist, or you may need to
-          re-link a director character on the <a href="/character">Characters</a> page. Back to{' '}
-          <Link href="/structures">Structures</Link>.
+          No structure {structureId} is visible. It may not exist, or you may need to re-link a director character on
+          the <a href="/character">Characters</a> page. Back to <Link href="/structures">Structures</Link>.
         </p>
       </>
     )
@@ -122,7 +121,7 @@ const StructurePage = async ({ params }: StructureParams) => {
         <tbody>
           <tr>
             <th>Structure ID</th>
-            <td className={retro.id}>{s.structure_id}</td>
+            <td>{s.structure_id}</td>
           </tr>
           <tr>
             <th>Name</th>
@@ -131,21 +130,20 @@ const StructurePage = async ({ params }: StructureParams) => {
           <tr>
             <th>Type</th>
             <td>
-              {typeName ? `${typeName} ` : ''}
-              <span className={retro.id}>#{s.type_id}</span>
+              {typeName ? `${typeName} ` : ''}#{s.type_id}
             </td>
           </tr>
           <tr>
             <th>System ID</th>
-            <td className={retro.id}>{s.system_id}</td>
+            <td>{s.system_id}</td>
           </tr>
           <tr>
             <th>Corp ID</th>
-            <td className={retro.id}>{s.corporation_id}</td>
+            <td>{s.corporation_id}</td>
           </tr>
           <tr>
             <th>Profile ID</th>
-            <td className={retro.id}>{show(s.profile_id)}</td>
+            <td>{show(s.profile_id)}</td>
           </tr>
           <tr>
             <th>State</th>

--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -89,11 +89,11 @@ const StructuresPage = async () => {
             <tbody>
               {list.map((s) => (
                 <tr key={`structure-${s.structure_id}`}>
-                  <td className={retro.id}>
+                  <td>
                     <a href={`/structures/${s.structure_id}`}>{s.structure_id}</a>
                   </td>
                   {/* Upwell structures share their structure_id with the station/facility id industry jobs run at. */}
-                  <td className={retro.id}>{s.structure_id}</td>
+                  <td>{s.structure_id}</td>
                   <td>{s.name ?? '—'}</td>
                   <td>{s.corporation_id}</td>
                   <td>{s.type_id}</td>


### PR DESCRIPTION
## What

Strips the remaining retro flourishes from `src/app/retro.module.css` so the tables use plain, default styling:

- **All colors removed** — dropped every `color` / border-color declaration. Borders now use `currentColor`.
- **Default text** — removed the `font-weight: bold` overrides so text renders with default styling. (`<th>` cells stay bold via the browser default, as expected.)
- **No bevels** — replaced the `outset` / `inset` / `ridge` border styles with plain `solid` borders (widths unchanged: 2px / 1.5px / 1px).
- **Cleanup** — the `.id` class held only the bold weight, so it's now removed along with its `className={retro.id}` usages across the industry and structures pages (the purpose-only `<span>` wrappers were unwrapped too).

Layout, spacing, alignment, and the table structure are unchanged.

## Verification
- `npx tsc --noEmit` clean.
- `npx eslint src/app/structures src/app/industry` clean (only pre-existing unrelated warnings).
- Prettier-formatted; pre-commit husky lint passed.
- Confirmed no `retro.id` references remain; the `retro` import stays in use for `.retro` and `.bestViewedIn`.

https://claude.ai/code/session_018QzbGxQ2G7jZj54kDvibwm

---
_Generated by [Claude Code](https://claude.ai/code/session_018QzbGxQ2G7jZj54kDvibwm)_