### PR TITLE
Warn on character page when no ESI scopes are enabled

### DIFF
--- a/src/app/character/character.module.css
+++ b/src/app/character/character.module.css
@@ -59,3 +59,24 @@
   color: var(--ink-faint);
   margin-right: 4pt;
 }
+
+.warning {
+  margin: 12pt 0;
+  padding: 10pt 12pt;
+  border: 1px solid #d9a441;
+  border-left-width: 3px;
+  border-radius: var(--radius);
+  background: color-mix(in srgb, #d9a441 12%, var(--paper-raised));
+}
+
+.warningTitle {
+  display: block;
+  font-family: var(--serif);
+  font-size: 10pt;
+}
+
+.warningBody {
+  margin: 4pt 0 0;
+  font-size: 9pt;
+  color: var(--ink-soft);
+}

--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -1,7 +1,10 @@
+import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
 import { register } from './actions'
+import { requiredScopes } from './scopes'
+import { getEnabledScopes } from './userScopes'
 import styles from './character.module.css'
 
 const CharacterPage = async () => {
@@ -27,9 +30,24 @@ const CharacterPage = async () => {
   const formatIsk = (raw: string | number) =>
     new Intl.NumberFormat('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(Number(raw))
 
+  // If the player has turned off every optional ESI scope, characters they add
+  // grant nothing beyond identification, so almost no features will work.
+  const enabledScopes = await getEnabledScopes(supabase, data.user.id)
+  const hasNoOptionalScopes = enabledScopes.every((scope) => requiredScopes.includes(scope))
+
   return (
     <>
       <h1>Characters</h1>
+      {hasNoOptionalScopes && (
+        <div className={styles.warning} role="alert">
+          <strong className={styles.warningTitle}>Limited access selected</strong>
+          <p className={styles.warningBody}>
+            You haven&apos;t enabled any ESI permissions, so characters you add will only be identified — no wallet,
+            assets, industry, market, or structure data can be tracked. Choose what to share in{' '}
+            <Link href="/account/settings">settings</Link>.
+          </p>
+        </div>
+      )}
       <ul className={styles.grid}>
         {characters?.map((c) => (
           <li key={`character-${c.id}`} className={styles.tile}>


### PR DESCRIPTION
## What

Adds a warning banner to the top of the **Characters** page (`/character`) shown when the signed-in player has disabled every optional ESI scope in settings. In that state, any character they add grants nothing beyond identification, so almost no features (wallet, assets, industry, market, structures) will work — the banner makes that explicit and links to settings.

## How

- **`src/app/character/page.tsx`** — reuses `getEnabledScopes()` (the same resolver the add-character flow uses) and compares the result against `requiredScopes`. If every enabled scope is a required one, no optional data was granted, so the banner renders. Links to `/account/settings` via `next/link`.
- **`src/app/character/character.module.css`** — a `.warning` style using an amber accent that reads in both light and dark themes (uses `color-mix`, already used elsewhere in the project for tints).

The banner uses `role="alert"` for accessibility.

## Notes

- The check matches the existing semantics from #349: a player with no saved preferences gets all scopes by default, so they won't see the warning until they explicitly turn everything off.
- `tsc` and `next build` pass.

https://claude.ai/code/session_01Xd5wrtxmUt9ETAfNR7GtEu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd5wrtxmUt9ETAfNR7GtEu)_