### PR TITLE
Add per-location assets drill-down page

### DIFF
--- a/src/app/assets/[locationId]/page.tsx
+++ b/src/app/assets/[locationId]/page.tsx
@@ -1,0 +1,153 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+
+import { createClient } from '@/utils/supabase/server'
+import { Name } from '../../names'
+import retro from '../../retro.module.css'
+import { fetchStationNames, fetchStationSystems } from '../../stationNames'
+import { fetchSystemNames } from '../../systemNames'
+import { fetchTypeNames } from '../../typeNames'
+
+// Bigint ids arrive from PostgREST as strings; keep them as strings and only
+// convert at the API/system-lookup boundary (mirrors the assets index page).
+type Asset = {
+  item_id: number | string
+  type_id: number | string
+  location_id: number | string | null
+  location_flag: string | null
+  location_type: string | null
+  quantity: number | string | null
+  is_singleton: boolean | null
+}
+
+type Structure = {
+  structure_id: number | string
+  name: string | null
+  system_id: number | string | null
+}
+
+const AssetLocationPage = async ({ params }: { params: Promise<{ locationId: string }> }) => {
+  const { locationId } = await params
+  const supabase = await createClient()
+
+  const { data: auth, error: authError } = await supabase.auth.getUser()
+  if (authError || !auth?.user) {
+    redirect('/')
+  }
+
+  // Page through every current asset (PostgREST caps a select at the API "Max
+  // rows" limit) so the parent→child map is complete: contents counts walk it.
+  const PAGE = 1000
+  const list: Asset[] = []
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await supabase
+      .from('asset')
+      .select('item_id, type_id, location_id, location_flag, location_type, quantity, is_singleton')
+      .order('id', { ascending: true })
+      .range(from, from + PAGE - 1)
+    if (error || !data || data.length === 0) break
+    list.push(...(data as Asset[]))
+    if (data.length < PAGE) break
+  }
+
+  // Items grouped by the container/location they sit directly in.
+  const childrenByParent = new Map<string, Asset[]>()
+  for (const a of list) {
+    if (a.location_id == null) continue
+    const key = String(a.location_id)
+    const siblings = childrenByParent.get(key)
+    if (siblings) siblings.push(a)
+    else childrenByParent.set(key, [a])
+  }
+
+  // Root-level assets at this location: ships, containers and loose stacks that
+  // sit directly in the station/structure/system (not nested in another item).
+  const rootItems = childrenByParent.get(locationId) ?? []
+
+  // Total items held inside a ship/container, walking the whole subtree.
+  const contentsCount = (itemId: string, seen = new Set<string>()): number => {
+    if (seen.has(itemId)) return 0
+    seen.add(itemId)
+    const kids = childrenByParent.get(itemId) ?? []
+    return kids.reduce((n, k) => n + 1 + contentsCount(String(k.item_id), seen), 0)
+  }
+
+  // Resolve the location's own name/system the same way the index page does:
+  // own-corp + foreign player structures from the DB, NPC stations and systems
+  // from eve-build-calculator.
+  const numericId = Number(locationId)
+  const { data: corpStructures } = await supabase
+    .from('corp_structure')
+    .select('structure_id, name, system_id')
+    .eq('structure_id', numericId)
+  const { data: playerStructures } = await supabase
+    .from('structure')
+    .select('structure_id, name, system_id')
+    .eq('structure_id', numericId)
+  const structure = ((corpStructures?.[0] ?? playerStructures?.[0]) ?? null) as Structure | null
+
+  const locationType = rootItems[0]?.location_type ?? null
+  const [stationNames, stationSystems] = await Promise.all([
+    fetchStationNames([numericId]),
+    fetchStationSystems([numericId]),
+  ])
+
+  const systemId = structure?.system_id != null ? Number(structure.system_id) : stationSystems[numericId]
+  const systemNames = await fetchSystemNames(
+    [systemId, locationType === 'solar_system' ? numericId : undefined].filter((n): n is number => n != null),
+  )
+
+  const locationName = structure
+    ? (structure.name ?? `Structure #${locationId}`)
+    : (stationNames[numericId] ?? (locationType === 'solar_system' ? systemNames[numericId] : undefined))
+  const systemName = systemId != null ? (systemNames[systemId] ?? `#${systemId}`) : undefined
+
+  const typeNames = await fetchTypeNames(rootItems.map((a) => Number(a.type_id)))
+
+  // Containers/ships (those holding items) first, then by name for stability.
+  const rows = rootItems
+    .map((a) => ({ asset: a, contents: contentsCount(String(a.item_id)), name: typeNames[Number(a.type_id)] }))
+    .sort((a, b) => b.contents - a.contents || (a.name ?? '').localeCompare(b.name ?? ''))
+
+  return (
+    <>
+      <h1 className="serif">{locationName ?? `Location #${locationId}`}</h1>
+      {systemName && systemName !== locationName ? (
+        <p>
+          System: <span className="serif">{systemName}</span>
+        </p>
+      ) : null}
+      <p>
+        <Link href="/assets">&laquo; Back to Assets</Link>
+      </p>
+
+      {rows.length > 0 ? (
+        <table className={retro.retro}>
+          <thead>
+            <tr>
+              <th>Item</th>
+              <th className={retro.num}>Quantity</th>
+              <th>Hangar</th>
+              <th className={retro.num}>Contents</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(({ asset, contents, name }) => (
+              <tr key={`item-${asset.item_id}`}>
+                <td>
+                  <Name name={name} id={asset.type_id} />
+                </td>
+                <td className={retro.num}>{asset.is_singleton ? '—' : (asset.quantity ?? 1)}</td>
+                <td>{asset.location_flag ?? '—'}</td>
+                <td className={retro.num}>{contents > 0 ? contents : '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p>No assets known at this location.</p>
+      )}
+    </>
+  )
+}
+export default AssetLocationPage

--- a/src/app/assets/page.tsx
+++ b/src/app/assets/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
@@ -164,7 +165,11 @@ const AssetsPage = async () => {
               const name = labelFor(loc)
               return (
                 <tr key={`location-${loc.id}`}>
-                  <td className="serif">{name}</td>
+                  <td>
+                    <Link href={`/assets/${loc.id}`} className="serif">
+                      {name}
+                    </Link>
+                  </td>
                   <td className="serif">{system && system !== name ? system : '—'}</td>
                   <td className={retro.num}>{loc.count}</td>
                 </tr>


### PR DESCRIPTION
## What

Adds a drill-down subpage for assets. Clicking a row on the Assets index now navigates to `/assets/[locationId]`, which lists the ships, containers, and loose stacks that sit **directly** in that station / structure / solar system.

## Details

- **New route `src/app/assets/[locationId]/page.tsx`** — pages through all current assets (same approach as the index, so the parent→child map is complete), groups items by their direct `location_id`, and shows the root-level items at this location. Each row shows:
  - **Item** — type name (resolved via eve-build-calculator, with `#id` fallback)
  - **Quantity** — the stack size (`—` for assembled singletons like fitted ships)
  - **Hangar** — the item's `location_flag`
  - **Contents** — count of items held inside, walking the full nested subtree (so ships/containers surface how much they hold); `—` when empty. Containers/ships sort first.
- The location's **name and system** are resolved with the same sources as the index (own-corp + foreign player structures from the DB, NPC stations and systems from eve-build-calculator).
- **Index page** (`assets/page.tsx`) — the Location cell is now a `<Link>` to the subpage.

Build and lint pass (the two `no-unused-vars` warnings are pre-existing).

https://claude.ai/code/session_01GoGDdqs8zUt3jJ56ZbX1eF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoGDdqs8zUt3jJ56ZbX1eF)_