### PR TITLE
Resolve structure names across all characters and tokens

### DIFF
--- a/src/structureNames.js
+++ b/src/structureNames.js
@@ -6,13 +6,20 @@ const UNIVERSE_STRUCTURES_SCOPE = 'esi-universe.read_structures.v1'
 
 // Player Upwell structures use ids in this range; NPC stations (≤64M) and solar
 // systems sit far below it, and an item id in this range that's also one of the
-// character's own items is a ship/container, not a structure.
+// characters' own items is a ship/container, not a structure.
 const STRUCTURE_ID_FLOOR = 100_000_000_000
 
+// PostgREST caps a single select; page through asset_over_time so a large hangar
+// doesn't silently truncate the candidate/own-item sets.
+const ASSET_PAGE = 1000
+
 // Resolve and cache (in hangar.structure) the names/systems of the player
-// structures characters hold assets in, using each character's own token so
-// docking access is guaranteed. Cheap in steady state: candidates exclude
-// structures we already know (our corp's, plus anything resolved before).
+// structures characters hold assets in. Candidates are pooled across *all*
+// linked characters and each is attempted against *every* scoped token until one
+// can dock and resolve it — a structure only needs a single character with
+// docking access, and that character is often not the one whose assets sit there.
+// Cheap in steady state: candidates exclude structures we already know (our
+// corp's, plus anything resolved before).
 export const resolveStructureNames = async () => {
   const { data: tokens, error } = await sudoSupabase
     .schema('hangar')
@@ -31,61 +38,93 @@ export const resolveStructureNames = async () => {
   for (const s of corpStructs ?? []) resolved.add(Number(s.structure_id))
   for (const s of knownStructs ?? []) resolved.add(Number(s.structure_id))
 
-  let upserted = 0
-  for (const tokenRow of tokens) {
+  // Pool candidate structure ids from every character's live assets. itemIds is
+  // the union of all owned item ids across characters: a location in the
+  // structure range that's also someone's item is a ship/container, not a
+  // structure. Read asset_over_time (the base table service_role can reach)
+  // filtered to live rows, rather than the `asset` view (granted to authenticated).
+  const itemIds = new Set()
+  const locationIds = new Set()
+  for (let from = 0; ; from += ASSET_PAGE) {
+    const { data: rows, error: assetsErr } = await sudoSupabase
+      .schema('hangar')
+      .from('asset_over_time')
+      .select('item_id, location_id')
+      .eq('is_current', true)
+      .range(from, from + ASSET_PAGE - 1)
+    if (assetsErr) throw assetsErr
+    if (!rows || rows.length === 0) break
+    for (const r of rows) {
+      itemIds.add(Number(r.item_id))
+      const id = Number(r.location_id)
+      if (Number.isFinite(id) && id >= STRUCTURE_ID_FLOOR) locationIds.add(id)
+    }
+    if (rows.length < ASSET_PAGE) break
+  }
+  const candidates = [...locationIds].filter((id) => !itemIds.has(id) && !resolved.has(id))
+  console.log(`[structures] ${candidates.length} candidate player structure(s) to resolve`)
+  if (candidates.length === 0) return
+
+  // Refresh each token's access token at most once and remember the result, so
+  // attempting many candidates against many tokens doesn't re-refresh. null means
+  // the token couldn't be refreshed or no longer carries the scope.
+  const accessByToken = new Map()
+  const getAccess = async (tokenRow) => {
+    if (accessByToken.has(tokenRow.id)) return accessByToken.get(tokenRow.id)
+    let access = null
     try {
       const { access_token, scope } = await refreshAccessToken(tokenRow)
-      if (!scope.includes(UNIVERSE_STRUCTURES_SCOPE)) continue
-
-      // Candidate structures = root locations in this character's assets that sit in
-      // the player-structure id range and aren't one of the character's own items.
-      // Read asset_over_time (the base table service_role can reach) filtered to the
-      // live rows, rather than the `asset` view, which is only granted to authenticated.
-      const { data: assets, error: assetsErr } = await sudoSupabase
-        .schema('hangar')
-        .from('asset_over_time')
-        .select('item_id, location_id')
-        .eq('character_id', tokenRow.character_id)
-        .eq('is_current', true)
-      if (assetsErr) throw assetsErr
-      const itemIds = new Set((assets ?? []).map((a) => Number(a.item_id)))
-      const candidates = new Set()
-      for (const a of assets ?? []) {
-        const id = Number(a.location_id)
-        if (Number.isFinite(id) && id >= STRUCTURE_ID_FLOOR && !itemIds.has(id) && !resolved.has(id)) {
-          candidates.add(id)
-        }
-      }
-      if (candidates.size === 0) continue
-
-      for (const structureID of candidates) {
-        try {
-          const info = await universeStructure(access_token, structureID)
-          const { error: upErr } = await sudoSupabase
-            .schema('hangar')
-            .from('structure')
-            .upsert(
-              {
-                structure_id: structureID,
-                name: info?.name ?? null,
-                system_id: info?.solar_system_id ?? null,
-                type_id: info?.type_id ?? null,
-                resolved_at: new Date().toISOString(),
-              },
-              { onConflict: 'structure_id' }
-            )
-          if (upErr) throw upErr
-          resolved.add(structureID)
-          upserted += 1
-        } catch (e) {
-          // 403 = this character can't dock there (e.g. access since revoked); another
-          // character with access may still resolve it on a later pass, so don't cache.
-          console.warn(`[structures] structure ${structureID} via token ${tokenRow.id} failed: ${e?.message}`)
-        }
-      }
+      if (scope.includes(UNIVERSE_STRUCTURES_SCOPE)) access = access_token
     } catch (e) {
-      console.error(`[structures] structure-name token ${tokenRow.id} FAILED: ${e?.message}`)
+      console.error(`[structures] structure-name token ${tokenRow.id} refresh FAILED: ${e?.message}`)
     }
+    accessByToken.set(tokenRow.id, access)
+    return access
+  }
+
+  let upserted = 0
+  for (const structureID of candidates) {
+    let info = null
+    let lastError
+    for (const tokenRow of tokens) {
+      const access = await getAccess(tokenRow)
+      if (!access) continue
+      try {
+        info = await universeStructure(access, structureID)
+        break
+      } catch (e) {
+        // Usually 403 = this character can't dock here; another linked character
+        // might, so try the next token before giving up on this structure.
+        lastError = e
+      }
+    }
+    if (!info) {
+      // No linked character can resolve it (e.g. nobody has docking access). Don't
+      // cache — a later pass may succeed if access is granted.
+      console.warn(
+        `[structures] structure ${structureID} unresolved by any token: ${lastError?.message ?? 'no scoped token'}`
+      )
+      continue
+    }
+    const { error: upErr } = await sudoSupabase
+      .schema('hangar')
+      .from('structure')
+      .upsert(
+        {
+          structure_id: structureID,
+          name: info?.name ?? null,
+          system_id: info?.solar_system_id ?? null,
+          type_id: info?.type_id ?? null,
+          resolved_at: new Date().toISOString(),
+        },
+        { onConflict: 'structure_id' }
+      )
+    if (upErr) {
+      console.warn(`[structures] structure ${structureID} upsert failed: ${upErr.message}`)
+      continue
+    }
+    resolved.add(structureID)
+    upserted += 1
   }
   console.log(`[structures] resolved ${upserted} player structure name(s)`)
 }


### PR DESCRIPTION
## Problem

A player structure that a character holds assets in (e.g. `1050038310811`) never showed up in `hangar.structure`, even though a *different* structure (`1049588174021`) resolved fine.

`resolveStructureNames` only attempted a structure using the **same character that owned the assets sitting there**, with that character's own token:

- candidates were drawn per-token from `asset_over_time` filtered to `character_id = tokenRow.character_id`, and
- each candidate was tried against only that one token.

So a structure was never resolved when:

1. the asset owner **can't currently dock** there (ESI `/universe/structures/{id}` returns 403 — you keep assets in a structure after losing dock access), or
2. the character whose assets sit there **didn't grant** `esi-universe.read_structures.v1` — even if another linked character could dock and resolve it.

## Fix

- **Pool candidates across all characters.** Gather every structure-range `location_id` from all characters' live assets, with `itemIds` as the union of all owned item ids (so a location that's actually someone's ship/container is still excluded).
- **Try each candidate against every scoped token** until one can dock and resolve it. A structure only needs a single linked character with docking access, and that character is often not the asset owner.
- **Page through `asset_over_time`** so a large hangar doesn't silently truncate at the PostgREST row cap.
- **Refresh each token's access token at most once**, cached, so attempting many candidates against many tokens doesn't re-refresh.

Structures that no linked character can resolve are logged and left uncached, so a later pass can pick them up once access is granted.

## Notes / follow-up

This addresses the *producer* side. There's a separate *consumer* gap not touched here: the Industry and Structures pages look up location names only in `corp_structure`, not the resolved `hangar.structure` cache — happy to follow up if wanted.

If a structure is still missing after this, it means **no** linked character can dock there, which is an ESI limitation (no docking access → no name).

https://claude.ai/code/session_01HM8cPp2mk25X3wAmXv9gsd

---
_Generated by [Claude Code](https://claude.ai/code/session_01HM8cPp2mk25X3wAmXv9gsd)_