### PR TITLE
Fix footer repo link after eve-hangar → edencom-link rename

### DIFF
--- a/src/app/layout/footer.tsx
+++ b/src/app/layout/footer.tsx
@@ -1,7 +1,7 @@
 import { DateTime } from '../DateTime'
 import styles from './footer.module.css'
 
-const REPO = 'https://github.com/philihp/eve-hangar'
+const REPO = 'https://github.com/philihp/edencom-link'
 
 const Footer = () => {
   const buildTime = process.env.BUILD_TIME


### PR DESCRIPTION
## What

Updates the footer's `REPO` constant from `philihp/eve-hangar` to `philihp/edencom-link`, so the build/commit-SHA link in the footer points at the renamed GitHub repository directly instead of relying on GitHub's old-slug redirect.

## Why

I checked into the domain/rename status:

- ✅ **`https://edencom.link` is live** and serving the app (HTTP 200, title "Edencom Link"). An anonymous fetch returns 403 because the Vercel deployment has **Vercel Authentication / deployment protection** enabled — not a domain problem.
- ✅ The GitHub repo has been renamed `eve-hangar` → **`philihp/edencom-link`**.
- ✅ The app is already branded "Edencom Link" everywhere (package name, `<title>`, header).
- The codebase is otherwise **host-agnostic** — there are no hardcoded app URLs. Hosting domain comes from Vercel, and the EVE SSO redirect comes from the `EVE_CALLBACK_URL` env var.

The only stale in-repo reference to the old name was this footer link, which is what this PR fixes.

## Not in this repo (heads-up, no action taken)

- If the EVE SSO callback should move to `https://edencom.link/character/callback`, that requires updating the `EVE_CALLBACK_URL` env var **and** the allowed callback in the EVE developer application — neither lives in this repo.
- Vercel deployment protection is what makes the site return 403 to anonymous/crawler requests; disable it if the app is meant to be publicly crawlable.

https://claude.ai/code/session_012hJ6XsC6k7ZaqRxeNq3dRp

---
_Generated by [Claude Code](https://claude.ai/code/session_012hJ6XsC6k7ZaqRxeNq3dRp)_