### PR TITLE
Add character filter to assets pages

### DIFF
--- a/src/app/assets/[locationId]/locationAssets.tsx
+++ b/src/app/assets/[locationId]/locationAssets.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import retro from '../../retro.module.css'
+import { TypeName } from '../../typeName'
+import styles from '../assets.module.css'
+import { ALL_CHARACTERS, CharacterFilter, useCharacterFilter, type Character } from '../characterFilter'
+
+export type ItemRow = {
+  itemId: string
+  characterId: string
+  typeId: number
+  quantity: number | string | null
+  isSingleton: boolean | null
+  flag: string | null
+  contents: number
+}
+
+type LocationAssetsProps = {
+  rows: ItemRow[]
+  characters: Character[]
+  typeNamesPromise: Promise<Record<number, string>>
+}
+
+export const LocationAssets = ({ rows, characters, typeNamesPromise }: LocationAssetsProps) => {
+  const [characterId, setCharacterId] = useCharacterFilter(characters)
+
+  const filtered = rows.filter((r) => characterId === ALL_CHARACTERS || r.characterId === characterId)
+
+  return (
+    <section>
+      <div className={styles.filters}>
+        <CharacterFilter characters={characters} value={characterId} onChange={setCharacterId} />
+      </div>
+      {filtered.length > 0 ? (
+        <table className={retro.retro}>
+          <thead>
+            <tr>
+              <th>Item</th>
+              <th className={retro.num}>Quantity</th>
+              <th>Hangar</th>
+              <th className={retro.num}>Contents</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((row) => (
+              <tr key={`item-${row.itemId}`}>
+                <td>
+                  <TypeName id={row.typeId} promise={typeNamesPromise} />
+                </td>
+                <td className={retro.num}>{row.isSingleton ? '—' : (row.quantity ?? 1)}</td>
+                <td>{row.flag ?? '—'}</td>
+                <td className={retro.num}>{row.contents > 0 ? row.contents : '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p>No assets known at this location.</p>
+      )}
+    </section>
+  )
+}

--- a/src/app/assets/[locationId]/page.tsx
+++ b/src/app/assets/[locationId]/page.tsx
@@ -2,16 +2,16 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
-import retro from '../../retro.module.css'
 import { fetchStationNames, fetchStationSystems } from '../../stationNames'
 import { fetchSystemNames } from '../../systemNames'
-import { TypeName } from '../../typeName'
 import { fetchTypeNames } from '../../typeNames'
+import { LocationAssets, type ItemRow } from './locationAssets'
 
 // Bigint ids arrive from PostgREST as strings; keep them as strings and only
 // convert at the API/system-lookup boundary (mirrors the assets index page).
 type Asset = {
   item_id: number | string
+  character_id: string
   type_id: number | string
   location_id: number | string | null
   location_flag: string | null
@@ -42,7 +42,7 @@ const AssetLocationPage = async ({ params }: { params: Promise<{ locationId: str
   for (let from = 0; ; from += PAGE) {
     const { data, error } = await supabase
       .from('asset')
-      .select('item_id, type_id, location_id, location_flag, location_type, quantity, is_singleton')
+      .select('item_id, character_id, type_id, location_id, location_flag, location_type, quantity, is_singleton')
       .order('id', { ascending: true })
       .range(from, from + PAGE - 1)
     if (error || !data || data.length === 0) break
@@ -102,15 +102,26 @@ const AssetLocationPage = async ({ params }: { params: Promise<{ locationId: str
     : (stationNames[numericId] ?? (locationType === 'solar_system' ? systemNames[numericId] : undefined))
   const systemName = systemId != null ? (systemNames[systemId] ?? `#${systemId}`) : undefined
 
+  const { data: characters } = await supabase.from('registration').select('id, name')
+  const sortedCharacters = [...(characters ?? [])].sort((a, b) => a.name.localeCompare(b.name))
+
   // Resolve type names without blocking render: fire the lookup and let each
   // TypeName stream in (Suspense), falling back to #id. A big hangar can hold
   // hundreds of distinct types, and awaiting them all here times the page out.
   const typeNamesPromise = fetchTypeNames(rootItems.map((a) => Number(a.type_id)))
 
   // Containers/ships (those holding items) first, then a stable id order.
-  const rows = rootItems
-    .map((a) => ({ asset: a, contents: contentsCount(String(a.item_id)) }))
-    .sort((a, b) => b.contents - a.contents || Number(a.asset.type_id) - Number(b.asset.type_id))
+  const rows: ItemRow[] = rootItems
+    .map((a) => ({
+      itemId: String(a.item_id),
+      characterId: a.character_id,
+      typeId: Number(a.type_id),
+      quantity: a.quantity,
+      isSingleton: a.is_singleton,
+      flag: a.location_flag,
+      contents: contentsCount(String(a.item_id)),
+    }))
+    .sort((a, b) => b.contents - a.contents || a.typeId - b.typeId)
 
   return (
     <>
@@ -124,32 +135,7 @@ const AssetLocationPage = async ({ params }: { params: Promise<{ locationId: str
         <Link href="/assets">&laquo; Back to Assets</Link>
       </p>
 
-      {rows.length > 0 ? (
-        <table className={retro.retro}>
-          <thead>
-            <tr>
-              <th>Item</th>
-              <th className={retro.num}>Quantity</th>
-              <th>Hangar</th>
-              <th className={retro.num}>Contents</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map(({ asset, contents }) => (
-              <tr key={`item-${asset.item_id}`}>
-                <td>
-                  <TypeName id={Number(asset.type_id)} promise={typeNamesPromise} />
-                </td>
-                <td className={retro.num}>{asset.is_singleton ? '—' : (asset.quantity ?? 1)}</td>
-                <td>{asset.location_flag ?? '—'}</td>
-                <td className={retro.num}>{contents > 0 ? contents : '—'}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      ) : (
-        <p>No assets known at this location.</p>
-      )}
+      <LocationAssets rows={rows} characters={sortedCharacters} typeNamesPromise={typeNamesPromise} />
     </>
   )
 }

--- a/src/app/assets/assets.module.css
+++ b/src/app/assets/assets.module.css
@@ -3,3 +3,28 @@
   color: var(--ink-faint);
   font-size: 12px;
 }
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12pt;
+}
+
+.header h1 {
+  margin: 0;
+}
+
+.filters {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12pt;
+  margin: 0 0 12pt;
+}
+
+.filter {
+  font-size: 10pt;
+  color: var(--ink-soft);
+}
+

--- a/src/app/assets/assetsTable.tsx
+++ b/src/app/assets/assetsTable.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import Link from 'next/link'
+
+import retro from '../retro.module.css'
+import styles from './assets.module.css'
+import { ALL_CHARACTERS, CharacterFilter, useCharacterFilter, type Character } from './characterFilter'
+
+export type Location = {
+  id: string
+  name: string
+  system: string | null
+  // character_id → number of item stacks that character has at this location.
+  counts: Record<string, number>
+}
+
+type AssetsTableProps = {
+  locations: Location[]
+  characters: Character[]
+}
+
+export const AssetsTable = ({ locations, characters }: AssetsTableProps) => {
+  const [characterId, setCharacterId] = useCharacterFilter(characters)
+
+  const rows = locations
+    .map((loc) => ({
+      loc,
+      count:
+        characterId === ALL_CHARACTERS
+          ? Object.values(loc.counts).reduce((a, b) => a + b, 0)
+          : (loc.counts[characterId] ?? 0),
+    }))
+    .filter((row) => row.count > 0)
+    // Busiest locations first, then by name for a stable order.
+    .sort((a, b) => b.count - a.count || a.loc.name.localeCompare(b.loc.name))
+
+  return (
+    <section>
+      <div className={styles.header}>
+        <h1>Assets</h1>
+        <CharacterFilter characters={characters} value={characterId} onChange={setCharacterId} />
+      </div>
+      {locations.length === 0 ? (
+        <p>
+          No assets visible. Link a character with the <code>esi-assets.read_assets.v1</code> scope on the{' '}
+          <a href="/character">Characters</a> page so the hourly job can fetch them.
+        </p>
+      ) : rows.length > 0 ? (
+        <table className={retro.retro}>
+          <thead>
+            <tr>
+              <th>Location</th>
+              <th>System</th>
+              <th className={retro.num}>Items</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(({ loc, count }) => (
+              <tr key={`location-${loc.id}`}>
+                <td>
+                  <Link href={`/assets/${loc.id}`} className="serif">
+                    {loc.name}
+                  </Link>
+                </td>
+                <td className="serif">{loc.system && loc.system !== loc.name ? loc.system : '—'}</td>
+                <td className={retro.num}>{count}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p>No assets for this character.</p>
+      )}
+    </section>
+  )
+}

--- a/src/app/assets/characterFilter.tsx
+++ b/src/app/assets/characterFilter.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { usePersist } from '../market/usePersist'
+import styles from './assets.module.css'
+
+export type Character = { id: string; name: string }
+
+export const ALL_CHARACTERS = ''
+// Shared across the index and the per-location page so a chosen character
+// follows you when you drill in.
+const STORAGE_KEY = 'assets.characterId'
+
+export const useCharacterFilter = (characters: Character[]) =>
+  usePersist<string>(STORAGE_KEY, ALL_CHARACTERS, (raw) =>
+    raw === ALL_CHARACTERS || characters.some((c) => c.id === raw) ? raw : undefined,
+  )
+
+type CharacterFilterProps = {
+  characters: Character[]
+  value: string
+  onChange: (id: string) => void
+}
+
+export const CharacterFilter = ({ characters, value, onChange }: CharacterFilterProps) => (
+  <label className={styles.filter}>
+    Character:&nbsp;
+    <select value={value} onChange={(e) => onChange(e.target.value)}>
+      <option value={ALL_CHARACTERS}>All characters</option>
+      {characters.map((c) => (
+        <option key={c.id} value={c.id}>
+          {c.name}
+        </option>
+      ))}
+    </select>
+  </label>
+)

--- a/src/app/assets/page.tsx
+++ b/src/app/assets/page.tsx
@@ -1,17 +1,17 @@
-import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
 import { DateTime } from '../DateTime'
-import retro from '../retro.module.css'
 import { fetchStationNames, fetchStationSystems } from '../stationNames'
 import { fetchSystemNames } from '../systemNames'
 import styles from './assets.module.css'
+import { AssetsTable, type Location } from './assetsTable'
 
 // Bigint ids arrive from PostgREST as strings, so every id is kept as a string
 // and only converted to a number at the API/system-lookup boundary.
 type Asset = {
   item_id: number | string
+  character_id: string
   location_id: number | string | null
   location_type: string | null
 }
@@ -46,7 +46,7 @@ const AssetsPage = async () => {
   for (let from = 0; ; from += PAGE) {
     const { data, error } = await supabase
       .from('asset')
-      .select('item_id, location_id, location_type')
+      .select('item_id, character_id, location_id, location_type')
       .order('id', { ascending: true })
       .range(from, from + PAGE - 1)
     if (error || !data || data.length === 0) break
@@ -54,6 +54,9 @@ const AssetsPage = async () => {
     if (data.length < PAGE) break
   }
   const assetByItem = new Map(list.map((a) => [String(a.item_id), a]))
+
+  const { data: characters } = await supabase.from('registration').select('id, name')
+  const sortedCharacters = [...(characters ?? [])].sort((a, b) => a.name.localeCompare(b.name))
 
   const rootLocation = (a: Asset): Root | null => {
     let cur: Asset | undefined = a
@@ -70,14 +73,15 @@ const AssetsPage = async () => {
     return null
   }
 
-  // Tally how many item stacks resolve to each location.
-  const byLocation = new Map<string, Root & { count: number }>()
+  // Tally how many item stacks resolve to each location, split by the character
+  // that owns each stack so the client can filter by character.
+  const byLocation = new Map<string, { root: Root; counts: Map<string, number> }>()
   for (const a of list) {
     const root = rootLocation(a)
     if (!root) continue
-    const existing = byLocation.get(root.id)
-    if (existing) existing.count += 1
-    else byLocation.set(root.id, { ...root, count: 1 })
+    const entry = byLocation.get(root.id) ?? { root, counts: new Map<string, number>() }
+    entry.counts.set(a.character_id, (entry.counts.get(a.character_id) ?? 0) + 1)
+    byLocation.set(root.id, entry)
   }
 
   // Structure names + systems come from two caches: our own corp's structures
@@ -99,17 +103,19 @@ const AssetsPage = async () => {
   // NPC station names come from eve-build-calculator (same curated source as the
   // type/system lookups); player structures aren't there, so those still resolve
   // via corp_structure above.
-  const stationIds = [...byLocation.values()].filter((loc) => loc.type === 'station').map((loc) => Number(loc.id))
+  const stationIds = [...byLocation.values()]
+    .filter(({ root }) => root.type === 'station')
+    .map(({ root }) => Number(root.id))
   const [stationNames, stationSystems] = await Promise.all([fetchStationNames(stationIds), fetchStationSystems(stationIds)])
 
   const systemIds = new Set<number>()
-  for (const loc of byLocation.values()) {
-    if (loc.type === 'solar_system') systemIds.add(Number(loc.id))
-    const structure = structureById.get(loc.id)
+  for (const { root } of byLocation.values()) {
+    if (root.type === 'solar_system') systemIds.add(Number(root.id))
+    const structure = structureById.get(root.id)
     if (structure?.system_id != null) systemIds.add(Number(structure.system_id))
     // NPC stations aren't in corp_structure/structure; their system comes from
     // the calculator's station lookup above.
-    if (loc.type === 'station' && stationSystems[Number(loc.id)] != null) systemIds.add(stationSystems[Number(loc.id)])
+    if (root.type === 'station' && stationSystems[Number(root.id)] != null) systemIds.add(stationSystems[Number(root.id)])
   }
   const systemNames = await fetchSystemNames(systemIds)
 
@@ -132,8 +138,12 @@ const AssetsPage = async () => {
     return undefined
   }
 
-  // Busiest locations first, then by name for a stable order.
-  const rows = [...byLocation.values()].sort((a, b) => b.count - a.count || labelFor(a).localeCompare(labelFor(b)))
+  const locations: Location[] = [...byLocation.values()].map(({ root, counts }) => ({
+    id: root.id,
+    name: labelFor(root),
+    system: systemFor(root) ?? null,
+    counts: Object.fromEntries(counts),
+  }))
 
   // When the Assets background job last finished. Each scheduled run writes a
   // public.heartbeat row stamped with ended_at and a link to the workflow run; we
@@ -149,40 +159,7 @@ const AssetsPage = async () => {
 
   return (
     <>
-      <h1>Assets</h1>
-      {rows.length > 0 ? (
-        <table className={retro.retro}>
-          <thead>
-            <tr>
-              <th>Location</th>
-              <th>System</th>
-              <th className={retro.num}>Items</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((loc) => {
-              const system = systemFor(loc)
-              const name = labelFor(loc)
-              return (
-                <tr key={`location-${loc.id}`}>
-                  <td>
-                    <Link href={`/assets/${loc.id}`} className="serif">
-                      {name}
-                    </Link>
-                  </td>
-                  <td className="serif">{system && system !== name ? system : '—'}</td>
-                  <td className={retro.num}>{loc.count}</td>
-                </tr>
-              )
-            })}
-          </tbody>
-        </table>
-      ) : (
-        <p>
-          No assets visible. Link a character with the <code>esi-assets.read_assets.v1</code> scope on the{' '}
-          <a href="/character">Characters</a> page so the hourly job can fetch them.
-        </p>
-      )}
+      <AssetsTable locations={locations} characters={sortedCharacters} />
       <p className={styles.lastRun}>
         Assets last refreshed:{' '}
         {lastRun?.run_url ? (


### PR DESCRIPTION
## What

Adds a **character dropdown** to both assets pages — the index (`/assets`) and the per-location page (`/assets/[locationId]`) — mirroring the filter on the industry jobs page. Selection is persisted in localStorage under a shared key, so the chosen character follows you when you drill from the index into a location.

## How

The heavy work stays on the server; only filtering/re-sorting moves to the client:

- **Index** (`assets/page.tsx`) now tallies item counts **per character per location** (`counts: Record<characterId, number>`) instead of a single total. New client `AssetsTable` sums across characters for "All", or picks one character's counts, then filters out empty locations and sorts.
- **Per-location** (`assets/[locationId]/page.tsx`) tags each root item with its `character_id`. New client `LocationAssets` filters the rows and keeps streaming type names via the `TypeName`/Suspense promise.
- **`characterFilter.tsx`** — shared `CharacterFilter` dropdown + `useCharacterFilter` hook (one localStorage key, `assets.characterId`).

Empty states are preserved: the index still shows the "link a character…" help when there are no assets at all, and "No assets for this character" when a filter hides everything.

Build and lint pass (the two `no-unused-vars` warnings are pre-existing).

https://claude.ai/code/session_01GoGDdqs8zUt3jJ56ZbX1eF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoGDdqs8zUt3jJ56ZbX1eF)_