### PR TITLE
Fix structure-name resolver so player structures actually populate

### DIFF
--- a/src/structureNames.js
+++ b/src/structureNames.js
@@ -39,11 +39,15 @@ export const resolveStructureNames = async () => {
 
       // Candidate structures = root locations in this character's assets that sit in
       // the player-structure id range and aren't one of the character's own items.
-      const { data: assets } = await sudoSupabase
+      // Read asset_over_time (the base table service_role can reach) filtered to the
+      // live rows, rather than the `asset` view, which is only granted to authenticated.
+      const { data: assets, error: assetsErr } = await sudoSupabase
         .schema('hangar')
-        .from('asset')
+        .from('asset_over_time')
         .select('item_id, location_id')
         .eq('character_id', tokenRow.character_id)
+        .eq('is_current', true)
+      if (assetsErr) throw assetsErr
       const itemIds = new Set((assets ?? []).map((a) => Number(a.item_id)))
       const candidates = new Set()
       for (const a of assets ?? []) {


### PR DESCRIPTION
## Problem
Player Upwell structures on the assets page still showed as `Location #…` even after merging #350, re-linking, and running the structures job — `hangar.structure` stayed empty.

## Cause
`resolveStructureNames()` read the `hangar.asset` **view** via `sudoSupabase` (the **service_role**). But that view is granted to `authenticated` only — service_role can only reach the `asset_over_time` base table. So the query returned nothing, no candidate structures were ever found, and nothing was resolved. (The error was also silently swallowed.)

## Fix
- Read `asset_over_time` with `is_current = true` instead of the `asset` view — the same pattern the asset ingest (`assets.js`) already uses for service-role access.
- Surface the query error (`throw`) instead of ignoring it, so a future access problem fails loudly.

No schema or scope changes. Once merged, the structures job (`npm run structures`) will populate `hangar.structure` for characters that have granted `esi-universe.read_structures.v1` and can dock at the structure.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCVrEHyyvMAYC8pGYauBxc)_