### PR TITLE
feat: generic DateTime component, standardized dates, swap cell padding/spacing

### DIFF
--- a/src/app/DateTime.tsx
+++ b/src/app/DateTime.tsx
@@ -1,0 +1,21 @@
+// Standard date/time rendering for the whole app: YYYY-MM-DD HH:MM, 24-hour.
+const formatter = new Intl.DateTimeFormat('sv-SE', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+})
+
+type DateTimeProps = {
+  value: string | number | Date | null | undefined
+  fallback?: string
+}
+
+export const DateTime = ({ value, fallback = '—' }: DateTimeProps) => {
+  if (value === null || value === undefined || value === '') return <>{fallback}</>
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) return <>{fallback}</>
+  return <time dateTime={date.toISOString()}>{formatter.format(date)}</time>
+}

--- a/src/app/industry/activeJobs.tsx
+++ b/src/app/industry/activeJobs.tsx
@@ -2,10 +2,11 @@
 
 import { useEffect, useState } from 'react'
 
+import { DateTime } from '../DateTime'
 import { usePersist } from '../market/usePersist'
 import retro from '../retro.module.css'
 import styles from './industry.module.css'
-import { ACTIVITY_NAMES, formatDate } from './jobFields'
+import { ACTIVITY_NAMES } from './jobFields'
 
 export type Job = {
   job_id: number | string
@@ -83,7 +84,7 @@ export const ActiveJobs = ({ jobs, characters, initialNow, typeNames }: ActiveJo
       </div>
       {filtered.length > 0 ? (
         <>
-          <table className={retro.retro} border={3} cellPadding={0} cellSpacing={2}>
+          <table className={retro.retro} border={3} cellPadding={2} cellSpacing={0}>
             <thead>
               <tr>
                 <th>Character</th>
@@ -110,8 +111,12 @@ export const ActiveJobs = ({ jobs, characters, initialNow, typeNames }: ActiveJo
                   </td>
                   <td>{j.runs}</td>
                   <td>{(j.station_id ?? j.facility_id) != null ? String(j.station_id ?? j.facility_id) : '—'}</td>
-                  <td>{formatDate(j.start_date)}</td>
-                  <td>{formatDate(j.end_date)}</td>
+                  <td>
+                    <DateTime value={j.start_date} />
+                  </td>
+                  <td>
+                    <DateTime value={j.end_date} />
+                  </td>
                   <td>{formatRemaining(j.end_date, now)}</td>
                 </tr>
               ))}

--- a/src/app/industry/jobFields.ts
+++ b/src/app/industry/jobFields.ts
@@ -7,13 +7,3 @@ export const ACTIVITY_NAMES: Record<number, string> = {
   8: 'Invention',
   9: 'Reactions',
 }
-
-export const formatDate = (iso: string) =>
-  new Intl.DateTimeFormat('sv-SE', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  }).format(new Date(iso))

--- a/src/app/market/recentSales.tsx
+++ b/src/app/market/recentSales.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { DateTime } from '../DateTime'
 import styles from './market.module.css'
 import { usePersist } from './usePersist'
 
@@ -55,17 +56,6 @@ const IskPrice = ({ raw }: { raw: string | number }) => {
   )
 }
 
-const formatDate = (iso: string) =>
-  new Intl.DateTimeFormat('sv-SE', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    hour12: false,
-  }).format(new Date(iso))
-
 export const RecentSales = ({ sales, characters, typeNames }: RecentSalesProps) => {
   const characterName: Record<string, string> = Object.fromEntries(characters.map((c) => [c.id, c.name]))
 
@@ -75,13 +65,13 @@ export const RecentSales = ({ sales, characters, typeNames }: RecentSalesProps) 
   })
 
   const [characterId, setCharacterId] = usePersist<string>(CHARACTER_STORAGE_KEY, ALL_CHARACTERS, (raw) =>
-    raw === ALL_CHARACTERS || characters.some((c) => c.id === raw) ? raw : undefined,
+    raw === ALL_CHARACTERS || characters.some((c) => c.id === raw) ? raw : undefined
   )
 
   const filtered = sales.filter(
     (s) =>
       Number(s.unit_price) * Number(s.quantity) >= threshold &&
-      (characterId === ALL_CHARACTERS || s.character_id === characterId),
+      (characterId === ALL_CHARACTERS || s.character_id === characterId)
   )
 
   return (
@@ -137,8 +127,12 @@ export const RecentSales = ({ sales, characters, typeNames }: RecentSalesProps) 
                 <td>
                   <IskPrice raw={Number(s.unit_price) * Number(s.quantity)} />
                 </td>
-                <td>{formatDate(s.date)}</td>
-                <td>{formatDate(s.seen_at)}</td>
+                <td>
+                  <DateTime value={s.date} />
+                </td>
+                <td>
+                  <DateTime value={s.seen_at} />
+                </td>
               </tr>
             ))}
           </tbody>

--- a/src/app/retro.module.css
+++ b/src/app/retro.module.css
@@ -1,23 +1,23 @@
 /*
- * Plain table styling — beveled grey borders, no cell padding.
+ * Plain table styling — beveled grey borders, padded cells, no spacing.
  */
 
 .retro {
   border: 1px outset #808080;
-  border-spacing: 2px;
+  border-spacing: 0;
   margin: 12pt 0;
 }
 
 .retro th {
   border: 1px solid #808080;
-  padding: 0;
+  padding: 2px;
   text-align: left;
   white-space: nowrap;
 }
 
 .retro td {
   border: 1px inset #808080;
-  padding: 0;
+  padding: 2px;
   text-align: left;
 }
 

--- a/src/app/structures/[structureId]/page.tsx
+++ b/src/app/structures/[structureId]/page.tsx
@@ -2,7 +2,8 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
-import { ACTIVITY_NAMES, formatDate } from '../../industry/jobFields'
+import { DateTime } from '../../DateTime'
+import { ACTIVITY_NAMES } from '../../industry/jobFields'
 import { fetchTypeNames } from '../../typeNames'
 import retro from '../../retro.module.css'
 
@@ -116,7 +117,7 @@ const StructurePage = async ({ params }: StructureParams) => {
         <Link href="/structures">&laquo; Back to Structures</Link>
       </p>
 
-      <table className={retro.retro} border={3} cellPadding={0} cellSpacing={2}>
+      <table className={retro.retro} border={3} cellPadding={2} cellSpacing={0}>
         <tbody>
           <tr>
             <th>Structure ID</th>
@@ -150,11 +151,15 @@ const StructurePage = async ({ params }: StructureParams) => {
           </tr>
           <tr>
             <th>Fuel Expires</th>
-            <td>{show(s.fuel_expires)}</td>
+            <td>
+              <DateTime value={s.fuel_expires} />
+            </td>
           </tr>
           <tr>
             <th>Unanchors At</th>
-            <td>{show(s.unanchors_at)}</td>
+            <td>
+              <DateTime value={s.unanchors_at} />
+            </td>
           </tr>
           <tr>
             <th>Reinforce Hour</th>
@@ -170,7 +175,9 @@ const StructurePage = async ({ params }: StructureParams) => {
           </tr>
           <tr>
             <th>Next Reinforce Apply</th>
-            <td>{show(s.next_reinforce_apply)}</td>
+            <td>
+              <DateTime value={s.next_reinforce_apply} />
+            </td>
           </tr>
           <tr>
             <th>Services</th>
@@ -178,18 +185,22 @@ const StructurePage = async ({ params }: StructureParams) => {
           </tr>
           <tr>
             <th>Last Seen</th>
-            <td>{s.last_seen_at}</td>
+            <td>
+              <DateTime value={s.last_seen_at} />
+            </td>
           </tr>
           <tr>
             <th>Updated At</th>
-            <td>{show(s.updated_at)}</td>
+            <td>
+              <DateTime value={s.updated_at} />
+            </td>
           </tr>
         </tbody>
       </table>
 
       <h2>Industry Jobs</h2>
       {jobs.length > 0 ? (
-        <table className={retro.retro} border={3} cellPadding={0} cellSpacing={2}>
+        <table className={retro.retro} border={3} cellPadding={2} cellSpacing={0}>
           <thead>
             <tr>
               <th>Character</th>
@@ -213,8 +224,12 @@ const StructurePage = async ({ params }: StructureParams) => {
                 </td>
                 <td>{j.runs}</td>
                 <td>{j.status}</td>
-                <td>{formatDate(j.start_date)}</td>
-                <td>{formatDate(j.end_date)}</td>
+                <td>
+                  <DateTime value={j.start_date} />
+                </td>
+                <td>
+                  <DateTime value={j.end_date} />
+                </td>
               </tr>
             ))}
           </tbody>

--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
+import { DateTime } from '../DateTime'
 import retro from '../retro.module.css'
 
 type Structure = {
@@ -69,7 +70,7 @@ const StructuresPage = async () => {
       <h1>Structures</h1>
       {list.length > 0 ? (
         <>
-          <table className={retro.retro} border={3} cellPadding={0} cellSpacing={2}>
+          <table className={retro.retro} border={3} cellPadding={2} cellSpacing={0}>
             <thead>
               <tr>
                 <th>Structure ID</th>
@@ -98,10 +99,16 @@ const StructuresPage = async () => {
                   <td>{s.type_id}</td>
                   <td>{s.system_id}</td>
                   <td>{s.state ?? '—'}</td>
-                  <td>{s.fuel_expires ?? '—'}</td>
-                  <td>{s.unanchors_at ?? '—'}</td>
+                  <td>
+                    <DateTime value={s.fuel_expires} />
+                  </td>
+                  <td>
+                    <DateTime value={s.unanchors_at} />
+                  </td>
                   <td>{s.services?.map((svc) => svc.name).join(', ') ?? '—'}</td>
-                  <td>{s.last_seen_at}</td>
+                  <td>
+                    <DateTime value={s.last_seen_at} />
+                  </td>
                 </tr>
               ))}
             </tbody>
@@ -117,7 +124,7 @@ const StructuresPage = async () => {
 
       <h2>Corp Wallet (last 30 days)</h2>
       {journalEntries.length > 0 ? (
-        <table className={retro.retro} border={3} cellPadding={0} cellSpacing={2}>
+        <table className={retro.retro} border={3} cellPadding={2} cellSpacing={0}>
           <thead>
             <tr>
               <th>Date</th>
@@ -132,7 +139,9 @@ const StructuresPage = async () => {
           <tbody>
             {journalEntries.map((e) => (
               <tr key={`journal-${e.corporation_id}-${e.division}-${e.entry_id}`}>
-                <td>{e.date}</td>
+                <td>
+                  <DateTime value={e.date} />
+                </td>
                 <td>{e.corporation_id}</td>
                 <td>{e.division}</td>
                 <td>{e.ref_type}</td>


### PR DESCRIPTION
## What

Two changes:

### 1. Generic `<DateTime>` component + standardized date format
- New `src/app/DateTime.tsx` renders dates as **`YYYY-MM-DD HH:MM` (24-hour)** in a semantic `<time>` element, with a `—` fallback for null/invalid values.
- Replaced every ad-hoc date render with it:
  - **Industry** active jobs (start/end) — was a local `formatDate`.
  - **Structure detail** — fuel expires, unanchors at, next reinforce apply, last seen, updated at, and job start/end.
  - **Structures list** — fuel expires, unanchors at, last seen.
  - **Corp wallet** — entry date.
  - **Recent market sales** — sold/seen (this formatter previously included seconds; now standardized to minute precision).
- Removed the now-duplicate `formatDate` helpers from `industry/jobFields.ts` and `market/recentSales.tsx`.

### 2. Swap cell padding / spacing on the retro tables
- Cell padding `0 → 2px`, cell spacing (`border-spacing`) `2px → 0`, and the matching `cellPadding`/`cellSpacing` table attributes swapped on all five tables.

## Verification
- `npx tsc --noEmit` clean.
- `npx eslint` clean on all changed files (only pre-existing unrelated warnings remain).
- Prettier-formatted; pre-commit husky lint passed.

https://claude.ai/code/session_018QzbGxQ2G7jZj54kDvibwm

---
_Generated by [Claude Code](https://claude.ai/code/session_018QzbGxQ2G7jZj54kDvibwm)_