### PR TITLE
Add Unselect all button to ESI scope settings

### DIFF
--- a/src/app/account/settings/scopeSettings.module.css
+++ b/src/app/account/settings/scopeSettings.module.css
@@ -4,7 +4,9 @@
   margin: 0 0 12pt;
 }
 
-.selectAll {
+.bulkActions {
+  display: flex;
+  gap: 8pt;
   margin-bottom: 12pt;
 }
 

--- a/src/app/account/settings/scopeSettings.tsx
+++ b/src/app/account/settings/scopeSettings.tsx
@@ -24,6 +24,9 @@ const ScopeSettings = ({ scopes, enabled }: ScopeSettingsProps) => {
 
   const selectAll = () => setChecked(Object.fromEntries(scopes.map((s) => [s.scope, true])))
 
+  // Required scopes stay checked since they are always granted.
+  const unselectAll = () => setChecked(Object.fromEntries(scopes.map((s) => [s.scope, Boolean(s.required)])))
+
   const save = async (formData: FormData) => {
     const error = await saveScopePreferences(formData)
     if (error) {
@@ -44,9 +47,14 @@ const ScopeSettings = ({ scopes, enabled }: ScopeSettingsProps) => {
         apply to characters you add from now on.
       </p>
       <form>
-        <button type="button" className={styles.selectAll} onClick={selectAll}>
-          Select all
-        </button>
+        <div className={styles.bulkActions}>
+          <button type="button" onClick={selectAll}>
+            Select all
+          </button>
+          <button type="button" onClick={unselectAll}>
+            Unselect all
+          </button>
+        </div>
         <ul className={styles.list}>
           {scopes.map((s) => (
             <li key={s.scope} className={styles.item}>


### PR DESCRIPTION
## What

Adds an **Unselect all** button next to the existing **Select all** button in the ESI Access section of the settings page.

## How

- **`src/app/account/settings/scopeSettings.tsx`** — new `unselectAll` handler that clears every optional scope. Required scopes (e.g. `publicData`) stay checked since they're always granted and their checkboxes are disabled. The two buttons are grouped in a flex row.
- **`src/app/account/settings/scopeSettings.module.css`** — replaced the single-button `.selectAll` style with a `.bulkActions` flex container that lays the two buttons out side by side.

`tsc` and `next build` pass.

https://claude.ai/code/session_01Xd5wrtxmUt9ETAfNR7GtEu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd5wrtxmUt9ETAfNR7GtEu)_