### PR TITLE
Resolve unaccounted-tax payer names hourly so the structures dropdown shows names, not IDs

### DIFF
--- a/src/daily.js
+++ b/src/daily.js
@@ -1,69 +1,8 @@
-import { characterAffiliations, universeNames } from './esi.js'
+import { characterAffiliations } from './esi.js'
+import { resolveBatch, resolveCorpJournalNames } from './resolveNames.js'
 import { sudoSupabase } from './supabase.js'
 
-const LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000
 const BATCH_SIZE = 1000
-
-// ESI /universe/names/ rejects the whole batch if any id is invalid, so bisect on failure
-// until either the batch resolves or we narrow down to single bad ids we can drop.
-const resolveBatch = async (ids) => {
-  if (ids.length === 0) return []
-  try {
-    return await universeNames(ids)
-  } catch (e) {
-    if (ids.length === 1) {
-      console.warn(`[daily] universe/names id=${ids[0]} failed: ${e?.message}`)
-      return []
-    }
-    const mid = Math.floor(ids.length / 2)
-    const [a, b] = await Promise.all([resolveBatch(ids.slice(0, mid)), resolveBatch(ids.slice(mid))])
-    return [...a, ...b]
-  }
-}
-
-const resolveCorpJournalNames = async () => {
-  const cutoff = new Date(Date.now() - LOOKBACK_MS).toISOString()
-
-  const { data: journal, error: journalErr } = await sudoSupabase
-    .schema('hangar')
-    .from('corp_wallet_journal')
-    .select('first_party_id, second_party_id')
-    .gte('date', cutoff)
-  if (journalErr) throw journalErr
-
-  const ids = new Set()
-  for (const r of journal ?? []) {
-    if (r.first_party_id != null) ids.add(Number(r.first_party_id))
-    if (r.second_party_id != null) ids.add(Number(r.second_party_id))
-  }
-
-  const { data: known, error: knownErr } = await sudoSupabase.schema('hangar').from('eve_name').select('id')
-  if (knownErr) throw knownErr
-  for (const k of known ?? []) ids.delete(Number(k.id))
-
-  const toResolve = [...ids].filter((n) => Number.isFinite(n) && n > 0)
-  console.log(`[daily] corp journal: ${ids.size} unknown id(s) seen in last 30d, ${toResolve.length} to resolve`)
-  if (toResolve.length === 0) return
-
-  const resolved = []
-  for (let i = 0; i < toResolve.length; i += BATCH_SIZE) {
-    const batch = toResolve.slice(i, i + BATCH_SIZE)
-    const names = await resolveBatch(batch)
-    resolved.push(...names)
-  }
-
-  if (resolved.length === 0) {
-    console.log('[daily] no names resolved')
-    return
-  }
-
-  const rows = resolved.map((n) => ({ id: n.id, name: n.name, category: n.category }))
-  const { error: upErr } = await sudoSupabase.schema('hangar').from('eve_name').upsert(rows, { onConflict: 'id' })
-  if (upErr) throw upErr
-
-  const characterCount = rows.filter((r) => r.category === 'character').length
-  console.log(`[daily] upserted ${rows.length} name(s) (${characterCount} character)`)
-}
 
 // Map each known character to the corporation they currently belong to, so the UI can show who paid
 // industry tax and which corp they fly for. Affiliations are public (no token) and resolved in

--- a/src/resolveNames.js
+++ b/src/resolveNames.js
@@ -1,0 +1,70 @@
+import { universeNames } from './esi.js'
+import { sudoSupabase } from './supabase.js'
+
+const LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000
+const BATCH_SIZE = 1000
+
+// ESI /universe/names/ rejects the whole batch if any id is invalid, so bisect on failure
+// until either the batch resolves or we narrow down to single bad ids we can drop.
+export const resolveBatch = async (ids) => {
+  if (ids.length === 0) return []
+  try {
+    return await universeNames(ids)
+  } catch (e) {
+    if (ids.length === 1) {
+      console.warn(`[names] universe/names id=${ids[0]} failed: ${e?.message}`)
+      return []
+    }
+    const mid = Math.floor(ids.length / 2)
+    const [a, b] = await Promise.all([resolveBatch(ids.slice(0, mid)), resolveBatch(ids.slice(mid))])
+    return [...a, ...b]
+  }
+}
+
+// Resolve and cache (in eve_name) the name of every party seen in the corp wallet journal over the
+// last 30 days that we don't already have a name for. The UI reads eve_name to show who paid each
+// unaccounted industry tax instead of a raw id. Cheap to run often: it only resolves ids missing
+// from eve_name, so steady-state runs resolve nothing.
+export const resolveCorpJournalNames = async () => {
+  const cutoff = new Date(Date.now() - LOOKBACK_MS).toISOString()
+
+  const { data: journal, error: journalErr } = await sudoSupabase
+    .schema('hangar')
+    .from('corp_wallet_journal')
+    .select('first_party_id, second_party_id')
+    .gte('date', cutoff)
+  if (journalErr) throw journalErr
+
+  const ids = new Set()
+  for (const r of journal ?? []) {
+    if (r.first_party_id != null) ids.add(Number(r.first_party_id))
+    if (r.second_party_id != null) ids.add(Number(r.second_party_id))
+  }
+
+  const { data: known, error: knownErr } = await sudoSupabase.schema('hangar').from('eve_name').select('id')
+  if (knownErr) throw knownErr
+  for (const k of known ?? []) ids.delete(Number(k.id))
+
+  const toResolve = [...ids].filter((n) => Number.isFinite(n) && n > 0)
+  console.log(`[names] corp journal: ${ids.size} unknown id(s) seen in last 30d, ${toResolve.length} to resolve`)
+  if (toResolve.length === 0) return
+
+  const resolved = []
+  for (let i = 0; i < toResolve.length; i += BATCH_SIZE) {
+    const batch = toResolve.slice(i, i + BATCH_SIZE)
+    const names = await resolveBatch(batch)
+    resolved.push(...names)
+  }
+
+  if (resolved.length === 0) {
+    console.log('[names] no names resolved')
+    return
+  }
+
+  const rows = resolved.map((n) => ({ id: n.id, name: n.name, category: n.category }))
+  const { error: upErr } = await sudoSupabase.schema('hangar').from('eve_name').upsert(rows, { onConflict: 'id' })
+  if (upErr) throw upErr
+
+  const characterCount = rows.filter((r) => r.category === 'character').length
+  console.log(`[names] upserted ${rows.length} name(s) (${characterCount} character)`)
+}

--- a/src/structures.js
+++ b/src/structures.js
@@ -1,5 +1,6 @@
 import { pullCorpWalletJournals } from './corpWalletJournal.js'
-import { character as fetchCharacter, corpAssets, corpStructures, corpWalletJournal, universeNames } from './esi.js'
+import { character as fetchCharacter, corpAssets, corpStructures, universeNames } from './esi.js'
+import { resolveCorpJournalNames } from './resolveNames.js'
 import { sudoSupabase } from './supabase.js'
 import { refreshAccessToken } from './tokenRefresh.js'
 
@@ -244,6 +245,15 @@ const execute = async () => {
       const dt = Date.now() - t0
       console.error(`[structures] ${ctx}: FAILED after ${dt}ms name=${e?.name} message=${e?.message}\n${e?.stack ?? e}`)
     }
+  }
+
+  // Cache names for the journal parties we just pulled (industry-tax payers etc.) so the structures
+  // page shows who paid instead of a raw id. Doing it here keeps names within an hour of the journal
+  // rather than waiting on the once-a-day job.
+  try {
+    await resolveCorpJournalNames()
+  } catch (e) {
+    console.error(`[structures] name resolution FAILED name=${e?.name} message=${e?.message}`)
   }
 }
 


### PR DESCRIPTION
## Problem

The "Breakdown by payer" dropdown under unaccounted tax revenue on the structures page often showed a raw character **ID** instead of the character **name**.

The UI lookup itself is correct — payer names are read from the `eve_name` table. The issue is how that table gets populated: only the **daily** job (`daily.js` → `resolveCorpJournalNames`) resolves journal-party names, and in `daily.yml` it runs *after* a large, failure-prone SDE import (download the multi-GB fuzzwork dump → `pg_restore` → `psql`). If any import step fails the job aborts before name resolution ever runs; even on success, names lag up to 24h behind the hourly journal pulls. Meanwhile the page falls back to the raw id.

## Fix

Resolve the journal-party names in the **hourly structures job**, which already pulls the corp wallet journal and already imports the `universeNames` ESI helper — decoupled from the SDE import.

- **`src/resolveNames.js`** (new) — extracts the shared `resolveBatch` (bisecting `/universe/names/` resolver) and `resolveCorpJournalNames` (resolves every journal party from the last 30 days that isn't already in `eve_name`, then upserts). Cheap to run often: steady-state runs resolve nothing.
- **`src/daily.js`** — now imports those from the shared module instead of defining them; `resolveCharacterCorps` is unchanged.
- **`src/structures.js`** — calls `resolveCorpJournalNames()` once at the end of the run, right after the journals are pulled, so payer names land in `eve_name` within the hour. Also drops a pre-existing unused `corpWalletJournal` import.

No UI changes were needed and no ESI is called from the UI — names still come from the DB. Behavior of the daily job is unchanged; it just shares the same implementation now.

## Testing

`node --check`, `eslint`, and `prettier` all pass on the changed files. The data path can't be exercised here (no Supabase/ESI credentials in this environment); the change reuses the exact resolution logic the daily job already ran, just on the hourly cadence.

https://claude.ai/code/session_01Y8LYKPaKXcnBCXtDDuCxTc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8LYKPaKXcnBCXtDDuCxTc)_