### PR TITLE
Resolve solar system for NPC stations in assets

### DIFF
--- a/src/app/assets/page.tsx
+++ b/src/app/assets/page.tsx
@@ -3,7 +3,7 @@ import { redirect } from 'next/navigation'
 import { createClient } from '@/utils/supabase/server'
 import { DateTime } from '../DateTime'
 import retro from '../retro.module.css'
-import { fetchStationNames } from '../stationNames'
+import { fetchStationNames, fetchStationSystems } from '../stationNames'
 import { fetchSystemNames } from '../systemNames'
 import styles from './assets.module.css'
 
@@ -99,13 +99,16 @@ const AssetsPage = async () => {
   // type/system lookups); player structures aren't there, so those still resolve
   // via corp_structure above.
   const stationIds = [...byLocation.values()].filter((loc) => loc.type === 'station').map((loc) => Number(loc.id))
-  const stationNames = await fetchStationNames(stationIds)
+  const [stationNames, stationSystems] = await Promise.all([fetchStationNames(stationIds), fetchStationSystems(stationIds)])
 
   const systemIds = new Set<number>()
   for (const loc of byLocation.values()) {
     if (loc.type === 'solar_system') systemIds.add(Number(loc.id))
     const structure = structureById.get(loc.id)
     if (structure?.system_id != null) systemIds.add(Number(structure.system_id))
+    // NPC stations aren't in corp_structure/structure; their system comes from
+    // the calculator's station lookup above.
+    if (loc.type === 'station' && stationSystems[Number(loc.id)] != null) systemIds.add(stationSystems[Number(loc.id)])
   }
   const systemNames = await fetchSystemNames(systemIds)
 
@@ -121,6 +124,10 @@ const AssetsPage = async () => {
     const structure = structureById.get(loc.id)
     if (structure?.system_id != null) return systemNames[Number(structure.system_id)] ?? `#${structure.system_id}`
     if (loc.type === 'solar_system') return systemNames[Number(loc.id)]
+    if (loc.type === 'station') {
+      const systemId = stationSystems[Number(loc.id)]
+      if (systemId != null) return systemNames[systemId] ?? `#${systemId}`
+    }
     return undefined
   }
 

--- a/src/app/stationNames.ts
+++ b/src/app/stationNames.ts
@@ -1,30 +1,54 @@
-// Resolve station names from eve-build-calculator, mirroring the system lookup in
-// systemNames.ts. Unresolved ids are simply omitted so callers can fall back to
-// showing the raw id (never read the evesde SDE).
-const cache = new Map<number, Promise<string | null>>()
+// Resolve station details from eve-build-calculator, mirroring the system lookup
+// in systemNames.ts. Unresolved ids are simply omitted so callers can fall back
+// to showing the raw id (never read the evesde SDE).
+type Station = { name: string | null; solarSystemId: number | null }
 
-const fetchOne = (stationID: number): Promise<string | null> =>
+type StationResponse = {
+  name?: { en?: string } | string
+  // The calculator exposes the station's solar system so callers can resolve its
+  // name via /api/system/{id}; tolerate either casing the API might return.
+  solarSystemId?: number
+  solarSystemID?: number
+}
+
+const cache = new Map<number, Promise<Station | null>>()
+
+const fetchOne = (stationID: number): Promise<Station | null> =>
   fetch(`https://eve-build-calculator.philihp.com/api/station/${stationID}`)
     .then((res) => (res.ok ? res.json() : null))
-    .then((station: { name?: { en?: string } | string } | null) => {
+    .then((station: StationResponse | null) => {
       if (!station) return null
-      return typeof station.name === 'string' ? station.name : (station.name?.en ?? null)
+      const name = typeof station.name === 'string' ? station.name : (station.name?.en ?? null)
+      const solarSystemId = station.solarSystemId ?? station.solarSystemID ?? null
+      return { name, solarSystemId }
     })
     .catch(() => null)
 
-const lookup = (stationID: number): Promise<string | null> => {
+const lookup = (stationID: number): Promise<Station | null> => {
   const cached = cache.get(stationID)
   if (cached) return cached
   const promise = fetchOne(stationID)
   cache.set(stationID, promise)
-  promise.then((name) => {
-    if (name === null) cache.delete(stationID)
+  promise.then((station) => {
+    if (station === null) cache.delete(stationID)
   })
   return promise
 }
 
-export const fetchStationNames = async (stationIDs: Iterable<number>): Promise<Record<number, string>> => {
+const resolve = async <T>(stationIDs: Iterable<number>, pick: (s: Station) => T | null): Promise<Record<number, T>> => {
   const ids = Array.from(new Set([...stationIDs].filter((n) => Number.isFinite(n))))
-  const pairs = await Promise.all(ids.map(async (id) => [id, await lookup(id)] as const))
-  return Object.fromEntries(pairs.filter(([, name]) => name !== null) as [number, string][])
+  const pairs = await Promise.all(
+    ids.map(async (id) => {
+      const station = await lookup(id)
+      return [id, station ? pick(station) : null] as const
+    }),
+  )
+  return Object.fromEntries(pairs.filter(([, value]) => value !== null) as [number, T][])
 }
+
+export const fetchStationNames = (stationIDs: Iterable<number>): Promise<Record<number, string>> =>
+  resolve(stationIDs, (s) => s.name)
+
+// stationID → solarSystemID, for resolving the system an NPC station sits in.
+export const fetchStationSystems = (stationIDs: Iterable<number>): Promise<Record<number, number>> =>
+  resolve(stationIDs, (s) => s.solarSystemId)


### PR DESCRIPTION
## Problem

The assets view showed a blank **System** column for NPC stations. `systemFor()` could only determine a location's system if it was a player structure (which carries `system_id` from `corp_structure`/`structure`) or if the location itself was a solar system. NPC stations are neither, so there was nothing to feed into `fetchSystemNames`.

## Fix

The eve-build-calculator `/api/station/{id}` endpoint now returns `solarSystemId`, so the consumer side can use it:

- **`stationNames.ts`** now caches the full station record and exposes a new `fetchStationSystems` helper (stationID → solarSystemID) alongside the existing `fetchStationNames` — both share one cached fetch, so no extra network calls. The name API is unchanged.
- **`assets/page.tsx`** feeds station system ids into the `systemIds` set used for `fetchSystemNames`, and `systemFor()` now resolves an NPC station's system the same way it does for player structures (with a `#id` fallback).

No schema or behavioral change beyond filling in the previously-blank System column. Build and lint pass (the two `no-unused-vars` warnings are pre-existing).

https://claude.ai/code/session_01GoGDdqs8zUt3jJ56ZbX1eF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoGDdqs8zUt3jJ56ZbX1eF)_