### PR TITLE
Add deploy-info footer, replacing the Netscape line

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,11 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  env: {
+    // Captured at build time (i.e. when the deployment is built).
+    BUILD_TIME: new Date().toISOString(),
+    // Vercel exposes the deployed commit sha at build time.
+    COMMIT_SHA: process.env.VERCEL_GIT_COMMIT_SHA ?? '',
+  },
+}
 
 export default nextConfig

--- a/src/app/industry/activeJobs.tsx
+++ b/src/app/industry/activeJobs.tsx
@@ -128,7 +128,6 @@ export const ActiveJobs = ({ jobs, characters, initialNow, typeNames, stationNam
               ))}
             </tbody>
           </table>
-          <p className={retro.bestViewedIn}>Best viewed in Netscape Navigator 3.0 at 800&times;600</p>
         </>
       ) : (
         <p>No active industry jobs.</p>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { SpeedInsights } from '@vercel/speed-insights/next'
 import type { Metadata } from 'next'
 import './globals.css'
 import Header from './layout/header'
+import Footer from './layout/footer'
 
 export const metadata: Metadata = {
   title: 'EVE Hangar',
@@ -38,6 +39,7 @@ const RootLayout = async ({
         <Header />
         <hr />
         {children}
+        <Footer />
         <Analytics />
         <SpeedInsights />
       </body>

--- a/src/app/layout/footer.module.css
+++ b/src/app/layout/footer.module.css
@@ -1,0 +1,9 @@
+.footer {
+  margin: 16px 0 8px;
+  color: var(--ink-faint);
+  font-size: 12px;
+}
+
+.footer a {
+  font-family: var(--mono);
+}

--- a/src/app/layout/footer.tsx
+++ b/src/app/layout/footer.tsx
@@ -1,0 +1,32 @@
+import { DateTime } from '../DateTime'
+import styles from './footer.module.css'
+
+const REPO = 'https://github.com/philihp/eve-hangar'
+
+const Footer = () => {
+  const buildTime = process.env.BUILD_TIME
+  const sha = process.env.COMMIT_SHA
+
+  return (
+    <>
+      <hr />
+      <footer className={styles.footer}>
+        Made with love by Sir Cuddles
+        {buildTime ? (
+          <>
+            {' — '}
+            <DateTime value={buildTime} />
+          </>
+        ) : null}
+        {sha ? (
+          <>
+            {' · '}
+            <a href={`${REPO}/commit/${sha}`}>{sha.slice(0, 7)}</a>
+          </>
+        ) : null}
+      </footer>
+    </>
+  )
+}
+
+export default Footer

--- a/src/app/retro.module.css
+++ b/src/app/retro.module.css
@@ -40,9 +40,3 @@
   text-align: right;
   white-space: nowrap;
 }
-
-.bestViewedIn {
-  margin: 4pt 0 16pt;
-  color: var(--ink-faint);
-  font-size: 12px;
-}

--- a/src/app/structures/[structureId]/page.tsx
+++ b/src/app/structures/[structureId]/page.tsx
@@ -233,8 +233,6 @@ const StructurePage = async ({ params }: StructureParams) => {
       ) : (
         <p>No industry jobs known at this structure.</p>
       )}
-
-      <p className={retro.bestViewedIn}>Best viewed in Netscape Navigator 3.0 at 800&times;600</p>
     </>
   )
 }

--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -218,7 +218,6 @@ const StructuresPage = async () => {
             <span>Clone revenue:</span>
             <span className={styles.footerValue}>{formatMisk(cloneRevenue)}</span>
           </div>
-          <p className={styles.bestViewedIn}>Best viewed in Netscape Navigator 3.0 at 800&times;600</p>
         </>
       ) : (
         <p>

--- a/src/app/structures/structures.module.css
+++ b/src/app/structures/structures.module.css
@@ -153,9 +153,3 @@
   font-variant-numeric: tabular-nums;
   text-align: right;
 }
-
-.bestViewedIn {
-  margin: 4pt 0 16pt;
-  color: var(--ink-faint);
-  font-size: 12px;
-}


### PR DESCRIPTION
## Summary

Replaces the per-page "Best viewed in Netscape Navigator" line with a single site-wide footer.

- New `Footer` component (rendered in the root layout): an `<hr/>` followed by **"Made with love by Sir Cuddles"**, the **deploy timestamp**, and the **commit hash** linked to the GitHub repo (`/commit/<sha>`).
- Build time and commit sha are surfaced via `next.config.mjs` `env` (`BUILD_TIME` captured at build; `COMMIT_SHA` from Vercel's `VERCEL_GIT_COMMIT_SHA`). Each piece renders only when present, so it degrades gracefully (the hash link won't show in local dev where the sha isn't set).
- Removed the old Netscape lines from the structures list, structure detail, and industry pages, and the now-unused `.bestViewedIn` styles.

## Verification
- `next build` — succeeds across all routes
- `eslint` — no new warnings

https://claude.ai/code/session_01W96GdhJJZzpqeYjDyHQVae

---
_Generated by [Claude Code](https://claude.ai/code/session_01W96GdhJJZzpqeYjDyHQVae)_