### PR TITLE
Add Supabase MCP server to project config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "supabase": {
+      "type": "http",
+      "url": "https://mcp.supabase.com/mcp?project_ref=ifqywgxsdjxbonsytqya&read_only=true"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the Supabase MCP server to the project's shared MCP configuration (`.mcp.json`), so anyone working in this repo with Claude Code picks it up automatically.

- Transport: HTTP
- Endpoint: `https://mcp.supabase.com/mcp?project_ref=ifqywgxsdjxbonsytqya&read_only=true`
- `read_only=true` — the server is restricted to read-only operations against the Supabase project.

## Follow-up (manual, can't be done in this environment)

Authentication is an interactive OAuth flow that must be completed in a regular terminal (not the IDE extension):

```
claude /mcp
```

Select the `supabase` server, then choose **Authenticate** to begin the flow.

Optionally, install the Supabase Agent Skills:

```
npx skills add supabase/agent-skills
```

https://claude.ai/code/session_01L9bfQWg52L5wEJNBAFWkjh

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9bfQWg52L5wEJNBAFWkjh)_