### PR TITLE
Apply Supabase migrations via GitHub Actions

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -1,0 +1,32 @@
+name: Migrate
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/**'
+      - '.github/workflows/migrate.yml'
+
+# Avoid two pushes racing to apply migrations against the same database.
+concurrency:
+  group: migrate
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 2.102.0
+      - name: Link project
+        run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
+        env:
+          SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF }}
+      - name: Push migrations
+        run: supabase db push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,14 +15,14 @@ EVE Online hangar/wallet/industry tracker. Package name `edencom-link` (private)
 - **No test runner / no `test` script** — there are no automated tests. No `typecheck` script (rely on `next build` / editor).
 - Pre-commit: husky + lint-staged auto-format & `eslint --fix` staged files.
 - Cron scripts (run via GitHub Actions, see below): `npm run hourly` / `daily` / `assets` / `structures` / `heartbeat`. `connect`, `ping`, `refresh` are DB/token utilities.
-- DB migrations (Supabase CLI, configured by `supabase/config.toml`): `npm run db:new <name>` scaffolds a migration under `supabase/migrations/`; `npm run db:push` applies pending migrations to the linked project (`supabase link --project-ref <ref>` first).
+- DB migrations (Supabase CLI, configured by `supabase/config.toml`): `npm run db:new <name>` scaffolds a migration under `supabase/migrations/`; `npm run db:push` applies pending migrations to the linked project (`supabase link --project-ref <ref>` first). On push to `main` that touches `supabase/migrations/**`, the `Migrate` workflow runs `supabase db push` automatically (also manually dispatchable).
 
 ## Layout
 
 - `src/app/` — Next.js App Router. Page routes: `account/`, `assets/`, `character/`, `industry/`, `market/`, `structures/`, plus `theme/`, `layout/` (Header/Footer), `private/`. Shared helpers at top level: `typeNames.ts`/`typeName.tsx`, `systemNames.ts`, `stationNames.ts`, `isk.ts`, `DateTime.tsx`.
 - `src/` (Node cron/scripts): `esi.js` (ESI API wrapper), `supabase.js` (clients — anon + `sudoSupabase` service role that bypasses RLS), `hourly.js`, `daily.js`, `assets.js`, `structures.js`, `corpWalletJournal.js`, `resolveNames.js`, `structureNames.js`, `tokenRefresh.js`/`refresh.js`, `proxy.ts`, `utils/`.
 - `schema.sql` — the single source of truth for the Supabase schema (in the default `public` schema). It's a full reset: it DROPs the app's tables and recreates them, so re-running wipes data — never run it against a database with data you want to keep. To change the schema, edit this file (so a fresh reset stays correct) **and** add a non-destructive incremental migration under `supabase/migrations/` (Supabase CLI format, applied with `supabase db push`) so the change can be rolled out to existing databases without wiping data.
-- `.github/workflows/` — `hourly.yml`, `daily.yml`, `assets.yml`, `structures.yml`, `heartbeat.yml` (each a scheduled cron + manual dispatch).
+- `.github/workflows/` — `hourly.yml`, `daily.yml`, `assets.yml`, `structures.yml`, `heartbeat.yml` (each a scheduled cron + manual dispatch); `migrate.yml` (applies Supabase migrations on push to `main`).
 
 ## Database & ESI
 


### PR DESCRIPTION
## Summary

Runs the Supabase migration workflow (set up in #380) automatically in CI instead of relying on a local `npm run db:push`.

New workflow `.github/workflows/migrate.yml`:
- **Triggers:** push to `main` that touches `supabase/migrations/**` (or the workflow file), plus `workflow_dispatch` for manual runs.
- **Steps:** checkout → `supabase/setup-cli` (pinned to `2.102.0`, matching the repo's CLI devDependency) → `supabase link --project-ref $SUPABASE_PROJECT_REF` → `supabase db push`.
- **Concurrency:** a `migrate` group (no cancel-in-progress) so two pushes can't race migrations against the same database.

## Required repo configuration

The workflow expects these to be set in the repo (Settings → Secrets and variables → Actions):

- **Variable** `SUPABASE_PROJECT_REF` — the project ref to link.
- **Secrets** `SUPABASE_ACCESS_TOKEN` (Supabase personal access token) and `SUPABASE_DB_PASSWORD` (database password).

These are new — the existing workflows use `SUPABASE_URL`/`SUPABASE_KEY`/`SUPABASE_SERVICE_KEY`, which are for the JS client, not the CLI.

## Testing

- YAML validated locally.
- Will exercise end-to-end on the first push to `main` under `supabase/migrations/**` (or via manual dispatch) once the secrets/var above are configured.

https://claude.ai/code/session_01MpsfgR6FKEeXBLpPP1FcAc

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpsfgR6FKEeXBLpPP1FcAc)_