### PR TITLE
Refine Claude look: sans text, cleaner tables, tax revenue in millions

### DIFF
--- a/src/app/character/character.module.css
+++ b/src/app/character/character.module.css
@@ -39,6 +39,7 @@
 }
 
 .name {
+  font-family: var(--serif);
   font-weight: bold;
   font-size: 11pt;
   overflow: hidden;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,11 +1,11 @@
 /*
  * Claude Code inspired theme.
  *
- * Warm Anthropic palette (cream paper + clay/coral accent). Reading text is
- * set in a Claude-style serif (Tiempos/Copernicus, with a free serif
- * fallback); the monospace face is reserved for code and numeric data, and a
- * sans is used for interactive controls. Light by default, with a dark variant
- * for prefers-color-scheme.
+ * Warm Anthropic palette (cream paper + clay/coral accent). Following the
+ * claude.ai convention: a sans for static UI (labels, chrome, headers), a
+ * Claude-style serif (Tiempos/Copernicus, with a free serif fallback) for the
+ * dynamic text specific to a thing (names, titles), and a monospace face for
+ * code and numeric data. Light by default, dark via prefers-color-scheme.
  */
 
 :root {
@@ -67,8 +67,8 @@ body {
   padding: 0 16px 48px;
   background: var(--paper);
   color: var(--ink);
-  font-family: var(--serif);
-  font-size: 15px;
+  font-family: var(--sans);
+  font-size: 14px;
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
 }
@@ -123,6 +123,11 @@ h1 {
 
 h2 {
   font-size: 17px;
+}
+
+/* Serif for dynamic, item-specific text — a thing's name or title. */
+.serif {
+  font-family: var(--serif);
 }
 
 code,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,9 +1,11 @@
 /*
  * Claude Code inspired theme.
  *
- * Warm Anthropic palette (cream paper + clay/coral accent) with a clean
- * proportional sans for text and a monospace face reserved for code and
- * numeric data. Light by default, with a dark variant for prefers-color-scheme.
+ * Warm Anthropic palette (cream paper + clay/coral accent). Reading text is
+ * set in a Claude-style serif (Tiempos/Copernicus, with a free serif
+ * fallback); the monospace face is reserved for code and numeric data, and a
+ * sans is used for interactive controls. Light by default, with a dark variant
+ * for prefers-color-scheme.
  */
 
 :root {
@@ -24,7 +26,12 @@
   --radius: 10px;
   --radius-sm: 7px;
 
-  /* Proportional sans for text. */
+  /* Claude reading serif — Tiempos/Copernicus with a free serif fallback. */
+  --serif:
+    'Tiempos Text', Tiempos, Copernicus, ui-serif, Charter, 'Iowan Old Style',
+    Georgia, Cambria, 'Times New Roman', serif;
+
+  /* Proportional sans for interactive controls. */
   --sans:
     ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
     Helvetica, Arial, sans-serif;
@@ -60,8 +67,8 @@ body {
   padding: 0 16px 48px;
   background: var(--paper);
   color: var(--ink);
-  font-family: var(--sans);
-  font-size: 14px;
+  font-family: var(--serif);
+  font-size: 15px;
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
 }
@@ -135,6 +142,7 @@ header {
   background: var(--paper-raised);
   border: 1px solid var(--line);
   border-radius: var(--radius);
+  font-family: var(--sans);
   font-size: 13px;
   color: var(--ink-soft);
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,9 +1,9 @@
 /*
  * Claude Code inspired theme.
  *
- * Warm Anthropic palette (cream paper + clay/coral accent) paired with a
- * monospace, terminal-flavored type system. Light by default, with a dark
- * "terminal" variant when the OS prefers dark mode.
+ * Warm Anthropic palette (cream paper + clay/coral accent) with a clean
+ * proportional sans for text and a monospace face reserved for code and
+ * numeric data. Light by default, with a dark variant for prefers-color-scheme.
  */
 
 :root {
@@ -24,6 +24,12 @@
   --radius: 10px;
   --radius-sm: 7px;
 
+  /* Proportional sans for text. */
+  --sans:
+    ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    Helvetica, Arial, sans-serif;
+
+  /* Fixed-width face — reserved for code and numbers. */
   --mono:
     'SF Mono', 'JetBrains Mono', 'Fira Code', 'Cascadia Code', ui-monospace,
     'Menlo', 'Consolas', monospace;
@@ -54,7 +60,7 @@ body {
   padding: 0 16px 48px;
   background: var(--paper);
   color: var(--ink);
-  font-family: var(--mono);
+  font-family: var(--sans);
   font-size: 14px;
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
@@ -160,7 +166,7 @@ hr {
 button {
   margin: 6px 0;
   padding: 7px 14px;
-  font-family: var(--mono);
+  font-family: var(--sans);
   font-size: 13px;
   color: var(--paper-raised);
   background: var(--clay);
@@ -189,7 +195,7 @@ button:disabled {
 input,
 select,
 textarea {
-  font-family: var(--mono);
+  font-family: var(--sans);
   font-size: 13px;
   color: var(--ink);
   background: var(--paper-raised);

--- a/src/app/industry/activeJobs.tsx
+++ b/src/app/industry/activeJobs.tsx
@@ -84,15 +84,15 @@ export const ActiveJobs = ({ jobs, characters, initialNow, typeNames }: ActiveJo
       </div>
       {filtered.length > 0 ? (
         <>
-          <table className={retro.retro} border={3} cellPadding={2} cellSpacing={0}>
+          <table className={retro.retro}>
             <thead>
               <tr>
                 <th>Character</th>
                 <th>Activity</th>
                 <th>Blueprint</th>
                 <th>Product</th>
-                <th>Runs</th>
-                <th>Station ID</th>
+                <th className={retro.num}>Runs</th>
+                <th className={retro.num}>Station ID</th>
                 <th>Start</th>
                 <th>End</th>
                 <th>Remaining</th>
@@ -109,8 +109,10 @@ export const ActiveJobs = ({ jobs, characters, initialNow, typeNames }: ActiveJo
                       ? (typeNames[Number(j.product_type_id)] ?? `#${j.product_type_id}`)
                       : '—'}
                   </td>
-                  <td>{j.runs}</td>
-                  <td>{(j.station_id ?? j.facility_id) != null ? String(j.station_id ?? j.facility_id) : '—'}</td>
+                  <td className={retro.num}>{j.runs}</td>
+                  <td className={retro.num}>
+                    {(j.station_id ?? j.facility_id) != null ? String(j.station_id ?? j.facility_id) : '—'}
+                  </td>
                   <td>
                     <DateTime value={j.start_date} />
                   </td>

--- a/src/app/industry/activeJobs.tsx
+++ b/src/app/industry/activeJobs.tsx
@@ -101,10 +101,10 @@ export const ActiveJobs = ({ jobs, characters, initialNow, typeNames }: ActiveJo
             <tbody>
               {filtered.map((j) => (
                 <tr key={`job-${j.job_id}`}>
-                  <td>{characterName[j.character_id] ?? '—'}</td>
+                  <td className="serif">{characterName[j.character_id] ?? '—'}</td>
                   <td>{ACTIVITY_NAMES[j.activity_id] ?? `#${j.activity_id}`}</td>
-                  <td>{typeNames[Number(j.blueprint_type_id)] ?? `#${j.blueprint_type_id}`}</td>
-                  <td>
+                  <td className="serif">{typeNames[Number(j.blueprint_type_id)] ?? `#${j.blueprint_type_id}`}</td>
+                  <td className="serif">
                     {j.product_type_id != null
                       ? (typeNames[Number(j.product_type_id)] ?? `#${j.product_type_id}`)
                       : '—'}

--- a/src/app/market/market.module.css
+++ b/src/app/market/market.module.css
@@ -28,7 +28,6 @@
   margin: 12pt 0;
 }
 
-.sales th,
 .sales td {
   border-bottom: 1px solid var(--line-soft);
   padding: 6pt 8pt;
@@ -36,9 +35,15 @@
 }
 
 .sales th {
-  background: var(--paper-raised);
+  border-bottom: 1px solid var(--line);
+  padding: 6pt 8pt;
+  text-align: left;
   color: var(--ink-soft);
   font-weight: 600;
+}
+
+.sales tbody tr:last-child td {
+  border-bottom: none;
 }
 
 .sales td:nth-child(3),
@@ -49,6 +54,13 @@
 .sales th:nth-child(5) {
   text-align: right;
   font-variant-numeric: tabular-nums;
+}
+
+/* Numeric columns are the only place we use the fixed-width face. */
+.sales td:nth-child(3),
+.sales td:nth-child(4),
+.sales td:nth-child(5) {
+  font-family: var(--mono);
 }
 
 .suffix {

--- a/src/app/market/recentSales.tsx
+++ b/src/app/market/recentSales.tsx
@@ -118,8 +118,8 @@ export const RecentSales = ({ sales, characters, typeNames }: RecentSalesProps) 
           <tbody>
             {filtered.map((s) => (
               <tr key={`sale-${s.transaction_id}`}>
-                <td>{characterName[s.character_id] ?? '—'}</td>
-                <td>{typeNames[Number(s.type_id)] ?? `#${s.type_id}`}</td>
+                <td className="serif">{characterName[s.character_id] ?? '—'}</td>
+                <td className="serif">{typeNames[Number(s.type_id)] ?? `#${s.type_id}`}</td>
                 <td>{s.quantity}</td>
                 <td>
                   <IskPrice raw={s.unit_price} />

--- a/src/app/retro.module.css
+++ b/src/app/retro.module.css
@@ -1,35 +1,44 @@
 /*
- * Plain data table — soft warm borders that match the Claude Code theme.
+ * Data table — clean, borderless Claude look. A single rule under the header
+ * row, hairline separators between rows, and no surrounding box.
  */
 
 .retro {
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  border-spacing: 0;
-  border-collapse: separate;
-  overflow: hidden;
+  border-collapse: collapse;
   margin: 16px 0;
   font-size: 13px;
 }
 
 .retro th {
   border-bottom: 1px solid var(--line);
-  background: var(--paper-raised);
   color: var(--ink-soft);
   font-weight: 600;
-  padding: 6px 10px;
+  padding: 8px 12px;
   text-align: left;
   white-space: nowrap;
 }
 
 .retro td {
   border-bottom: 1px solid var(--line-soft);
-  padding: 6px 10px;
+  padding: 8px 12px;
   text-align: left;
+  vertical-align: top;
 }
 
-.retro tr:last-child td {
+.retro tbody tr:last-child td {
   border-bottom: none;
+}
+
+.retro tbody tr:hover td {
+  background: var(--paper-raised);
+}
+
+/* Numeric cells: the only place we use the fixed-width face. */
+.num {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
 }
 
 .bestViewedIn {

--- a/src/app/structures/[structureId]/page.tsx
+++ b/src/app/structures/[structureId]/page.tsx
@@ -112,7 +112,7 @@ const StructurePage = async ({ params }: StructureParams) => {
 
   return (
     <>
-      <h1>{s.name ?? `Structure #${s.structure_id}`}</h1>
+      <h1 className="serif">{s.name ?? `Structure #${s.structure_id}`}</h1>
       <p>
         <Link href="/structures">&laquo; Back to Structures</Link>
       </p>
@@ -126,7 +126,7 @@ const StructurePage = async ({ params }: StructureParams) => {
           <tr>
             <th>Type</th>
             <td>
-              {typeName ? `${typeName} ` : ''}#{s.type_id}
+              {typeName ? <span className="serif">{typeName} </span> : ''}#{s.type_id}
             </td>
           </tr>
           <tr>
@@ -212,10 +212,10 @@ const StructurePage = async ({ params }: StructureParams) => {
           <tbody>
             {jobs.map((j) => (
               <tr key={`job-${j.job_id}`}>
-                <td>{characterName[j.character_id] ?? '—'}</td>
+                <td className="serif">{characterName[j.character_id] ?? '—'}</td>
                 <td>{ACTIVITY_NAMES[j.activity_id] ?? `#${j.activity_id}`}</td>
-                <td>{typeNames[Number(j.blueprint_type_id)] ?? `#${j.blueprint_type_id}`}</td>
-                <td>
+                <td className="serif">{typeNames[Number(j.blueprint_type_id)] ?? `#${j.blueprint_type_id}`}</td>
+                <td className="serif">
                   {j.product_type_id != null ? (typeNames[Number(j.product_type_id)] ?? `#${j.product_type_id}`) : '—'}
                 </td>
                 <td className={retro.num}>{j.runs}</td>

--- a/src/app/structures/[structureId]/page.tsx
+++ b/src/app/structures/[structureId]/page.tsx
@@ -117,7 +117,7 @@ const StructurePage = async ({ params }: StructureParams) => {
         <Link href="/structures">&laquo; Back to Structures</Link>
       </p>
 
-      <table className={retro.retro} border={3} cellPadding={2} cellSpacing={0}>
+      <table className={retro.retro}>
         <tbody>
           <tr>
             <th>Structure ID</th>
@@ -196,14 +196,14 @@ const StructurePage = async ({ params }: StructureParams) => {
 
       <h2>Industry Jobs</h2>
       {jobs.length > 0 ? (
-        <table className={retro.retro} border={3} cellPadding={2} cellSpacing={0}>
+        <table className={retro.retro}>
           <thead>
             <tr>
               <th>Character</th>
               <th>Activity</th>
               <th>Blueprint</th>
               <th>Product</th>
-              <th>Runs</th>
+              <th className={retro.num}>Runs</th>
               <th>Status</th>
               <th>Start</th>
               <th>End</th>
@@ -218,7 +218,7 @@ const StructurePage = async ({ params }: StructureParams) => {
                 <td>
                   {j.product_type_id != null ? (typeNames[Number(j.product_type_id)] ?? `#${j.product_type_id}`) : '—'}
                 </td>
-                <td>{j.runs}</td>
+                <td className={retro.num}>{j.runs}</td>
                 <td>{j.status}</td>
                 <td>
                   <DateTime value={j.start_date} />

--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -35,9 +35,10 @@ type RigRow = {
   type_id: number | string
 }
 
-const formatIsk = (raw: string | number | null) => {
+// Tax revenue is shown in millions of ISK.
+const formatIskMillions = (raw: string | number | null) => {
   if (raw === null) return '—'
-  const n = Number(raw)
+  const n = Number(raw) / 1_000_000
   return n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
 }
 
@@ -141,16 +142,16 @@ const StructuresPage = async () => {
       <h1>Structures</h1>
       {list.length > 0 ? (
         <>
-          <table className={retro.retro} border={3} cellPadding={2} cellSpacing={0}>
+          <table className={retro.retro}>
             <thead>
               <tr>
-                <th>Structure ID</th>
-                <th>Station ID</th>
+                <th className={retro.num}>Structure ID</th>
+                <th className={retro.num}>Station ID</th>
                 <th>Name</th>
-                <th>Tax Revenue</th>
-                <th>Corp ID</th>
-                <th>Type ID</th>
-                <th>System ID</th>
+                <th className={retro.num}>Tax Revenue (M ISK)</th>
+                <th className={retro.num}>Corp ID</th>
+                <th className={retro.num}>Type ID</th>
+                <th className={retro.num}>System ID</th>
                 <th>State</th>
                 <th>Fuel Expires</th>
                 <th>Unanchors At</th>
@@ -162,16 +163,16 @@ const StructuresPage = async () => {
             <tbody>
               {list.map((s) => (
                 <tr key={`structure-${s.structure_id}`}>
-                  <td>
+                  <td className={retro.num}>
                     <a href={`/structures/${s.structure_id}`}>{s.structure_id}</a>
                   </td>
                   {/* Upwell structures share their structure_id with the station/facility id industry jobs run at. */}
-                  <td>{s.structure_id}</td>
+                  <td className={retro.num}>{s.structure_id}</td>
                   <td>{s.name ?? '—'}</td>
-                  <td>{formatIsk(totalByStructure.get(String(s.structure_id)) ?? 0)}</td>
-                  <td>{s.corporation_id}</td>
-                  <td>{s.type_id}</td>
-                  <td>{s.system_id}</td>
+                  <td className={retro.num}>{formatIskMillions(totalByStructure.get(String(s.structure_id)) ?? 0)}</td>
+                  <td className={retro.num}>{s.corporation_id}</td>
+                  <td className={retro.num}>{s.type_id}</td>
+                  <td className={retro.num}>{s.system_id}</td>
                   <td>{s.state ?? '—'}</td>
                   <td>
                     <DateTime value={s.fuel_expires} />
@@ -188,8 +189,8 @@ const StructuresPage = async () => {
               ))}
             </tbody>
           </table>
-          <p>Unaccounted tax revenue: {formatIsk(unaccounted)} ISK</p>
-          <p>Clone revenue: {formatIsk(cloneRevenue)} ISK</p>
+          <p>Unaccounted tax revenue: {formatIskMillions(unaccounted)} M ISK</p>
+          <p>Clone revenue: {formatIskMillions(cloneRevenue)} M ISK</p>
           <p className={retro.bestViewedIn}>Best viewed in Netscape Navigator 3.0 at 800&times;600</p>
         </>
       ) : (

--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -168,7 +168,7 @@ const StructuresPage = async () => {
                   </td>
                   {/* Upwell structures share their structure_id with the station/facility id industry jobs run at. */}
                   <td className={retro.num}>{s.structure_id}</td>
-                  <td>{s.name ?? '—'}</td>
+                  <td className="serif">{s.name ?? '—'}</td>
                   <td className={retro.num}>{formatIskMillions(totalByStructure.get(String(s.structure_id)) ?? 0)}</td>
                   <td className={retro.num}>{s.corporation_id}</td>
                   <td className={retro.num}>{s.type_id}</td>


### PR DESCRIPTION
Follow-up to #326, polishing the Claude look based on feedback.

## Changes

**Typography — sans for text, mono for numbers**
- UI text now uses a clean proportional sans-serif (the claude.ai feel).
- The fixed-width monospace face is reserved for code and numeric/tabular cells only.

**Tables — cleaner, borderless Claude look**
- Removed the boxed/rounded table styling and the legacy HTML `border={3} cellPadding cellSpacing` attributes that were producing the chunky borders.
- New look: a single rule under the header row, hairline separators between rows, no surrounding box, and a subtle row-hover tint.

**Numeric / ISK cells**
- Added a shared `.num` cell class (monospace + `tabular-nums` + right-aligned) and applied it to numeric columns across the structures and industry-jobs tables. Market price/total columns are right-aligned + monospace too.

**Tax revenue in millions**
- Structure tax revenue is now displayed in millions of ISK (`Tax Revenue (M ISK)` column). The "Unaccounted tax revenue" and "Clone revenue" summary lines are shown in millions as well for consistency — let me know if you'd prefer clone revenue left in full ISK.

## Verification
- `tsc --noEmit` — clean
- `eslint` — no new warnings (only pre-existing ones)
- `next build` — succeeds across all routes

https://claude.ai/code/session_01W96GdhJJZzpqeYjDyHQVae

---
_Generated by [Claude Code](https://claude.ai/code/session_01W96GdhJJZzpqeYjDyHQVae)_