### PR TITLE
Claude Code inspired look and feel

### DIFF
--- a/src/app/character/character.module.css
+++ b/src/app/character/character.module.css
@@ -10,10 +10,15 @@
 .tile {
   display: flex;
   gap: 10pt;
-  padding: 10pt;
-  border: 1px solid #ccc;
-  border-radius: 6pt;
-  background: #fafafa;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper-raised);
+  transition: border-color 0.12s ease;
+}
+
+.tile:hover {
+  border-color: var(--clay);
 }
 
 .avatar {
@@ -21,8 +26,8 @@
   height: 64px;
   flex-shrink: 0;
   border-radius: 50%;
-  background: #ddd;
-  border: 1px solid #bbb;
+  background: var(--line-soft);
+  border: 1px solid var(--line);
 }
 
 .body {
@@ -43,13 +48,13 @@
 
 .meta {
   font-size: 9pt;
-  color: #666;
+  color: var(--ink-soft);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .metaLabel {
-  color: #999;
+  color: var(--ink-faint);
   margin-right: 4pt;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,10 +1,83 @@
+/*
+ * Claude Code inspired theme.
+ *
+ * Warm Anthropic palette (cream paper + clay/coral accent) paired with a
+ * monospace, terminal-flavored type system. Light by default, with a dark
+ * "terminal" variant when the OS prefers dark mode.
+ */
+
+:root {
+  /* Anthropic warm neutrals */
+  --paper: #f0eee6;
+  --paper-raised: #faf9f5;
+  --ink: #1f1e1d;
+  --ink-soft: #53514c;
+  --ink-faint: #8a877e;
+  --line: #ddd9cc;
+  --line-soft: #e8e5da;
+
+  /* Claude clay / coral accent */
+  --clay: #d97757;
+  --clay-strong: #c45c3a;
+  --clay-tint: #f6e9e2;
+
+  --radius: 10px;
+  --radius-sm: 7px;
+
+  --mono:
+    'SF Mono', 'JetBrains Mono', 'Fira Code', 'Cascadia Code', ui-monospace,
+    'Menlo', 'Consolas', monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --paper: #1a1815;
+    --paper-raised: #24211d;
+    --ink: #f0eee6;
+    --ink-soft: #c4bfb3;
+    --ink-faint: #8a877e;
+    --line: #38342d;
+    --line-soft: #2d2a24;
+    --clay: #e08a6c;
+    --clay-strong: #d97757;
+    --clay-tint: #2e241f;
+  }
+}
+
 html,
 body {
   text-rendering: geometricPrecision;
 }
 
+body {
+  margin: 0;
+  padding: 0 16px 48px;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 14px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
 * {
   box-sizing: border-box;
+}
+
+/* Page content sits in a centered "prompt" column. */
+body > header,
+body > hr,
+body > main,
+body > div,
+body > form,
+body > section {
+  max-width: 980px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+main {
+  padding-top: 4px;
 }
 
 img {
@@ -12,7 +85,131 @@ img {
   display: block;
 }
 
+a {
+  color: var(--clay-strong);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--clay);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+h1,
+h2,
+h3 {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.25;
+}
+
+h1 {
+  font-size: 22px;
+}
+
+h2 {
+  font-size: 17px;
+}
+
+code,
+pre,
+kbd {
+  font-family: var(--mono);
+}
+
+/* Terminal-style top bar. */
+header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  padding: 14px 18px;
+  margin-top: 20px;
+  background: var(--paper-raised);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  font-size: 13px;
+  color: var(--ink-soft);
+}
+
+header a {
+  color: var(--ink-soft);
+}
+
+header a:hover {
+  color: var(--clay);
+}
+
+/* The leading "✻ EVE Hangar" mark, set apart from the nav. */
+header::before {
+  content: '✻';
+  color: var(--clay);
+  margin-right: 8px;
+  font-size: 15px;
+}
+
+/* The <hr/> between header and content reads as a faint divider. */
+hr {
+  border: none;
+  border-top: 1px solid var(--line-soft);
+  margin: 18px auto;
+}
+
+/* Buttons styled like a focused prompt action. */
 button {
-  margin: 5pt 0;
-  padding: 5pt 10pt;
+  margin: 6px 0;
+  padding: 7px 14px;
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--paper-raised);
+  background: var(--clay);
+  border: 1px solid var(--clay-strong);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition:
+    background 0.12s ease,
+    transform 0.04s ease;
+}
+
+button:hover {
+  background: var(--clay-strong);
+}
+
+button:active {
+  transform: translateY(1px);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Inputs read like terminal fields. */
+input,
+select,
+textarea {
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--ink);
+  background: var(--paper-raised);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 6px 10px;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--clay);
+  box-shadow: 0 0 0 2px var(--clay-tint);
+}
+
+label {
+  color: var(--ink-soft);
+}
+
+::selection {
+  background: var(--clay-tint);
 }

--- a/src/app/home.module.css
+++ b/src/app/home.module.css
@@ -1,0 +1,61 @@
+.wrap {
+  margin: 24px auto;
+}
+
+.welcome {
+  border: 1px solid var(--clay);
+  border-radius: var(--radius);
+  background: var(--paper-raised);
+  padding: 18px 20px;
+  max-width: 620px;
+}
+
+.title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.spark {
+  color: var(--clay);
+  margin-right: 8px;
+}
+
+.tip {
+  margin: 12px 0 0;
+  color: var(--ink-soft);
+  font-size: 13px;
+}
+
+.prompt {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 22px auto 0;
+  max-width: 620px;
+  padding: 12px 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper-raised);
+  color: var(--ink-faint);
+}
+
+.caret {
+  color: var(--clay);
+  font-weight: 600;
+}
+
+.hints {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 18px;
+  margin: 14px auto 0;
+  max-width: 620px;
+  color: var(--ink-faint);
+  font-size: 12px;
+}
+
+.hints a {
+  color: var(--ink-soft);
+}

--- a/src/app/industry/industry.module.css
+++ b/src/app/industry/industry.module.css
@@ -18,7 +18,7 @@
 
 .jobsFilter {
   font-size: 10pt;
-  color: #555;
+  color: var(--ink-soft);
 }
 
 .jobs {
@@ -30,14 +30,15 @@
 
 .jobs th,
 .jobs td {
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--line-soft);
   padding: 6pt 8pt;
   text-align: left;
 }
 
 .jobs th {
-  background: #fafafa;
-  font-weight: bold;
+  background: var(--paper-raised);
+  color: var(--ink-soft);
+  font-weight: 600;
 }
 
 .jobs td:nth-child(5),

--- a/src/app/layout/header.module.css
+++ b/src/app/layout/header.module.css
@@ -1,0 +1,31 @@
+.brand {
+  font-weight: 600;
+  color: var(--ink) !important;
+  margin-right: auto;
+  letter-spacing: -0.01em;
+}
+
+.brand:hover {
+  color: var(--clay) !important;
+  text-decoration: none;
+}
+
+.nav {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.user {
+  color: var(--ink-faint);
+  margin-right: 4px;
+}
+
+.bracket {
+  color: var(--ink-faint);
+}
+
+.sep {
+  color: var(--line);
+}

--- a/src/app/layout/header.tsx
+++ b/src/app/layout/header.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { createClient } from '@/utils/supabase/server'
+import styles from './header.module.css'
 
 const Header = async () => {
   const supabase = await createClient()
@@ -10,31 +11,33 @@ const Header = async () => {
   const userId = user?.email ?? undefined
   return (
     <header>
-      EVE Hangar
+      <Link href="/" className={styles.brand}>
+        EVE Hangar
+      </Link>
       {!userId && (
-        <>
-          &nbsp;[&nbsp;
-          <Link href="/account/login">Login</Link>
-          &nbsp;|&nbsp;
-          <Link href="/account/register">Register</Link>
-          &nbsp;]
-        </>
+        <nav className={styles.nav}>
+          <span className={styles.bracket}>[</span>
+          <Link href="/account/login">login</Link>
+          <span className={styles.sep}>|</span>
+          <Link href="/account/register">register</Link>
+          <span className={styles.bracket}>]</span>
+        </nav>
       )}
       {userId && (
-        <>
-          &nbsp;[&nbsp;
-          {userId}
-          &nbsp;|&nbsp;
-          <Link href="/character/">Characters</Link>
-          &nbsp;|&nbsp;
-          <Link href="/market">Market</Link>
-          &nbsp;|&nbsp;
-          <Link href="/industry">Industry</Link>
-          &nbsp;|&nbsp;
-          <Link href="/structures">Structures</Link>
-          &nbsp;|&nbsp;
-          <Link href="/account/settings">Settings</Link> ]
-        </>
+        <nav className={styles.nav}>
+          <span className={styles.user}>{userId}</span>
+          <span className={styles.bracket}>[</span>
+          <Link href="/character/">characters</Link>
+          <span className={styles.sep}>|</span>
+          <Link href="/market">market</Link>
+          <span className={styles.sep}>|</span>
+          <Link href="/industry">industry</Link>
+          <span className={styles.sep}>|</span>
+          <Link href="/structures">structures</Link>
+          <span className={styles.sep}>|</span>
+          <Link href="/account/settings">settings</Link>
+          <span className={styles.bracket}>]</span>
+        </nav>
       )}
     </header>
   )

--- a/src/app/market/market.module.css
+++ b/src/app/market/market.module.css
@@ -18,7 +18,7 @@
 
 .salesFilter {
   font-size: 10pt;
-  color: #555;
+  color: var(--ink-soft);
 }
 
 .sales {
@@ -30,14 +30,15 @@
 
 .sales th,
 .sales td {
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--line-soft);
   padding: 6pt 8pt;
   text-align: left;
 }
 
 .sales th {
-  background: #fafafa;
-  font-weight: bold;
+  background: var(--paper-raised);
+  color: var(--ink-soft);
+  font-weight: 600;
 }
 
 .sales td:nth-child(3),

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,32 @@
+import Link from 'next/link'
+import styles from './home.module.css'
+
 export default function Home() {
-  return <main />
+  return (
+    <main className={styles.wrap}>
+      <section className={styles.welcome}>
+        <p className={styles.title}>
+          <span className={styles.spark}>✻</span>
+          Welcome to EVE Hangar
+        </p>
+        <p className={styles.tip}>
+          Your market, industry, and structure data — tracked from ESI and
+          ready to read.
+        </p>
+      </section>
+
+      <div className={styles.prompt}>
+        <span className={styles.caret}>&gt;</span>
+        <span>where to next?</span>
+      </div>
+
+      <nav className={styles.hints}>
+        <Link href="/character/">/characters</Link>
+        <Link href="/market">/market</Link>
+        <Link href="/industry">/industry</Link>
+        <Link href="/structures">/structures</Link>
+        <Link href="/account/settings">/settings</Link>
+      </nav>
+    </main>
+  )
 }

--- a/src/app/retro.module.css
+++ b/src/app/retro.module.css
@@ -1,27 +1,39 @@
 /*
- * Plain table styling — beveled grey borders, padded cells, no spacing.
+ * Plain data table — soft warm borders that match the Claude Code theme.
  */
 
 .retro {
-  border: 1px outset #808080;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
   border-spacing: 0;
-  margin: 12pt 0;
+  border-collapse: separate;
+  overflow: hidden;
+  margin: 16px 0;
+  font-size: 13px;
 }
 
 .retro th {
-  border: 1px outset #808080;
-  background: #efefef;
-  padding: 2px;
+  border-bottom: 1px solid var(--line);
+  background: var(--paper-raised);
+  color: var(--ink-soft);
+  font-weight: 600;
+  padding: 6px 10px;
   text-align: left;
   white-space: nowrap;
 }
 
 .retro td {
-  border: 1px inset #808080;
-  padding: 2px;
+  border-bottom: 1px solid var(--line-soft);
+  padding: 6px 10px;
   text-align: left;
+}
+
+.retro tr:last-child td {
+  border-bottom: none;
 }
 
 .bestViewedIn {
   margin: 4pt 0 16pt;
+  color: var(--ink-faint);
+  font-size: 12px;
 }


### PR DESCRIPTION
## Summary

Reskins the app to evoke the **Claude Code** aesthetic — Anthropic's warm cream "paper" palette, the signature clay/coral accent, and a monospace, terminal-flavored type system.

### What changed
- **`globals.css`** — Full theme rebuild: CSS custom properties for the warm neutral + clay/coral palette, monospace font stack, styled links/buttons/inputs, a centered "prompt column" layout, and an automatic **dark terminal variant** via `prefers-color-scheme`.
- **Header** (`header.tsx` + new `header.module.css`) — Becomes a terminal-style top bar: a `✻` sparkle mark, bold `EVE Hangar` brand, and bracketed lowercase nav (`[ market | industry | ... ]`).
- **Home page** (`page.tsx` + new `home.module.css`) — Replaces the blank `<main />` with the iconic Claude Code-style welcome box, a `>` prompt line, and slash-style nav hints.
- **Tables** (`retro`, `market`, `industry`) — Soft warm borders, raised header rows, rounded corners, all driven by the shared theme variables.
- **Character tiles** — Warm card styling with a coral hover border.

### Verification
- `tsc --noEmit` — clean
- `eslint` — no new warnings (only pre-existing ones)
- `next build` — succeeds, all 17 routes generate

Both light and dark color schemes are supported automatically.

https://claude.ai/code/session_01W96GdhJJZzpqeYjDyHQVae

---
_Generated by [Claude Code](https://claude.ai/code/session_01W96GdhJJZzpqeYjDyHQVae)_