### PR TITLE
Speed up assets pages: stream the index and aggregate locations in Postgres

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ EVE Online hangar/wallet/industry tracker. Package name `edencom-link` (private)
 
 - `src/app/` — Next.js App Router. Page routes: `account/`, `assets/`, `character/`, `industry/`, `market/`, `structures/`, plus `theme/`, `layout/` (Header/Footer), `private/`. Shared helpers at top level: `typeNames.ts`/`typeName.tsx`, `systemNames.ts`, `stationNames.ts`, `isk.ts`, `DateTime.tsx`.
 - `src/` (Node cron/scripts): `esi.js` (ESI API wrapper), `supabase.js` (clients — anon + `sudoSupabase` service role that bypasses RLS), `hourly.js`, `daily.js`, `assets.js`, `structures.js`, `corpWalletJournal.js`, `resolveNames.js`, `structureNames.js`, `tokenRefresh.js`/`refresh.js`, `proxy.ts`, `utils/`.
-- `schema.sql` — the single source of truth for the Supabase schema (in the default `public` schema). It's a full reset: it DROPs the app's tables and recreates them, so re-running wipes data. No separate migrations system — to change the schema, edit this file and re-run it.
+- `schema.sql` — the single source of truth for the Supabase schema (in the default `public` schema). It's a full reset: it DROPs the app's tables and recreates them, so re-running wipes data — never run it against a database with data you want to keep. To change the schema, edit this file (so a fresh reset stays correct) **and** add a non-destructive incremental migration under `supabase/migrations/` (Supabase CLI format, applied with `supabase db push`) so the change can be rolled out to existing databases without wiping data.
 - `.github/workflows/` — `hourly.yml`, `daily.yml`, `assets.yml`, `structures.yml`, `heartbeat.yml` (each a scheduled cron + manual dispatch).
 
 ## Database & ESI

--- a/schema.sql
+++ b/schema.sql
@@ -12,6 +12,8 @@
 -- objects in `public`. CASCADE clears dependent foreign keys and the asset view.
 drop schema if exists hangar cascade;
 
+drop function if exists public.asset_location_summary()        cascade;
+drop function if exists public.asset_location_contents(bigint) cascade;
 drop view  if exists public.asset                cascade;
 drop table if exists public.asset_over_time      cascade;
 drop table if exists public.wallet               cascade;
@@ -140,6 +142,80 @@ create view public.asset with (security_invoker = on) as
 grant select on public.asset_over_time to authenticated;
 grant select on public.asset           to authenticated;
 grant all    on public.asset_over_time to service_role;
+
+-- ── asset aggregation functions ───────────────────────────────────────────
+-- Items nest (a module in a ship in a station), so the UI used to page every
+-- live asset into Node and walk the location_id chains there — tens of
+-- thousands of rows per request, which timed the pages out. These do the walk
+-- in Postgres instead and return only the aggregate each page needs. Both are
+-- SECURITY INVOKER (the default), so the asset view's RLS still scopes every
+-- read to the caller's own characters. The depth caps guard against cycles.
+
+-- assets index (/assets): for every root location (a station, structure or
+-- solar system that isn't itself one of our items), the number of item stacks
+-- there, split by the character that owns each stack. Each asset is climbed up
+-- its location_id chain through items we also own until the parent isn't ours;
+-- that parent is the root.
+create or replace function public.asset_location_summary()
+returns table (location_id bigint, location_type text, character_id uuid, stacks bigint)
+language sql
+stable
+as $$
+  with recursive walk as (
+    select
+      a.item_id       as start_item,
+      a.character_id  as character_id,
+      a.location_id   as location_id,
+      a.location_type as location_type,
+      1               as depth
+    from public.asset a
+    union all
+    select
+      w.start_item,
+      w.character_id,
+      p.location_id,
+      p.location_type,
+      w.depth + 1
+    from walk w
+    join public.asset p on p.item_id = w.location_id
+    where w.depth < 64
+  )
+  select
+    w.location_id,
+    w.location_type,
+    w.character_id,
+    count(*) as stacks
+  from walk w
+  where w.location_id is not null
+    and not exists (select 1 from public.asset o where o.item_id = w.location_id)
+  group by w.location_id, w.location_type, w.character_id;
+$$;
+
+-- per-location page (/assets/[locationId]): for each item sitting directly in
+-- `parent`, the number of items nested inside it (the whole subtree, excluding
+-- the item itself).
+create or replace function public.asset_location_contents(parent bigint)
+returns table (item_id bigint, contents bigint)
+language sql
+stable
+as $$
+  with recursive descend as (
+    select a.item_id as root_child, a.item_id as node, 1 as depth
+    from public.asset a
+    where a.location_id = parent
+    union all
+    select d.root_child, c.item_id, d.depth + 1
+    from descend d
+    join public.asset c on c.location_id = d.node
+    where d.depth < 64
+  )
+  select root_child as item_id, count(*) - 1 as contents
+  from descend
+  group by root_child;
+$$;
+
+grant execute on function public.asset_location_summary()        to authenticated;
+grant execute on function public.asset_location_contents(bigint) to authenticated;
 
 -- ── heartbeat ─────────────────────────────────────────────────────────────
 -- One row per scheduled-job run. Workflows write a 'start' step (stamps

--- a/src/app/assets/[locationId]/page.tsx
+++ b/src/app/assets/[locationId]/page.tsx
@@ -35,48 +35,33 @@ const AssetLocationPage = async ({ params }: { params: Promise<{ locationId: str
     redirect('/')
   }
 
-  // Page through every current asset (PostgREST caps a select at the API "Max
-  // rows" limit) so the parent→child map is complete: contents counts walk it.
-  const PAGE = 1000
-  const list: Asset[] = []
-  for (let from = 0; ; from += PAGE) {
-    const { data, error } = await supabase
-      .from('asset')
-      .select('item_id, character_id, type_id, location_id, location_flag, location_type, quantity, is_singleton')
-      .order('id', { ascending: true })
-      .range(from, from + PAGE - 1)
-    if (error || !data || data.length === 0) break
-    list.push(...(data as Asset[]))
-    if (data.length < PAGE) break
-  }
-
-  // Items grouped by the container/location they sit directly in.
-  const childrenByParent = new Map<string, Asset[]>()
-  for (const a of list) {
-    if (a.location_id == null) continue
-    const key = String(a.location_id)
-    const siblings = childrenByParent.get(key)
-    if (siblings) siblings.push(a)
-    else childrenByParent.set(key, [a])
-  }
-  const assetByItem = new Map(list.map((a) => [String(a.item_id), a]))
-
   // Root-level assets at this location: ships, containers and loose stacks that
   // sit directly in the station/structure/system (not nested in another item).
-  const rootItems = childrenByParent.get(locationId) ?? []
+  // Only this level is fetched — the whole asset table no longer pages into Node.
+  const { data: children } = await supabase
+    .from('asset')
+    .select('item_id, character_id, type_id, location_id, location_flag, location_type, quantity, is_singleton')
+    .eq('location_id', locationId)
+  const rootItems = (children ?? []) as Asset[]
 
-  // Total items held inside a ship/container, walking the whole subtree.
-  const contentsCount = (itemId: string, seen = new Set<string>()): number => {
-    if (seen.has(itemId)) return 0
-    seen.add(itemId)
-    const kids = childrenByParent.get(itemId) ?? []
-    return kids.reduce((n, k) => n + 1 + contentsCount(String(k.item_id), seen), 0)
-  }
+  // Total items held inside each ship/container at this location, counted across
+  // the whole subtree by asset_location_contents() in Postgres.
+  const { data: contentsRows } = await supabase.rpc('asset_location_contents', { parent: locationId })
+  const contentsByItem = new Map<string, number>(
+    ((contentsRows ?? []) as { item_id: number | string; contents: number | string }[]).map((r) => [
+      String(r.item_id),
+      Number(r.contents),
+    ]),
+  )
 
   // The id is either a place (station / structure / solar system) or one of our
   // own items — a ship or container the user drilled into. Resolve the heading
   // and the "back" target accordingly.
-  const self = assetByItem.get(locationId)
+  const { data: self } = await supabase
+    .from('asset')
+    .select('item_id, type_id, location_id')
+    .eq('item_id', locationId)
+    .maybeSingle<Pick<Asset, 'item_id' | 'type_id' | 'location_id'>>()
 
   let heading: string
   let backHref = '/assets'
@@ -142,7 +127,7 @@ const AssetLocationPage = async ({ params }: { params: Promise<{ locationId: str
       quantity: a.quantity,
       isSingleton: a.is_singleton,
       flag: a.location_flag,
-      contents: contentsCount(String(a.item_id)),
+      contents: contentsByItem.get(String(a.item_id)) ?? 0,
     }))
     .sort((a, b) => b.contents - a.contents || a.typeId - b.typeId)
 

--- a/src/app/assets/page.tsx
+++ b/src/app/assets/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from 'next/navigation'
+import { Suspense } from 'react'
 
 import { createClient } from '@/utils/supabase/server'
 import { DateTime } from '../DateTime'
@@ -35,6 +36,29 @@ const AssetsPage = async () => {
   if (authError || !auth?.user) {
     redirect('/')
   }
+
+  // The location buckets are expensive to build (every asset is paged in and walked
+  // up its location chain, then station/structure/system names are resolved), so the
+  // page shell streams immediately and the table streams in once Locations() resolves.
+  return (
+    <Suspense fallback={<AssetsLoading />}>
+      <Locations />
+    </Suspense>
+  )
+}
+export default AssetsPage
+
+const AssetsLoading = () => (
+  <section>
+    <div className={styles.header}>
+      <h1>Assets</h1>
+    </div>
+    <p>Loading locations…</p>
+  </section>
+)
+
+const Locations = async () => {
+  const supabase = await createClient()
 
   // PostgREST caps a single select (Supabase's default API "Max rows" is 1000), but a
   // hangar can hold tens of thousands of items. The location buckets are built by walking
@@ -173,4 +197,3 @@ const AssetsPage = async () => {
     </>
   )
 }
-export default AssetsPage

--- a/src/app/assets/page.tsx
+++ b/src/app/assets/page.tsx
@@ -10,11 +10,11 @@ import { AssetsTable, type Location } from './assetsTable'
 
 // Bigint ids arrive from PostgREST as strings, so every id is kept as a string
 // and only converted to a number at the API/system-lookup boundary.
-type Asset = {
-  item_id: number | string
-  character_id: string
-  location_id: number | string | null
+type SummaryRow = {
+  location_id: number | string
   location_type: string | null
+  character_id: string
+  stacks: number | string
 }
 
 type Structure = {
@@ -60,52 +60,23 @@ const AssetsLoading = () => (
 const Locations = async () => {
   const supabase = await createClient()
 
-  // PostgREST caps a single select (Supabase's default API "Max rows" is 1000), but a
-  // hangar can hold tens of thousands of items. The location buckets are built by walking
-  // each item up its location_id chain through the items we own, so a truncated set breaks
-  // the walk: it stops at an intermediate ship/container whose own row was past the cap and
-  // emits that item id as a phantom `Location #…`. Page through every current asset first.
-  const PAGE = 1000
-  const list: Asset[] = []
-  for (let from = 0; ; from += PAGE) {
-    const { data, error } = await supabase
-      .from('asset')
-      .select('item_id, character_id, location_id, location_type')
-      .order('id', { ascending: true })
-      .range(from, from + PAGE - 1)
-    if (error || !data || data.length === 0) break
-    list.push(...(data as Asset[]))
-    if (data.length < PAGE) break
-  }
-  const assetByItem = new Map(list.map((a) => [String(a.item_id), a]))
+  // A hangar can hold tens of thousands of nested items; paging them all into
+  // Node and walking the location_id chains here timed the page out. The
+  // asset_location_summary() function does the walk in Postgres and returns one
+  // small row per location/character pair instead (RLS still scopes it to us).
+  const { data: summary } = await supabase.rpc('asset_location_summary')
 
   const { data: characters } = await supabase.from('registration').select('id, name')
   const sortedCharacters = [...(characters ?? [])].sort((a, b) => a.name.localeCompare(b.name))
 
-  const rootLocation = (a: Asset): Root | null => {
-    let cur: Asset | undefined = a
-    const seen = new Set<string>()
-    while (cur && cur.location_id != null) {
-      const key = String(cur.location_id)
-      const parent = assetByItem.get(key)
-      // Parent isn't one of our items (or we've looped) — cur sits directly in
-      // this location, so it's the root.
-      if (!parent || seen.has(key)) return { id: key, type: cur.location_type }
-      seen.add(key)
-      cur = parent
-    }
-    return null
-  }
-
-  // Tally how many item stacks resolve to each location, split by the character
-  // that owns each stack so the client can filter by character.
+  // Tally stacks per location, split by the character that owns each stack so
+  // the client can filter by character.
   const byLocation = new Map<string, { root: Root; counts: Map<string, number> }>()
-  for (const a of list) {
-    const root = rootLocation(a)
-    if (!root) continue
-    const entry = byLocation.get(root.id) ?? { root, counts: new Map<string, number>() }
-    entry.counts.set(a.character_id, (entry.counts.get(a.character_id) ?? 0) + 1)
-    byLocation.set(root.id, entry)
+  for (const row of (summary ?? []) as SummaryRow[]) {
+    const id = String(row.location_id)
+    const entry = byLocation.get(id) ?? { root: { id, type: row.location_type }, counts: new Map<string, number>() }
+    entry.counts.set(row.character_id, (entry.counts.get(row.character_id) ?? 0) + Number(row.stacks))
+    byLocation.set(id, entry)
   }
 
   // Structure names + systems come from two caches: our own corp's structures

--- a/supabase/migrations/20260602100856_asset_location_functions.sql
+++ b/supabase/migrations/20260602100856_asset_location_functions.sql
@@ -1,0 +1,77 @@
+-- Asset location aggregation functions.
+--
+-- Items nest (a module in a ship in a station), so the assets UI used to page
+-- every live asset into Node and walk the location_id chains there — tens of
+-- thousands of rows per request, which timed the pages out. These do the walk
+-- in Postgres instead and return only the aggregate each page needs. Both are
+-- SECURITY INVOKER (the default), so the asset view's RLS still scopes every
+-- read to the caller's own characters. The depth caps guard against cycles.
+--
+-- This migration is non-destructive (create or replace) and is mirrored in
+-- schema.sql, which remains the canonical full-reset snapshot of the schema.
+
+-- assets index (/assets): for every root location (a station, structure or
+-- solar system that isn't itself one of our items), the number of item stacks
+-- there, split by the character that owns each stack. Each asset is climbed up
+-- its location_id chain through items we also own until the parent isn't ours;
+-- that parent is the root.
+create or replace function public.asset_location_summary()
+returns table (location_id bigint, location_type text, character_id uuid, stacks bigint)
+language sql
+stable
+as $$
+  with recursive walk as (
+    select
+      a.item_id       as start_item,
+      a.character_id  as character_id,
+      a.location_id   as location_id,
+      a.location_type as location_type,
+      1               as depth
+    from public.asset a
+    union all
+    select
+      w.start_item,
+      w.character_id,
+      p.location_id,
+      p.location_type,
+      w.depth + 1
+    from walk w
+    join public.asset p on p.item_id = w.location_id
+    where w.depth < 64
+  )
+  select
+    w.location_id,
+    w.location_type,
+    w.character_id,
+    count(*) as stacks
+  from walk w
+  where w.location_id is not null
+    and not exists (select 1 from public.asset o where o.item_id = w.location_id)
+  group by w.location_id, w.location_type, w.character_id;
+$$;
+
+-- per-location page (/assets/[locationId]): for each item sitting directly in
+-- `parent`, the number of items nested inside it (the whole subtree, excluding
+-- the item itself).
+create or replace function public.asset_location_contents(parent bigint)
+returns table (item_id bigint, contents bigint)
+language sql
+stable
+as $$
+  with recursive descend as (
+    select a.item_id as root_child, a.item_id as node, 1 as depth
+    from public.asset a
+    where a.location_id = parent
+    union all
+    select d.root_child, c.item_id, d.depth + 1
+    from descend d
+    join public.asset c on c.location_id = d.node
+    where d.depth < 64
+  )
+  select root_child as item_id, count(*) - 1 as contents
+  from descend
+  group by root_child;
+$$;
+
+grant execute on function public.asset_location_summary()        to authenticated;
+grant execute on function public.asset_location_contents(bigint) to authenticated;


### PR DESCRIPTION
## Problem

The `/assets` index felt slow, and the per-location page `/assets/[locationId]` was hitting a **Vercel Runtime Timeout Error** in production. Both pages paged the **entire `asset` table** into Node on every request (1000 rows per round-trip) and walked the `location_id` nesting chains in JavaScript. For a large hangar that's tens of thousands of rows per page view.

## Changes

**1. Stream the index shell (Suspense).** The cheap `auth.getUser()` check stays synchronous (so the `/` redirect still happens immediately); the expensive location-bucket build moved into a `<Suspense>`-wrapped async child with a lightweight "Loading locations…" fallback, so the page shell streams instantly.

**2. Aggregate in Postgres instead of paging in Node.** Two new `SECURITY INVOKER` SQL functions (so the `asset` view's RLS still scopes every read to the caller's own characters) do the chain-walking in the database and return only the aggregate each page needs:

- `asset_location_summary()` — stacks per root location, split by owning character (index page).
- `asset_location_contents(parent)` — descendant counts per direct child (per-location page).

The per-location page now fetches only the **direct children** of the location plus the drilled-into item, instead of the whole table. This removes the timeout's root cause rather than masking it with a higher `maxDuration`.

## Applying the DB change

The functions are added two ways:

- **`schema.sql`** — keeps them in the canonical full-reset snapshot (so a fresh `psql -f schema.sql` still creates them).
- **`supabase/migrations/20260602100856_asset_location_functions.sql`** — a non-destructive `create or replace` migration to roll out to **existing** databases (e.g. production) without the full reset that wipes data. Apply with `supabase db push`.

Until the functions exist in the DB, the RPC calls return empty (pages render but show no/zero data); they don't crash. `CLAUDE.md` is updated to document the `schema.sql` + `supabase/migrations/` workflow.

## Testing

- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- No automated test runner in this project.

https://claude.ai/code/session_01MpsfgR6FKEeXBLpPP1FcAc