### PR TITLE
Resolve station and player-structure names on the assets page

### DIFF
--- a/hangar.sql
+++ b/hangar.sql
@@ -491,3 +491,36 @@ end $$;
 
 grant select on hangar.character_corp to authenticated;
 grant all    on hangar.character_corp to service_role;
+
+-- Cache of player Upwell structure details (name, system) resolved from ESI's
+-- authenticated /universe/structures endpoint by the structures job. Lets the
+-- assets UI show a name/system for structures that aren't our own corp's (those
+-- live in corp_structure) and aren't in the SDE.
+create table if not exists hangar.structure (
+  structure_id bigint primary key,
+  name text,
+  system_id bigint,
+  type_id bigint,
+  resolved_at timestamptz not null default now()
+);
+
+alter table hangar.structure enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'hangar'
+      and tablename = 'structure'
+      and policyname = 'Authenticated read structure'
+  ) then
+    create policy "Authenticated read structure"
+      on hangar.structure
+      for select
+      to authenticated
+      using (true);
+  end if;
+end $$;
+
+grant select on hangar.structure to authenticated;
+grant all    on hangar.structure to service_role;

--- a/src/app/assets/page.tsx
+++ b/src/app/assets/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
+import { fetchStationNames } from '../stationNames'
 import { fetchSystemNames } from '../systemNames'
 import styles from './assets.module.css'
 
@@ -75,6 +76,12 @@ const AssetsPage = async () => {
 
   const structureById = new Map(((structures ?? []) as Structure[]).map((s) => [String(s.structure_id), s]))
 
+  // NPC station names come from eve-build-calculator (same curated source as the
+  // type/system lookups); player structures aren't there, so those still resolve
+  // via corp_structure above.
+  const stationIds = [...byLocation.values()].filter((loc) => loc.type === 'station').map((loc) => Number(loc.id))
+  const stationNames = await fetchStationNames(stationIds)
+
   const systemIds = new Set<number>()
   for (const loc of byLocation.values()) {
     if (loc.type === 'solar_system') systemIds.add(Number(loc.id))
@@ -86,8 +93,8 @@ const AssetsPage = async () => {
   const labelFor = (loc: Root): string => {
     const structure = structureById.get(loc.id)
     if (structure) return structure.name ?? `Structure #${loc.id}`
+    if (loc.type === 'station') return stationNames[Number(loc.id)] ?? `Station #${loc.id}`
     if (loc.type === 'solar_system') return systemNames[Number(loc.id)] ?? `System #${loc.id}`
-    if (loc.type === 'station') return `Station #${loc.id}`
     return `Location #${loc.id}`
   }
 

--- a/src/app/assets/page.tsx
+++ b/src/app/assets/page.tsx
@@ -16,7 +16,7 @@ type Asset = {
 type Structure = {
   structure_id: number | string
   name: string | null
-  system_id: number | string
+  system_id: number | string | null
 }
 
 // The place an item ultimately sits. Items can be nested (a module in a ship in
@@ -66,19 +66,27 @@ const AssetsPage = async () => {
     else byLocation.set(root.id, { ...root, count: 1 })
   }
 
-  // Names + systems for the locations we can resolve: our corp's structures from
-  // the corp_structure table, and in-space `solar_system` locations whose id is
-  // the system itself. NPC stations have no non-SDE source, so they show raw ids.
-  const { data: structures } = await supabase
+  // Structure names + systems come from two caches: our own corp's structures
+  // (corp_structure) and foreign player structures characters hold assets in,
+  // resolved from ESI by the structures job (hangar.structure). Own-corp entries
+  // win on overlap. In-space `solar_system` locations are the system itself.
+  const locationIds = [...byLocation.keys()].map(Number).filter((n) => Number.isFinite(n))
+
+  const { data: corpStructures } = await supabase
     .schema('hangar')
     .from('corp_structure')
     .select('structure_id, name, system_id')
+  const { data: playerStructures } = locationIds.length
+    ? await supabase.schema('hangar').from('structure').select('structure_id, name, system_id').in('structure_id', locationIds)
+    : { data: [] }
 
-  const structureById = new Map(((structures ?? []) as Structure[]).map((s) => [String(s.structure_id), s]))
+  const structureById = new Map<string, Structure>()
+  for (const s of (playerStructures ?? []) as Structure[]) structureById.set(String(s.structure_id), s)
+  // Own-corp structures override the ESI-resolved cache.
+  for (const s of (corpStructures ?? []) as Structure[]) structureById.set(String(s.structure_id), s)
 
   // NPC station names come from eve-build-calculator (same curated source as the
-  // type/system lookups); player structures aren't there, so those still resolve
-  // via corp_structure above.
+  // type/system lookups).
   const stationIds = [...byLocation.values()].filter((loc) => loc.type === 'station').map((loc) => Number(loc.id))
   const stationNames = await fetchStationNames(stationIds)
 
@@ -86,7 +94,7 @@ const AssetsPage = async () => {
   for (const loc of byLocation.values()) {
     if (loc.type === 'solar_system') systemIds.add(Number(loc.id))
     const structure = structureById.get(loc.id)
-    if (structure) systemIds.add(Number(structure.system_id))
+    if (structure?.system_id != null) systemIds.add(Number(structure.system_id))
   }
   const systemNames = await fetchSystemNames(systemIds)
 
@@ -100,7 +108,7 @@ const AssetsPage = async () => {
 
   const systemFor = (loc: Root): string | undefined => {
     const structure = structureById.get(loc.id)
-    if (structure) return systemNames[Number(structure.system_id)] ?? `#${structure.system_id}`
+    if (structure?.system_id != null) return systemNames[Number(structure.system_id)] ?? `#${structure.system_id}`
     if (loc.type === 'solar_system') return systemNames[Number(loc.id)]
     return undefined
   }

--- a/src/app/character/sso.ts
+++ b/src/app/character/sso.ts
@@ -13,6 +13,7 @@ export const scopes = [
   'esi-corporations.read_structures.v1',
   'esi-wallet.read_corporation_wallets.v1',
   'esi-assets.read_corporation_assets.v1',
+  'esi-universe.read_structures.v1',
   // 'esi-characters.read_blueprints.v1',
 ]
 

--- a/src/app/stationNames.ts
+++ b/src/app/stationNames.ts
@@ -1,0 +1,30 @@
+// Resolve station names from eve-build-calculator, mirroring the system lookup in
+// systemNames.ts. Unresolved ids are simply omitted so callers can fall back to
+// showing the raw id (never read the evesde SDE).
+const cache = new Map<number, Promise<string | null>>()
+
+const fetchOne = (stationID: number): Promise<string | null> =>
+  fetch(`https://eve-build-calculator.philihp.com/api/station/${stationID}`)
+    .then((res) => (res.ok ? res.json() : null))
+    .then((station: { name?: { en?: string } | string } | null) => {
+      if (!station) return null
+      return typeof station.name === 'string' ? station.name : (station.name?.en ?? null)
+    })
+    .catch(() => null)
+
+const lookup = (stationID: number): Promise<string | null> => {
+  const cached = cache.get(stationID)
+  if (cached) return cached
+  const promise = fetchOne(stationID)
+  cache.set(stationID, promise)
+  promise.then((name) => {
+    if (name === null) cache.delete(stationID)
+  })
+  return promise
+}
+
+export const fetchStationNames = async (stationIDs: Iterable<number>): Promise<Record<number, string>> => {
+  const ids = Array.from(new Set([...stationIDs].filter((n) => Number.isFinite(n))))
+  const pairs = await Promise.all(ids.map(async (id) => [id, await lookup(id)] as const))
+  return Object.fromEntries(pairs.filter(([, name]) => name !== null) as [number, string][])
+}

--- a/src/esi.js
+++ b/src/esi.js
@@ -96,6 +96,14 @@ export const universeNames = (ids) =>
     label: `universeNames(${ids.length})`,
   })
 
+// Resolve a single player Upwell structure. Requires esi-universe.read_structures.v1
+// and docking access for the token's character, else ESI returns 403.
+export const universeStructure = (access_token, structureID) =>
+  esiJson(`/universe/structures/${structureID}/`, {
+    access_token,
+    label: `universeStructure ${structureID}`,
+  })
+
 export const characterAffiliations = (ids) =>
   esiJson(`/characters/affiliation/`, {
     method: 'POST',

--- a/src/structureNames.js
+++ b/src/structureNames.js
@@ -1,0 +1,87 @@
+import { universeStructure } from './esi.js'
+import { sudoSupabase } from './supabase.js'
+import { refreshAccessToken } from './tokenRefresh.js'
+
+const UNIVERSE_STRUCTURES_SCOPE = 'esi-universe.read_structures.v1'
+
+// Player Upwell structures use ids in this range; NPC stations (≤64M) and solar
+// systems sit far below it, and an item id in this range that's also one of the
+// character's own items is a ship/container, not a structure.
+const STRUCTURE_ID_FLOOR = 100_000_000_000
+
+// Resolve and cache (in hangar.structure) the names/systems of the player
+// structures characters hold assets in, using each character's own token so
+// docking access is guaranteed. Cheap in steady state: candidates exclude
+// structures we already know (our corp's, plus anything resolved before).
+export const resolveStructureNames = async () => {
+  const { data: tokens, error } = await sudoSupabase
+    .schema('hangar')
+    .from('token')
+    .select('id, character_id, refresh_token')
+    .contains('scope', [UNIVERSE_STRUCTURES_SCOPE])
+  if (error) throw error
+
+  console.log(`[structures] structure names: ${tokens?.length ?? 0} token(s) with ${UNIVERSE_STRUCTURES_SCOPE}`)
+  if (!tokens || tokens.length === 0) return
+
+  // Ids we don't need to resolve: our own corp structures and anything already cached.
+  const { data: corpStructs } = await sudoSupabase.schema('hangar').from('corp_structure').select('structure_id')
+  const { data: knownStructs } = await sudoSupabase.schema('hangar').from('structure').select('structure_id')
+  const resolved = new Set()
+  for (const s of corpStructs ?? []) resolved.add(Number(s.structure_id))
+  for (const s of knownStructs ?? []) resolved.add(Number(s.structure_id))
+
+  let upserted = 0
+  for (const tokenRow of tokens) {
+    try {
+      const { access_token, scope } = await refreshAccessToken(tokenRow)
+      if (!scope.includes(UNIVERSE_STRUCTURES_SCOPE)) continue
+
+      // Candidate structures = root locations in this character's assets that sit in
+      // the player-structure id range and aren't one of the character's own items.
+      const { data: assets } = await sudoSupabase
+        .schema('hangar')
+        .from('asset')
+        .select('item_id, location_id')
+        .eq('character_id', tokenRow.character_id)
+      const itemIds = new Set((assets ?? []).map((a) => Number(a.item_id)))
+      const candidates = new Set()
+      for (const a of assets ?? []) {
+        const id = Number(a.location_id)
+        if (Number.isFinite(id) && id >= STRUCTURE_ID_FLOOR && !itemIds.has(id) && !resolved.has(id)) {
+          candidates.add(id)
+        }
+      }
+      if (candidates.size === 0) continue
+
+      for (const structureID of candidates) {
+        try {
+          const info = await universeStructure(access_token, structureID)
+          const { error: upErr } = await sudoSupabase
+            .schema('hangar')
+            .from('structure')
+            .upsert(
+              {
+                structure_id: structureID,
+                name: info?.name ?? null,
+                system_id: info?.solar_system_id ?? null,
+                type_id: info?.type_id ?? null,
+                resolved_at: new Date().toISOString(),
+              },
+              { onConflict: 'structure_id' }
+            )
+          if (upErr) throw upErr
+          resolved.add(structureID)
+          upserted += 1
+        } catch (e) {
+          // 403 = this character can't dock there (e.g. access since revoked); another
+          // character with access may still resolve it on a later pass, so don't cache.
+          console.warn(`[structures] structure ${structureID} via token ${tokenRow.id} failed: ${e?.message}`)
+        }
+      }
+    } catch (e) {
+      console.error(`[structures] structure-name token ${tokenRow.id} FAILED: ${e?.message}`)
+    }
+  }
+  console.log(`[structures] resolved ${upserted} player structure name(s)`)
+}

--- a/src/structures.js
+++ b/src/structures.js
@@ -1,6 +1,7 @@
 import { pullCorpWalletJournals } from './corpWalletJournal.js'
 import { character as fetchCharacter, corpAssets, corpStructures, universeNames } from './esi.js'
 import { resolveCorpJournalNames } from './resolveNames.js'
+import { resolveStructureNames } from './structureNames.js'
 import { sudoSupabase } from './supabase.js'
 import { refreshAccessToken } from './tokenRefresh.js'
 
@@ -254,6 +255,14 @@ const execute = async () => {
     await resolveCorpJournalNames()
   } catch (e) {
     console.error(`[structures] name resolution FAILED name=${e?.name} message=${e?.message}`)
+  }
+
+  // Name the foreign player structures characters hold assets in (own-corp ones are
+  // already covered by corp_structure above), so the assets page can label them.
+  try {
+    await resolveStructureNames()
+  } catch (e) {
+    console.error(`[structures] structure-name resolution FAILED name=${e?.name} message=${e?.message}`)
   }
 }
 


### PR DESCRIPTION
Follow-up to #347 (the assets page itself). This makes the location tiles show real names/systems instead of raw `Location #id` / `Station #id`.

## Changes
- **NPC stations** resolve via eve-build-calculator's `/api/station/{id}` — a new `fetchStationNames` helper mirroring the existing `systemNames.ts` / `typeNames.ts` (curated, SDE-free source).
- **Foreign player structures** (the `1e12+` `Location #…` ids you can dock at but that aren't your own corp's) resolve in the **structures job**:
  - Adds the `esi-universe.read_structures.v1` scope.
  - New `resolveStructureNames()` pass: for each character with the scope, finds the structures they hold assets in and resolves each via ESI `/universe/structures/{id}` using that character's own token (so docking access is guaranteed), caching name/system/type into a new `hangar.structure` table.
  - The assets page reads `hangar.structure` alongside `corp_structure`, so these now show a name **and** solar system.

## Deploy notes
- **Re-link required:** existing tokens don't carry the new scope, so characters must re-link before foreign structures resolve.
- **Apply migration:** run `hangar.sql` to create `hangar.structure`. Until then it degrades gracefully (job try/catches, page treats missing table as no rows).
- Structures no character can dock at (ESI 403) remain raw ids — a hard ESI limit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCVrEHyyvMAYC8pGYauBxc)_