### PR TITLE
Rename hangar.character table to hangar.registration

### DIFF
--- a/hangar.sql
+++ b/hangar.sql
@@ -13,7 +13,7 @@ alter default privileges in schema hangar
 alter default privileges in schema hangar
   grant all on functions to anon, authenticated, service_role;
 
-create table hangar.character (
+create table hangar.registration (
   id uuid primary key default gen_random_uuid(),
   user_id uuid not null references auth.users(id) on delete cascade,
   owner text not null,
@@ -23,12 +23,12 @@ create table hangar.character (
   updated_at timestamptz not null default now(),
   unique (user_id, owner)
 );
-create index character_user_id_idx on hangar.character (user_id);
+create index character_user_id_idx on hangar.registration (user_id);
 
-alter table hangar.character enable row level security;
+alter table hangar.registration enable row level security;
 
 create policy "Users manage own characters"
-  on hangar.character
+  on hangar.registration
   for all
   to authenticated
   using (user_id = (select auth.uid()))
@@ -37,7 +37,7 @@ create policy "Users manage own characters"
 create table hangar.token (
   id uuid primary key default gen_random_uuid(),
   user_id uuid not null references auth.users(id) on delete cascade,
-  character_id uuid not null references hangar.character(id) on delete cascade,
+  character_id uuid not null references hangar.registration(id) on delete cascade,
   access_token text not null,
   refresh_token text not null,
   issued_at timestamptz not null,
@@ -84,7 +84,7 @@ end $$;
 create table if not exists hangar.asset_over_time (
   id bigint generated always as identity primary key,
   item_id bigint not null,
-  character_id uuid not null references hangar.character(id) on delete cascade,
+  character_id uuid not null references hangar.registration(id) on delete cascade,
   type_id bigint not null,
   location_id bigint,
   location_flag text,
@@ -134,7 +134,7 @@ begin
       to authenticated
       using (
         character_id in (
-          select id from hangar.character where user_id = (select auth.uid())
+          select id from hangar.registration where user_id = (select auth.uid())
         )
       );
   end if;
@@ -149,13 +149,13 @@ create or replace view hangar.asset with (security_invoker = on) as
 -- above only applies to tables created by the role that ran the statement,
 -- so this belt-and-suspenders grant ensures PostgREST's `authenticated` /
 -- `anon` / `service_role` roles can actually reach these tables. Re-runnable.
-grant select, insert, update, delete on hangar.character       to authenticated;
+grant select, insert, update, delete on hangar.registration       to authenticated;
 grant select, insert, update, delete on hangar.token           to authenticated;
 -- The view runs with the invoker's rights, so authenticated needs select on the
 -- underlying table for the `asset` view to resolve (RLS still scopes the rows).
 grant select                          on hangar.asset_over_time to authenticated;
 grant select                          on hangar.asset           to authenticated;
-grant all on hangar.character, hangar.token, hangar.asset_over_time to service_role;
+grant all on hangar.registration, hangar.token, hangar.asset_over_time to service_role;
 
 create table if not exists hangar.heartbeat (
   id uuid primary key default gen_random_uuid(),
@@ -168,11 +168,11 @@ create index if not exists heartbeat_ran_at_idx
 alter table hangar.heartbeat enable row level security;
 grant all on hangar.heartbeat to service_role;
 
-alter table hangar.character add column if not exists character_id bigint;
+alter table hangar.registration add column if not exists character_id bigint;
 
 create table if not exists hangar.wallet (
   id uuid primary key default gen_random_uuid(),
-  character_id uuid not null references hangar.character(id) on delete cascade,
+  character_id uuid not null references hangar.registration(id) on delete cascade,
   balance numeric(20, 2) not null,
   recorded_at timestamptz not null default now()
 );
@@ -187,7 +187,7 @@ create policy "Users read own wallets"
   to authenticated
   using (
     character_id in (
-      select id from hangar.character where user_id = (select auth.uid())
+      select id from hangar.registration where user_id = (select auth.uid())
     )
   );
 
@@ -224,7 +224,7 @@ end $$;
 
 create table if not exists hangar.market_transaction (
   transaction_id bigint primary key,
-  character_id uuid not null references hangar.character(id) on delete cascade,
+  character_id uuid not null references hangar.registration(id) on delete cascade,
   date timestamptz not null,
   type_id bigint not null,
   quantity bigint not null,
@@ -247,7 +247,7 @@ create policy "Users read own transactions"
   to authenticated
   using (
     character_id in (
-      select id from hangar.character where user_id = (select auth.uid())
+      select id from hangar.registration where user_id = (select auth.uid())
     )
   );
 
@@ -256,7 +256,7 @@ grant all    on hangar.market_transaction to service_role;
 
 create table if not exists hangar.industry_job (
   job_id bigint primary key,
-  character_id uuid not null references hangar.character(id) on delete cascade,
+  character_id uuid not null references hangar.registration(id) on delete cascade,
   installer_id bigint not null,
   facility_id bigint not null,
   station_id bigint,
@@ -299,7 +299,7 @@ begin
       to authenticated
       using (
         character_id in (
-          select id from hangar.character where user_id = (select auth.uid())
+          select id from hangar.registration where user_id = (select auth.uid())
         )
       );
   end if;
@@ -308,8 +308,8 @@ end $$;
 grant select on hangar.industry_job to authenticated;
 grant all    on hangar.industry_job to service_role;
 
-alter table hangar.character add column if not exists corporation_id bigint;
-create index if not exists character_corporation_id_idx on hangar.character (corporation_id);
+alter table hangar.registration add column if not exists corporation_id bigint;
+create index if not exists character_corporation_id_idx on hangar.registration (corporation_id);
 
 create table if not exists hangar.corp_structure (
   structure_id bigint primary key,
@@ -340,7 +340,7 @@ create policy "Users read structures for own corps"
   to authenticated
   using (
     corporation_id in (
-      select corporation_id from hangar.character
+      select corporation_id from hangar.registration
       where user_id = (select auth.uid()) and corporation_id is not null
     )
   );
@@ -379,7 +379,7 @@ begin
       to authenticated
       using (
         corporation_id in (
-          select corporation_id from hangar.character
+          select corporation_id from hangar.registration
           where user_id = (select auth.uid()) and corporation_id is not null
         )
       );
@@ -427,7 +427,7 @@ begin
       to authenticated
       using (
         corporation_id in (
-          select corporation_id from hangar.character
+          select corporation_id from hangar.registration
           where user_id = (select auth.uid()) and corporation_id is not null
         )
       );

--- a/src/app/character/callback/route.ts
+++ b/src/app/character/callback/route.ts
@@ -12,7 +12,7 @@ const upsertCharacter =
   async (columns: { user_id: string; owner: string; name: string; character_id: number }) => {
     const response = await supabase
       .schema('hangar')
-      .from('character')
+      .from('registration')
       .upsert(columns, { onConflict: 'user_id, owner' })
       .select()
     if (response.error) throw new Error(`upsert character failed: ${JSON.stringify(response.error)}`)

--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -15,7 +15,7 @@ const CharacterPage = async () => {
     redirect('/')
   }
 
-  const { data: characters, status, statusText, error } = await supabase.schema('hangar').from('character').select()
+  const { data: characters, status, statusText, error } = await supabase.schema('hangar').from('registration').select()
 
   const { data: wallets } = await supabase
     .schema('hangar')

--- a/src/app/industry/page.tsx
+++ b/src/app/industry/page.tsx
@@ -12,7 +12,7 @@ const IndustryPage = async () => {
     redirect('/')
   }
 
-  const { data: characters } = await supabase.schema('hangar').from('character').select('id, name')
+  const { data: characters } = await supabase.schema('hangar').from('registration').select('id, name')
 
   const { data: jobs } = await supabase
     .schema('hangar')

--- a/src/app/market/page.tsx
+++ b/src/app/market/page.tsx
@@ -12,7 +12,7 @@ const MarketPage = async () => {
     redirect('/')
   }
 
-  const { data: characters } = await supabase.schema('hangar').from('character').select('id, name')
+  const { data: characters } = await supabase.schema('hangar').from('registration').select('id, name')
 
   const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
   const { data: sales } = await supabase

--- a/src/app/structures/[structureId]/page.tsx
+++ b/src/app/structures/[structureId]/page.tsx
@@ -103,7 +103,7 @@ const StructurePage = async ({ params }: StructureParams) => {
 
   const jobs = (jobsData ?? []) as Job[]
 
-  const { data: characters } = await supabase.schema('hangar').from('character').select('id, name')
+  const { data: characters } = await supabase.schema('hangar').from('registration').select('id, name')
   const characterName: Record<string, string> = Object.fromEntries((characters ?? []).map((c) => [c.id, c.name]))
 
   // Rigs fitted to this structure (pulled from corp assets by the structures job).

--- a/src/assets.js
+++ b/src/assets.js
@@ -136,7 +136,7 @@ const reconcile = async (character_id, fetched) => {
 const execute = async () => {
   const { data: characters, error: charactersError } = await sudoSupabase
     .schema('hangar')
-    .from('character')
+    .from('registration')
     .select('id, name')
   if (charactersError) {
     console.error('[assets] character lookup failed:', charactersError)

--- a/src/hourly.js
+++ b/src/hourly.js
@@ -8,7 +8,7 @@ const INDUSTRY_SCOPE = 'esi-industry.read_character_jobs.v1'
 const execute = async () => {
   const { data: characters, error: charactersError } = await sudoSupabase
     .schema('hangar')
-    .from('character')
+    .from('registration')
     .select('id, name')
   if (charactersError) {
     console.error(charactersError)

--- a/src/structures.js
+++ b/src/structures.js
@@ -35,7 +35,7 @@ const corpLabelFor = (name, corporation_id) => (name ? `${name} (${corporation_i
 const execute = async () => {
   const { data: characters, error: charactersError } = await sudoSupabase
     .schema('hangar')
-    .from('character')
+    .from('registration')
     .select('id, name')
   if (charactersError) {
     console.error('[structures] character lookup failed:', charactersError)
@@ -95,7 +95,7 @@ const execute = async () => {
 
       const { error: charUpdateErr, status: charUpdateStatus } = await sudoSupabase
         .schema('hangar')
-        .from('character')
+        .from('registration')
         .update({ corporation_id })
         .eq('id', tokenRow.character_id)
       if (charUpdateErr) {

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -28,7 +28,7 @@ export const authenticate = async () => {
 export const upsertCharacter = async (columns) => {
   const response = await supabase
     .schema('hangar')
-    .from('character')
+    .from('registration')
     .upsert(columns, { onConflict: 'user_id, owner' })
     .select()
   return response.data?.[0]?.id
@@ -54,7 +54,7 @@ export const upsertAssets = async (assets) => {
 }
 
 export const selectCharacters = async (columns, owner) => {
-  let query = supabase.schema('hangar').from('character').select(columns)
+  let query = supabase.schema('hangar').from('registration').select(columns)
   if (owner !== undefined) query = query.eq('owner', owner)
   const response = await query
   return response?.data?.map((r) => r.id)


### PR DESCRIPTION
## Why

`hangar.character` doesn't hold EVE characters in general — it holds the **authenticated user's own linked SSO accounts** (`user_id` + `owner`, RLS-scoped per user, with the token relationship). Naming it `character` is misleading and blocks using that name for a general character-name directory (e.g. resolving the third-party characters/corporations that appear in the corp wallet journal, currently cached in `eve_name`).

This PR renames the table to `registration` and repoints everything at it, freeing up the `character` name for follow-up work.

## What changed

**`hangar.sql`**
- `hangar.character` → `hangar.registration`: the table, its RLS policy target, all foreign-key references (`token`, `asset_over_time`, `wallet`, `market_transaction`, `industry_job`), the per-user RLS subqueries on those tables, the corp-scoped policy subqueries (`corp_structure`, etc.), and the grants.
- **`hangar.character_corp` is intentionally left untouched** — it's a separate third-party character→corp affiliation directory, not the linked-accounts table.

**Code** — repointed every `.from('character')` accessor to `.from('registration')` (11 call sites across `supabase.js`, `hourly.js`, `assets.js`, `structures.js`, and the `industry` / `market` / `structures/[structureId]` / `character` pages + callback route).

Foreign-key columns keep the name `character_id` (they still reference the renamed table). Index identifiers are left as-is — functionally irrelevant, and it matches what an existing DB looks like after a plain table rename.

## Applying to the database (manual)

`hangar.sql` isn't applied by CI (the workflows only load the SDE dump + `policies.sql`), so this needs a manual one-liner against Supabase. Postgres carries the foreign keys, RLS policy expressions, and grants across a rename automatically, so this is all that's required:

```sql
alter table hangar.character rename to registration;
```

(Indexes keep their old `character_*` names, which is harmless.)

## Follow-up (not in this PR)

With `character` freed up, the next step is moving the character-category rows out of `eve_name` into a proper `character` name directory. Also note: `eve_name` itself still needs to be created in production — it was added in #338 but never applied (`relation "hangar.eve_name" does not exist` in the daily run). Happy to tackle either next.

https://claude.ai/code/session_01HM8cPp2mk25X3wAmXv9gsd

---
_Generated by [Claude Code](https://claude.ai/code/session_01HM8cPp2mk25X3wAmXv9gsd)_