### PR TITLE
Paginate assets query so location buckets resolve

### DIFF
--- a/src/app/assets/page.tsx
+++ b/src/app/assets/page.tsx
@@ -35,9 +35,23 @@ const AssetsPage = async () => {
     redirect('/')
   }
 
-  const { data: assets } = await supabase.from('asset').select('item_id, location_id, location_type')
-
-  const list = (assets ?? []) as Asset[]
+  // PostgREST caps a single select (Supabase's default API "Max rows" is 1000), but a
+  // hangar can hold tens of thousands of items. The location buckets are built by walking
+  // each item up its location_id chain through the items we own, so a truncated set breaks
+  // the walk: it stops at an intermediate ship/container whose own row was past the cap and
+  // emits that item id as a phantom `Location #…`. Page through every current asset first.
+  const PAGE = 1000
+  const list: Asset[] = []
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await supabase
+      .from('asset')
+      .select('item_id, location_id, location_type')
+      .order('id', { ascending: true })
+      .range(from, from + PAGE - 1)
+    if (error || !data || data.length === 0) break
+    list.push(...(data as Asset[]))
+    if (data.length < PAGE) break
+  }
   const assetByItem = new Map(list.map((a) => [String(a.item_id), a]))
 
   const rootLocation = (a: Asset): Root | null => {


### PR DESCRIPTION
## Problem

On `/assets`, a large number of buckets render as raw `Location #<id>` instead of a station or structure name — far more than could be explained by player citadels we lack docking access to.

## Root cause

The page fetched current assets with a single `supabase.from('asset').select(...)`, which PostgREST caps at **1000 rows** (Supabase's default API "Max rows"). The logged-in user has **20,436** current assets.

Buckets are built by `rootLocation()` walking each item up its `location_id` chain through items we own until it reaches a station/structure/system. On a truncated tree the walk breaks: any item whose containing **ship / container / asset-safety wrap** sat past row 1000 stopped the walk early and emitted that intermediate item's id as a phantom `Location #<id>`.

Confirmed against the live DB — every "unresolved" id was itself an asset sitting in a resolvable place, e.g.:

| Shown as | Really is | Sits in |
|---|---|---|
| `Location #1050835999336` (740 items) | a ship | NPC station `60003760` |
| `Location #256759579` | a ship | NPC station `60003757` |
| `Location #1016122896376` | a container | citadel `1049588174021` |
| `Location #1046975257300` | an AssetSafety wrap | NPC station `60013945` |

## Fix

Page through every current asset in the server component before building the hierarchy, mirroring the `ASSET_PAGE` loop already used in `src/structureNames.js` and `src/assets.js`. Ordered by the view's stable `id` so paging is deterministic. No schema change, no new data source.

## Verification

- `npm run build` and `eslint` on the changed file pass.
- Replaying the corrected walk over all 20,436 current assets collapses them to **135 NPC stations + 134 player structures** with **zero** roots that are themselves owned items (i.e. no phantom buckets).
- A small number of genuine player citadels (~6) will still show as raw ids — those legitimately 403 from ESI `/universe/structures/` because no linked character is on their docking ACL, which is an inherent ESI limitation, not this bug.

https://claude.ai/code/session_01GoGDdqs8zUt3jJ56ZbX1eF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoGDdqs8zUt3jJ56ZbX1eF)_