### PR TITLE
style(retro): beveled grey borders, zero padding, drop captions

### DIFF
--- a/src/app/industry/activeJobs.tsx
+++ b/src/app/industry/activeJobs.tsx
@@ -83,8 +83,7 @@ export const ActiveJobs = ({ jobs, characters, initialNow, typeNames }: ActiveJo
       </div>
       {filtered.length > 0 ? (
         <>
-          <table className={retro.retro} border={3} cellPadding={4} cellSpacing={2}>
-            <caption>~*~ Active Industry Jobs ~*~</caption>
+          <table className={retro.retro} border={3} cellPadding={0} cellSpacing={2}>
             <thead>
               <tr>
                 <th>Character</th>

--- a/src/app/retro.module.css
+++ b/src/app/retro.module.css
@@ -1,29 +1,23 @@
 /*
- * Plain table styling — thin solid borders, default text, no colors.
+ * Plain table styling — beveled grey borders, no cell padding.
  */
 
 .retro {
-  border: 2px solid;
+  border: 2px outset #808080;
   border-spacing: 2px;
   margin: 12pt 0;
 }
 
-.retro caption {
-  border: 1.5px solid;
-  padding: 4pt;
-  margin-bottom: 4pt;
-}
-
 .retro th {
-  border: 1.5px solid;
-  padding: 3pt 8pt;
+  border: 1px solid #808080;
+  padding: 0;
   text-align: left;
   white-space: nowrap;
 }
 
 .retro td {
-  border: 1px solid;
-  padding: 2pt 8pt;
+  border: 1px inset #808080;
+  padding: 0;
   text-align: left;
 }
 

--- a/src/app/retro.module.css
+++ b/src/app/retro.module.css
@@ -3,7 +3,7 @@
  */
 
 .retro {
-  border: 2px outset #808080;
+  border: 1px outset #808080;
   border-spacing: 2px;
   margin: 12pt 0;
 }

--- a/src/app/structures/[structureId]/page.tsx
+++ b/src/app/structures/[structureId]/page.tsx
@@ -116,8 +116,7 @@ const StructurePage = async ({ params }: StructureParams) => {
         <Link href="/structures">&laquo; Back to Structures</Link>
       </p>
 
-      <table className={retro.retro} border={3} cellPadding={4} cellSpacing={2}>
-        <caption>~*~ Structure Attributes ~*~</caption>
+      <table className={retro.retro} border={3} cellPadding={0} cellSpacing={2}>
         <tbody>
           <tr>
             <th>Structure ID</th>
@@ -190,8 +189,7 @@ const StructurePage = async ({ params }: StructureParams) => {
 
       <h2>Industry Jobs</h2>
       {jobs.length > 0 ? (
-        <table className={retro.retro} border={3} cellPadding={4} cellSpacing={2}>
-          <caption>~*~ Jobs Running Here ~*~</caption>
+        <table className={retro.retro} border={3} cellPadding={0} cellSpacing={2}>
           <thead>
             <tr>
               <th>Character</th>

--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -69,8 +69,7 @@ const StructuresPage = async () => {
       <h1>Structures</h1>
       {list.length > 0 ? (
         <>
-          <table className={retro.retro} border={3} cellPadding={4} cellSpacing={2}>
-            <caption>~*~ Corporation Structures ~*~</caption>
+          <table className={retro.retro} border={3} cellPadding={0} cellSpacing={2}>
             <thead>
               <tr>
                 <th>Structure ID</th>
@@ -118,8 +117,7 @@ const StructuresPage = async () => {
 
       <h2>Corp Wallet (last 30 days)</h2>
       {journalEntries.length > 0 ? (
-        <table className={retro.retro} border={3} cellPadding={4} cellSpacing={2}>
-          <caption>~*~ Corp Wallet ~*~</caption>
+        <table className={retro.retro} border={3} cellPadding={0} cellSpacing={2}>
           <thead>
             <tr>
               <th>Date</th>


### PR DESCRIPTION
## What

Adjusts the table styling in `src/app/retro.module.css` (and the table markup) per request:

- **Zero cell padding** — set `padding: 0` on `th`/`td` and changed each table's `cellPadding={4}` attribute to `cellPadding={0}`.
- **Outset table border** — the `.retro` table border is now `2px outset` in a neutral grey (`#808080`).
- **Inset TD borders** — each `td` border is now `1px inset` in the same neutral grey.
- **Removed `~*~` captions** — dropped the `<caption>~*~ … ~*~</caption>` headers from all five tables (industry jobs, structures list, corp wallet, structure attributes, structure jobs).

The `<th>` borders were also set to the same neutral grey (kept solid) so the palette stays consistent. Section `<h1>`/`<h2>` headings are untouched.

## Verification
- `npx tsc --noEmit` clean.
- `npx eslint src/app/structures src/app/industry` clean (only pre-existing unrelated warnings).
- Prettier-formatted; pre-commit husky lint passed.
- Confirmed no `<caption>` elements remain and all `cellPadding` attributes are `0`.

https://claude.ai/code/session_018QzbGxQ2G7jZj54kDvibwm

---
_Generated by [Claude Code](https://claude.ai/code/session_018QzbGxQ2G7jZj54kDvibwm)_