### PR TITLE
Render the assets page as a table

### DIFF
--- a/src/app/assets/assets.module.css
+++ b/src/app/assets/assets.module.css
@@ -1,63 +1,40 @@
 /*
- * Locations where the user holds assets, as a responsive tile grid mirroring
- * the structures page — two per row on phones, packing in more as it widens.
+ * Locations where the logged-in user holds assets, one row per location with a
+ * stack tally, styled to match the other data tables in the app.
  */
 
-.grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 12px;
-  list-style: none;
-  padding: 0;
-  margin: 16px 0;
+.assets {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 10pt;
+  margin: 12pt 0;
 }
 
-@media (min-width: 640px) {
-  .grid {
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  }
+.assets td {
+  border-bottom: 1px solid var(--line-soft);
+  padding: 6pt 8pt;
+  text-align: left;
 }
 
-.tile {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 14px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: var(--paper-raised);
-  transition: border-color 0.12s ease;
-  min-width: 0;
-}
-
-.tile:hover {
-  border-color: var(--accent);
-}
-
-.head {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.name {
-  font-family: var(--serif);
-  font-size: 16px;
-  font-weight: 600;
-  line-height: 1.25;
-  color: var(--ink);
-  overflow-wrap: anywhere;
-}
-
-.system {
-  font-size: 12px;
-  color: var(--ink-faint);
-  overflow-wrap: anywhere;
-}
-
-.count {
-  font-family: var(--mono);
-  font-variant-numeric: tabular-nums;
-  font-size: 12px;
+.assets th {
+  border-bottom: 1px solid var(--line);
+  padding: 6pt 8pt;
+  text-align: left;
   color: var(--ink-soft);
+  font-weight: 600;
+}
+
+.assets tbody tr:last-child td {
+  border-bottom: none;
+}
+
+/* The stack count is the only numeric column. */
+.assets td:nth-child(3),
+.assets th:nth-child(3) {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.assets td:nth-child(3) {
+  font-family: var(--mono);
 }

--- a/src/app/assets/page.tsx
+++ b/src/app/assets/page.tsx
@@ -33,10 +33,7 @@ const AssetsPage = async () => {
     redirect('/')
   }
 
-  const { data: assets } = await supabase
-    .schema('hangar')
-    .from('asset')
-    .select('item_id, location_id, location_type')
+  const { data: assets } = await supabase.schema('hangar').from('asset').select('item_id, location_id, location_type')
 
   const list = (assets ?? []) as Asset[]
   const assetByItem = new Map(list.map((a) => [String(a.item_id), a]))
@@ -77,7 +74,11 @@ const AssetsPage = async () => {
     .from('corp_structure')
     .select('structure_id, name, system_id')
   const { data: playerStructures } = locationIds.length
-    ? await supabase.schema('hangar').from('structure').select('structure_id, name, system_id').in('structure_id', locationIds)
+    ? await supabase
+        .schema('hangar')
+        .from('structure')
+        .select('structure_id, name, system_id')
+        .in('structure_id', locationIds)
     : { data: [] }
 
   const structureById = new Map<string, Structure>()
@@ -121,23 +122,28 @@ const AssetsPage = async () => {
     <>
       <h1>Assets</h1>
       {rows.length > 0 ? (
-        <ul className={styles.grid}>
-          {rows.map((loc) => {
-            const system = systemFor(loc)
-            const name = labelFor(loc)
-            return (
-              <li key={`location-${loc.id}`} className={styles.tile}>
-                <div className={styles.head}>
-                  <span className={styles.name}>{name}</span>
-                  {system && system !== name && <span className={styles.system}>{system}</span>}
-                </div>
-                <span className={styles.count}>
-                  {loc.count} {loc.count === 1 ? 'stack' : 'stacks'}
-                </span>
-              </li>
-            )
-          })}
-        </ul>
+        <table className={styles.assets}>
+          <thead>
+            <tr>
+              <th>Location</th>
+              <th>System</th>
+              <th>Stacks</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((loc) => {
+              const system = systemFor(loc)
+              const name = labelFor(loc)
+              return (
+                <tr key={`location-${loc.id}`}>
+                  <td className="serif">{name}</td>
+                  <td>{system && system !== name ? system : '—'}</td>
+                  <td>{loc.count}</td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
       ) : (
         <p>
           No assets visible. Link a character with the <code>esi-assets.read_assets.v1</code> scope on the{' '}


### PR DESCRIPTION
The assets page already scopes to the logged-in user — it reads `supabase.auth.getUser()` and relies on the `hangar.asset` view's RLS policy to return only that user's characters' assets, so no character is passed in.

This change swaps the tile-grid presentation for a proper table, matching the styling used by the other data tables in the app (e.g. Recent Sales on the market page):

- **Location** — resolved structure / station / system name (serif)
- **System** — the containing solar system, or `—` when it's the location itself
- **Stacks** — stack count, right-aligned with tabular/mono numerals

Rows stay sorted busiest-location-first, then alphabetically. The empty state is unchanged. `assets.module.css` drops the grid/tile rules in favor of table rules borrowed from `market.module.css`.

https://claude.ai/code/session_01JgqciZhYTrVn5tc6iKXzHD

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgqciZhYTrVn5tc6iKXzHD)_