### PR TITLE
Link industry job tax to job via wallet journal context_id

### DIFF
--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -26,6 +26,7 @@ type JobRow = {
 
 type JournalRow = {
   amount: number | string | null
+  context_id: number | string | null
   description: string | null
 }
 
@@ -60,10 +61,11 @@ const StructuresPage = async () => {
 
   const list = (structures ?? []) as Structure[]
 
-  // Tax revenue each structure generates. Each industry-tax journal entry references a job by id in
-  // its description; outer-join those job ids to the industry_job table to find the structure
-  // (station_id, falling back to facility_id) the job is installed in, then sum the journal amounts.
-  // Bigint ids can come back from PostgREST as strings, so key every map by string.
+  // Tax revenue each structure generates. Each industry-tax journal entry references its job via
+  // context_id (context_id_type = industry_job_id); outer-join those job ids to the industry_job
+  // table to find the structure (station_id, falling back to facility_id) the job is installed in,
+  // then sum the journal amounts. Bigint ids can come back from PostgREST as strings, so key every
+  // map by string.
   const structureIds = list.map((s) => Number(s.structure_id))
   const { data: jobs } = structureIds.length
     ? await supabase
@@ -103,18 +105,21 @@ const StructuresPage = async () => {
   const { data: journal } = await supabase
     .schema('hangar')
     .from('corp_wallet_journal')
-    .select('amount, description')
+    .select('amount, context_id, description')
     .eq('ref_type', 'industry_job_tax')
 
   const totalByStructure = new Map<string, number>()
   let unaccounted = 0
   for (const entry of (journal ?? []) as JournalRow[]) {
     const amount = Number(entry.amount ?? 0)
-    // The job id is interpolated into the description; find the token that joins to a known job.
-    let structureId: string | undefined
-    for (const token of entry.description?.match(/\d+/g) ?? []) {
-      structureId = structureByJob.get(token)
-      if (structureId) break
+    // The job id is the entry's context_id; fall back to parsing it out of the description for older
+    // entries (or any ref_type variants) where ESI didn't populate context_id.
+    let structureId = entry.context_id != null ? structureByJob.get(String(entry.context_id)) : undefined
+    if (!structureId) {
+      for (const token of entry.description?.match(/\d+/g) ?? []) {
+        structureId = structureByJob.get(token)
+        if (structureId) break
+      }
     }
     if (structureId) {
       totalByStructure.set(structureId, (totalByStructure.get(structureId) ?? 0) + amount)


### PR DESCRIPTION
## Summary

The structures page sums per-structure industry tax revenue by tying each `industry_job_tax` wallet-journal entry to a job, then mapping that job to the structure it ran in. Previously it guessed the job id by regex-scanning every number in the entry's free-text `description` and checking each against the `industry_job` table — brittle against ISK amounts/dates/IDs colliding in the string and against any CCP wording change.

ESI already provides the job id directly: for `ref_type = industry_job_tax`, `context_id` is the industry job id (`context_id_type = industry_job_id`). We already ingest and store `context_id`/`context_id_type` in `corp_wallet_journal` (see `src/corpWalletJournal.js`), so this is a **read-side change only** — no schema change, no backfill.

## Changes

- `src/app/structures/page.tsx`: select `context_id` and look the job up by `context_id` directly.
- Falls back to the previous description-regex parsing only when `context_id` is null, covering older rows or any entries where ESI didn't populate it.

## Verification

I could not run `tsc`/`eslint` in the dev container — `node_modules` is not installed there, so both failed on missing dependencies (e.g. `@types/node`, `@supabase/ssr`, `@eslint/js`), not on this change. The change is type-safe by inspection: it adds `context_id` to the `JournalRow` type and reads it with a null guard. CI / the Vercel build will exercise the real checks.

## Note

I also couldn't query the live `corp_wallet_journal` table from the dev environment, so I kept the description regex as a fallback rather than removing it outright. Once you've confirmed `context_id` is populated on (nearly) all `industry_job_tax` rows, e.g.:

```sql
select context_id_type, count(*), count(context_id) as with_ctx
from hangar.corp_wallet_journal
where ref_type = 'industry_job_tax'
group by 1;
```

the fallback can be dropped for a clean `context_id`-only implementation.

https://claude.ai/code/session_0193qV8RsQyKhmLJNnciLaTt