### PR TITLE
Generalize dynamic-text typography into components

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -152,7 +152,16 @@ h2 {
   font-size: 17px;
 }
 
-/* Serif for dynamic, item-specific text — a thing's name or title. */
+/*
+ * Typography roles:
+ *   --serif  dynamic, item-specific text — a thing's name, title or value
+ *   --sans   static UI chrome — labels, headers, controls (the page default)
+ *   --mono   numbers and code (see `.num` in retro.module.css, `code`/`pre` below)
+ *
+ * Prefer the self-serif components (`TypeName`, `DateTime`, and the `Name`
+ * family in names.tsx) for entity names and timestamps; reach for this `.serif`
+ * utility for one-off dynamic text that has no dedicated component.
+ */
 .serif {
   font-family: var(--serif);
 }

--- a/src/app/industry/activeJobs.tsx
+++ b/src/app/industry/activeJobs.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 
 import { DateTime } from '../DateTime'
 import { usePersist } from '../market/usePersist'
+import { CharacterName } from '../names'
 import retro from '../retro.module.css'
 import { TypeName } from '../typeName'
 import styles from './industry.module.css'
@@ -102,9 +103,11 @@ export const ActiveJobs = ({ jobs, characters, initialNow, typeNamesPromise, sta
             <tbody>
               {filtered.map((j) => (
                 <tr key={`job-${j.job_id}`}>
-                  <td className="serif">{characterName[j.character_id] ?? '—'}</td>
+                  <td>
+                    <CharacterName name={characterName[j.character_id]} />
+                  </td>
                   <td className="serif">{ACTIVITY_NAMES[j.activity_id] ?? `#${j.activity_id}`}</td>
-                  <td className="serif">
+                  <td>
                     {j.product_type_id != null ? (
                       <TypeName id={Number(j.product_type_id)} promise={typeNamesPromise} />
                     ) : (

--- a/src/app/market/recentSales.tsx
+++ b/src/app/market/recentSales.tsx
@@ -2,6 +2,7 @@
 
 import { DateTime } from '../DateTime'
 import { formatMiskValue } from '../isk'
+import { CharacterName } from '../names'
 import { TypeName } from '../typeName'
 import styles from './market.module.css'
 import { usePersist } from './usePersist'
@@ -101,8 +102,10 @@ export const RecentSales = ({ sales, characters, typeNamesPromise }: RecentSales
           <tbody>
             {filtered.map((s) => (
               <tr key={`sale-${s.transaction_id}`}>
-                <td className="serif">{characterName[s.character_id] ?? '—'}</td>
-                <td className="serif">
+                <td>
+                  <CharacterName name={characterName[s.character_id]} />
+                </td>
+                <td>
                   <TypeName id={Number(s.type_id)} promise={typeNamesPromise} />
                 </td>
                 <td>{s.quantity}</td>

--- a/src/app/names.tsx
+++ b/src/app/names.tsx
@@ -1,0 +1,26 @@
+// Dynamic, item-specific names — a thing's name or title — render in the serif
+// face (see the typography note in globals.css). These thin components wrap the
+// resolver-map lookups each page already performs, applying that face in one
+// place plus a consistent fallback: the numeric `#id` when a name hasn't
+// resolved yet, or `—` when there is nothing to show.
+//
+// Pair with the existing self-serif primitives: `TypeName` (async type lookup)
+// and `DateTime` (timestamps). For one-off dynamic text that isn't an entity
+// name (a countdown, an activity label), use the `.serif` utility class directly.
+
+type NameProps = {
+  name?: string | null
+  /** Shown as `#id` when `name` is missing; omit to fall back to `—`. */
+  id?: string | number | null
+}
+
+export const Name = ({ name, id }: NameProps) => (
+  <span className="serif">{name ?? (id != null ? `#${id}` : '—')}</span>
+)
+
+// Characters fall back to `—`: their id is an opaque uuid, not worth showing.
+export const CharacterName = ({ name }: { name?: string | null }) => <Name name={name} />
+
+export const SystemName = (props: NameProps) => <Name {...props} />
+
+export const StationName = (props: NameProps) => <Name {...props} />

--- a/src/app/structures/[structureId]/page.tsx
+++ b/src/app/structures/[structureId]/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from 'next/navigation'
 import { createClient } from '@/utils/supabase/server'
 import { DateTime } from '../../DateTime'
 import { ACTIVITY_NAMES } from '../../industry/jobFields'
+import { CharacterName, Name, SystemName } from '../../names'
 import { fetchSystemNames } from '../../systemNames'
 import { fetchTypeNames } from '../../typeNames'
 import retro from '../../retro.module.css'
@@ -144,12 +145,14 @@ const StructurePage = async ({ params }: StructureParams) => {
           <tr>
             <th>Type</th>
             <td>
-              <span className="serif">{typeName ?? `#${s.type_id}`}</span>
+              <Name name={typeName} id={s.type_id} />
             </td>
           </tr>
           <tr>
             <th>System</th>
-            <td>{systemName ?? s.system_id}</td>
+            <td>
+              <SystemName name={systemName} id={s.system_id} />
+            </td>
           </tr>
           <tr>
             <th>Profile ID</th>
@@ -232,11 +235,19 @@ const StructurePage = async ({ params }: StructureParams) => {
           <tbody>
             {jobs.map((j) => (
               <tr key={`job-${j.job_id}`}>
-                <td className="serif">{characterName[j.character_id] ?? '—'}</td>
-                <td>{ACTIVITY_NAMES[j.activity_id] ?? `#${j.activity_id}`}</td>
-                <td className="serif">{typeNames[Number(j.blueprint_type_id)] ?? `#${j.blueprint_type_id}`}</td>
-                <td className="serif">
-                  {j.product_type_id != null ? (typeNames[Number(j.product_type_id)] ?? `#${j.product_type_id}`) : '—'}
+                <td>
+                  <CharacterName name={characterName[j.character_id]} />
+                </td>
+                <td className="serif">{ACTIVITY_NAMES[j.activity_id] ?? `#${j.activity_id}`}</td>
+                <td>
+                  <Name name={typeNames[Number(j.blueprint_type_id)]} id={j.blueprint_type_id} />
+                </td>
+                <td>
+                  {j.product_type_id != null ? (
+                    <Name name={typeNames[Number(j.product_type_id)]} id={j.product_type_id} />
+                  ) : (
+                    '—'
+                  )}
                 </td>
                 <td className={retro.num}>{j.runs}</td>
                 <td>{j.status}</td>

--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation'
 import { createClient } from '@/utils/supabase/server'
 import { DateTime } from '../DateTime'
 import { formatMisk } from '../isk'
+import { Name, SystemName } from '../names'
 import { fetchSystemNames } from '../systemNames'
 import { fetchTypeNames } from '../typeNames'
 import { StructureSilhouette } from './silhouette'
@@ -223,13 +224,15 @@ const StructuresPage = async () => {
                       {formatMisk(totalByStructure.get(String(s.structure_id)) ?? 0)}
                     </span>
                     <span className={styles.label}>Type</span>
-                    <span className={`${styles.value} serif`}>
-                      {structureTypeNames[Number(s.type_id)] ?? `#${s.type_id}`}
+                    <span className={styles.value}>
+                      <Name name={structureTypeNames[Number(s.type_id)]} id={s.type_id} />
                     </span>
                     <span className={styles.label}>System</span>
-                    <span className={`${styles.value} serif`}>{systemNames[Number(s.system_id)] ?? s.system_id}</span>
+                    <span className={styles.value}>
+                      <SystemName name={systemNames[Number(s.system_id)]} id={s.system_id} />
+                    </span>
                     <span className={styles.label}>Fuel Expires</span>
-                    <span className={`${styles.value} serif`}>
+                    <span className={styles.value}>
                       <DateTime value={s.fuel_expires} />
                     </span>
                   </div>

--- a/src/app/typeName.tsx
+++ b/src/app/typeName.tsx
@@ -13,7 +13,11 @@ const Resolved = ({ id, promise }: TypeNameProps) => {
 }
 
 export const TypeName = ({ id, promise }: TypeNameProps) => (
-  <Suspense fallback={`#${id}`}>
-    <Resolved id={id} promise={promise} />
-  </Suspense>
+  // A type/item name is always dynamic, item-specific text, so it owns the serif
+  // face (see globals.css) rather than relying on each caller to add it.
+  <span className="serif">
+    <Suspense fallback={`#${id}`}>
+      <Resolved id={id} promise={promise} />
+    </Suspense>
+  </span>
 )


### PR DESCRIPTION
Follow-up to the typography tweaks (#369): generalize the serif/sans/mono convention so it's applied consistently and isn't re-typed at every call site.

## What changed

- **New `Name` family** (`src/app/names.tsx`): `Name`, `CharacterName`, `SystemName`, `StationName` — thin components that render an entity name in the serif (dynamic-text) face with a consistent fallback (`#id`, or `—` for characters). They wrap the resolver-map lookups each page already does.
- **`TypeName` now owns its serif face** (like `DateTime` already does), so a type name is correct anywhere without the caller adding `className="serif"`.
- **Call sites** in `market/recentSales`, `industry/activeJobs`, `structures/page`, and `structures/[structureId]/page` now render names/timestamps through these components and drop the redundant per-cell `className="serif"`.
- **`globals.css`** documents the three typographic roles (serif = dynamic text, sans = static chrome, mono = numbers) and points to the components, with `.serif` kept as the escape hatch for one-off dynamic text (e.g. the Remaining countdown, Activity label).

## Why

The per-cell `className="serif"` had drifted out of sync — e.g. **System** and **Activity** were serif on some pages but plain on the structure-detail page. Centralizing the rule in the data components fixes those inconsistencies and makes future tables correct by default.

No behavioral change; build and lint pass (the two `no-unused-vars` warnings are pre-existing).

https://claude.ai/code/session_01GoGDdqs8zUt3jJ56ZbX1eF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoGDdqs8zUt3jJ56ZbX1eF)_