### PR TITLE
Make page content full width

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -101,18 +101,6 @@ body {
   box-sizing: border-box;
 }
 
-/* Page content sits in a centered "prompt" column. */
-body > header,
-body > hr,
-body > main,
-body > div,
-body > form,
-body > section {
-  max-width: 980px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
 main {
   padding-top: 4px;
 }


### PR DESCRIPTION
## Summary

On desktop, some content (tables, lists, headings) spanned the full viewport while other content (the `<main>`/`<section>`/`<div>` wrappers) was capped at 980px and centered — an inconsistent look.

This removes that `max-width: 980px` rule (which only matched a subset of direct `body` children), so all page content now fills the viewport width within the body's existing 16px gutters.

## Verification
- `next build` — succeeds across all routes
- `eslint` — no new warnings

https://claude.ai/code/session_01W96GdhJJZzpqeYjDyHQVae

---
_Generated by [Claude Code](https://claude.ai/code/session_01W96GdhJJZzpqeYjDyHQVae)_