### PR TITLE
Comment out deprecated evesde SDE import in daily workflow

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -11,38 +11,42 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # once a day, we want to download the export from Steve and cache it.
-      - run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-        id: date
-      - uses: actions/cache@v5
-        id: cache
-        with:
-          path: postgres-latest.dmp.bz2
-          key: active-${{ steps.date.outputs.date }}  
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: curl -L -o postgres-latest.dmp.bz2 https://www.fuzzwork.co.uk/dump/postgres-latest.dmp.bz2
-
-      # decompress it
-      - run: bzip2 --keep --decompress postgres-latest.dmp.bz2
-
-      # and then convert it to an SQL file we can import into Supabase
-      - run: pg_restore --no-owner --role=postgres --clean --if-exists -f postgres-latest.sql postgres-latest.dmp
-
-      - run: sed -i 's/public\./evesde\./g' postgres-latest.sql
-
-      - run: psql -p 6543 -d postgres < postgres-latest.sql
-        env:
-          PGHOST: ${{ vars.SUPABASE_HOST }}
-          PGUSER: postgres.${{ vars.SUPABASE_PROJECT_REF }}
-          PGPASSWORD: ${{ secrets.SUPABASE_PASSWORD }}
-          PGDATABASE: postgres
-
-      - run: psql -p 6543 -d postgres < policies.sql
-        env:
-          PGHOST: ${{ vars.SUPABASE_HOST }}
-          PGUSER: postgres.${{ vars.SUPABASE_PROJECT_REF }}
-          PGPASSWORD: ${{ secrets.SUPABASE_PASSWORD }}
-          PGDATABASE: postgres
+      # DEPRECATED: the evesde SDE import (Fuzzwork dump + RLS policies) is no
+      # longer used — SDE lookups now go through eve-build-calculator instead of
+      # the evesde schema. Kept commented for reference.
+      #
+      # # once a day, we want to download the export from Steve and cache it.
+      # - run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+      #   id: date
+      # - uses: actions/cache@v5
+      #   id: cache
+      #   with:
+      #     path: postgres-latest.dmp.bz2
+      #     key: active-${{ steps.date.outputs.date }}
+      # - if: steps.cache.outputs.cache-hit != 'true'
+      #   run: curl -L -o postgres-latest.dmp.bz2 https://www.fuzzwork.co.uk/dump/postgres-latest.dmp.bz2
+      #
+      # # decompress it
+      # - run: bzip2 --keep --decompress postgres-latest.dmp.bz2
+      #
+      # # and then convert it to an SQL file we can import into Supabase
+      # - run: pg_restore --no-owner --role=postgres --clean --if-exists -f postgres-latest.sql postgres-latest.dmp
+      #
+      # - run: sed -i 's/public\./evesde\./g' postgres-latest.sql
+      #
+      # - run: psql -p 6543 -d postgres < postgres-latest.sql
+      #   env:
+      #     PGHOST: ${{ vars.SUPABASE_HOST }}
+      #     PGUSER: postgres.${{ vars.SUPABASE_PROJECT_REF }}
+      #     PGPASSWORD: ${{ secrets.SUPABASE_PASSWORD }}
+      #     PGDATABASE: postgres
+      #
+      # - run: psql -p 6543 -d postgres < policies.sql
+      #   env:
+      #     PGHOST: ${{ vars.SUPABASE_HOST }}
+      #     PGUSER: postgres.${{ vars.SUPABASE_PROJECT_REF }}
+      #     PGPASSWORD: ${{ secrets.SUPABASE_PASSWORD }}
+      #     PGDATABASE: postgres
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Why

The daily workflow's first half imports the EVE SDE (Fuzzwork dump → `pg_restore` → `evesde` schema → `policies.sql` RLS). That's deprecated: SDE lookups now go through eve-build-calculator instead of the `evesde` schema (per the project's data-source guidance). Only the `npm run daily` step (corp wallet-journal name resolution) is still wanted.

## What changed

In `.github/workflows/daily.yml`, commented out the entire SDE block:
- Fuzzwork dump download + cache
- `bzip2` decompress
- `pg_restore`
- `sed public. → evesde.`
- `psql < postgres-latest.sql` (evesde import)
- `psql < policies.sql` (evesde RLS)

Kept commented (not deleted) for reference. The remaining active steps are: **checkout → setup-node → `npm install` → `npm run daily`**.

YAML validated; the only executed steps now are the Node/daily ones.

https://claude.ai/code/session_01HM8cPp2mk25X3wAmXv9gsd

---
_Generated by [Claude Code](https://claude.ai/code/session_01HM8cPp2mk25X3wAmXv9gsd)_