### PR TITLE
Rename hangar.character table to registration

### DIFF
--- a/hangar.sql
+++ b/hangar.sql
@@ -13,7 +13,76 @@ alter default privileges in schema hangar
 alter default privileges in schema hangar
   grant all on functions to anon, authenticated, service_role;
 
-create table hangar.character (
+-- Rename the `character` table to `registration` and realign every relationship
+-- that pointed at it. Idempotent and guarded so it is a no-op on a fresh install
+-- (the create statements below already produce the `registration` shape) and on
+-- re-runs. A plain rename keeps foreign keys, index contents, and dependent policy
+-- expressions pointing at the renamed objects automatically; these steps only
+-- realign the leftover identifiers (table, columns, indexes, constraint, policy).
+-- This must run before the create-if-not-exists statements below, otherwise an
+-- existing deployment would get a second, empty `registration` table.
+do $$
+begin
+  if exists (
+    select 1 from information_schema.tables
+    where table_schema = 'hangar' and table_name = 'character' and table_type = 'BASE TABLE'
+  ) then
+    alter table hangar.character rename to registration;
+  end if;
+
+  -- The table's own index and policy keep their old names through a table rename.
+  alter index if exists hangar.character_user_id_idx rename to registration_user_id_idx;
+  alter index if exists hangar.character_corporation_id_idx rename to registration_corporation_id_idx;
+  if exists (
+    select 1 from pg_policies
+    where schemaname = 'hangar' and tablename = 'registration'
+      and policyname = 'Users manage own characters'
+  ) then
+    alter policy "Users manage own characters" on hangar.registration
+      rename to "Users manage own registrations";
+  end if;
+
+  -- Repoint the uuid foreign keys that referenced hangar.character(id). The plain
+  -- column rename keeps each FK and its dependent index/policy pointing at the
+  -- renamed table; only the column identifier needs realigning. (The bigint EVE
+  -- character ids -- registration.character_id, character_corp, completed_character_id,
+  -- client_id -- are a different concept and are intentionally left untouched.)
+  if exists (select 1 from information_schema.columns
+             where table_schema = 'hangar' and table_name = 'token' and column_name = 'character_id') then
+    alter table hangar.token rename column character_id to registration_id;
+  end if;
+  if exists (select 1 from information_schema.columns
+             where table_schema = 'hangar' and table_name = 'asset_over_time' and column_name = 'character_id') then
+    alter table hangar.asset_over_time rename column character_id to registration_id;
+  end if;
+  if exists (select 1 from information_schema.columns
+             where table_schema = 'hangar' and table_name = 'wallet' and column_name = 'character_id') then
+    alter table hangar.wallet rename column character_id to registration_id;
+  end if;
+  if exists (select 1 from information_schema.columns
+             where table_schema = 'hangar' and table_name = 'market_transaction' and column_name = 'character_id') then
+    alter table hangar.market_transaction rename column character_id to registration_id;
+  end if;
+  if exists (select 1 from information_schema.columns
+             where table_schema = 'hangar' and table_name = 'industry_job' and column_name = 'character_id') then
+    alter table hangar.industry_job rename column character_id to registration_id;
+  end if;
+
+  -- Realign the dependent indexes and the token uniqueness constraint.
+  alter index if exists hangar.token_character_id_idx rename to token_registration_id_idx;
+  alter index if exists hangar.asset_over_time_character_id_idx rename to asset_over_time_registration_id_idx;
+  alter index if exists hangar.wallet_character_id_recorded_at_idx rename to wallet_registration_id_recorded_at_idx;
+  alter index if exists hangar.market_transaction_character_id_date_idx rename to market_transaction_registration_id_date_idx;
+  alter index if exists hangar.industry_job_character_id_end_date_idx rename to industry_job_registration_id_end_date_idx;
+  if exists (
+    select 1 from pg_constraint
+    where conname = 'token_character_id_key' and connamespace = 'hangar'::regnamespace
+  ) then
+    alter table hangar.token rename constraint token_character_id_key to token_registration_id_key;
+  end if;
+end $$;
+
+create table if not exists hangar.registration (
   id uuid primary key default gen_random_uuid(),
   user_id uuid not null references auth.users(id) on delete cascade,
   owner text not null,
@@ -23,21 +92,30 @@ create table hangar.character (
   updated_at timestamptz not null default now(),
   unique (user_id, owner)
 );
-create index character_user_id_idx on hangar.character (user_id);
+create index if not exists registration_user_id_idx on hangar.registration (user_id);
 
-alter table hangar.character enable row level security;
+alter table hangar.registration enable row level security;
 
-create policy "Users manage own characters"
-  on hangar.character
-  for all
-  to authenticated
-  using (user_id = (select auth.uid()))
-  with check (user_id = (select auth.uid()));
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'hangar' and tablename = 'registration'
+      and policyname = 'Users manage own registrations'
+  ) then
+    create policy "Users manage own registrations"
+      on hangar.registration
+      for all
+      to authenticated
+      using (user_id = (select auth.uid()))
+      with check (user_id = (select auth.uid()));
+  end if;
+end $$;
 
-create table hangar.token (
+create table if not exists hangar.token (
   id uuid primary key default gen_random_uuid(),
   user_id uuid not null references auth.users(id) on delete cascade,
-  character_id uuid not null references hangar.character(id) on delete cascade,
+  registration_id uuid not null references hangar.registration(id) on delete cascade,
   access_token text not null,
   refresh_token text not null,
   issued_at timestamptz not null,
@@ -45,19 +123,28 @@ create table hangar.token (
   scope text[] not null default '{}',
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
-  unique (character_id)
+  unique (registration_id)
 );
-create index token_character_id_idx on hangar.token (character_id);
-create index token_user_id_idx on hangar.token (user_id);
+create index if not exists token_registration_id_idx on hangar.token (registration_id);
+create index if not exists token_user_id_idx on hangar.token (user_id);
 
 alter table hangar.token enable row level security;
 
-create policy "Users manage own tokens"
-  on hangar.token
-  for all
-  to authenticated
-  using (user_id = (select auth.uid()))
-  with check (user_id = (select auth.uid()));
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'hangar' and tablename = 'token'
+      and policyname = 'Users manage own tokens'
+  ) then
+    create policy "Users manage own tokens"
+      on hangar.token
+      for all
+      to authenticated
+      using (user_id = (select auth.uid()))
+      with check (user_id = (select auth.uid()));
+  end if;
+end $$;
 
 -- Assets are stored as a slowly changing dimension (SCD type 2) in
 -- asset_over_time: each row is a versioned snapshot of one item's state. When the
@@ -84,7 +171,7 @@ end $$;
 create table if not exists hangar.asset_over_time (
   id bigint generated always as identity primary key,
   item_id bigint not null,
-  character_id uuid not null references hangar.character(id) on delete cascade,
+  registration_id uuid not null references hangar.registration(id) on delete cascade,
   type_id bigint not null,
   location_id bigint,
   location_flag text,
@@ -96,7 +183,7 @@ create table if not exists hangar.asset_over_time (
   first_seen_at timestamptz not null default now(),
   last_seen_at timestamptz not null default now()
 );
-create index if not exists asset_over_time_character_id_idx on hangar.asset_over_time (character_id);
+create index if not exists asset_over_time_registration_id_idx on hangar.asset_over_time (registration_id);
 -- At most one live row per item; also the conflict target the extract relies on.
 create unique index if not exists asset_over_time_current_item_idx on hangar.asset_over_time (item_id) where is_current;
 -- Time-travel lookups walking an item's version history.
@@ -133,8 +220,8 @@ begin
       for select
       to authenticated
       using (
-        character_id in (
-          select id from hangar.character where user_id = (select auth.uid())
+        registration_id in (
+          select id from hangar.registration where user_id = (select auth.uid())
         )
       );
   end if;
@@ -149,13 +236,13 @@ create or replace view hangar.asset with (security_invoker = on) as
 -- above only applies to tables created by the role that ran the statement,
 -- so this belt-and-suspenders grant ensures PostgREST's `authenticated` /
 -- `anon` / `service_role` roles can actually reach these tables. Re-runnable.
-grant select, insert, update, delete on hangar.character       to authenticated;
+grant select, insert, update, delete on hangar.registration    to authenticated;
 grant select, insert, update, delete on hangar.token           to authenticated;
 -- The view runs with the invoker's rights, so authenticated needs select on the
 -- underlying table for the `asset` view to resolve (RLS still scopes the rows).
 grant select                          on hangar.asset_over_time to authenticated;
 grant select                          on hangar.asset           to authenticated;
-grant all on hangar.character, hangar.token, hangar.asset_over_time to service_role;
+grant all on hangar.registration, hangar.token, hangar.asset_over_time to service_role;
 
 create table if not exists hangar.heartbeat (
   id uuid primary key default gen_random_uuid(),
@@ -168,28 +255,37 @@ create index if not exists heartbeat_ran_at_idx
 alter table hangar.heartbeat enable row level security;
 grant all on hangar.heartbeat to service_role;
 
-alter table hangar.character add column if not exists character_id bigint;
+alter table hangar.registration add column if not exists character_id bigint;
 
 create table if not exists hangar.wallet (
   id uuid primary key default gen_random_uuid(),
-  character_id uuid not null references hangar.character(id) on delete cascade,
+  registration_id uuid not null references hangar.registration(id) on delete cascade,
   balance numeric(20, 2) not null,
   recorded_at timestamptz not null default now()
 );
-create index if not exists wallet_character_id_recorded_at_idx
-  on hangar.wallet (character_id, recorded_at desc);
+create index if not exists wallet_registration_id_recorded_at_idx
+  on hangar.wallet (registration_id, recorded_at desc);
 
 alter table hangar.wallet enable row level security;
 
-create policy "Users read own wallets"
-  on hangar.wallet
-  for select
-  to authenticated
-  using (
-    character_id in (
-      select id from hangar.character where user_id = (select auth.uid())
-    )
-  );
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'hangar' and tablename = 'wallet'
+      and policyname = 'Users read own wallets'
+  ) then
+    create policy "Users read own wallets"
+      on hangar.wallet
+      for select
+      to authenticated
+      using (
+        registration_id in (
+          select id from hangar.registration where user_id = (select auth.uid())
+        )
+      );
+  end if;
+end $$;
 
 grant select on hangar.wallet to authenticated;
 grant all    on hangar.wallet to service_role;
@@ -201,7 +297,7 @@ where id in (
   select id from (
     select id,
       row_number() over (
-        partition by character_id
+        partition by registration_id
         order by coalesce(array_length(scope, 1), 0) desc, updated_at desc
       ) as rn
     from hangar.token
@@ -215,16 +311,16 @@ do $$
 begin
   if not exists (
     select 1 from pg_constraint
-    where conname = 'token_character_id_key'
+    where conname = 'token_registration_id_key'
       and conrelid = 'hangar.token'::regclass
   ) then
-    alter table hangar.token add constraint token_character_id_key unique (character_id);
+    alter table hangar.token add constraint token_registration_id_key unique (registration_id);
   end if;
 end $$;
 
 create table if not exists hangar.market_transaction (
   transaction_id bigint primary key,
-  character_id uuid not null references hangar.character(id) on delete cascade,
+  registration_id uuid not null references hangar.registration(id) on delete cascade,
   date timestamptz not null,
   type_id bigint not null,
   quantity bigint not null,
@@ -236,27 +332,36 @@ create table if not exists hangar.market_transaction (
   journal_ref_id bigint not null,
   seen_at timestamptz not null default now()
 );
-create index if not exists market_transaction_character_id_date_idx
-  on hangar.market_transaction (character_id, date desc);
+create index if not exists market_transaction_registration_id_date_idx
+  on hangar.market_transaction (registration_id, date desc);
 
 alter table hangar.market_transaction enable row level security;
 
-create policy "Users read own transactions"
-  on hangar.market_transaction
-  for select
-  to authenticated
-  using (
-    character_id in (
-      select id from hangar.character where user_id = (select auth.uid())
-    )
-  );
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'hangar' and tablename = 'market_transaction'
+      and policyname = 'Users read own transactions'
+  ) then
+    create policy "Users read own transactions"
+      on hangar.market_transaction
+      for select
+      to authenticated
+      using (
+        registration_id in (
+          select id from hangar.registration where user_id = (select auth.uid())
+        )
+      );
+  end if;
+end $$;
 
 grant select on hangar.market_transaction to authenticated;
 grant all    on hangar.market_transaction to service_role;
 
 create table if not exists hangar.industry_job (
   job_id bigint primary key,
-  character_id uuid not null references hangar.character(id) on delete cascade,
+  registration_id uuid not null references hangar.registration(id) on delete cascade,
   installer_id bigint not null,
   facility_id bigint not null,
   station_id bigint,
@@ -280,8 +385,8 @@ create table if not exists hangar.industry_job (
   successful_runs integer,
   seen_at timestamptz not null default now()
 );
-create index if not exists industry_job_character_id_end_date_idx
-  on hangar.industry_job (character_id, end_date desc);
+create index if not exists industry_job_registration_id_end_date_idx
+  on hangar.industry_job (registration_id, end_date desc);
 
 alter table hangar.industry_job enable row level security;
 
@@ -298,8 +403,8 @@ begin
       for select
       to authenticated
       using (
-        character_id in (
-          select id from hangar.character where user_id = (select auth.uid())
+        registration_id in (
+          select id from hangar.registration where user_id = (select auth.uid())
         )
       );
   end if;
@@ -308,8 +413,8 @@ end $$;
 grant select on hangar.industry_job to authenticated;
 grant all    on hangar.industry_job to service_role;
 
-alter table hangar.character add column if not exists corporation_id bigint;
-create index if not exists character_corporation_id_idx on hangar.character (corporation_id);
+alter table hangar.registration add column if not exists corporation_id bigint;
+create index if not exists registration_corporation_id_idx on hangar.registration (corporation_id);
 
 create table if not exists hangar.corp_structure (
   structure_id bigint primary key,
@@ -340,7 +445,7 @@ create policy "Users read structures for own corps"
   to authenticated
   using (
     corporation_id in (
-      select corporation_id from hangar.character
+      select corporation_id from hangar.registration
       where user_id = (select auth.uid()) and corporation_id is not null
     )
   );
@@ -379,7 +484,7 @@ begin
       to authenticated
       using (
         corporation_id in (
-          select corporation_id from hangar.character
+          select corporation_id from hangar.registration
           where user_id = (select auth.uid()) and corporation_id is not null
         )
       );
@@ -427,7 +532,7 @@ begin
       to authenticated
       using (
         corporation_id in (
-          select corporation_id from hangar.character
+          select corporation_id from hangar.registration
           where user_id = (select auth.uid()) and corporation_id is not null
         )
       );

--- a/src/app/character/callback/route.ts
+++ b/src/app/character/callback/route.ts
@@ -12,7 +12,7 @@ const upsertCharacter =
   async (columns: { user_id: string; owner: string; name: string; character_id: number }) => {
     const response = await supabase
       .schema('hangar')
-      .from('character')
+      .from('registration')
       .upsert(columns, { onConflict: 'user_id, owner' })
       .select()
     if (response.error) throw new Error(`upsert character failed: ${JSON.stringify(response.error)}`)
@@ -24,7 +24,7 @@ const upsertToken =
   (supabase: SupabaseClient) =>
   async (columns: {
     user_id: string
-    character_id: string
+    registration_id: string
     access_token: string
     refresh_token: string
     issued_at: string
@@ -34,7 +34,7 @@ const upsertToken =
     const response = await supabase
       .schema('hangar')
       .from('token')
-      .upsert(columns, { onConflict: 'character_id' })
+      .upsert(columns, { onConflict: 'registration_id' })
       .select()
     if (response.error) throw new Error(`upsert token failed: ${JSON.stringify(response.error)}`)
     if (!response.data?.[0]?.id) throw new Error(`upsert token returned no row: ${JSON.stringify(response)}`)
@@ -62,10 +62,10 @@ export const GET = async (request: NextRequest) => {
   // why are we doing this, again? can this be deleted?
   await sso.getAccessToken(refresh_token, true)
 
-  const character_id = await upsertCharacter(supabase)({ user_id, owner, name, character_id: eve_character_id })
+  const registration_id = await upsertCharacter(supabase)({ user_id, owner, name, character_id: eve_character_id })
   const token_id = await upsertToken(supabase)({
     user_id,
-    character_id,
+    registration_id,
     access_token,
     refresh_token,
     issued_at,

--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -15,17 +15,20 @@ const CharacterPage = async () => {
     redirect('/')
   }
 
-  const { data: characters, status, statusText, error } = await supabase.schema('hangar').from('character').select()
+  const { data: characters, status, statusText, error } = await supabase
+    .schema('hangar')
+    .from('registration')
+    .select()
 
   const { data: wallets } = await supabase
     .schema('hangar')
     .from('wallet')
-    .select('character_id, balance, recorded_at')
+    .select('registration_id, balance, recorded_at')
     .order('recorded_at', { ascending: false })
 
   const latestBalance = new Map<string, string>()
   for (const w of wallets ?? []) {
-    if (!latestBalance.has(w.character_id)) latestBalance.set(w.character_id, w.balance)
+    if (!latestBalance.has(w.registration_id)) latestBalance.set(w.registration_id, w.balance)
   }
   const formatIsk = (raw: string | number) =>
     new Intl.NumberFormat('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(Number(raw))

--- a/src/app/industry/activeJobs.tsx
+++ b/src/app/industry/activeJobs.tsx
@@ -11,7 +11,7 @@ import { ACTIVITY_NAMES } from './jobFields'
 
 export type Job = {
   job_id: number | string
-  character_id: string
+  registration_id: string
   activity_id: number
   blueprint_type_id: number | string
   product_type_id: number | string | null
@@ -58,7 +58,7 @@ export const ActiveJobs = ({ jobs, characters, initialNow, typeNamesPromise, sta
     raw === ALL_CHARACTERS || characters.some((c) => c.id === raw) ? raw : undefined
   )
 
-  const filtered = jobs.filter((j) => characterId === ALL_CHARACTERS || j.character_id === characterId)
+  const filtered = jobs.filter((j) => characterId === ALL_CHARACTERS || j.registration_id === characterId)
 
   const [now, setNow] = useState<number>(initialNow)
   useEffect(() => {
@@ -102,7 +102,7 @@ export const ActiveJobs = ({ jobs, characters, initialNow, typeNamesPromise, sta
             <tbody>
               {filtered.map((j) => (
                 <tr key={`job-${j.job_id}`}>
-                  <td className="serif">{characterName[j.character_id] ?? '—'}</td>
+                  <td className="serif">{characterName[j.registration_id] ?? '—'}</td>
                   <td>{ACTIVITY_NAMES[j.activity_id] ?? `#${j.activity_id}`}</td>
                   <td className="serif">
                     {j.product_type_id != null ? (

--- a/src/app/industry/page.tsx
+++ b/src/app/industry/page.tsx
@@ -12,13 +12,13 @@ const IndustryPage = async () => {
     redirect('/')
   }
 
-  const { data: characters } = await supabase.schema('hangar').from('character').select('id, name')
+  const { data: characters } = await supabase.schema('hangar').from('registration').select('id, name')
 
   const { data: jobs } = await supabase
     .schema('hangar')
     .from('industry_job')
     .select(
-      'job_id, character_id, activity_id, blueprint_type_id, product_type_id, runs, status, start_date, end_date, station_id, facility_id'
+      'job_id, registration_id, activity_id, blueprint_type_id, product_type_id, runs, status, start_date, end_date, station_id, facility_id'
     )
     .eq('status', 'active')
     .order('end_date', { ascending: true })

--- a/src/app/market/page.tsx
+++ b/src/app/market/page.tsx
@@ -12,13 +12,13 @@ const MarketPage = async () => {
     redirect('/')
   }
 
-  const { data: characters } = await supabase.schema('hangar').from('character').select('id, name')
+  const { data: characters } = await supabase.schema('hangar').from('registration').select('id, name')
 
   const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
   const { data: sales } = await supabase
     .schema('hangar')
     .from('market_transaction')
-    .select('transaction_id, character_id, date, type_id, quantity, unit_price, seen_at')
+    .select('transaction_id, registration_id, date, type_id, quantity, unit_price, seen_at')
     .eq('is_buy', false)
     .gte('date', sevenDaysAgo)
     .order('date', { ascending: false })

--- a/src/app/market/recentSales.tsx
+++ b/src/app/market/recentSales.tsx
@@ -8,7 +8,7 @@ import { usePersist } from './usePersist'
 
 export type Sale = {
   transaction_id: string | number
-  character_id: string
+  registration_id: string
   date: string
   type_id: number | string
   quantity: number | string
@@ -54,7 +54,7 @@ export const RecentSales = ({ sales, characters, typeNamesPromise }: RecentSales
   const filtered = sales.filter(
     (s) =>
       Number(s.unit_price) * Number(s.quantity) >= threshold &&
-      (characterId === ALL_CHARACTERS || s.character_id === characterId)
+      (characterId === ALL_CHARACTERS || s.registration_id === characterId)
   )
 
   return (
@@ -101,7 +101,7 @@ export const RecentSales = ({ sales, characters, typeNamesPromise }: RecentSales
           <tbody>
             {filtered.map((s) => (
               <tr key={`sale-${s.transaction_id}`}>
-                <td className="serif">{characterName[s.character_id] ?? '—'}</td>
+                <td className="serif">{characterName[s.registration_id] ?? '—'}</td>
                 <td className="serif">
                   <TypeName id={Number(s.type_id)} promise={typeNamesPromise} />
                 </td>

--- a/src/app/structures/[structureId]/page.tsx
+++ b/src/app/structures/[structureId]/page.tsx
@@ -29,7 +29,7 @@ type Structure = {
 
 type Job = {
   job_id: number | string
-  character_id: string
+  registration_id: string
   activity_id: number
   blueprint_type_id: number | string
   product_type_id: number | string | null
@@ -96,14 +96,14 @@ const StructurePage = async ({ params }: StructureParams) => {
     .schema('hangar')
     .from('industry_job')
     .select(
-      'job_id, character_id, activity_id, blueprint_type_id, product_type_id, runs, status, start_date, end_date, station_id, facility_id'
+      'job_id, registration_id, activity_id, blueprint_type_id, product_type_id, runs, status, start_date, end_date, station_id, facility_id'
     )
     .or(`station_id.eq.${structureId},facility_id.eq.${structureId}`)
     .order('end_date', { ascending: true })
 
   const jobs = (jobsData ?? []) as Job[]
 
-  const { data: characters } = await supabase.schema('hangar').from('character').select('id, name')
+  const { data: characters } = await supabase.schema('hangar').from('registration').select('id, name')
   const characterName: Record<string, string> = Object.fromEntries((characters ?? []).map((c) => [c.id, c.name]))
 
   // Rigs fitted to this structure (pulled from corp assets by the structures job).
@@ -235,7 +235,7 @@ const StructurePage = async ({ params }: StructureParams) => {
           <tbody>
             {jobs.map((j) => (
               <tr key={`job-${j.job_id}`}>
-                <td className="serif">{characterName[j.character_id] ?? '—'}</td>
+                <td className="serif">{characterName[j.registration_id] ?? '—'}</td>
                 <td>{ACTIVITY_NAMES[j.activity_id] ?? `#${j.activity_id}`}</td>
                 <td className="serif">{typeNames[Number(j.blueprint_type_id)] ?? `#${j.blueprint_type_id}`}</td>
                 <td className="serif">

--- a/src/assets.js
+++ b/src/assets.js
@@ -65,14 +65,14 @@ const fetchAssets = async (access_token, characterID) => {
 // Reconcile the freshly fetched assets against the character's current (open)
 // rows: unchanged items get their last_seen_at extended, changed items have
 // their old row closed and a new one inserted, and vanished items are closed.
-const reconcile = async (character_id, fetched) => {
+const reconcile = async (registration_id, fetched) => {
   const { data: current, error } = await sudoSupabase
     .schema('hangar')
     .from('asset_over_time')
     .select(
       'id, item_id, type_id, location_id, location_flag, location_type, quantity, is_singleton, is_blueprint_copy'
     )
-    .eq('character_id', character_id)
+    .eq('registration_id', registration_id)
     .eq('is_current', true)
   if (error) throw error
 
@@ -92,7 +92,7 @@ const reconcile = async (character_id, fetched) => {
       // first_seen_at is left to its `default now()` so it marks this version's debut.
       inserts.push({
         item_id: a.item_id,
-        character_id,
+        registration_id,
         type_id: a.type_id,
         location_id: a.location_id ?? null,
         location_flag: a.location_flag ?? null,
@@ -136,7 +136,7 @@ const reconcile = async (character_id, fetched) => {
 const execute = async () => {
   const { data: characters, error: charactersError } = await sudoSupabase
     .schema('hangar')
-    .from('character')
+    .from('registration')
     .select('id, name')
   if (charactersError) {
     console.error('[assets] character lookup failed:', charactersError)
@@ -147,7 +147,7 @@ const execute = async () => {
   const { data: tokens, error } = await sudoSupabase
     .schema('hangar')
     .from('token')
-    .select('id, character_id, refresh_token')
+    .select('id, registration_id, refresh_token')
     .contains('scope', [ASSETS_SCOPE])
 
   if (error) {
@@ -159,8 +159,8 @@ const execute = async () => {
 
   for (const tokenRow of tokens ?? []) {
     const t0 = Date.now()
-    const name = characterName.get(tokenRow.character_id) ?? '?'
-    const ctx = `character=${name} (${tokenRow.character_id}) token=${tokenRow.id}`
+    const name = characterName.get(tokenRow.registration_id) ?? '?'
+    const ctx = `character=${name} (${tokenRow.registration_id}) token=${tokenRow.id}`
     try {
       const { access_token, characterID, scope } = await refreshToken(tokenRow)
       if (!scope.includes(ASSETS_SCOPE)) {
@@ -169,7 +169,7 @@ const execute = async () => {
       }
 
       const { all, totalPages } = await fetchAssets(access_token, characterID)
-      const { touched, opened, closed } = await reconcile(tokenRow.character_id, all)
+      const { touched, opened, closed } = await reconcile(tokenRow.registration_id, all)
 
       const dt = Date.now() - t0
       console.log(

--- a/src/hourly.js
+++ b/src/hourly.js
@@ -8,7 +8,7 @@ const INDUSTRY_SCOPE = 'esi-industry.read_character_jobs.v1'
 const execute = async () => {
   const { data: characters, error: charactersError } = await sudoSupabase
     .schema('hangar')
-    .from('character')
+    .from('registration')
     .select('id, name')
   if (charactersError) {
     console.error(charactersError)
@@ -19,7 +19,7 @@ const execute = async () => {
   const { data: tokens, error } = await sudoSupabase
     .schema('hangar')
     .from('token')
-    .select('id, character_id, refresh_token')
+    .select('id, registration_id, refresh_token')
     .contains('scope', [WALLET_SCOPE])
 
   if (error) {
@@ -28,22 +28,22 @@ const execute = async () => {
   }
 
   for (const tokenRow of tokens ?? []) {
-    const name = characterName.get(tokenRow.character_id) ?? '?'
+    const name = characterName.get(tokenRow.registration_id) ?? '?'
     try {
       const { access_token, characterID } = await refreshAccessToken(tokenRow)
       const balance = await wallet(access_token, characterID)
       const { error: insertError } = await sudoSupabase
         .schema('hangar')
         .from('wallet')
-        .insert({ character_id: tokenRow.character_id, balance })
+        .insert({ registration_id: tokenRow.registration_id, balance })
       if (insertError) throw insertError
-      console.log(`wallet ${name} ${tokenRow.character_id} (${characterID}): ${balance}`)
+      console.log(`wallet ${name} ${tokenRow.registration_id} (${characterID}): ${balance}`)
 
       const txns = await transactions(access_token, characterID)
       if (txns.length > 0) {
         const rows = txns.map((t) => ({
           transaction_id: t.transaction_id,
-          character_id: tokenRow.character_id,
+          registration_id: tokenRow.registration_id,
           date: t.date,
           type_id: t.type_id,
           quantity: t.quantity,
@@ -59,17 +59,17 @@ const execute = async () => {
           .from('market_transaction')
           .upsert(rows, { onConflict: 'transaction_id', ignoreDuplicates: true })
         if (txError) throw txError
-        console.log(`transactions ${name} ${tokenRow.character_id} (${characterID}): ${txns.length} fetched`)
+        console.log(`transactions ${name} ${tokenRow.registration_id} (${characterID}): ${txns.length} fetched`)
       }
     } catch (e) {
-      console.error(`refresh failed for ${name} ${tokenRow.character_id}:`, e)
+      console.error(`refresh failed for ${name} ${tokenRow.registration_id}:`, e)
     }
   }
 
   const { data: industryTokens, error: industryTokensError } = await sudoSupabase
     .schema('hangar')
     .from('token')
-    .select('id, character_id, refresh_token')
+    .select('id, registration_id, refresh_token')
     .contains('scope', [INDUSTRY_SCOPE])
 
   if (industryTokensError) {
@@ -78,14 +78,14 @@ const execute = async () => {
   }
 
   for (const tokenRow of industryTokens ?? []) {
-    const name = characterName.get(tokenRow.character_id) ?? '?'
+    const name = characterName.get(tokenRow.registration_id) ?? '?'
     try {
       const { access_token, characterID } = await refreshAccessToken(tokenRow)
       const jobs = await industryJobs(access_token, characterID)
       if (jobs.length > 0) {
         const rows = jobs.map((j) => ({
           job_id: j.job_id,
-          character_id: tokenRow.character_id,
+          registration_id: tokenRow.registration_id,
           installer_id: j.installer_id,
           facility_id: j.facility_id,
           station_id: j.station_id ?? null,
@@ -114,9 +114,9 @@ const execute = async () => {
           .upsert(rows, { onConflict: 'job_id' })
         if (jobError) throw jobError
       }
-      console.log(`industry ${name} ${tokenRow.character_id} (${characterID}): ${jobs.length} jobs`)
+      console.log(`industry ${name} ${tokenRow.registration_id} (${characterID}): ${jobs.length} jobs`)
     } catch (e) {
-      console.error(`industry refresh failed for ${name} ${tokenRow.character_id}:`, e)
+      console.error(`industry refresh failed for ${name} ${tokenRow.registration_id}:`, e)
     }
   }
 }

--- a/src/refresh.js
+++ b/src/refresh.js
@@ -17,10 +17,10 @@ const scopes = [
   'esi-markets.read_character_orders.v1',
 ]
 
-const accessToken = async (character_id) => {
+const accessToken = async (registration_id) => {
   // get the oldest refresh token that has all of the scopes we need, refresh that so we get a new unexpired
   // access_token (it's probably expired, but even if it isn't, shouldn't hurt to do it anyway
-  const token = await selectToken(character_id, scopes)
+  const token = await selectToken(registration_id, scopes)
   const old_token = token?.data[0]?.refresh_token
   const {
     access_token,
@@ -29,7 +29,7 @@ const accessToken = async (character_id) => {
   } = await sso.getAccessToken(old_token, true)
   const characterID = sub.split(':')[2]
   await upsertToken({
-    character_id,
+    registration_id,
     access_token,
     refresh_token,
     issued_at: new Date(iat * 1000).toISOString(),
@@ -52,8 +52,8 @@ const execute = async () => {
     console.error('no character found for owner')
     process.exit(1)
   }
-  const character_id = characters[0]
-  const [refresh_token, characterID] = await accessToken(character_id)
+  const registration_id = characters[0]
+  const [refresh_token, characterID] = await accessToken(registration_id)
 
   console.time(`all asst chunk`)
 
@@ -61,13 +61,13 @@ const execute = async () => {
   console.time(`asst chunk 1`)
   const [firstAssetPage, maxPages] = await assets(refresh_token, characterID, 1)
   console.timeEnd(`asst chunk 1`)
-  const firstAssets = firstAssetPage.map((a) => ({ ...a, character_id, is_blueprint_copy: !!a.is_blueprint_copy }))
+  const firstAssets = firstAssetPage.map((a) => ({ ...a, registration_id, is_blueprint_copy: !!a.is_blueprint_copy }))
   assetList.push(...firstAssets)
 
   await range(2, Number.parseInt(maxPages, 10) + 1).reduce(async (accum, page) => {
     console.time(`asst chunk ${page}`)
     const [assetPage] = await assets(refresh_token, characterID, page)
-    const newAssets = assetPage.map((a) => ({ ...a, character_id, is_blueprint_copy: !!a.is_blueprint_copy }))
+    const newAssets = assetPage.map((a) => ({ ...a, registration_id, is_blueprint_copy: !!a.is_blueprint_copy }))
     console.timeEnd(`asst chunk ${page}`)
     assetList.push(...newAssets)
     return accum

--- a/src/structureNames.js
+++ b/src/structureNames.js
@@ -24,7 +24,7 @@ export const resolveStructureNames = async () => {
   const { data: tokens, error } = await sudoSupabase
     .schema('hangar')
     .from('token')
-    .select('id, character_id, refresh_token')
+    .select('id, registration_id, refresh_token')
     .contains('scope', [UNIVERSE_STRUCTURES_SCOPE])
   if (error) throw error
 

--- a/src/structures.js
+++ b/src/structures.js
@@ -35,7 +35,7 @@ const corpLabelFor = (name, corporation_id) => (name ? `${name} (${corporation_i
 const execute = async () => {
   const { data: characters, error: charactersError } = await sudoSupabase
     .schema('hangar')
-    .from('character')
+    .from('registration')
     .select('id, name')
   if (charactersError) {
     console.error('[structures] character lookup failed:', charactersError)
@@ -46,7 +46,7 @@ const execute = async () => {
   const { data: tokens, error } = await sudoSupabase
     .schema('hangar')
     .from('token')
-    .select('id, character_id, refresh_token')
+    .select('id, registration_id, refresh_token')
     .contains('scope', [STRUCTURES_SCOPE])
 
   if (error) {
@@ -56,9 +56,9 @@ const execute = async () => {
 
   console.log(`[structures] found ${tokens?.length ?? 0} token(s) with ${STRUCTURES_SCOPE}`)
   for (const t of tokens ?? []) {
-    const name = characterName.get(t.character_id) ?? '?'
+    const name = characterName.get(t.registration_id) ?? '?'
     console.log(
-      `[structures]   token ${t.id} character ${name} (${t.character_id}) refresh ...${tail(t.refresh_token)}`
+      `[structures]   token ${t.id} character ${name} (${t.registration_id}) refresh ...${tail(t.refresh_token)}`
     )
   }
 
@@ -67,8 +67,8 @@ const execute = async () => {
   const seenAssetCorps = new Set()
   for (const tokenRow of tokens ?? []) {
     const t0 = Date.now()
-    const name = characterName.get(tokenRow.character_id) ?? '?'
-    const ctx = `character=${name} (${tokenRow.character_id}) token=${tokenRow.id}`
+    const name = characterName.get(tokenRow.registration_id) ?? '?'
+    const ctx = `character=${name} (${tokenRow.registration_id}) token=${tokenRow.id}`
     try {
       console.log(`[structures] ${ctx}: refreshing token (refresh ...${tail(tokenRow.refresh_token)})`)
       const { access_token, characterID, scope, issued_at, expires_at } = await refreshAccessToken(tokenRow)
@@ -95,9 +95,9 @@ const execute = async () => {
 
       const { error: charUpdateErr, status: charUpdateStatus } = await sudoSupabase
         .schema('hangar')
-        .from('character')
+        .from('registration')
         .update({ corporation_id })
-        .eq('id', tokenRow.character_id)
+        .eq('id', tokenRow.registration_id)
       if (charUpdateErr) {
         console.error(
           `[structures] ${ctx}: character.corporation_id update failed status=${charUpdateStatus} code=${charUpdateErr.code} message=${charUpdateErr.message} details=${charUpdateErr.details} hint=${charUpdateErr.hint}`

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -28,7 +28,7 @@ export const authenticate = async () => {
 export const upsertCharacter = async (columns) => {
   const response = await supabase
     .schema('hangar')
-    .from('character')
+    .from('registration')
     .upsert(columns, { onConflict: 'user_id, owner' })
     .select()
   return response.data?.[0]?.id
@@ -38,7 +38,7 @@ export const upsertToken = async (columns) => {
   const response = await supabase
     .schema('hangar')
     .from('token')
-    .upsert(columns, { onConflict: ['character_id'] })
+    .upsert(columns, { onConflict: ['registration_id'] })
     .select()
   if (response.error) console.error(response.error)
   return response.data?.[0]?.id
@@ -54,18 +54,18 @@ export const upsertAssets = async (assets) => {
 }
 
 export const selectCharacters = async (columns, owner) => {
-  let query = supabase.schema('hangar').from('character').select(columns)
+  let query = supabase.schema('hangar').from('registration').select(columns)
   if (owner !== undefined) query = query.eq('owner', owner)
   const response = await query
   return response?.data?.map((r) => r.id)
 }
 
-export const selectToken = async (character_id, scope = []) => {
+export const selectToken = async (registration_id, scope = []) => {
   const response = await supabase
     .schema('hangar')
     .from('token')
     .select('refresh_token, scope')
-    .eq('character_id', character_id)
+    .eq('registration_id', registration_id)
     .contains('scope', [scope].flat())
     .order('expires_at', { ascending: true })
   return response


### PR DESCRIPTION
## Summary

Renames the `hangar.character` table to `hangar.registration` and repoints every relationship at the new name.

The uuid foreign keys that referenced `hangar.character(id)` — on `token`, `asset_over_time`, `wallet`, `market_transaction`, and `industry_job` — are renamed `character_id` → `registration_id`, along with their indexes, the token uniqueness constraint, and the RLS policy subqueries.

The bigint **EVE** character ids (`registration.character_id`, `character_corp`, `completed_character_id`, `client_id`) are a different concept (a number from ESI, not a FK) and are **intentionally left untouched**.

As decided with the requester, the `/character` route, the `src/app/character/` folder, and the `Character` UI naming are left as-is — only the database layer and the queries change.

## Migration (`hangar.sql`)

The rename is **guarded and idempotent**, following the file's existing convention (e.g. the earlier `asset` → `asset_over_time` rename):

- On an **existing** deployment it renames the objects in place — preserving data, and because a plain rename auto-updates dependent FKs, index contents, and policy expressions, only the leftover identifiers (table, columns, indexes, constraint, policy names) need realigning.
- On a **fresh** install the guarded block is a no-op and the `create … if not exists` statements below produce the same `registration` shape directly.
- The rename block is placed **before** the create statements so an existing DB doesn't get a second, empty `registration` table.

Early `create table`/`create index`/`create policy` statements for the affected tables were made idempotent (`if not exists` / `pg_policies` guards) so the script can be re-applied.

## Application code

- `.from('character')` → `.from('registration')` across the cron jobs (`hourly`, `assets`, `structures`, `refresh`) and the server components.
- Queries that select/insert/filter the uuid FK now use `registration_id` (select strings, `.eq`, `.upsert` payloads, `onConflict`).
- `Job`/`Sale` UI types and the rows they map gained `registration_id`; the EVE-id usages (portrait URL, `character_corp` lookups) are unchanged.

## Verification

- `npx tsc --noEmit` — clean (0 errors)
- `npx eslint .` — 0 errors (8 pre-existing warnings, unrelated)

> ⚠️ The migration SQL needs to be applied to the Supabase `hangar` schema (the MCP server here is read-only) before the deployed app reads from `registration`.

https://claude.ai/code/session_01D3qT5UE9trthSbUXboecGg

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3qT5UE9trthSbUXboecGg)_