### PR TITLE
Add assets page listing locations where assets are held

### DIFF
--- a/src/app/assets/assets.module.css
+++ b/src/app/assets/assets.module.css
@@ -1,0 +1,63 @@
+/*
+ * Locations where the user holds assets, as a responsive tile grid mirroring
+ * the structures page — two per row on phones, packing in more as it widens.
+ */
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+  list-style: none;
+  padding: 0;
+  margin: 16px 0;
+}
+
+@media (min-width: 640px) {
+  .grid {
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  }
+}
+
+.tile {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper-raised);
+  transition: border-color 0.12s ease;
+  min-width: 0;
+}
+
+.tile:hover {
+  border-color: var(--accent);
+}
+
+.head {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.name {
+  font-family: var(--serif);
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.25;
+  color: var(--ink);
+  overflow-wrap: anywhere;
+}
+
+.system {
+  font-size: 12px;
+  color: var(--ink-faint);
+  overflow-wrap: anywhere;
+}
+
+.count {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  color: var(--ink-soft);
+}

--- a/src/app/assets/page.tsx
+++ b/src/app/assets/page.tsx
@@ -1,0 +1,134 @@
+import { redirect } from 'next/navigation'
+
+import { createClient } from '@/utils/supabase/server'
+import { fetchSystemNames } from '../systemNames'
+import styles from './assets.module.css'
+
+// Bigint ids arrive from PostgREST as strings, so every id is kept as a string
+// and only converted to a number at the API/system-lookup boundary.
+type Asset = {
+  item_id: number | string
+  location_id: number | string | null
+  location_type: string | null
+}
+
+type Structure = {
+  structure_id: number | string
+  name: string | null
+  system_id: number | string
+}
+
+// The place an item ultimately sits. Items can be nested (a module in a ship in
+// a station), so the root is found by walking location_id up through any parent
+// items we also own until it points at something that isn't one of our items —
+// a station, structure, or solar system.
+type Root = { id: string; type: string | null }
+
+const AssetsPage = async () => {
+  const supabase = await createClient()
+
+  const { data: auth, error: authError } = await supabase.auth.getUser()
+  if (authError || !auth?.user) {
+    redirect('/')
+  }
+
+  const { data: assets } = await supabase
+    .schema('hangar')
+    .from('asset')
+    .select('item_id, location_id, location_type')
+
+  const list = (assets ?? []) as Asset[]
+  const assetByItem = new Map(list.map((a) => [String(a.item_id), a]))
+
+  const rootLocation = (a: Asset): Root | null => {
+    let cur: Asset | undefined = a
+    const seen = new Set<string>()
+    while (cur && cur.location_id != null) {
+      const key = String(cur.location_id)
+      const parent = assetByItem.get(key)
+      // Parent isn't one of our items (or we've looped) — cur sits directly in
+      // this location, so it's the root.
+      if (!parent || seen.has(key)) return { id: key, type: cur.location_type }
+      seen.add(key)
+      cur = parent
+    }
+    return null
+  }
+
+  // Tally how many item stacks resolve to each location.
+  const byLocation = new Map<string, Root & { count: number }>()
+  for (const a of list) {
+    const root = rootLocation(a)
+    if (!root) continue
+    const existing = byLocation.get(root.id)
+    if (existing) existing.count += 1
+    else byLocation.set(root.id, { ...root, count: 1 })
+  }
+
+  // Names + systems for the locations we can resolve: our corp's structures from
+  // the corp_structure table, and in-space `solar_system` locations whose id is
+  // the system itself. NPC stations have no non-SDE source, so they show raw ids.
+  const { data: structures } = await supabase
+    .schema('hangar')
+    .from('corp_structure')
+    .select('structure_id, name, system_id')
+
+  const structureById = new Map(((structures ?? []) as Structure[]).map((s) => [String(s.structure_id), s]))
+
+  const systemIds = new Set<number>()
+  for (const loc of byLocation.values()) {
+    if (loc.type === 'solar_system') systemIds.add(Number(loc.id))
+    const structure = structureById.get(loc.id)
+    if (structure) systemIds.add(Number(structure.system_id))
+  }
+  const systemNames = await fetchSystemNames(systemIds)
+
+  const labelFor = (loc: Root): string => {
+    const structure = structureById.get(loc.id)
+    if (structure) return structure.name ?? `Structure #${loc.id}`
+    if (loc.type === 'solar_system') return systemNames[Number(loc.id)] ?? `System #${loc.id}`
+    if (loc.type === 'station') return `Station #${loc.id}`
+    return `Location #${loc.id}`
+  }
+
+  const systemFor = (loc: Root): string | undefined => {
+    const structure = structureById.get(loc.id)
+    if (structure) return systemNames[Number(structure.system_id)] ?? `#${structure.system_id}`
+    if (loc.type === 'solar_system') return systemNames[Number(loc.id)]
+    return undefined
+  }
+
+  // Busiest locations first, then by name for a stable order.
+  const rows = [...byLocation.values()].sort((a, b) => b.count - a.count || labelFor(a).localeCompare(labelFor(b)))
+
+  return (
+    <>
+      <h1>Assets</h1>
+      {rows.length > 0 ? (
+        <ul className={styles.grid}>
+          {rows.map((loc) => {
+            const system = systemFor(loc)
+            const name = labelFor(loc)
+            return (
+              <li key={`location-${loc.id}`} className={styles.tile}>
+                <div className={styles.head}>
+                  <span className={styles.name}>{name}</span>
+                  {system && system !== name && <span className={styles.system}>{system}</span>}
+                </div>
+                <span className={styles.count}>
+                  {loc.count} {loc.count === 1 ? 'stack' : 'stacks'}
+                </span>
+              </li>
+            )
+          })}
+        </ul>
+      ) : (
+        <p>
+          No assets visible. Link a character with the <code>esi-assets.read_assets.v1</code> scope on the{' '}
+          <a href="/character">Characters</a> page so the hourly job can fetch them.
+        </p>
+      )}
+    </>
+  )
+}
+export default AssetsPage

--- a/src/app/layout/header.tsx
+++ b/src/app/layout/header.tsx
@@ -30,6 +30,8 @@ const Header = async () => {
             <>
               <Link href="/character/">characters</Link>
               <span className={styles.sep}>|</span>
+              <Link href="/assets">assets</Link>
+              <span className={styles.sep}>|</span>
               <Link href="/market">market</Link>
               <span className={styles.sep}>|</span>
               <Link href="/industry">industry</Link>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,6 +22,7 @@ export default function Home() {
 
       <nav className={styles.hints}>
         <Link href="/character/">/characters</Link>
+        <Link href="/assets">/assets</Link>
         <Link href="/market">/market</Link>
         <Link href="/industry">/industry</Link>
         <Link href="/structures">/structures</Link>


### PR DESCRIPTION
Group current assets by their root location (walking nested items up to the station/structure/system they sit in) and list each place with a stack count. Corp structures and in-space solar_system locations resolve to a system name via the corp_structure table and the eve-build-calculator system API; NPC stations have no non-SDE source so they show their raw id.