### PR TITLE
Add manual Migrate workflow to apply pending DDL (rename + eve_name)

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -1,0 +1,32 @@
+name: Migrate
+
+# Manually-triggered DDL migrations against the hangar schema. Run this after
+# merging a change that adds files under migrations/. Every migration is
+# idempotent, so re-running the workflow is a no-op.
+on:
+  workflow_dispatch:
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Apply migrations
+        run: |
+          shopt -s nullglob
+          files=(migrations/*.sql)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No migrations to apply."
+            exit 0
+          fi
+          for f in "${files[@]}"; do
+            echo "::group::Applying $f"
+            psql -p 6543 -d postgres -v ON_ERROR_STOP=1 -f "$f"
+            echo "::endgroup::"
+          done
+        env:
+          PGHOST: ${{ vars.SUPABASE_HOST }}
+          PGUSER: postgres.${{ vars.SUPABASE_PROJECT_REF }}
+          PGPASSWORD: ${{ secrets.SUPABASE_PASSWORD }}
+          PGDATABASE: postgres

--- a/migrations/20260601_rename_character_to_registration_and_create_eve_name.sql
+++ b/migrations/20260601_rename_character_to_registration_and_create_eve_name.sql
@@ -1,0 +1,47 @@
+-- Idempotent migrations for an already-provisioned database. hangar.sql is the
+-- canonical schema for a fresh install but isn't re-runnable wholesale (it has
+-- plain `create table` statements), so incremental changes to an existing DB
+-- live here and are applied by the Migrate workflow. Safe to re-run.
+
+-- PR #359: the linked-accounts table was renamed character -> registration.
+-- Postgres carries the foreign keys, RLS policy expressions, and grants across
+-- the rename automatically; only rename if it hasn't happened yet.
+do $$
+begin
+  if exists (
+    select 1 from information_schema.tables
+    where table_schema = 'hangar' and table_name = 'character'
+  ) then
+    alter table hangar.character rename to registration;
+  end if;
+end $$;
+
+-- #338: eve_name was added to hangar.sql but never applied, so the daily job
+-- fails with `relation "hangar.eve_name" does not exist`. Create it.
+create table if not exists hangar.eve_name (
+  id bigint primary key,
+  name text not null,
+  category text not null,
+  resolved_at timestamptz not null default now()
+);
+
+alter table hangar.eve_name enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'hangar'
+      and tablename = 'eve_name'
+      and policyname = 'Authenticated read eve_name'
+  ) then
+    create policy "Authenticated read eve_name"
+      on hangar.eve_name
+      for select
+      to authenticated
+      using (true);
+  end if;
+end $$;
+
+grant select on hangar.eve_name to authenticated;
+grant all    on hangar.eve_name to service_role;


### PR DESCRIPTION
## Why

The merged changes need DDL applied to the live database — but `hangar.sql` isn't run by any workflow, and this session/agent can't reach the DB (no credentials, network policy blocks the host, and the Supabase MCP is read-only). The DB *is* reachable from CI, which already holds the `SUPABASE_*` secrets the daily job uses. This PR adds a manually-triggered workflow to run pending migrations there.

## What's here

**`.github/workflows/migrate.yml`** — a `workflow_dispatch` job that applies every `migrations/*.sql` in sorted order via `psql`, reusing the exact `PGHOST` / `PGUSER` / `PGPASSWORD` wiring as `daily.yml`. `ON_ERROR_STOP=1` fails the run on the first error.

**`migrations/20260601_rename_character_to_registration_and_create_eve_name.sql`** — idempotent DDL:
1. Rename `hangar.character` → `hangar.registration` (#359), guarded so it only runs if not already renamed. FKs, RLS policies, and grants follow the rename automatically.
2. Create `hangar.eve_name` (#338 — it was added to `hangar.sql` but never applied, which is what currently fails the daily run with `relation "hangar.eve_name" does not exist`).

Every statement is idempotent (`if exists` / `if not exists` guards), so re-running the workflow is a no-op.

## How to run it

After this merges: **Actions → Migrate → Run workflow** (on `main`). That's the step that actually applies the rename + creates `eve_name`. The workflow output will show each file applied; if anything errors, the job goes red.

I can't trigger or verify it from here, so once you've run it, the rename and `eve_name` will be live.

## Note

I included `eve_name` because the daily job is broken without it *today*. If you'd rather skip it because the `eve_name` → `character`-directory follow-up is coming, just delete that section of the migration file before merging.

https://claude.ai/code/session_01HM8cPp2mk25X3wAmXv9gsd

---
_Generated by [Claude Code](https://claude.ai/code/session_01HM8cPp2mk25X3wAmXv9gsd)_