### PR TITLE
Add ESI scope selection to settings page

### DIFF
--- a/hangar.sql
+++ b/hangar.sql
@@ -524,3 +524,34 @@ end $$;
 
 grant select on hangar.structure to authenticated;
 grant all    on hangar.structure to service_role;
+
+-- Per-user preferences. `enabled_scopes` is the set of ESI OAuth scopes the
+-- user has opted into requesting when they add a character; an absent row means
+-- "request everything" (see src/app/character/userScopes.ts).
+create table if not exists hangar.user_settings (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  enabled_scopes text[] not null default '{}',
+  updated_at timestamptz not null default now()
+);
+
+alter table hangar.user_settings enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'hangar'
+      and tablename = 'user_settings'
+      and policyname = 'Users manage own settings'
+  ) then
+    create policy "Users manage own settings"
+      on hangar.user_settings
+      for all
+      to authenticated
+      using (user_id = (select auth.uid()))
+      with check (user_id = (select auth.uid()));
+  end if;
+end $$;
+
+grant select, insert, update, delete on hangar.user_settings to authenticated;
+grant all                            on hangar.user_settings to service_role;

--- a/src/app/account/settings/page.tsx
+++ b/src/app/account/settings/page.tsx
@@ -1,9 +1,12 @@
 import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
+import { esiScopes } from '@/app/character/scopes'
+import { getEnabledScopes } from '@/app/character/userScopes'
 
 import ChangePassword from './changePassword'
 import { LogoffButton } from './logoffButton'
+import ScopeSettings from './scopeSettings'
 
 const SettingsPage = async () => {
   const supabase = await createClient()
@@ -13,15 +16,18 @@ const SettingsPage = async () => {
     redirect('/account/login')
   }
 
+  const enabledScopes = await getEnabledScopes(supabase, data.user.id)
+
   return (
     <>
       <h1>Settings</h1>
 
       <ChangePassword />
 
+      <ScopeSettings scopes={esiScopes} enabled={enabledScopes} />
+
       <h2>Logoff</h2>
       <LogoffButton />
-      {/* <pre>{JSON.stringify(data?.user, undefined, 2)}</pre> */}
     </>
   )
 }

--- a/src/app/account/settings/scopeActions.ts
+++ b/src/app/account/settings/scopeActions.ts
@@ -1,0 +1,29 @@
+'use server'
+
+import { createClient } from '@/utils/supabase/server'
+import { optionalScopes, requiredScopes } from '@/app/character/scopes'
+
+export const saveScopePreferences = async (formData: FormData) => {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+  if (error || !user?.id) {
+    return 'You are not signed in'
+  }
+
+  // Only optional scopes are toggleable; required scopes are always stored.
+  const selectedOptional = optionalScopes.filter((scope) => formData.get(scope) === 'on')
+  const enabled_scopes = [...requiredScopes, ...selectedOptional]
+
+  const { error: upsertError } = await supabase
+    .schema('hangar')
+    .from('user_settings')
+    .upsert({ user_id: user.id, enabled_scopes, updated_at: new Date().toISOString() }, { onConflict: 'user_id' })
+
+  if (upsertError) {
+    return upsertError.message
+  }
+}

--- a/src/app/account/settings/scopeSettings.module.css
+++ b/src/app/account/settings/scopeSettings.module.css
@@ -1,0 +1,59 @@
+.intro {
+  color: var(--ink-soft);
+  max-width: 60ch;
+  margin: 0 0 12pt;
+}
+
+.selectAll {
+  margin-bottom: 12pt;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 16pt;
+  display: flex;
+  flex-direction: column;
+  gap: 8pt;
+}
+
+.item {
+  padding: 10pt 12pt;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper-raised);
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 8pt;
+  cursor: pointer;
+}
+
+.name {
+  font-family: var(--serif);
+  font-weight: bold;
+}
+
+.badge {
+  font-size: 8pt;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ink-faint);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 1pt 5pt;
+}
+
+.why {
+  font-size: 9pt;
+  color: var(--ink-soft);
+  margin: 6pt 0 0 24pt;
+}
+
+.without {
+  font-size: 9pt;
+  color: var(--accent);
+  margin: 4pt 0 0 24pt;
+}

--- a/src/app/account/settings/scopeSettings.tsx
+++ b/src/app/account/settings/scopeSettings.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { useState } from 'react'
+
+import type { EsiScope } from '@/app/character/scopes'
+
+import Dot from './dot'
+import { saveScopePreferences } from './scopeActions'
+import styles from './scopeSettings.module.css'
+
+type ScopeSettingsProps = {
+  scopes: EsiScope[]
+  enabled: string[]
+}
+
+const ScopeSettings = ({ scopes, enabled }: ScopeSettingsProps) => {
+  const [checked, setChecked] = useState<Record<string, boolean>>(() =>
+    Object.fromEntries(scopes.map((s) => [s.scope, Boolean(s.required) || enabled.includes(s.scope)])),
+  )
+  const [response, setResponse] = useState('')
+  const [color, setColor] = useState('#000000')
+
+  const toggle = (scope: string) => setChecked((prev) => ({ ...prev, [scope]: !prev[scope] }))
+
+  const selectAll = () => setChecked(Object.fromEntries(scopes.map((s) => [s.scope, true])))
+
+  const save = async (formData: FormData) => {
+    const error = await saveScopePreferences(formData)
+    if (error) {
+      setColor('#FF0000')
+      setResponse(error)
+      return
+    }
+    setColor('#00AF00')
+    setResponse('Preferences saved')
+  }
+
+  return (
+    <>
+      <h2>ESI Access</h2>
+      <p className={styles.intro}>
+        When you add a character we ask EVE Online for permission to read the data below. Uncheck anything you would
+        rather not share &mdash; we just won&apos;t be able to provide the related features for that character. Changes
+        apply to characters you add from now on.
+      </p>
+      <form>
+        <button type="button" className={styles.selectAll} onClick={selectAll}>
+          Select all
+        </button>
+        <ul className={styles.list}>
+          {scopes.map((s) => (
+            <li key={s.scope} className={styles.item}>
+              <label className={styles.row}>
+                <input
+                  type="checkbox"
+                  name={s.scope}
+                  checked={checked[s.scope] ?? false}
+                  disabled={s.required}
+                  onChange={() => toggle(s.scope)}
+                />
+                <span className={styles.name}>{s.name}</span>
+                {s.required && <span className={styles.badge}>required</span>}
+              </label>
+              <p className={styles.why}>{s.why}</p>
+              {!checked[s.scope] && <p className={styles.without}>Without this, {s.without}</p>}
+            </li>
+          ))}
+        </ul>
+        <button formAction={save}>Save ESI Access</button>
+      </form>
+      <p>{response && <Dot color={color} response={response} />}</p>
+    </>
+  )
+}
+
+export default ScopeSettings

--- a/src/app/assets/page.tsx
+++ b/src/app/assets/page.tsx
@@ -86,11 +86,6 @@ const AssetsPage = async () => {
   for (const s of (corpStructures ?? []) as Structure[]) structureById.set(String(s.structure_id), s)
 
   // NPC station names come from eve-build-calculator (same curated source as the
-  // type/system lookups).
-  const stationIds = [...byLocation.values()].filter((loc) => loc.type === 'station').map((loc) => Number(loc.id))
-  const stationNames = await fetchStationNames(stationIds)
-
-  // NPC station names come from eve-build-calculator (same curated source as the
   // type/system lookups); player structures aren't there, so those still resolve
   // via corp_structure above.
   const stationIds = [...byLocation.values()].filter((loc) => loc.type === 'station').map((loc) => Number(loc.id))

--- a/src/app/character/actions.ts
+++ b/src/app/character/actions.ts
@@ -2,8 +2,21 @@
 
 import { redirect } from 'next/navigation'
 
-import { sso, scopes } from './sso'
+import { createClient } from '@/utils/supabase/server'
+
+import { sso } from './sso'
+import { getEnabledScopes } from './userScopes'
 
 export const register = async (formData: FormData) => {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user?.id) {
+    redirect('/account/login')
+  }
+
+  const scopes = await getEnabledScopes(supabase, user.id)
   redirect(sso.getRedirectUrl('state', scopes))
 }

--- a/src/app/character/scopes.ts
+++ b/src/app/character/scopes.ts
@@ -1,0 +1,84 @@
+// Metadata for every ESI OAuth scope we may request when a player adds a
+// character. The settings page renders this list so players can choose which
+// scopes to grant; `sso.ts` derives the default request set from it and the
+// register flow narrows the request to the player's saved preferences.
+
+export type EsiScope = {
+  /** The ESI OAuth scope string sent to EVE's SSO. */
+  scope: string
+  /** Short, human-friendly label for the scope. */
+  name: string
+  /** Why the app asks for this scope. */
+  why: string
+  /** What the app cannot do for the character if this scope is declined. */
+  without: string
+  /** Required scopes are always requested and cannot be turned off. */
+  required?: boolean
+}
+
+export const esiScopes: EsiScope[] = [
+  {
+    scope: 'publicData',
+    name: 'Public data',
+    why: 'Identifies the pilot you are adding (character name and owner hash) so the login can be attached to the right character. This is the minimum EVE requires to complete a login.',
+    without: 'we could not tell which character you authorized, so the character cannot be added at all. This scope is required.',
+    required: true,
+  },
+  {
+    scope: 'esi-wallet.read_character_wallet.v1',
+    name: 'Character wallet',
+    why: 'Records this character’s ISK balance over time and their market transaction history.',
+    without: 'we cannot show a wallet balance or transaction history for this character.',
+  },
+  {
+    scope: 'esi-assets.read_assets.v1',
+    name: 'Character assets',
+    why: 'Lists the items and ships this character holds in hangars across New Eden.',
+    without: 'this character’s assets, and the locations where they are stored, will not appear on the assets page.',
+  },
+  {
+    scope: 'esi-industry.read_character_jobs.v1',
+    name: 'Industry jobs',
+    why: 'Tracks this character’s manufacturing, research, invention and reaction jobs, and when they finish.',
+    without: 'industry jobs run by this character will not be tracked.',
+  },
+  {
+    scope: 'esi-markets.read_character_orders.v1',
+    name: 'Market orders',
+    why: 'Shows this character’s open buy and sell orders.',
+    without: 'this character’s market orders will not be shown.',
+  },
+  {
+    scope: 'esi-corporations.read_structures.v1',
+    name: 'Corporation structures',
+    why: 'Monitors your corporation’s Upwell structures, including fuel and reinforcement timers. Requires the Station Manager or Director role in game.',
+    without: 'corporation structures and their fuel timers will not be tracked from this character.',
+  },
+  {
+    scope: 'esi-wallet.read_corporation_wallets.v1',
+    name: 'Corporation wallet',
+    why: 'Reads your corporation’s wallet division journals. Requires the Accountant or Junior Accountant role in game.',
+    without: 'corporation wallet journals will not be tracked from this character.',
+  },
+  {
+    scope: 'esi-assets.read_corporation_assets.v1',
+    name: 'Corporation assets',
+    why: 'Lists corporation assets, which also reveals the rigs fitted to your structures. Requires the Director role in game.',
+    without: 'corporation assets and structure fittings will not be tracked from this character.',
+  },
+  {
+    scope: 'esi-universe.read_structures.v1',
+    name: 'Structure names',
+    why: 'Resolves the names of player-owned Upwell structures where this character keeps assets, so they show a name instead of a raw ID.',
+    without: 'player structures where this character holds assets will appear as a numeric ID rather than their name.',
+  },
+]
+
+/** Every scope, requested by default when a player has saved no preferences. */
+export const defaultScopes = esiScopes.map((s) => s.scope)
+
+/** Scopes that are always requested regardless of the player's preferences. */
+export const requiredScopes = esiScopes.filter((s) => s.required).map((s) => s.scope)
+
+/** Scopes the player is free to toggle on or off. */
+export const optionalScopes = esiScopes.filter((s) => !s.required).map((s) => s.scope)

--- a/src/app/character/sso.ts
+++ b/src/app/character/sso.ts
@@ -1,21 +1,14 @@
 import SingleSignOn from 'eve-sso'
 
+import { defaultScopes } from './scopes'
+
 const EVE_CLIENT_ID = process.env.EVE_CLIENT_ID
 const EVE_SECRET_KEY = process.env.EVE_SECRET_KEY
 const EVE_CALLBACK_URL = process.env.EVE_CALLBACK_URL
 
-export const scopes = [
-  'publicData',
-  'esi-wallet.read_character_wallet.v1',
-  'esi-assets.read_assets.v1',
-  'esi-industry.read_character_jobs.v1',
-  'esi-markets.read_character_orders.v1',
-  'esi-corporations.read_structures.v1',
-  'esi-wallet.read_corporation_wallets.v1',
-  'esi-assets.read_corporation_assets.v1',
-  'esi-universe.read_structures.v1',
-  // 'esi-characters.read_blueprints.v1',
-]
+// Every scope we may request. The set actually requested for a given player is
+// narrowed to their saved preferences in the register flow; see scopes.ts.
+export const scopes = defaultScopes
 
 export const userAgent = 'philihp@gmail.com edencom-link discord:philihp'
 export const sso = new SingleSignOn(EVE_CLIENT_ID!, EVE_SECRET_KEY!, EVE_CALLBACK_URL!, userAgent)

--- a/src/app/character/userScopes.ts
+++ b/src/app/character/userScopes.ts
@@ -1,0 +1,22 @@
+import { SupabaseClient } from '@supabase/supabase-js'
+
+import { defaultScopes, optionalScopes, requiredScopes } from './scopes'
+
+// Resolve the set of ESI scopes to request when this user adds a character.
+// A player who has never saved preferences gets every scope. Otherwise we
+// always include the required scopes and add back whichever optional scopes
+// the player left checked.
+export const getEnabledScopes = async (supabase: SupabaseClient, userId: string): Promise<string[]> => {
+  const { data } = await supabase
+    .schema('hangar')
+    .from('user_settings')
+    .select('enabled_scopes')
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  if (!data) return defaultScopes
+
+  const saved: string[] = data.enabled_scopes ?? []
+  const enabledOptional = optionalScopes.filter((scope) => saved.includes(scope))
+  return [...requiredScopes, ...enabledOptional]
+}


### PR DESCRIPTION
## What

Adds an **ESI Access** section to the settings page (`/account/settings`) that lists every ESI scope the app may request when a player adds a character. For each scope there's:

- a **checkbox** to opt in/out,
- an explanation of **why** we request it, and
- a note of **what functionality is lost** when it's unchecked.

There's a **Select all** button at the top, and a **Save** button that persists the choice.

When the player later adds a character, the SSO request is narrowed to only the scopes they kept enabled.

## How

- **`src/app/character/scopes.ts`** — new central metadata for each scope (label, why, what's lost, required flag). `publicData` is marked `required` since EVE needs it to identify the character; it's always requested and rendered as a non-toggleable checkbox.
- **`src/app/character/sso.ts`** — derives its default `scopes` array from the metadata instead of a hardcoded list (no behavior change to the default set).
- **`src/app/character/userScopes.ts`** — `getEnabledScopes()` resolves the scopes to request for a user: everything if they've never saved preferences, otherwise required scopes plus whatever optional scopes they left checked.
- **`src/app/character/actions.ts`** — `register()` now looks up the signed-in user's saved scopes and requests only those.
- **`src/app/account/settings/scopeSettings.tsx` / `scopeActions.ts` / `scopeSettings.module.css`** — client component with the checkboxes, select-all, and save (server action upserts preferences). Styling reuses the existing theme variables.
- **`hangar.sql`** — new `hangar.user_settings` table (`user_id` PK, `enabled_scopes text[]`) with RLS so users only manage their own row, plus grants. An absent row means "request everything".

## Notes

- Preferences are per account and apply to characters added from then on; existing tokens are unchanged.
- Requires applying the new table from `hangar.sql` to the Supabase project.
- `tsc`, `eslint`, and `next build` all pass (only pre-existing lint warnings remain).

https://claude.ai/code/session_01Xd5wrtxmUt9ETAfNR7GtEu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd5wrtxmUt9ETAfNR7GtEu)_