### PR TITLE
feat(daily): resolve character names seen on corp wallet journal

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -43,3 +43,15 @@ jobs:
           PGUSER: postgres.${{ vars.SUPABASE_PROJECT_REF }}
           PGPASSWORD: ${{ secrets.SUPABASE_PASSWORD }}
           PGDATABASE: postgres
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm install
+      - run: npm run daily
+        env:
+          SUPABASE_URL: ${{ vars.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}

--- a/hangar.sql
+++ b/hangar.sql
@@ -373,3 +373,31 @@ end $$;
 
 grant select on hangar.corp_wallet_journal to authenticated;
 grant all    on hangar.corp_wallet_journal to service_role;
+
+create table if not exists hangar.eve_name (
+  id bigint primary key,
+  name text not null,
+  category text not null,
+  resolved_at timestamptz not null default now()
+);
+
+alter table hangar.eve_name enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'hangar'
+      and tablename = 'eve_name'
+      and policyname = 'Authenticated read eve_name'
+  ) then
+    create policy "Authenticated read eve_name"
+      on hangar.eve_name
+      for select
+      to authenticated
+      using (true);
+  end if;
+end $$;
+
+grant select on hangar.eve_name to authenticated;
+grant all    on hangar.eve_name to service_role;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "build": "next build",
     "connect": "node src/connect.js",
+    "daily": "node src/daily.js",
     "dev": "next dev",
     "heartbeat": "node src/heartbeat.js",
     "hourly": "node src/hourly.js",

--- a/src/app/industry/activeJobs.tsx
+++ b/src/app/industry/activeJobs.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react'
 import { DateTime } from '../DateTime'
 import { usePersist } from '../market/usePersist'
 import retro from '../retro.module.css'
+import { TypeName } from '../typeName'
 import styles from './industry.module.css'
 import { ACTIVITY_NAMES } from './jobFields'
 
@@ -31,7 +32,7 @@ type ActiveJobsProps = {
   jobs: Job[]
   characters: Character[]
   initialNow: number
-  typeNames: Record<number, string>
+  typeNamesPromise: Promise<Record<number, string>>
   stationNames: Record<string, string>
 }
 
@@ -50,7 +51,7 @@ const formatRemaining = (endIso: string, now: number) => {
   return `${minutes}m`
 }
 
-export const ActiveJobs = ({ jobs, characters, initialNow, typeNames, stationNames }: ActiveJobsProps) => {
+export const ActiveJobs = ({ jobs, characters, initialNow, typeNamesPromise, stationNames }: ActiveJobsProps) => {
   const characterName: Record<string, string> = Object.fromEntries(characters.map((c) => [c.id, c.name]))
 
   const [characterId, setCharacterId] = usePersist<string>(CHARACTER_STORAGE_KEY, ALL_CHARACTERS, (raw) =>
@@ -104,9 +105,11 @@ export const ActiveJobs = ({ jobs, characters, initialNow, typeNames, stationNam
                   <td className="serif">{characterName[j.character_id] ?? '—'}</td>
                   <td>{ACTIVITY_NAMES[j.activity_id] ?? `#${j.activity_id}`}</td>
                   <td className="serif">
-                    {j.product_type_id != null
-                      ? (typeNames[Number(j.product_type_id)] ?? `#${j.product_type_id}`)
-                      : '—'}
+                    {j.product_type_id != null ? (
+                      <TypeName id={Number(j.product_type_id)} promise={typeNamesPromise} />
+                    ) : (
+                      '—'
+                    )}
                   </td>
                   <td className={retro.num}>{j.runs}</td>
                   <td>

--- a/src/app/industry/page.tsx
+++ b/src/app/industry/page.tsx
@@ -34,12 +34,8 @@ const IndustryPage = async () => {
   )
 
   const jobRows = (jobs ?? []) as Job[]
-  const typeNames = await fetchTypeNames(
-    jobRows.flatMap((j) => {
-      const ids = [Number(j.blueprint_type_id)]
-      if (j.product_type_id != null) ids.push(Number(j.product_type_id))
-      return ids
-    })
+  const typeNamesPromise = fetchTypeNames(
+    jobRows.flatMap((j) => (j.product_type_id != null ? [Number(j.product_type_id)] : []))
   )
 
   // eslint-disable-next-line react-hooks/purity
@@ -52,7 +48,7 @@ const IndustryPage = async () => {
         jobs={jobRows}
         characters={sortedCharacters}
         initialNow={initialNow}
-        typeNames={typeNames}
+        typeNamesPromise={typeNamesPromise}
         stationNames={stationNames}
       />
     </>

--- a/src/app/market/page.tsx
+++ b/src/app/market/page.tsx
@@ -26,12 +26,12 @@ const MarketPage = async () => {
 
   const sortedCharacters = [...(characters ?? [])].sort((a, b) => a.name.localeCompare(b.name))
 
-  const typeNames = await fetchTypeNames((sales ?? []).map((s) => Number(s.type_id)))
+  const typeNamesPromise = fetchTypeNames((sales ?? []).map((s) => Number(s.type_id)))
 
   return (
     <>
       <h1>Market</h1>
-      <RecentSales sales={sales ?? []} characters={sortedCharacters} typeNames={typeNames} />
+      <RecentSales sales={sales ?? []} characters={sortedCharacters} typeNamesPromise={typeNamesPromise} />
     </>
   )
 }

--- a/src/app/market/recentSales.tsx
+++ b/src/app/market/recentSales.tsx
@@ -2,6 +2,7 @@
 
 import { DateTime } from '../DateTime'
 import { formatMisk } from '../isk'
+import { TypeName } from '../typeName'
 import styles from './market.module.css'
 import { usePersist } from './usePersist'
 
@@ -23,7 +24,7 @@ type Character = {
 type RecentSalesProps = {
   sales: Sale[]
   characters: Character[]
-  typeNames: Record<number, string>
+  typeNamesPromise: Promise<Record<number, string>>
 }
 
 const THRESHOLDS: Array<{ label: string; value: number }> = [
@@ -38,7 +39,7 @@ const THRESHOLD_STORAGE_KEY = 'market.recentSales.threshold'
 const CHARACTER_STORAGE_KEY = 'market.recentSales.characterId'
 const ALL_CHARACTERS = ''
 
-export const RecentSales = ({ sales, characters, typeNames }: RecentSalesProps) => {
+export const RecentSales = ({ sales, characters, typeNamesPromise }: RecentSalesProps) => {
   const characterName: Record<string, string> = Object.fromEntries(characters.map((c) => [c.id, c.name]))
 
   const [threshold, setThreshold] = usePersist(THRESHOLD_STORAGE_KEY, 0, (raw) => {
@@ -101,7 +102,9 @@ export const RecentSales = ({ sales, characters, typeNames }: RecentSalesProps) 
             {filtered.map((s) => (
               <tr key={`sale-${s.transaction_id}`}>
                 <td className="serif">{characterName[s.character_id] ?? '—'}</td>
-                <td className="serif">{typeNames[Number(s.type_id)] ?? `#${s.type_id}`}</td>
+                <td className="serif">
+                  <TypeName id={Number(s.type_id)} promise={typeNamesPromise} />
+                </td>
                 <td>{s.quantity}</td>
                 <td>{formatMisk(s.unit_price)}</td>
                 <td>{formatMisk(Number(s.unit_price) * Number(s.quantity))}</td>

--- a/src/app/typeName.tsx
+++ b/src/app/typeName.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { Suspense, use } from 'react'
+
+type TypeNameProps = {
+  id: number
+  promise: Promise<Record<number, string>>
+}
+
+const Resolved = ({ id, promise }: TypeNameProps) => {
+  const names = use(promise)
+  return <>{names[id] ?? `#${id}`}</>
+}
+
+export const TypeName = ({ id, promise }: TypeNameProps) => (
+  <Suspense fallback={`#${id}`}>
+    <Resolved id={id} promise={promise} />
+  </Suspense>
+)

--- a/src/daily.js
+++ b/src/daily.js
@@ -1,0 +1,80 @@
+import { universeNames } from './esi.js'
+import { sudoSupabase } from './supabase.js'
+
+const LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000
+const BATCH_SIZE = 1000
+
+// ESI /universe/names/ rejects the whole batch if any id is invalid, so bisect on failure
+// until either the batch resolves or we narrow down to single bad ids we can drop.
+const resolveBatch = async (ids) => {
+  if (ids.length === 0) return []
+  try {
+    return await universeNames(ids)
+  } catch (e) {
+    if (ids.length === 1) {
+      console.warn(`[daily] universe/names id=${ids[0]} failed: ${e?.message}`)
+      return []
+    }
+    const mid = Math.floor(ids.length / 2)
+    const [a, b] = await Promise.all([resolveBatch(ids.slice(0, mid)), resolveBatch(ids.slice(mid))])
+    return [...a, ...b]
+  }
+}
+
+const resolveCorpJournalNames = async () => {
+  const cutoff = new Date(Date.now() - LOOKBACK_MS).toISOString()
+
+  const { data: journal, error: journalErr } = await sudoSupabase
+    .schema('hangar')
+    .from('corp_wallet_journal')
+    .select('first_party_id, second_party_id')
+    .gte('date', cutoff)
+  if (journalErr) throw journalErr
+
+  const ids = new Set()
+  for (const r of journal ?? []) {
+    if (r.first_party_id != null) ids.add(Number(r.first_party_id))
+    if (r.second_party_id != null) ids.add(Number(r.second_party_id))
+  }
+
+  const { data: known, error: knownErr } = await sudoSupabase.schema('hangar').from('eve_name').select('id')
+  if (knownErr) throw knownErr
+  for (const k of known ?? []) ids.delete(Number(k.id))
+
+  const toResolve = [...ids].filter((n) => Number.isFinite(n) && n > 0)
+  console.log(`[daily] corp journal: ${ids.size} unknown id(s) seen in last 30d, ${toResolve.length} to resolve`)
+  if (toResolve.length === 0) return
+
+  const resolved = []
+  for (let i = 0; i < toResolve.length; i += BATCH_SIZE) {
+    const batch = toResolve.slice(i, i + BATCH_SIZE)
+    const names = await resolveBatch(batch)
+    resolved.push(...names)
+  }
+
+  if (resolved.length === 0) {
+    console.log('[daily] no names resolved')
+    return
+  }
+
+  const rows = resolved.map((n) => ({ id: n.id, name: n.name, category: n.category }))
+  const { error: upErr } = await sudoSupabase
+    .schema('hangar')
+    .from('eve_name')
+    .upsert(rows, { onConflict: 'id' })
+  if (upErr) throw upErr
+
+  const characterCount = rows.filter((r) => r.category === 'character').length
+  console.log(`[daily] upserted ${rows.length} name(s) (${characterCount} character)`)
+}
+
+const execute = async () => {
+  try {
+    await resolveCorpJournalNames()
+  } catch (e) {
+    console.error('[daily] FAILED', e)
+    process.exit(1)
+  }
+}
+
+execute()

--- a/src/esi.js
+++ b/src/esi.js
@@ -3,7 +3,7 @@ export const userAgent = 'philihp@gmail.com eve-hangar discord:philihp'
 const ESI_BASE = 'https://esi.evetech.net/latest'
 
 const esiFetch = async (path, { access_token, params = {}, method = 'GET', body, label } = {}) => {
-  const search = new URLSearchParams({ token: access_token, ...params })
+  const search = new URLSearchParams({ ...(access_token ? { token: access_token } : {}), ...params })
   const headers = { 'User-Agent': userAgent }
   if (body !== undefined) {
     headers['Content-Type'] = 'application/json'
@@ -87,4 +87,11 @@ export const assetNames = (access_token, characterID, ids) =>
     method: 'POST',
     body: ids,
     label: `assetNames ${characterID}`,
+  })
+
+export const universeNames = (ids) =>
+  esiJson(`/universe/names/`, {
+    method: 'POST',
+    body: ids,
+    label: `universeNames(${ids.length})`,
   })


### PR DESCRIPTION
## Summary
- Adds `hangar.eve_name (id, name, category, resolved_at)` cache table with RLS.
- New `npm run daily` script (`src/daily.js`) wired into the existing daily GH Actions workflow. It collects distinct `first_party_id` / `second_party_id` from `corp_wallet_journal` for the last 30 days, drops ids already cached, and resolves the rest via ESI `POST /universe/names/`. ESI rejects an entire batch if any one id is invalid, so `resolveBatch` bisects on failure to isolate bad ids.
- Adds `universeNames(ids)` to `src/esi.js`; also teaches `esiFetch` to omit the `token` query param when there's no access token (the endpoint is public).
- Stores whatever categories ESI returns in the same batch (characters, corps, NPC entities) so future lookups for non-character entity names get cached for free.

## Test plan
- [ ] Run `npm run daily` locally against a populated database and confirm new rows land in `hangar.eve_name`.
- [ ] Verify the daily GH Action runs the new step without disturbing the SDE refresh.
- [ ] Re-run and confirm zero new ids are resolved (idempotency).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCkJhn6BqF87vcHSqPkA29)_