### PR TITLE
Blue/purple links and a green header accent

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,6 +23,13 @@
   --clay-strong: #c45c3a;
   --clay-tint: #f6e9e2;
 
+  /* Header accent (green, not the Claude orange). */
+  --green: #2e7d32;
+
+  /* Hyperlinks use the classic browser blue / purple. */
+  --link: #0000ee;
+  --link-visited: #551a8b;
+
   --radius: 10px;
   --radius-sm: 7px;
 
@@ -54,6 +61,9 @@
     --clay: #e08a6c;
     --clay-strong: #d97757;
     --clay-tint: #2e241f;
+    --green: #5cc46a;
+    --link: #6ea8fe;
+    --link-visited: #c699f7;
   }
 }
 
@@ -99,12 +109,15 @@ img {
 }
 
 a {
-  color: var(--clay-strong);
+  color: var(--link);
   text-decoration: none;
 }
 
+a:visited {
+  color: var(--link-visited);
+}
+
 a:hover {
-  color: var(--clay);
   text-decoration: underline;
   text-underline-offset: 2px;
 }
@@ -152,18 +165,19 @@ header {
   color: var(--ink-soft);
 }
 
-header a {
+header a,
+header a:visited {
   color: var(--ink-soft);
 }
 
 header a:hover {
-  color: var(--clay);
+  color: var(--green);
 }
 
 /* The leading "✻ EVE Hangar" mark, set apart from the nav. */
 header::before {
   content: '✻';
-  color: var(--clay);
+  color: var(--green);
   margin-right: 8px;
   font-size: 15px;
 }

--- a/src/app/layout/header.module.css
+++ b/src/app/layout/header.module.css
@@ -6,7 +6,7 @@
 }
 
 .brand:hover {
-  color: var(--clay) !important;
+  color: var(--green) !important;
   text-decoration: none;
 }
 


### PR DESCRIPTION
## Summary

- **Links** now use the classic browser blue (`#0000ee`), turning purple (`#551a8b`) once visited, instead of the clay/coral accent. Dark mode uses readable light blue/purple variants.
- **Header accent is green, not Claude orange** — the `✻` sparkle mark and the nav/brand hover state now use a green accent (`--green`). Header chrome links keep their neutral color and don't pick up the visited-purple.

Other clay/coral usage (buttons, input focus, the home welcome box) is unchanged, per the request which scoped the orange→green swap to the header.

## Verification
- `next build` — succeeds across all routes
- `eslint` — no new warnings (only pre-existing ones)

https://claude.ai/code/session_01W96GdhJJZzpqeYjDyHQVae

---
_Generated by [Claude Code](https://claude.ai/code/session_01W96GdhJJZzpqeYjDyHQVae)_