### PR TITLE
Show rigs installed in each structure

### DIFF
--- a/hangar.sql
+++ b/hangar.sql
@@ -285,6 +285,47 @@ create policy "Users read structures for own corps"
 grant select on hangar.corp_structure to authenticated;
 grant all    on hangar.corp_structure to service_role;
 
+-- Rigs (and other fitted modules) installed in Upwell structures. ESI has no
+-- dedicated structure-fitting endpoint; these come from the corporation assets
+-- endpoint as items whose location_id is the structure_id and whose
+-- location_flag is a RigSlot (RigSlot0..RigSlot7).
+create table if not exists hangar.corp_structure_rig (
+  structure_id bigint not null,
+  location_flag text not null,
+  type_id bigint not null,
+  corporation_id bigint not null,
+  updated_at timestamptz not null default now(),
+  primary key (structure_id, location_flag)
+);
+create index if not exists corp_structure_rig_corporation_id_idx
+  on hangar.corp_structure_rig (corporation_id);
+
+alter table hangar.corp_structure_rig enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'hangar'
+      and tablename = 'corp_structure_rig'
+      and policyname = 'Users read structure rigs for own corps'
+  ) then
+    create policy "Users read structure rigs for own corps"
+      on hangar.corp_structure_rig
+      for select
+      to authenticated
+      using (
+        corporation_id in (
+          select corporation_id from hangar.character
+          where user_id = (select auth.uid()) and corporation_id is not null
+        )
+      );
+  end if;
+end $$;
+
+grant select on hangar.corp_structure_rig to authenticated;
+grant all    on hangar.corp_structure_rig to service_role;
+
 create table if not exists hangar.corp_wallet_journal (
   corporation_id bigint not null,
   division smallint not null,

--- a/src/app/character/sso.ts
+++ b/src/app/character/sso.ts
@@ -12,6 +12,7 @@ export const scopes = [
   'esi-markets.read_character_orders.v1',
   'esi-corporations.read_structures.v1',
   'esi-wallet.read_corporation_wallets.v1',
+  'esi-assets.read_corporation_assets.v1',
   // 'esi-characters.read_blueprints.v1',
 ]
 

--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation'
 import { createClient } from '@/utils/supabase/server'
 import { DateTime } from '../DateTime'
 import retro from '../retro.module.css'
+import { fetchTypeNames } from '../typeNames'
 
 type Structure = {
   structure_id: number
@@ -26,6 +27,12 @@ type JobRow = {
 type JournalRow = {
   amount: number | string | null
   description: string | null
+}
+
+type RigRow = {
+  structure_id: number | string
+  location_flag: string
+  type_id: number | string
 }
 
 const formatIsk = (raw: string | number | null) => {
@@ -70,6 +77,27 @@ const StructuresPage = async () => {
   for (const j of (jobs ?? []) as JobRow[]) {
     const structureId = j.station_id ?? j.facility_id
     if (structureId != null) structureByJob.set(String(j.job_id), String(structureId))
+  }
+
+  // Rigs fitted to each structure (pulled from corp assets by the structures job).
+  const { data: rigRows } = structureIds.length
+    ? await supabase
+        .schema('hangar')
+        .from('corp_structure_rig')
+        .select('structure_id, location_flag, type_id')
+        .in('structure_id', structureIds)
+        .order('location_flag', { ascending: true })
+    : { data: [] }
+
+  const rigList = (rigRows ?? []) as RigRow[]
+  const rigTypeNames = await fetchTypeNames(rigList.map((r) => Number(r.type_id)))
+  const rigsByStructure = new Map<string, string[]>()
+  for (const r of rigList) {
+    const key = String(r.structure_id)
+    const name = rigTypeNames[Number(r.type_id)] ?? String(r.type_id)
+    const existing = rigsByStructure.get(key)
+    if (existing) existing.push(name)
+    else rigsByStructure.set(key, [name])
   }
 
   const { data: journal } = await supabase
@@ -127,6 +155,7 @@ const StructuresPage = async () => {
                 <th>Fuel Expires</th>
                 <th>Unanchors At</th>
                 <th>Services</th>
+                <th>Rigs</th>
                 <th>Last Seen</th>
               </tr>
             </thead>
@@ -151,6 +180,7 @@ const StructuresPage = async () => {
                     <DateTime value={s.unanchors_at} />
                   </td>
                   <td>{s.services?.map((svc) => svc.name).join(', ') ?? '—'}</td>
+                  <td>{rigsByStructure.get(String(s.structure_id))?.join(', ') ?? '—'}</td>
                   <td>
                     <DateTime value={s.last_seen_at} />
                   </td>

--- a/src/esi.js
+++ b/src/esi.js
@@ -67,6 +67,13 @@ export const corpStructures = (access_token, corporationID, page = 1) =>
     label: `corpStructures ${corporationID} page=${page}`,
   })
 
+export const corpAssets = (access_token, corporationID, page = 1) =>
+  esiPaged(`/corporations/${corporationID}/assets/`, {
+    access_token,
+    params: { page },
+    label: `corpAssets ${corporationID} page=${page}`,
+  })
+
 export const corpWalletJournal = (access_token, corporationID, division, page = 1) =>
   esiPaged(`/corporations/${corporationID}/wallets/${division}/journal/`, {
     access_token,

--- a/src/structures.js
+++ b/src/structures.js
@@ -1,6 +1,6 @@
 import SingleSignOn from 'eve-sso'
 import { pullCorpWalletJournals } from './corpWalletJournal.js'
-import { character as fetchCharacter, corpStructures, corpWalletJournal, userAgent } from './esi.js'
+import { character as fetchCharacter, corpAssets, corpStructures, corpWalletJournal, userAgent } from './esi.js'
 import { sudoSupabase } from './supabase.js'
 
 const EVE_CLIENT_ID = process.env.EVE_CLIENT_ID
@@ -9,6 +9,11 @@ const EVE_CALLBACK_URL = process.env.EVE_CALLBACK_URL
 
 const STRUCTURES_SCOPE = 'esi-corporations.read_structures.v1'
 const WALLET_SCOPE = 'esi-wallet.read_corporation_wallets.v1'
+const ASSETS_SCOPE = 'esi-assets.read_corporation_assets.v1'
+
+// Items fitted to an Upwell structure show up in corp assets with location_id
+// equal to the structure_id and a RigSlotN location_flag.
+const isRigSlot = (flag) => typeof flag === 'string' && flag.startsWith('RigSlot')
 
 const sso = new SingleSignOn(EVE_CLIENT_ID, EVE_SECRET_KEY, EVE_CALLBACK_URL, userAgent)
 
@@ -49,6 +54,7 @@ const execute = async () => {
 
   const seenStructureCorps = new Set()
   const seenWalletCorps = new Set()
+  const seenAssetCorps = new Set()
   for (const tokenRow of tokens ?? []) {
     const t0 = Date.now()
     const ctx = `character=${tokenRow.character_id} token=${tokenRow.id}`
@@ -149,6 +155,73 @@ const execute = async () => {
 
         const dt = Date.now() - t0
         console.log(`[structures] ${ctx}: done corp ${corporation_id} ${rows.length} fetched in ${dt}ms`)
+      }
+
+      if (!scope.includes(ASSETS_SCOPE)) {
+        console.log(`[structures] ${ctx}: corp ${corporation_id} token lacks ${ASSETS_SCOPE}, skipping structure rigs`)
+      } else if (seenAssetCorps.has(corporation_id)) {
+        console.log(`[structures] ${ctx}: corp ${corporation_id} assets already pulled this run, skipping rigs`)
+      } else {
+        seenAssetCorps.add(corporation_id)
+        try {
+          // Our structures double as asset location_ids; only keep rigs fitted to them.
+          const { data: ownStructures, error: ownErr } = await sudoSupabase
+            .schema('hangar')
+            .from('corp_structure')
+            .select('structure_id')
+            .eq('corporation_id', corporation_id)
+          if (ownErr) throw ownErr
+          const structureIds = new Set((ownStructures ?? []).map((s) => Number(s.structure_id)))
+
+          const ta = Date.now()
+          const assets = []
+          console.log(`[structures] ${ctx}: fetching corp ${corporation_id} assets page 1`)
+          const [firstAssetPage, assetPagesHeader] = await corpAssets(access_token, corporation_id, 1)
+          assets.push(...firstAssetPage)
+          const assetPages = Math.max(1, Number.parseInt(assetPagesHeader, 10) || 1)
+          for (let page = 2; page <= assetPages; page++) {
+            const [more] = await corpAssets(access_token, corporation_id, page)
+            assets.push(...more)
+          }
+          console.log(
+            `[structures] ${ctx}: corp ${corporation_id} returned ${assets.length} asset(s) across ${assetPages} page(s)`
+          )
+
+          const now = new Date().toISOString()
+          const rigRows = assets
+            .filter((a) => isRigSlot(a.location_flag) && structureIds.has(Number(a.location_id)))
+            .map((a) => ({
+              structure_id: a.location_id,
+              location_flag: a.location_flag,
+              type_id: a.type_id,
+              corporation_id,
+              updated_at: now,
+            }))
+
+          // Replace this corp's rig rows wholesale so removed/swapped rigs don't linger.
+          if (structureIds.size > 0) {
+            const { error: delErr } = await sudoSupabase
+              .schema('hangar')
+              .from('corp_structure_rig')
+              .delete()
+              .eq('corporation_id', corporation_id)
+            if (delErr) throw delErr
+          }
+          if (rigRows.length > 0) {
+            const { error: rigErr } = await sudoSupabase
+              .schema('hangar')
+              .from('corp_structure_rig')
+              .upsert(rigRows, { onConflict: 'structure_id,location_flag' })
+            if (rigErr) throw rigErr
+          }
+          console.log(
+            `[structures] ${ctx}: corp ${corporation_id} stored ${rigRows.length} structure rig(s) in ${Date.now() - ta}ms`
+          )
+        } catch (e) {
+          console.error(
+            `[structures] ${ctx}: corp ${corporation_id} rig pull FAILED name=${e?.name} message=${e?.message}`
+          )
+        }
       }
 
       if (!scope.includes(WALLET_SCOPE)) {


### PR DESCRIPTION
## What

Adds a **Rigs** column to the structures list showing the rigs fitted to each Upwell structure.

## How ESI exposes structure rigs

ESI has **no** dedicated structure-fitting endpoint. `/corporations/{id}/structures/` returns fuel/state/services but not rigs. Instead, items fitted to a structure appear in the **corporation assets** endpoint as ordinary assets where:

- `location_id` = the `structure_id`
- `location_flag` = `RigSlot0` … `RigSlot7`
- `type_id` = the rig type

So this fetches corp assets and filters to `RigSlot*` items whose `location_id` matches a known structure.

## Changes

- **`src/esi.js`** — new `corpAssets` paged helper for `/corporations/{id}/assets/`.
- **`src/app/character/sso.ts`** — request `esi-assets.read_corporation_assets.v1` (new scope; **users must re-link a director character** to grant it). Requires the Director role, same as the structures read.
- **`hangar.sql`** — new `hangar.corp_structure_rig` table (`structure_id`, `location_flag`, `type_id`, `corporation_id`), RLS-scoped to corps the user belongs to, mirroring `corp_structure`.
- **`src/structures.js`** — after pulling structures, fetch corp assets (paged), keep `RigSlot*` items landing on our structures, and replace each corp's rig rows wholesale so swapped/removed rigs don't linger. Skipped gracefully if the token lacks the assets scope.
- **`src/app/structures/page.tsx`** — new **Rigs** column; rig `type_id`s resolved to names via `fetchTypeNames` (build-calculator API, not the SDE).

## Notes

- `hangar.sql` adds a table + RLS policy — needs to be applied to the database.
- Type names resolve through the external API per `CLAUDE.md`; raw type ids are shown as a fallback.

https://claude.ai/code/session_01CG6XMW3UbS4GMSpaKSL5fq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CG6XMW3UbS4GMSpaKSL5fq)_