### PR TITLE
Green accent + structure-tile refinements (silhouette, system name)

### DIFF
--- a/src/app/character/character.module.css
+++ b/src/app/character/character.module.css
@@ -18,7 +18,7 @@
 }
 
 .tile:hover {
-  border-color: var(--clay);
+  border-color: var(--accent);
 }
 
 .avatar {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,7 @@
 /*
  * Claude Code inspired theme.
  *
- * Warm Anthropic palette (cream paper + clay/coral accent). Following the
+ * Warm Anthropic palette (cream paper + green accent). Following the
  * claude.ai convention: a sans for static UI (labels, chrome, headers), a
  * Claude-style serif (Tiempos/Copernicus, with a free serif fallback) for the
  * dynamic text specific to a thing (names, titles), and a monospace face for
@@ -18,10 +18,10 @@
   --line: #ddd9cc;
   --line-soft: #e8e5da;
 
-  /* Claude clay / coral accent */
-  --clay: #d97757;
-  --clay-strong: #c45c3a;
-  --clay-tint: #f6e9e2;
+  /* Green accent */
+  --accent: #2f8f4f;
+  --accent-strong: #246b3c;
+  --accent-tint: #e3efe4;
 
   /* Hyperlinks use the classic browser blue / purple. */
   --link: #0000ee;
@@ -55,9 +55,9 @@
     --ink-faint: #8a877e;
     --line: #38342d;
     --line-soft: #2d2a24;
-    --clay: #e08a6c;
-    --clay-strong: #d97757;
-    --clay-tint: #2e241f;
+    --accent: #6cc486;
+    --accent-strong: #57b673;
+    --accent-tint: #23301f;
     --link: #6ea8fe;
     --link-visited: #c699f7;
   }
@@ -185,8 +185,8 @@ button {
   font-family: var(--sans);
   font-size: 13px;
   color: var(--paper-raised);
-  background: var(--clay);
-  border: 1px solid var(--clay-strong);
+  background: var(--accent);
+  border: 1px solid var(--accent-strong);
   border-radius: var(--radius-sm);
   cursor: pointer;
   transition:
@@ -195,7 +195,7 @@ button {
 }
 
 button:hover {
-  background: var(--clay-strong);
+  background: var(--accent-strong);
 }
 
 button:active {
@@ -224,8 +224,8 @@ input:focus,
 select:focus,
 textarea:focus {
   outline: none;
-  border-color: var(--clay);
-  box-shadow: 0 0 0 2px var(--clay-tint);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-tint);
 }
 
 label {
@@ -233,5 +233,5 @@ label {
 }
 
 ::selection {
-  background: var(--clay-tint);
+  background: var(--accent-tint);
 }

--- a/src/app/home.module.css
+++ b/src/app/home.module.css
@@ -3,7 +3,7 @@
 }
 
 .welcome {
-  border: 1px solid var(--clay);
+  border: 1px solid var(--accent);
   border-radius: var(--radius);
   background: var(--paper-raised);
   padding: 18px 20px;
@@ -18,7 +18,7 @@
 }
 
 .spark {
-  color: var(--clay);
+  color: var(--accent);
   margin-right: 8px;
 }
 
@@ -42,7 +42,7 @@
 }
 
 .caret {
-  color: var(--clay);
+  color: var(--accent);
   font-weight: 600;
 }
 

--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -4,6 +4,7 @@ import { createClient } from '@/utils/supabase/server'
 import { DateTime } from '../DateTime'
 import { formatMisk } from '../isk'
 import { fetchTypeNames } from '../typeNames'
+import { StructureSilhouette } from './silhouette'
 import styles from './structures.module.css'
 
 type Structure = {
@@ -147,6 +148,7 @@ const StructuresPage = async () => {
               const services = s.services?.map((svc) => svc.name) ?? []
               return (
                 <li key={`structure-${s.structure_id}`} className={styles.tile}>
+                  <StructureSilhouette typeId={s.type_id} className={styles.silhouette} />
                   <div className={styles.head}>
                     <div>
                       <a href={`/structures/${s.structure_id}`} className={styles.name}>
@@ -155,10 +157,13 @@ const StructuresPage = async () => {
                       {/* Upwell structures share their structure_id with the station/facility id industry jobs run at. */}
                       <span className={styles.subId}>#{s.structure_id}</span>
                     </div>
-                    <span className={styles.revenue}>{formatMisk(totalByStructure.get(String(s.structure_id)) ?? 0)}</span>
                   </div>
 
                   <div className={styles.fields}>
+                    <span className={styles.label}>Revenue</span>
+                    <span className={`${styles.value} ${styles.num}`}>
+                      {formatMisk(totalByStructure.get(String(s.structure_id)) ?? 0)}
+                    </span>
                     <span className={styles.label}>Corp ID</span>
                     <span className={`${styles.value} ${styles.num}`}>{s.corporation_id}</span>
                     <span className={styles.label}>Type ID</span>

--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation'
 import { createClient } from '@/utils/supabase/server'
 import { DateTime } from '../DateTime'
 import { formatMisk } from '../isk'
+import { fetchSystemNames } from '../systemNames'
 import { fetchTypeNames } from '../typeNames'
 import { StructureSilhouette } from './silhouette'
 import styles from './structures.module.css'
@@ -98,6 +99,8 @@ const StructuresPage = async () => {
     else rigsByStructure.set(key, [name])
   }
 
+  const systemNames = await fetchSystemNames(list.map((s) => Number(s.system_id)))
+
   const { data: journal } = await supabase
     .schema('hangar')
     .from('corp_wallet_journal')
@@ -164,25 +167,13 @@ const StructuresPage = async () => {
                     <span className={`${styles.value} ${styles.num}`}>
                       {formatMisk(totalByStructure.get(String(s.structure_id)) ?? 0)}
                     </span>
-                    <span className={styles.label}>Corp ID</span>
-                    <span className={`${styles.value} ${styles.num}`}>{s.corporation_id}</span>
                     <span className={styles.label}>Type ID</span>
                     <span className={`${styles.value} ${styles.num}`}>{s.type_id}</span>
-                    <span className={styles.label}>System ID</span>
-                    <span className={`${styles.value} ${styles.num}`}>{s.system_id}</span>
-                    <span className={styles.label}>State</span>
-                    <span className={styles.value}>{s.state ?? '—'}</span>
+                    <span className={styles.label}>System</span>
+                    <span className={styles.value}>{systemNames[Number(s.system_id)] ?? s.system_id}</span>
                     <span className={styles.label}>Fuel Expires</span>
                     <span className={styles.value}>
                       <DateTime value={s.fuel_expires} />
-                    </span>
-                    <span className={styles.label}>Unanchors At</span>
-                    <span className={styles.value}>
-                      <DateTime value={s.unanchors_at} />
-                    </span>
-                    <span className={styles.label}>Last Seen</span>
-                    <span className={styles.value}>
-                      <DateTime value={s.last_seen_at} />
                     </span>
                   </div>
 

--- a/src/app/structures/silhouette.tsx
+++ b/src/app/structures/silhouette.tsx
@@ -1,0 +1,68 @@
+/*
+ * Schematic line-art silhouettes for Upwell structures, grouped by family:
+ *   - Citadels (Astrahus / Fortizar / Keepstar) — tall spindle
+ *   - Engineering Complexes (Raitaru / Azbel / Sotiyo) — angular wedge
+ *   - Refineries (Athanor / Tatara) — ringed core
+ * These are stylized outlines, not exact models — enough to tell families apart.
+ */
+
+const CITADELS = new Set([35832, 35833, 35834])
+const ENGINEERING = new Set([35825, 35826, 35827])
+const REFINERIES = new Set([35835, 35836])
+
+type Family = 'citadel' | 'engineering' | 'refinery'
+
+const familyFor = (typeId: number): Family => {
+  if (ENGINEERING.has(typeId)) return 'engineering'
+  if (REFINERIES.has(typeId)) return 'refinery'
+  return 'citadel'
+}
+
+const PATHS: Record<Family, React.ReactNode> = {
+  // Vertical spindle with a collar — the citadel look (Fortizar).
+  citadel: (
+    <>
+      <path d="M50 6 L64 34 L60 70 L50 94 L40 70 L36 34 Z" />
+      <path d="M36 40 L20 48 M64 40 L80 48" />
+      <path d="M40 58 L60 58" />
+      <path d="M50 6 L50 94" />
+    </>
+  ),
+  // Compact angular wedge with side arms — the engineering complex (Raitaru).
+  engineering: (
+    <>
+      <path d="M50 10 L78 64 L60 80 L50 66 L40 80 L22 64 Z" />
+      <path d="M50 10 L50 66" />
+      <path d="M34 52 L66 52" />
+    </>
+  ),
+  // A reprocessing ring around a central core — the refinery (Tatara).
+  refinery: (
+    <>
+      <circle cx="50" cy="54" r="28" />
+      <path d="M50 14 L50 90" />
+      <path d="M40 38 L60 38 L56 70 L44 70 Z" />
+    </>
+  ),
+}
+
+type Props = {
+  typeId: number | string
+  className?: string
+}
+
+export const StructureSilhouette = ({ typeId, className }: Props) => (
+  <svg
+    className={className}
+    viewBox="0 0 100 100"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinejoin="round"
+    strokeLinecap="round"
+    aria-hidden="true"
+    preserveAspectRatio="xMidYMid meet"
+  >
+    {PATHS[familyFor(Number(typeId))]}
+  </svg>
+)

--- a/src/app/structures/silhouette.tsx
+++ b/src/app/structures/silhouette.tsx
@@ -6,7 +6,9 @@
  * These are stylized outlines, not exact models — enough to tell families apart.
  */
 
-const CITADELS = new Set([35832, 35833, 35834])
+// Engineering complexes (Raitaru / Azbel / Sotiyo) and refineries
+// (Athanor / Tatara); everything else (the citadels, and unknown types) falls
+// back to the citadel spindle.
 const ENGINEERING = new Set([35825, 35826, 35827])
 const REFINERIES = new Set([35835, 35836])
 

--- a/src/app/structures/structures.module.css
+++ b/src/app/structures/structures.module.css
@@ -34,10 +34,18 @@
   border-color: var(--accent);
 }
 
+/* Line-art structure silhouette above the title. */
+.silhouette {
+  display: block;
+  width: 100%;
+  height: 72px;
+  margin-bottom: 4px;
+  color: var(--ink-soft);
+}
+
 .head {
   display: flex;
   align-items: baseline;
-  justify-content: space-between;
   gap: 8px;
 }
 
@@ -62,15 +70,6 @@
   font-size: 11px;
   color: var(--ink-faint);
   margin-top: 2px;
-}
-
-.revenue {
-  flex-shrink: 0;
-  font-family: var(--mono);
-  font-variant-numeric: tabular-nums;
-  font-size: 12px;
-  color: var(--ink-soft);
-  white-space: nowrap;
 }
 
 /* Label / value pairs. */
@@ -118,10 +117,11 @@
   color: var(--ink-faint);
 }
 
-/* Rigs rendered as tiles-within-the-tile. */
+/* Rigs/services rendered as tiles-within-the-tile. An equal-column grid keeps
+ * every chip the same width as they wrap, instead of flex's ragged widths. */
 .chips {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
   gap: 6px;
   list-style: none;
   padding: 0;
@@ -136,6 +136,7 @@
   border-radius: var(--radius-sm);
   background: var(--paper);
   color: var(--ink-soft);
+  overflow-wrap: anywhere;
 }
 
 .footer {

--- a/src/app/structures/structures.module.css
+++ b/src/app/structures/structures.module.css
@@ -31,7 +31,7 @@
 }
 
 .tile:hover {
-  border-color: var(--clay);
+  border-color: var(--accent);
 }
 
 .head {
@@ -51,7 +51,7 @@
 }
 
 .name:hover {
-  color: var(--clay) !important;
+  color: var(--accent) !important;
   text-decoration: none;
 }
 

--- a/src/app/systemNames.ts
+++ b/src/app/systemNames.ts
@@ -1,0 +1,30 @@
+// Resolve solar-system names from eve-build-calculator, mirroring the type
+// lookup in typeNames.ts. Unresolved ids are simply omitted so callers can fall
+// back to showing the raw id (never read the evesde SDE).
+const cache = new Map<number, Promise<string | null>>()
+
+const fetchOne = (systemID: number): Promise<string | null> =>
+  fetch(`https://eve-build-calculator.philihp.com/api/system/${systemID}`)
+    .then((res) => (res.ok ? res.json() : null))
+    .then((system: { name?: { en?: string } | string } | null) => {
+      if (!system) return null
+      return typeof system.name === 'string' ? system.name : (system.name?.en ?? null)
+    })
+    .catch(() => null)
+
+const lookup = (systemID: number): Promise<string | null> => {
+  const cached = cache.get(systemID)
+  if (cached) return cached
+  const promise = fetchOne(systemID)
+  cache.set(systemID, promise)
+  promise.then((name) => {
+    if (name === null) cache.delete(systemID)
+  })
+  return promise
+}
+
+export const fetchSystemNames = async (systemIDs: Iterable<number>): Promise<Record<number, string>> => {
+  const ids = Array.from(new Set([...systemIDs].filter((n) => Number.isFinite(n))))
+  const pairs = await Promise.all(ids.map(async (id) => [id, await lookup(id)] as const))
+  return Object.fromEntries(pairs.filter(([, name]) => name !== null) as [number, string][])
+}


### PR DESCRIPTION
## Summary

Accent recolor + a round of structure-tile refinements.

### Accent
- Renamed the `--clay` accent variables to `--accent` and gave them green values (light + dark). Updated every reference: buttons, focus rings, selection, tile hover borders, and the home welcome box/sparkle/caret.

### Structure tiles
- Added a schematic **SVG line-art silhouette** above each tile title, chosen by structure family (citadel / engineering complex / refinery).
- **Revenue** is now the first field instead of a top-right badge.
- **Services and rigs render in an equal-column grid**, so chips keep a consistent width as they wrap (flex left them ragged).
- Trimmed the fields: removed **Corp ID, State, Unanchors At, Last Seen**.
- **System** now shows the resolved solar-system name (new `fetchSystemNames` helper hitting eve-build-calculator, same pattern as `fetchTypeNames`), falling back to the raw id when unresolved.

> ⚠️ Note: this sandbox's network policy blocks `eve-build-calculator.philihp.com`, so I couldn't verify the system endpoint. I used the analog of the type route (`/api/system/:id`) with the same response shape and a graceful raw-id fallback. If system names don't resolve on the preview, the endpoint path/shape likely differs — easy to adjust.

## Verification
- `next build` — succeeds across all routes
- `eslint` — no new warnings

https://claude.ai/code/session_01W96GdhJJZzpqeYjDyHQVae