### PR TITLE
feat(structures): tax revenue per structure, unaccounted + clone revenue; drop detail Name row

### DIFF
--- a/src/app/structures/[structureId]/page.tsx
+++ b/src/app/structures/[structureId]/page.tsx
@@ -124,10 +124,6 @@ const StructurePage = async ({ params }: StructureParams) => {
             <td>{s.structure_id}</td>
           </tr>
           <tr>
-            <th>Name</th>
-            <td>{show(s.name)}</td>
-          </tr>
-          <tr>
             <th>Type</th>
             <td>
               {typeName ? `${typeName} ` : ''}#{s.type_id}

--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -17,10 +17,15 @@ type Structure = {
   last_seen_at: string
 }
 
-type Transaction = {
-  location_id: number | string
-  unit_price: number | string
-  quantity: number | string
+type JobRow = {
+  job_id: number | string
+  station_id: number | string | null
+  facility_id: number | string | null
+}
+
+type JournalRow = {
+  amount: number | string | null
+  description: string | null
 }
 
 const formatIsk = (raw: string | number | null) => {
@@ -48,22 +53,38 @@ const StructuresPage = async () => {
 
   const list = (structures ?? []) as Structure[]
 
-  // Total up every transaction's amount (unit price × quantity) per structure it happened at.
-  // structure_id / location_id are bigints, which PostgREST may return as strings; key the map by
-  // string on both sides so the lookup doesn't silently miss (and totals don't all read as zero).
+  // Total the corp wallet activity per structure. Each industry-tax journal entry references a job
+  // by id in its description; outer-join those job ids to the industry_job table to find the
+  // structure (station_id, falling back to facility_id) the job is installed in, then sum amounts.
+  // Bigint ids can come back from PostgREST as strings, so key every map by string.
   const structureIds = list.map((s) => Number(s.structure_id))
-  const { data: transactions } = structureIds.length
+  const { data: jobs } = structureIds.length
     ? await supabase
         .schema('hangar')
-        .from('market_transaction')
-        .select('location_id, unit_price, quantity')
-        .in('location_id', structureIds)
+        .from('industry_job')
+        .select('job_id, station_id, facility_id')
+        .or(`station_id.in.(${structureIds.join(',')}),facility_id.in.(${structureIds.join(',')})`)
     : { data: [] }
 
+  const structureByJob = new Map<string, string>()
+  for (const j of (jobs ?? []) as JobRow[]) {
+    const structureId = j.station_id ?? j.facility_id
+    if (structureId != null) structureByJob.set(String(j.job_id), String(structureId))
+  }
+
+  const { data: journal } = await supabase.schema('hangar').from('corp_wallet_journal').select('amount, description')
+
   const totalByStructure = new Map<string, number>()
-  for (const t of (transactions ?? []) as Transaction[]) {
-    const id = String(t.location_id)
-    totalByStructure.set(id, (totalByStructure.get(id) ?? 0) + Number(t.unit_price) * Number(t.quantity))
+  for (const entry of (journal ?? []) as JournalRow[]) {
+    if (!entry.description) continue
+    // The job id is interpolated into the description; find the token that joins to a known job.
+    for (const token of entry.description.match(/\d+/g) ?? []) {
+      const structureId = structureByJob.get(token)
+      if (structureId) {
+        totalByStructure.set(structureId, (totalByStructure.get(structureId) ?? 0) + Number(entry.amount ?? 0))
+        break
+      }
+    }
   }
 
   return (

--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -96,12 +96,12 @@ const StructuresPage = async () => {
     }
   }
 
-  // Revenue from structure clone bays (jump clone installation fees).
+  // Revenue from structure clone bays (jump clone installation and activation fees).
   const { data: cloneJournal } = await supabase
     .schema('hangar')
     .from('corp_wallet_journal')
     .select('amount')
-    .eq('ref_type', 'jump_clone_installation_fee')
+    .in('ref_type', ['jump_clone_installation_fee', 'jump_clone_activation_fee'])
 
   const cloneRevenue = ((cloneJournal ?? []) as Array<{ amount: number | string | null }>).reduce(
     (sum, entry) => sum + Number(entry.amount ?? 0),

--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -49,7 +49,9 @@ const StructuresPage = async () => {
   const list = (structures ?? []) as Structure[]
 
   // Total up every transaction's amount (unit price × quantity) per structure it happened at.
-  const structureIds = list.map((s) => s.structure_id)
+  // structure_id / location_id are bigints, which PostgREST may return as strings; key the map by
+  // string on both sides so the lookup doesn't silently miss (and totals don't all read as zero).
+  const structureIds = list.map((s) => Number(s.structure_id))
   const { data: transactions } = structureIds.length
     ? await supabase
         .schema('hangar')
@@ -58,9 +60,9 @@ const StructuresPage = async () => {
         .in('location_id', structureIds)
     : { data: [] }
 
-  const totalByStructure = new Map<number, number>()
+  const totalByStructure = new Map<string, number>()
   for (const t of (transactions ?? []) as Transaction[]) {
-    const id = Number(t.location_id)
+    const id = String(t.location_id)
     totalByStructure.set(id, (totalByStructure.get(id) ?? 0) + Number(t.unit_price) * Number(t.quantity))
   }
 
@@ -95,7 +97,7 @@ const StructuresPage = async () => {
                   {/* Upwell structures share their structure_id with the station/facility id industry jobs run at. */}
                   <td>{s.structure_id}</td>
                   <td>{s.name ?? '—'}</td>
-                  <td>{formatIsk(totalByStructure.get(s.structure_id) ?? 0)}</td>
+                  <td>{formatIsk(totalByStructure.get(String(s.structure_id)) ?? 0)}</td>
                   <td>{s.corporation_id}</td>
                   <td>{s.type_id}</td>
                   <td>{s.system_id}</td>

--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -96,6 +96,18 @@ const StructuresPage = async () => {
     }
   }
 
+  // Revenue from structure clone bays (jump clone install/activation fees etc.).
+  const { data: cloneJournal } = await supabase
+    .schema('hangar')
+    .from('corp_wallet_journal')
+    .select('amount')
+    .ilike('ref_type', '%clone%')
+
+  const cloneRevenue = ((cloneJournal ?? []) as Array<{ amount: number | string | null }>).reduce(
+    (sum, entry) => sum + Number(entry.amount ?? 0),
+    0
+  )
+
   return (
     <>
       <h1>Structures</h1>
@@ -147,6 +159,7 @@ const StructuresPage = async () => {
             </tbody>
           </table>
           <p>Unaccounted tax revenue: {formatIsk(unaccounted)} ISK</p>
+          <p>Clone revenue: {formatIsk(cloneRevenue)} ISK</p>
           <p className={retro.bestViewedIn}>Best viewed in Netscape Navigator 3.0 at 800&times;600</p>
         </>
       ) : (

--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -53,9 +53,9 @@ const StructuresPage = async () => {
 
   const list = (structures ?? []) as Structure[]
 
-  // Total the corp wallet activity per structure. Each industry-tax journal entry references a job
-  // by id in its description; outer-join those job ids to the industry_job table to find the
-  // structure (station_id, falling back to facility_id) the job is installed in, then sum amounts.
+  // Tax revenue each structure generates. Each industry-tax journal entry references a job by id in
+  // its description; outer-join those job ids to the industry_job table to find the structure
+  // (station_id, falling back to facility_id) the job is installed in, then sum the journal amounts.
   // Bigint ids can come back from PostgREST as strings, so key every map by string.
   const structureIds = list.map((s) => Number(s.structure_id))
   const { data: jobs } = structureIds.length
@@ -98,7 +98,7 @@ const StructuresPage = async () => {
                 <th>Structure ID</th>
                 <th>Station ID</th>
                 <th>Name</th>
-                <th>Transactions Total</th>
+                <th>Tax Revenue</th>
                 <th>Corp ID</th>
                 <th>Type ID</th>
                 <th>System ID</th>

--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -96,12 +96,12 @@ const StructuresPage = async () => {
     }
   }
 
-  // Revenue from structure clone bays (jump clone install/activation fees etc.).
+  // Revenue from structure clone bays (jump clone installation fees).
   const { data: cloneJournal } = await supabase
     .schema('hangar')
     .from('corp_wallet_journal')
     .select('amount')
-    .ilike('ref_type', '%clone%')
+    .eq('ref_type', 'jump_clone_installation_fee')
 
   const cloneRevenue = ((cloneJournal ?? []) as Array<{ amount: number | string | null }>).reduce(
     (sum, entry) => sum + Number(entry.amount ?? 0),

--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -72,18 +72,27 @@ const StructuresPage = async () => {
     if (structureId != null) structureByJob.set(String(j.job_id), String(structureId))
   }
 
-  const { data: journal } = await supabase.schema('hangar').from('corp_wallet_journal').select('amount, description')
+  const { data: journal } = await supabase
+    .schema('hangar')
+    .from('corp_wallet_journal')
+    .select('amount, description')
+    .eq('ref_type', 'industry_job_tax')
 
   const totalByStructure = new Map<string, number>()
+  let unaccounted = 0
   for (const entry of (journal ?? []) as JournalRow[]) {
-    if (!entry.description) continue
+    const amount = Number(entry.amount ?? 0)
     // The job id is interpolated into the description; find the token that joins to a known job.
-    for (const token of entry.description.match(/\d+/g) ?? []) {
-      const structureId = structureByJob.get(token)
-      if (structureId) {
-        totalByStructure.set(structureId, (totalByStructure.get(structureId) ?? 0) + Number(entry.amount ?? 0))
-        break
-      }
+    let structureId: string | undefined
+    for (const token of entry.description?.match(/\d+/g) ?? []) {
+      structureId = structureByJob.get(token)
+      if (structureId) break
+    }
+    if (structureId) {
+      totalByStructure.set(structureId, (totalByStructure.get(structureId) ?? 0) + amount)
+    } else {
+      // Tax we received but can't tie to one of our structures (e.g. jobs not in our table).
+      unaccounted += amount
     }
   }
 
@@ -137,6 +146,7 @@ const StructuresPage = async () => {
               ))}
             </tbody>
           </table>
+          <p>Unaccounted tax revenue: {formatIsk(unaccounted)} ISK</p>
           <p className={retro.bestViewedIn}>Best viewed in Netscape Navigator 3.0 at 800&times;600</p>
         </>
       ) : (


### PR DESCRIPTION
## What

Structures page revenue reporting, sourced from the corp wallet journal.

### Tax Revenue per structure
- Filter `corp_wallet_journal` to `ref_type = 'industry_job_tax'`.
- Extract the **job id** interpolated in each entry's `description` and **outer-join** it to `industry_job` to find the structure the job is installed in (`station_id`, falling back to `facility_id`).
- Sum the journal `amount`s per structure → **Tax Revenue** column.

### Unaccounted tax revenue
- Industry tax we received but can't tie to a known structure (e.g. jobs not in our table / outside pilots) is totaled and shown below the table.

### Clone revenue
- Sum corp wallet entries with clone-related ref types (`%clone%`, e.g. jump clone install/activation fees) and show the total below the table.

### Structure detail: drop redundant Name row
- Removed the **Name** attribute row from the structure detail page — it's already the `<h1>` title.

## Notes
- Bigint ids are compared as strings (PostgREST may return them as strings).
- `industry_job` rows are upserted and never deleted, so completed jobs remain joinable.
- Totals sum raw journal amounts; industry tax / clone fees are positive income in the structure owner's corp wallet.

## Verification
- `npx tsc --noEmit` clean.
- `npx eslint src/app/structures` clean (only pre-existing unrelated warnings).
- Prettier-formatted; pre-commit husky lint passed.

https://claude.ai/code/session_018QzbGxQ2G7jZj54kDvibwm