### PR TITLE
Add hourly assets extract in its own workflow

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -1,0 +1,25 @@
+name: Assets
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '26 * * * *'
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm install
+      - run: npm run assets
+        env:
+          EVE_CLIENT_ID: ${{ vars.EVE_CLIENT_ID }}
+          EVE_SECRET_KEY: ${{ secrets.EVE_SECRET_KEY }}
+          SUPABASE_URL: ${{ vars.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}

--- a/hangar.sql
+++ b/hangar.sql
@@ -59,15 +59,29 @@ create policy "Users manage own tokens"
   using (user_id = (select auth.uid()))
   with check (user_id = (select auth.uid()));
 
--- Assets are stored as a slowly changing dimension (SCD type 2): each row is a
--- versioned snapshot of one item's state. When the hourly extract sees an item
--- whose tracked attributes (location, quantity, ...) differ from its current
--- row, that row is closed (is_current = false) and a new row is inserted, so the
--- full history is retained and holdings can be reconstructed at any past time.
--- last_seen_at on the open row is extended every run the item is seen unchanged;
--- once the item changes or disappears, its row's last_seen_at marks the last time
--- that version was observed.
-create table hangar.asset (
+-- Assets are stored as a slowly changing dimension (SCD type 2) in
+-- asset_over_time: each row is a versioned snapshot of one item's state. When the
+-- hourly extract sees an item whose tracked attributes (location, quantity, ...)
+-- differ from its current row, that row is closed (is_current = false) and a new
+-- row is inserted, so the full history is retained and holdings can be
+-- reconstructed at any past time. last_seen_at on the open row is extended every
+-- run the item is seen unchanged; once the item changes or disappears, its row's
+-- last_seen_at marks the last time that version was observed. The `asset` view
+-- below exposes just the live rows.
+
+-- Existing deployments imported assets into a table literally named `asset`;
+-- rename it out of the way so `asset` can become the current-only view.
+do $$
+begin
+  if exists (
+    select 1 from information_schema.tables
+    where table_schema = 'hangar' and table_name = 'asset' and table_type = 'BASE TABLE'
+  ) then
+    alter table hangar.asset rename to asset_over_time;
+  end if;
+end $$;
+
+create table if not exists hangar.asset_over_time (
   id bigint generated always as identity primary key,
   item_id bigint not null,
   character_id uuid not null references hangar.character(id) on delete cascade,
@@ -82,50 +96,66 @@ create table hangar.asset (
   first_seen_at timestamptz not null default now(),
   last_seen_at timestamptz not null default now()
 );
-create index if not exists asset_character_id_idx on hangar.asset (character_id);
+create index if not exists asset_over_time_character_id_idx on hangar.asset_over_time (character_id);
 -- At most one live row per item; also the conflict target the extract relies on.
-create unique index if not exists asset_current_item_idx on hangar.asset (item_id) where is_current;
+create unique index if not exists asset_over_time_current_item_idx on hangar.asset_over_time (item_id) where is_current;
 -- Time-travel lookups walking an item's version history.
-create index if not exists asset_item_id_idx on hangar.asset (item_id, last_seen_at desc);
+create index if not exists asset_over_time_item_id_idx on hangar.asset_over_time (item_id, last_seen_at desc);
 
 -- Evolve existing deployments to the SCD shape above.
-alter table hangar.asset add column if not exists is_current    boolean     not null default true;
-alter table hangar.asset add column if not exists first_seen_at timestamptz not null default now();
-alter table hangar.asset add column if not exists last_seen_at  timestamptz not null default now();
+alter table hangar.asset_over_time add column if not exists is_current    boolean     not null default true;
+alter table hangar.asset_over_time add column if not exists first_seen_at timestamptz not null default now();
+alter table hangar.asset_over_time add column if not exists last_seen_at  timestamptz not null default now();
 do $$
 begin
   -- Swap the item_id primary key for a surrogate id so one item can have many
   -- historical rows.
   if not exists (
     select 1 from information_schema.columns
-    where table_schema = 'hangar' and table_name = 'asset' and column_name = 'id'
+    where table_schema = 'hangar' and table_name = 'asset_over_time' and column_name = 'id'
   ) then
-    alter table hangar.asset drop constraint if exists asset_pkey;
-    alter table hangar.asset add column id bigint generated always as identity;
-    alter table hangar.asset add primary key (id);
+    alter table hangar.asset_over_time drop constraint if exists asset_pkey;
+    alter table hangar.asset_over_time add column id bigint generated always as identity;
+    alter table hangar.asset_over_time add primary key (id);
   end if;
 end $$;
 
-alter table hangar.asset enable row level security;
+alter table hangar.asset_over_time enable row level security;
 
-create policy "Users read own assets"
-  on hangar.asset
-  for select
-  to authenticated
-  using (
-    character_id in (
-      select id from hangar.character where user_id = (select auth.uid())
-    )
-  );
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'hangar' and tablename = 'asset_over_time' and policyname = 'Users read own assets'
+  ) then
+    create policy "Users read own assets"
+      on hangar.asset_over_time
+      for select
+      to authenticated
+      using (
+        character_id in (
+          select id from hangar.character where user_id = (select auth.uid())
+        )
+      );
+  end if;
+end $$;
+
+-- Live snapshot of assets. security_invoker keeps the underlying RLS in force for
+-- the querying (authenticated) role rather than running as the view owner.
+create or replace view hangar.asset with (security_invoker = on) as
+  select * from hangar.asset_over_time where is_current;
 
 -- Explicit grants on the tables we just created. `alter default privileges`
 -- above only applies to tables created by the role that ran the statement,
 -- so this belt-and-suspenders grant ensures PostgREST's `authenticated` /
 -- `anon` / `service_role` roles can actually reach these tables. Re-runnable.
-grant select, insert, update, delete on hangar.character to authenticated;
-grant select, insert, update, delete on hangar.token     to authenticated;
-grant select                          on hangar.asset    to authenticated;
-grant all on hangar.character, hangar.token, hangar.asset to service_role;
+grant select, insert, update, delete on hangar.character       to authenticated;
+grant select, insert, update, delete on hangar.token           to authenticated;
+-- The view runs with the invoker's rights, so authenticated needs select on the
+-- underlying table for the `asset` view to resolve (RLS still scopes the rows).
+grant select                          on hangar.asset_over_time to authenticated;
+grant select                          on hangar.asset           to authenticated;
+grant all on hangar.character, hangar.token, hangar.asset_over_time to service_role;
 
 create table if not exists hangar.heartbeat (
   id uuid primary key default gen_random_uuid(),

--- a/hangar.sql
+++ b/hangar.sql
@@ -59,8 +59,17 @@ create policy "Users manage own tokens"
   using (user_id = (select auth.uid()))
   with check (user_id = (select auth.uid()));
 
+-- Assets are stored as a slowly changing dimension (SCD type 2): each row is a
+-- versioned snapshot of one item's state. When the hourly extract sees an item
+-- whose tracked attributes (location, quantity, ...) differ from its current
+-- row, that row is closed (is_current = false) and a new row is inserted, so the
+-- full history is retained and holdings can be reconstructed at any past time.
+-- last_seen_at on the open row is extended every run the item is seen unchanged;
+-- once the item changes or disappears, its row's last_seen_at marks the last time
+-- that version was observed.
 create table hangar.asset (
-  item_id bigint primary key,
+  id bigint generated always as identity primary key,
+  item_id bigint not null,
   character_id uuid not null references hangar.character(id) on delete cascade,
   type_id bigint not null,
   location_id bigint,
@@ -69,17 +78,33 @@ create table hangar.asset (
   quantity bigint,
   is_singleton boolean,
   is_blueprint_copy boolean,
+  is_current boolean not null default true,
   first_seen_at timestamptz not null default now(),
   last_seen_at timestamptz not null default now()
 );
-create index asset_character_id_idx on hangar.asset (character_id);
+create index if not exists asset_character_id_idx on hangar.asset (character_id);
+-- At most one live row per item; also the conflict target the extract relies on.
+create unique index if not exists asset_current_item_idx on hangar.asset (item_id) where is_current;
+-- Time-travel lookups walking an item's version history.
+create index if not exists asset_item_id_idx on hangar.asset (item_id, last_seen_at desc);
 
--- Evolve existing deployments: track when an item was first and last sighted by
--- the hourly assets extract instead of a single updated_at. first_seen_at is kept
--- out of the upsert payload so its `default now()` sticks from the first sighting;
--- last_seen_at is written every run.
+-- Evolve existing deployments to the SCD shape above.
+alter table hangar.asset add column if not exists is_current    boolean     not null default true;
 alter table hangar.asset add column if not exists first_seen_at timestamptz not null default now();
 alter table hangar.asset add column if not exists last_seen_at  timestamptz not null default now();
+do $$
+begin
+  -- Swap the item_id primary key for a surrogate id so one item can have many
+  -- historical rows.
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema = 'hangar' and table_name = 'asset' and column_name = 'id'
+  ) then
+    alter table hangar.asset drop constraint if exists asset_pkey;
+    alter table hangar.asset add column id bigint generated always as identity;
+    alter table hangar.asset add primary key (id);
+  end if;
+end $$;
 
 alter table hangar.asset enable row level security;
 

--- a/hangar.sql
+++ b/hangar.sql
@@ -69,9 +69,17 @@ create table hangar.asset (
   quantity bigint,
   is_singleton boolean,
   is_blueprint_copy boolean,
-  updated_at timestamptz not null default now()
+  first_seen_at timestamptz not null default now(),
+  last_seen_at timestamptz not null default now()
 );
 create index asset_character_id_idx on hangar.asset (character_id);
+
+-- Evolve existing deployments: track when an item was first and last sighted by
+-- the hourly assets extract instead of a single updated_at. first_seen_at is kept
+-- out of the upsert payload so its `default now()` sticks from the first sighting;
+-- last_seen_at is written every run.
+alter table hangar.asset add column if not exists first_seen_at timestamptz not null default now();
+alter table hangar.asset add column if not exists last_seen_at  timestamptz not null default now();
 
 alter table hangar.asset enable row level security;
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "scripts": {
     "build": "next build",
+    "assets": "node src/assets.js",
     "connect": "node src/connect.js",
     "daily": "node src/daily.js",
     "dev": "next dev",

--- a/src/assets.js
+++ b/src/assets.js
@@ -1,0 +1,101 @@
+import { assets, userAgent } from './esi.js'
+import SingleSignOn from 'eve-sso'
+import { sudoSupabase } from './supabase.js'
+
+const EVE_CLIENT_ID = process.env.EVE_CLIENT_ID
+const EVE_SECRET_KEY = process.env.EVE_SECRET_KEY
+const EVE_CALLBACK_URL = process.env.EVE_CALLBACK_URL
+
+const ASSETS_SCOPE = 'esi-assets.read_assets.v1'
+
+const sso = new SingleSignOn(EVE_CLIENT_ID, EVE_SECRET_KEY, EVE_CALLBACK_URL, userAgent)
+
+const refreshToken = async (tokenRow) => {
+  const refreshed = await sso.getAccessToken(tokenRow.refresh_token, true)
+  const { access_token, refresh_token } = refreshed
+  const { sub, scp = [], iat, exp } = refreshed.decoded_access_token
+  const characterID = sub.split(':')[2]
+  const scope = [scp].flat()
+  await sudoSupabase
+    .schema('hangar')
+    .from('token')
+    .update({
+      access_token,
+      refresh_token,
+      issued_at: new Date(iat * 1000).toISOString(),
+      expires_at: new Date(exp * 1000).toISOString(),
+      scope,
+    })
+    .eq('id', tokenRow.id)
+  return { access_token, characterID, scope }
+}
+
+const execute = async () => {
+  const { data: tokens, error } = await sudoSupabase
+    .schema('hangar')
+    .from('token')
+    .select('id, character_id, refresh_token')
+    .contains('scope', [ASSETS_SCOPE])
+
+  if (error) {
+    console.error('[assets] token lookup failed:', error)
+    process.exit(1)
+  }
+
+  console.log(`[assets] found ${tokens?.length ?? 0} token(s) with ${ASSETS_SCOPE}`)
+
+  for (const tokenRow of tokens ?? []) {
+    const t0 = Date.now()
+    const ctx = `character=${tokenRow.character_id} token=${tokenRow.id}`
+    try {
+      const { access_token, characterID, scope } = await refreshToken(tokenRow)
+      if (!scope.includes(ASSETS_SCOPE)) {
+        console.error(`[assets] ${ctx}: refreshed token no longer has ${ASSETS_SCOPE}, skipping`)
+        continue
+      }
+
+      const all = []
+      const [firstPage, pagesHeader] = await assets(access_token, characterID, 1)
+      all.push(...firstPage)
+      const totalPages = Math.max(1, Number.parseInt(pagesHeader, 10) || 1)
+      for (let page = 2; page <= totalPages; page++) {
+        const [more] = await assets(access_token, characterID, page)
+        all.push(...more)
+      }
+
+      const now = new Date().toISOString()
+      // first_seen_at is intentionally omitted: the column's `default now()` sets
+      // it on insert, and leaving it out of the upsert payload means it is never
+      // overwritten when an existing item_id conflicts. last_seen_at is sent every
+      // run so it always reflects the most recent sighting.
+      const rows = all.map((a) => ({
+        item_id: a.item_id,
+        character_id: tokenRow.character_id,
+        type_id: a.type_id,
+        location_id: a.location_id ?? null,
+        location_flag: a.location_flag ?? null,
+        location_type: a.location_type ?? null,
+        quantity: a.quantity ?? null,
+        is_singleton: a.is_singleton ?? null,
+        is_blueprint_copy: !!a.is_blueprint_copy,
+        last_seen_at: now,
+      }))
+
+      if (rows.length > 0) {
+        const { error: upsertErr } = await sudoSupabase
+          .schema('hangar')
+          .from('asset')
+          .upsert(rows, { onConflict: 'item_id' })
+        if (upsertErr) throw upsertErr
+      }
+
+      const dt = Date.now() - t0
+      console.log(`[assets] ${ctx}: ${rows.length} asset(s) across ${totalPages} page(s) in ${dt}ms`)
+    } catch (e) {
+      const dt = Date.now() - t0
+      console.error(`[assets] ${ctx}: FAILED after ${dt}ms name=${e?.name} message=${e?.message}\n${e?.stack ?? e}`)
+    }
+  }
+}
+
+execute()

--- a/src/assets.js
+++ b/src/assets.js
@@ -68,7 +68,7 @@ const fetchAssets = async (access_token, characterID) => {
 const reconcile = async (character_id, fetched) => {
   const { data: current, error } = await sudoSupabase
     .schema('hangar')
-    .from('asset')
+    .from('asset_over_time')
     .select('id, item_id, type_id, location_id, location_flag, location_type, quantity, is_singleton, is_blueprint_copy')
     .eq('character_id', character_id)
     .eq('is_current', true)
@@ -109,7 +109,7 @@ const reconcile = async (character_id, fetched) => {
   for (const ids of chunk(touchIds, 200)) {
     const { error: touchErr } = await sudoSupabase
       .schema('hangar')
-      .from('asset')
+      .from('asset_over_time')
       .update({ last_seen_at: now })
       .in('id', ids)
     if (touchErr) throw touchErr
@@ -118,13 +118,13 @@ const reconcile = async (character_id, fetched) => {
   for (const ids of chunk(closeIds, 200)) {
     const { error: closeErr } = await sudoSupabase
       .schema('hangar')
-      .from('asset')
+      .from('asset_over_time')
       .update({ is_current: false })
       .in('id', ids)
     if (closeErr) throw closeErr
   }
   for (const rows of chunk(inserts, 1000)) {
-    const { error: insertErr } = await sudoSupabase.schema('hangar').from('asset').insert(rows)
+    const { error: insertErr } = await sudoSupabase.schema('hangar').from('asset_over_time').insert(rows)
     if (insertErr) throw insertErr
   }
 

--- a/src/assets.js
+++ b/src/assets.js
@@ -10,6 +10,26 @@ const ASSETS_SCOPE = 'esi-assets.read_assets.v1'
 
 const sso = new SingleSignOn(EVE_CLIENT_ID, EVE_SECRET_KEY, EVE_CALLBACK_URL, userAgent)
 
+// Keep id lists under PostgREST's URL length limit when filtering with .in().
+const chunk = (arr, n) => {
+  const out = []
+  for (let i = 0; i < arr.length; i += n) out.push(arr.slice(i, i + n))
+  return out
+}
+
+// The tracked attributes that define a version of an item. Two sightings with
+// the same signature are the "same" row; any difference opens a new SCD row.
+const signature = (a) =>
+  JSON.stringify([
+    Number(a.type_id),
+    a.location_id == null ? null : Number(a.location_id),
+    a.location_flag ?? null,
+    a.location_type ?? null,
+    a.quantity == null ? null : Number(a.quantity),
+    a.is_singleton ?? null,
+    !!a.is_blueprint_copy,
+  ])
+
 const refreshToken = async (tokenRow) => {
   const refreshed = await sso.getAccessToken(tokenRow.refresh_token, true)
   const { access_token, refresh_token } = refreshed
@@ -28,6 +48,87 @@ const refreshToken = async (tokenRow) => {
     })
     .eq('id', tokenRow.id)
   return { access_token, characterID, scope }
+}
+
+const fetchAssets = async (access_token, characterID) => {
+  const all = []
+  const [firstPage, pagesHeader] = await assets(access_token, characterID, 1)
+  all.push(...firstPage)
+  const totalPages = Math.max(1, Number.parseInt(pagesHeader, 10) || 1)
+  for (let page = 2; page <= totalPages; page++) {
+    const [more] = await assets(access_token, characterID, page)
+    all.push(...more)
+  }
+  return { all, totalPages }
+}
+
+// Reconcile the freshly fetched assets against the character's current (open)
+// rows: unchanged items get their last_seen_at extended, changed items have
+// their old row closed and a new one inserted, and vanished items are closed.
+const reconcile = async (character_id, fetched) => {
+  const { data: current, error } = await sudoSupabase
+    .schema('hangar')
+    .from('asset')
+    .select('id, item_id, type_id, location_id, location_flag, location_type, quantity, is_singleton, is_blueprint_copy')
+    .eq('character_id', character_id)
+    .eq('is_current', true)
+  if (error) throw error
+
+  const currentByItem = new Map((current ?? []).map((r) => [Number(r.item_id), r]))
+
+  const now = new Date().toISOString()
+  const touchIds = [] // unchanged: bump last_seen_at on the open row
+  const closeIds = [] // changed or gone: close the old open row
+  const inserts = [] // changed or new: open a fresh version
+
+  for (const a of fetched) {
+    const cur = currentByItem.get(Number(a.item_id))
+    if (cur && signature(cur) === signature(a)) {
+      touchIds.push(cur.id)
+    } else {
+      if (cur) closeIds.push(cur.id)
+      // first_seen_at is left to its `default now()` so it marks this version's debut.
+      inserts.push({
+        item_id: a.item_id,
+        character_id,
+        type_id: a.type_id,
+        location_id: a.location_id ?? null,
+        location_flag: a.location_flag ?? null,
+        location_type: a.location_type ?? null,
+        quantity: a.quantity ?? null,
+        is_singleton: a.is_singleton ?? null,
+        is_blueprint_copy: !!a.is_blueprint_copy,
+        last_seen_at: now,
+      })
+    }
+    currentByItem.delete(Number(a.item_id))
+  }
+  // Anything still open but not seen this run has left the character's assets.
+  for (const cur of currentByItem.values()) closeIds.push(cur.id)
+
+  for (const ids of chunk(touchIds, 200)) {
+    const { error: touchErr } = await sudoSupabase
+      .schema('hangar')
+      .from('asset')
+      .update({ last_seen_at: now })
+      .in('id', ids)
+    if (touchErr) throw touchErr
+  }
+  // Close before inserting so the unique-current-per-item index never collides.
+  for (const ids of chunk(closeIds, 200)) {
+    const { error: closeErr } = await sudoSupabase
+      .schema('hangar')
+      .from('asset')
+      .update({ is_current: false })
+      .in('id', ids)
+    if (closeErr) throw closeErr
+  }
+  for (const rows of chunk(inserts, 1000)) {
+    const { error: insertErr } = await sudoSupabase.schema('hangar').from('asset').insert(rows)
+    if (insertErr) throw insertErr
+  }
+
+  return { touched: touchIds.length, opened: inserts.length, closed: closeIds.length }
 }
 
 const execute = async () => {
@@ -54,43 +155,13 @@ const execute = async () => {
         continue
       }
 
-      const all = []
-      const [firstPage, pagesHeader] = await assets(access_token, characterID, 1)
-      all.push(...firstPage)
-      const totalPages = Math.max(1, Number.parseInt(pagesHeader, 10) || 1)
-      for (let page = 2; page <= totalPages; page++) {
-        const [more] = await assets(access_token, characterID, page)
-        all.push(...more)
-      }
-
-      const now = new Date().toISOString()
-      // first_seen_at is intentionally omitted: the column's `default now()` sets
-      // it on insert, and leaving it out of the upsert payload means it is never
-      // overwritten when an existing item_id conflicts. last_seen_at is sent every
-      // run so it always reflects the most recent sighting.
-      const rows = all.map((a) => ({
-        item_id: a.item_id,
-        character_id: tokenRow.character_id,
-        type_id: a.type_id,
-        location_id: a.location_id ?? null,
-        location_flag: a.location_flag ?? null,
-        location_type: a.location_type ?? null,
-        quantity: a.quantity ?? null,
-        is_singleton: a.is_singleton ?? null,
-        is_blueprint_copy: !!a.is_blueprint_copy,
-        last_seen_at: now,
-      }))
-
-      if (rows.length > 0) {
-        const { error: upsertErr } = await sudoSupabase
-          .schema('hangar')
-          .from('asset')
-          .upsert(rows, { onConflict: 'item_id' })
-        if (upsertErr) throw upsertErr
-      }
+      const { all, totalPages } = await fetchAssets(access_token, characterID)
+      const { touched, opened, closed } = await reconcile(tokenRow.character_id, all)
 
       const dt = Date.now() - t0
-      console.log(`[assets] ${ctx}: ${rows.length} asset(s) across ${totalPages} page(s) in ${dt}ms`)
+      console.log(
+        `[assets] ${ctx}: ${all.length} asset(s) across ${totalPages} page(s); ${touched} unchanged, ${opened} opened, ${closed} closed in ${dt}ms`
+      )
     } catch (e) {
       const dt = Date.now() - t0
       console.error(`[assets] ${ctx}: FAILED after ${dt}ms name=${e?.name} message=${e?.message}\n${e?.stack ?? e}`)


### PR DESCRIPTION
## What

Adds a character **asset extract** to the hourly cadence. Because pulling every character's assets is a heavy, multi-page ESI request, it runs in its own new **Assets** workflow at `:26` past the hour rather than being folded into the existing `Hourly` job (`:44`) — keeping the two from competing.

Assets are stored as a **slowly changing dimension (SCD type 2)**: every observed change spawns a new row, so the full history is retained and holdings can be reconstructed at any past point in time.

## Changes

- **`.github/workflows/assets.yml`** — new workflow, `cron: '26 * * * *'` (plus `workflow_dispatch`), runs `npm run assets`. Mirrors the env/setup of the existing `structures.yml` / `hourly.yml`.
- **`src/assets.js`** — new extractor: finds every token with `esi-assets.read_assets.v1`, refreshes it, pages through `/characters/{id}/assets/`, then **reconciles** against the character's current rows. The UI keeps reading from the DB; this never calls ESI from the server.
- **`hangar.sql`** — `hangar.asset` reworked into the SCD shape (surrogate `id` PK, `is_current`, `first_seen_at`, `last_seen_at`) with idempotent migrations for existing deployments.
- **`package.json`** — adds the `assets` script.

## SCD reconciliation

Each run compares the fetched assets against the open (`is_current = true`) rows for that character, keyed on `item_id`, comparing a signature of the tracked attributes (`type_id`, `location_id`, `location_flag`, `location_type`, `quantity`, `is_singleton`, `is_blueprint_copy`):

- **unchanged** → bump `last_seen_at` on the open row.
- **changed** → close the old row (`is_current = false`, its `last_seen_at` marks when that version was last seen) and insert a new open row (`first_seen_at` = now via column default).
- **vanished** (open in DB, absent from ESI) → close the row.

A partial unique index `(item_id) where is_current` enforces at most one live row per item; closes are applied before inserts so it never collides, and `.in('id', …)` filters are chunked to stay under PostgREST URL limits.

### Time travel

- Live snapshot: `where is_current`.
- Holdings around time `T`: the version of each `item_id` with `first_seen_at <= T <= last_seen_at` (walked via the `(item_id, last_seen_at desc)` index).

https://claude.ai/code/session_01KG12oTqHxmQBriaLCQSAGt