### PR TITLE
Rename project to Edencom Link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "eve-hangar",
+  "name": "edencom-link",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "eve-hangar",
+      "name": "edencom-link",
       "version": "0.1.0",
       "dependencies": {
         "@next/third-parties": "16.2.6",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eve-hangar",
+  "name": "edencom-link",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/src/app/character/sso.ts
+++ b/src/app/character/sso.ts
@@ -16,5 +16,5 @@ export const scopes = [
   // 'esi-characters.read_blueprints.v1',
 ]
 
-export const userAgent = 'philihp@gmail.com eve-hangar discord:philihp'
+export const userAgent = 'philihp@gmail.com edencom-link discord:philihp'
 export const sso = new SingleSignOn(EVE_CLIENT_ID!, EVE_SECRET_KEY!, EVE_CALLBACK_URL!, userAgent)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,7 @@ import Header from './layout/header'
 import Footer from './layout/footer'
 
 export const metadata: Metadata = {
-  title: 'EVE Hangar',
+  title: 'Edencom Link',
   // Stop mobile browsers from turning long numeric IDs into "tap to dial" links.
   formatDetection: { telephone: false },
   icons: {

--- a/src/app/layout/header.tsx
+++ b/src/app/layout/header.tsx
@@ -14,7 +14,7 @@ const Header = async () => {
       <div className={styles.bar}>
         <div className={styles.top}>
           <Link href="/" className={styles.brand}>
-            EVE Hangar
+            Edencom Link
           </Link>
           {userId && <span className={styles.user}>{userId}</span>}
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ export default function Home() {
       <section className={styles.welcome}>
         <p className={styles.title}>
           <span className={styles.spark}>✻</span>
-          Welcome to EVE Hangar
+          Welcome to Edencom Link
         </p>
         <p className={styles.tip}>
           Your market, industry, and structure data — tracked from ESI and

--- a/src/esi.js
+++ b/src/esi.js
@@ -1,4 +1,4 @@
-export const userAgent = 'philihp@gmail.com eve-hangar discord:philihp'
+export const userAgent = 'philihp@gmail.com edencom-link discord:philihp'
 
 const ESI_BASE = 'https://esi.evetech.net/latest'
 


### PR DESCRIPTION
## Summary

Renames the project from **EVE Hangar** to **Edencom Link**.

### User-facing brand name
- `src/app/layout.tsx` — page `<title>`
- `src/app/layout/header.tsx` — header brand link
- `src/app/page.tsx` — "Welcome to …" on the home page

### Internal identifiers
- `package.json` / `package-lock.json` — npm package `name` (`eve-hangar` → `edencom-link`)
- `src/esi.js` and `src/app/character/sso.ts` — ESI `User-Agent` string

### Intentionally left unchanged
- The **`hangar` database schema** referenced via `.schema('hangar')` throughout `src/` — this is a live Supabase schema; renaming it would break data access and requires a separate DB migration.
- The **GitHub repo URL** in `src/app/layout/footer.tsx` (`github.com/philihp/eve-hangar`) — the repository itself has not been renamed.
- Generic in-copy uses of "hangar" (e.g. "access your hangar") on the login/register pages — these are EVE game-term references, not the brand.

https://claude.ai/code/session_01X99jsRZDxZaGKwwCxLb9NU

---
_Generated by [Claude Code](https://claude.ai/code/session_01X99jsRZDxZaGKwwCxLb9NU)_