### PR TITLE
Show character and corporation names in scheduled job logs

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -69,7 +69,9 @@ const reconcile = async (character_id, fetched) => {
   const { data: current, error } = await sudoSupabase
     .schema('hangar')
     .from('asset_over_time')
-    .select('id, item_id, type_id, location_id, location_flag, location_type, quantity, is_singleton, is_blueprint_copy')
+    .select(
+      'id, item_id, type_id, location_id, location_flag, location_type, quantity, is_singleton, is_blueprint_copy'
+    )
     .eq('character_id', character_id)
     .eq('is_current', true)
   if (error) throw error
@@ -132,6 +134,16 @@ const reconcile = async (character_id, fetched) => {
 }
 
 const execute = async () => {
+  const { data: characters, error: charactersError } = await sudoSupabase
+    .schema('hangar')
+    .from('character')
+    .select('id, name')
+  if (charactersError) {
+    console.error('[assets] character lookup failed:', charactersError)
+    process.exit(1)
+  }
+  const characterName = new Map((characters ?? []).map((c) => [c.id, c.name]))
+
   const { data: tokens, error } = await sudoSupabase
     .schema('hangar')
     .from('token')
@@ -147,7 +159,8 @@ const execute = async () => {
 
   for (const tokenRow of tokens ?? []) {
     const t0 = Date.now()
-    const ctx = `character=${tokenRow.character_id} token=${tokenRow.id}`
+    const name = characterName.get(tokenRow.character_id) ?? '?'
+    const ctx = `character=${name} (${tokenRow.character_id}) token=${tokenRow.id}`
     try {
       const { access_token, characterID, scope } = await refreshToken(tokenRow)
       if (!scope.includes(ASSETS_SCOPE)) {

--- a/src/corpWalletJournal.js
+++ b/src/corpWalletJournal.js
@@ -38,7 +38,7 @@ const fetchDivision = async (access_token, corporation_id, division, cutoff) => 
   return rows
 }
 
-export const pullCorpWalletJournals = async ({ access_token, corporation_id, ctx }) => {
+export const pullCorpWalletJournals = async ({ access_token, corporation_id, ctx, corpLabel = corporation_id }) => {
   const cutoff = Date.now() - JOURNAL_LOOKBACK_MS
   for (const division of WALLET_DIVISIONS) {
     try {
@@ -50,9 +50,9 @@ export const pullCorpWalletJournals = async ({ access_token, corporation_id, ctx
           .upsert(rows, { onConflict: 'corporation_id,division,entry_id', ignoreDuplicates: true })
         if (error) throw error
       }
-      console.log(`[corp-wallet] ${ctx}: corp ${corporation_id} div ${division} ${rows.length} entries`)
+      console.log(`[corp-wallet] ${ctx}: corp ${corpLabel} div ${division} ${rows.length} entries`)
     } catch (e) {
-      console.error(`[corp-wallet] ${ctx}: corp ${corporation_id} div ${division} FAILED message=${e?.message}`)
+      console.error(`[corp-wallet] ${ctx}: corp ${corpLabel} div ${division} FAILED message=${e?.message}`)
     }
   }
 }

--- a/src/hourly.js
+++ b/src/hourly.js
@@ -6,6 +6,16 @@ const WALLET_SCOPE = 'esi-wallet.read_character_wallet.v1'
 const INDUSTRY_SCOPE = 'esi-industry.read_character_jobs.v1'
 
 const execute = async () => {
+  const { data: characters, error: charactersError } = await sudoSupabase
+    .schema('hangar')
+    .from('character')
+    .select('id, name')
+  if (charactersError) {
+    console.error(charactersError)
+    process.exit(1)
+  }
+  const characterName = new Map((characters ?? []).map((c) => [c.id, c.name]))
+
   const { data: tokens, error } = await sudoSupabase
     .schema('hangar')
     .from('token')
@@ -18,6 +28,7 @@ const execute = async () => {
   }
 
   for (const tokenRow of tokens ?? []) {
+    const name = characterName.get(tokenRow.character_id) ?? '?'
     try {
       const { access_token, characterID } = await refreshAccessToken(tokenRow)
       const balance = await wallet(access_token, characterID)
@@ -26,7 +37,7 @@ const execute = async () => {
         .from('wallet')
         .insert({ character_id: tokenRow.character_id, balance })
       if (insertError) throw insertError
-      console.log(`wallet ${tokenRow.character_id} (${characterID}): ${balance}`)
+      console.log(`wallet ${name} ${tokenRow.character_id} (${characterID}): ${balance}`)
 
       const txns = await transactions(access_token, characterID)
       if (txns.length > 0) {
@@ -48,10 +59,10 @@ const execute = async () => {
           .from('market_transaction')
           .upsert(rows, { onConflict: 'transaction_id', ignoreDuplicates: true })
         if (txError) throw txError
-        console.log(`transactions ${tokenRow.character_id} (${characterID}): ${txns.length} fetched`)
+        console.log(`transactions ${name} ${tokenRow.character_id} (${characterID}): ${txns.length} fetched`)
       }
     } catch (e) {
-      console.error(`refresh failed for ${tokenRow.character_id}:`, e)
+      console.error(`refresh failed for ${name} ${tokenRow.character_id}:`, e)
     }
   }
 
@@ -67,6 +78,7 @@ const execute = async () => {
   }
 
   for (const tokenRow of industryTokens ?? []) {
+    const name = characterName.get(tokenRow.character_id) ?? '?'
     try {
       const { access_token, characterID } = await refreshAccessToken(tokenRow)
       const jobs = await industryJobs(access_token, characterID)
@@ -102,9 +114,9 @@ const execute = async () => {
           .upsert(rows, { onConflict: 'job_id' })
         if (jobError) throw jobError
       }
-      console.log(`industry ${tokenRow.character_id} (${characterID}): ${jobs.length} jobs`)
+      console.log(`industry ${name} ${tokenRow.character_id} (${characterID}): ${jobs.length} jobs`)
     } catch (e) {
-      console.error(`industry refresh failed for ${tokenRow.character_id}:`, e)
+      console.error(`industry refresh failed for ${name} ${tokenRow.character_id}:`, e)
     }
   }
 }

--- a/src/structures.js
+++ b/src/structures.js
@@ -1,5 +1,5 @@
 import { pullCorpWalletJournals } from './corpWalletJournal.js'
-import { character as fetchCharacter, corpAssets, corpStructures, corpWalletJournal } from './esi.js'
+import { character as fetchCharacter, corpAssets, corpStructures, corpWalletJournal, universeNames } from './esi.js'
 import { sudoSupabase } from './supabase.js'
 import { refreshAccessToken } from './tokenRefresh.js'
 
@@ -13,7 +13,34 @@ const isRigSlot = (flag) => typeof flag === 'string' && flag.startsWith('RigSlot
 
 const tail = (s) => (typeof s === 'string' && s.length > 4 ? s.slice(-4) : '????')
 
+// Corp names are public; resolve once per run and reuse so log lines read as
+// "Corp Name (98000001)" instead of a bare id.
+const corpNameCache = new Map()
+const resolveCorpName = async (corporation_id) => {
+  if (corpNameCache.has(corporation_id)) return corpNameCache.get(corporation_id)
+  let name = null
+  try {
+    const [n] = await universeNames([corporation_id])
+    name = n?.name ?? null
+  } catch (e) {
+    console.warn(`[structures] universe/names corp ${corporation_id} failed: ${e?.message}`)
+  }
+  corpNameCache.set(corporation_id, name)
+  return name
+}
+const corpLabelFor = (name, corporation_id) => (name ? `${name} (${corporation_id})` : `${corporation_id}`)
+
 const execute = async () => {
+  const { data: characters, error: charactersError } = await sudoSupabase
+    .schema('hangar')
+    .from('character')
+    .select('id, name')
+  if (charactersError) {
+    console.error('[structures] character lookup failed:', charactersError)
+    process.exit(1)
+  }
+  const characterName = new Map((characters ?? []).map((c) => [c.id, c.name]))
+
   const { data: tokens, error } = await sudoSupabase
     .schema('hangar')
     .from('token')
@@ -27,7 +54,10 @@ const execute = async () => {
 
   console.log(`[structures] found ${tokens?.length ?? 0} token(s) with ${STRUCTURES_SCOPE}`)
   for (const t of tokens ?? []) {
-    console.log(`[structures]   token ${t.id} character ${t.character_id} refresh ...${tail(t.refresh_token)}`)
+    const name = characterName.get(t.character_id) ?? '?'
+    console.log(
+      `[structures]   token ${t.id} character ${name} (${t.character_id}) refresh ...${tail(t.refresh_token)}`
+    )
   }
 
   const seenStructureCorps = new Set()
@@ -35,7 +65,8 @@ const execute = async () => {
   const seenAssetCorps = new Set()
   for (const tokenRow of tokens ?? []) {
     const t0 = Date.now()
-    const ctx = `character=${tokenRow.character_id} token=${tokenRow.id}`
+    const name = characterName.get(tokenRow.character_id) ?? '?'
+    const ctx = `character=${name} (${tokenRow.character_id}) token=${tokenRow.id}`
     try {
       console.log(`[structures] ${ctx}: refreshing token (refresh ...${tail(tokenRow.refresh_token)})`)
       const { access_token, characterID, scope, issued_at, expires_at } = await refreshAccessToken(tokenRow)
@@ -53,11 +84,12 @@ const execute = async () => {
       const info = await fetchCharacter(access_token, characterID)
       const corporation_id = info?.corporation_id
       const alliance_id = info?.alliance_id ?? null
-      console.log(`[structures] ${ctx}: character corporation_id=${corporation_id} alliance_id=${alliance_id}`)
       if (!corporation_id) {
         console.error(`[structures] ${ctx}: character payload missing corporation_id, raw=${JSON.stringify(info)}`)
         continue
       }
+      const corpLabel = corpLabelFor(await resolveCorpName(corporation_id), corporation_id)
+      console.log(`[structures] ${ctx}: character corporation=${corpLabel} alliance_id=${alliance_id}`)
 
       const { error: charUpdateErr, status: charUpdateStatus } = await sudoSupabase
         .schema('hangar')
@@ -73,22 +105,22 @@ const execute = async () => {
       }
 
       if (seenStructureCorps.has(corporation_id)) {
-        console.log(`[structures] ${ctx}: corp ${corporation_id} structures already pulled this run, skipping`)
+        console.log(`[structures] ${ctx}: corp ${corpLabel} structures already pulled this run, skipping`)
       } else {
         seenStructureCorps.add(corporation_id)
 
         const all = []
-        console.log(`[structures] ${ctx}: fetching corp ${corporation_id} structures page 1`)
+        console.log(`[structures] ${ctx}: fetching corp ${corpLabel} structures page 1`)
         const [firstPage, pagesHeader] = await corpStructures(access_token, corporation_id, 1)
         console.log(
-          `[structures] ${ctx}: corp ${corporation_id} page 1 returned ${firstPage?.length ?? 0} rows, x-pages=${pagesHeader}`
+          `[structures] ${ctx}: corp ${corpLabel} page 1 returned ${firstPage?.length ?? 0} rows, x-pages=${pagesHeader}`
         )
         all.push(...firstPage)
         const totalPages = Math.max(1, Number.parseInt(pagesHeader, 10) || 1)
         for (let page = 2; page <= totalPages; page++) {
-          console.log(`[structures] ${ctx}: fetching corp ${corporation_id} structures page ${page}/${totalPages}`)
+          console.log(`[structures] ${ctx}: fetching corp ${corpLabel} structures page ${page}/${totalPages}`)
           const [more] = await corpStructures(access_token, corporation_id, page)
-          console.log(`[structures] ${ctx}: corp ${corporation_id} page ${page} returned ${more?.length ?? 0} rows`)
+          console.log(`[structures] ${ctx}: corp ${corpLabel} page ${page} returned ${more?.length ?? 0} rows`)
           all.push(...more)
         }
 
@@ -114,7 +146,7 @@ const execute = async () => {
 
         if (rows.length > 0) {
           console.log(
-            `[structures] ${ctx}: upserting ${rows.length} structure row(s) for corp ${corporation_id} sample=${JSON.stringify(rows[0])}`
+            `[structures] ${ctx}: upserting ${rows.length} structure row(s) for corp ${corpLabel} sample=${JSON.stringify(rows[0])}`
           )
           const { error: upsertErr, status: upsertStatus } = await sudoSupabase
             .schema('hangar')
@@ -128,17 +160,17 @@ const execute = async () => {
           }
           console.log(`[structures] ${ctx}: upsert ok (status=${upsertStatus})`)
         } else {
-          console.log(`[structures] ${ctx}: corp ${corporation_id} returned zero structures, nothing to upsert`)
+          console.log(`[structures] ${ctx}: corp ${corpLabel} returned zero structures, nothing to upsert`)
         }
 
         const dt = Date.now() - t0
-        console.log(`[structures] ${ctx}: done corp ${corporation_id} ${rows.length} fetched in ${dt}ms`)
+        console.log(`[structures] ${ctx}: done corp ${corpLabel} ${rows.length} fetched in ${dt}ms`)
       }
 
       if (!scope.includes(ASSETS_SCOPE)) {
-        console.log(`[structures] ${ctx}: corp ${corporation_id} token lacks ${ASSETS_SCOPE}, skipping structure rigs`)
+        console.log(`[structures] ${ctx}: corp ${corpLabel} token lacks ${ASSETS_SCOPE}, skipping structure rigs`)
       } else if (seenAssetCorps.has(corporation_id)) {
-        console.log(`[structures] ${ctx}: corp ${corporation_id} assets already pulled this run, skipping rigs`)
+        console.log(`[structures] ${ctx}: corp ${corpLabel} assets already pulled this run, skipping rigs`)
       } else {
         seenAssetCorps.add(corporation_id)
         try {
@@ -153,7 +185,7 @@ const execute = async () => {
 
           const ta = Date.now()
           const assets = []
-          console.log(`[structures] ${ctx}: fetching corp ${corporation_id} assets page 1`)
+          console.log(`[structures] ${ctx}: fetching corp ${corpLabel} assets page 1`)
           const [firstAssetPage, assetPagesHeader] = await corpAssets(access_token, corporation_id, 1)
           assets.push(...firstAssetPage)
           const assetPages = Math.max(1, Number.parseInt(assetPagesHeader, 10) || 1)
@@ -162,7 +194,7 @@ const execute = async () => {
             assets.push(...more)
           }
           console.log(
-            `[structures] ${ctx}: corp ${corporation_id} returned ${assets.length} asset(s) across ${assetPages} page(s)`
+            `[structures] ${ctx}: corp ${corpLabel} returned ${assets.length} asset(s) across ${assetPages} page(s)`
           )
 
           const now = new Date().toISOString()
@@ -193,22 +225,20 @@ const execute = async () => {
             if (rigErr) throw rigErr
           }
           console.log(
-            `[structures] ${ctx}: corp ${corporation_id} stored ${rigRows.length} structure rig(s) in ${Date.now() - ta}ms`
+            `[structures] ${ctx}: corp ${corpLabel} stored ${rigRows.length} structure rig(s) in ${Date.now() - ta}ms`
           )
         } catch (e) {
-          console.error(
-            `[structures] ${ctx}: corp ${corporation_id} rig pull FAILED name=${e?.name} message=${e?.message}`
-          )
+          console.error(`[structures] ${ctx}: corp ${corpLabel} rig pull FAILED name=${e?.name} message=${e?.message}`)
         }
       }
 
       if (!scope.includes(WALLET_SCOPE)) {
-        console.log(`[structures] ${ctx}: corp ${corporation_id} token lacks ${WALLET_SCOPE}, skipping wallet journal`)
+        console.log(`[structures] ${ctx}: corp ${corpLabel} token lacks ${WALLET_SCOPE}, skipping wallet journal`)
       } else if (seenWalletCorps.has(corporation_id)) {
-        console.log(`[structures] ${ctx}: corp ${corporation_id} wallet journal already pulled this run, skipping`)
+        console.log(`[structures] ${ctx}: corp ${corpLabel} wallet journal already pulled this run, skipping`)
       } else {
         seenWalletCorps.add(corporation_id)
-        await pullCorpWalletJournals({ access_token, corporation_id, ctx })
+        await pullCorpWalletJournals({ access_token, corporation_id, ctx, corpLabel })
       }
     } catch (e) {
       const dt = Date.now() - t0


### PR DESCRIPTION
## Summary

The scheduled cron jobs (`hourly`, `assets`, `structures`) previously logged only opaque IDs, making the GitHub Actions output hard to read. This change displays the character name alongside its ID in every log line, and the corporation name alongside its ID wherever a corp is pulled.

## Changes

- **`src/hourly.js`** — Loads a `character_id → name` map up front and prefixes the wallet, transactions, and industry log lines (success and error) with the character name.
- **`src/assets.js`** — Same name map; the per-token `ctx` now reads `character=<name> (<uuid>) token=<id>`.
- **`src/structures.js`** — Same name map for the `ctx`, plus resolves corporation names via the existing `universeNames` ESI helper (cached once per run). Corp log lines now read `corp <name> (<corporation_id>)`.
- **`src/corpWalletJournal.js`** — `pullCorpWalletJournals` accepts an optional `corpLabel` (defaulting to the raw id) so its log lines show the corp name too.

Names come from `hangar.character` (for our own characters, matching the existing UI lookup pattern) and from ESI `/universe/names/` for corporations — no SDE access. Behavior of the data pulls themselves is unchanged; only log output is affected.

https://claude.ai/code/session_01Y8LYKPaKXcnBCXtDDuCxTc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8LYKPaKXcnBCXtDDuCxTc)_