### PR TITLE
Apply migrations via DB connection string instead of access token

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -16,17 +16,20 @@ concurrency:
 jobs:
   migrate:
     runs-on: ubuntu-latest
-    env:
-      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
     steps:
       - uses: actions/checkout@v6
       - uses: supabase/setup-cli@v1
         with:
           version: 2.102.0
-      - name: Link project
-        run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
-        env:
-          SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF }}
       - name: Push migrations
-        run: supabase db push
+        # Push straight to the database with its connection string, so no Supabase
+        # access token / `supabase link` is needed — just the DB password we
+        # already store. The password is URL-encoded (it may contain reserved
+        # characters) and masked so it never lands in the logs.
+        run: |
+          ENCODED_PW=$(python3 -c "import os, urllib.parse; print(urllib.parse.quote(os.environ['SUPABASE_DB_PASSWORD'], safe=''))")
+          echo "::add-mask::$ENCODED_PW"
+          supabase db push --db-url "postgresql://postgres:${ENCODED_PW}@db.${SUPABASE_PROJECT_REF}.supabase.co:5432/postgres"
+        env:
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+          SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF }}

--- a/schema.sql
+++ b/schema.sql
@@ -115,7 +115,10 @@ create table public.asset_over_time (
   is_blueprint_copy boolean,
   is_current boolean not null default true,
   first_seen_at timestamptz not null default now(),
-  last_seen_at timestamptz not null default now()
+  last_seen_at timestamptz not null default now(),
+  -- Player-assigned name (ship/container custom name) for singleton items; null
+  -- otherwise. Kept last to match the add-column migration's column order.
+  name text
 );
 create index asset_over_time_character_id_idx on public.asset_over_time (character_id);
 -- At most one live row per item; also the conflict target the extract relies on.

--- a/src/app/assets/[locationId]/locationAssets.tsx
+++ b/src/app/assets/[locationId]/locationAssets.tsx
@@ -11,6 +11,7 @@ export type ItemRow = {
   itemId: string
   characterId: string
   typeId: number
+  name: string | null
   quantity: number | string | null
   isSingleton: boolean | null
   flag: string | null
@@ -50,10 +51,10 @@ export const LocationAssets = ({ rows, characters, typeNamesPromise }: LocationA
                   {row.contents > 0 ? (
                     // Ships and containers hold items — drill into them.
                     <Link href={`/assets/${row.itemId}`}>
-                      <TypeName id={row.typeId} promise={typeNamesPromise} />
+                      <TypeName id={row.typeId} name={row.name} promise={typeNamesPromise} />
                     </Link>
                   ) : (
-                    <TypeName id={row.typeId} promise={typeNamesPromise} />
+                    <TypeName id={row.typeId} name={row.name} promise={typeNamesPromise} />
                   )}
                 </td>
                 <td className={retro.num}>{row.isSingleton ? '—' : (row.quantity ?? 1)}</td>

--- a/src/app/assets/[locationId]/page.tsx
+++ b/src/app/assets/[locationId]/page.tsx
@@ -18,6 +18,7 @@ type Asset = {
   location_type: string | null
   quantity: number | string | null
   is_singleton: boolean | null
+  name: string | null
 }
 
 type Structure = {
@@ -40,7 +41,7 @@ const AssetLocationPage = async ({ params }: { params: Promise<{ locationId: str
   // Only this level is fetched — the whole asset table no longer pages into Node.
   const { data: children } = await supabase
     .from('asset')
-    .select('item_id, character_id, type_id, location_id, location_flag, location_type, quantity, is_singleton')
+    .select('item_id, character_id, type_id, location_id, location_flag, location_type, quantity, is_singleton, name')
     .eq('location_id', locationId)
   const rootItems = (children ?? []) as Asset[]
 
@@ -59,9 +60,9 @@ const AssetLocationPage = async ({ params }: { params: Promise<{ locationId: str
   // and the "back" target accordingly.
   const { data: self } = await supabase
     .from('asset')
-    .select('item_id, type_id, location_id')
+    .select('item_id, type_id, location_id, name')
     .eq('item_id', locationId)
-    .maybeSingle<Pick<Asset, 'item_id' | 'type_id' | 'location_id'>>()
+    .maybeSingle<Pick<Asset, 'item_id' | 'type_id' | 'location_id' | 'name'>>()
 
   let heading: string
   let backHref = '/assets'
@@ -69,9 +70,11 @@ const AssetLocationPage = async ({ params }: { params: Promise<{ locationId: str
   let systemName: string | undefined
 
   if (self) {
-    // A ship/container: title it by its type, and step back to whatever holds it.
+    // A ship/container: title it by its custom name (if any) plus type, and step
+    // back to whatever holds it.
     const typeNames = await fetchTypeNames([Number(self.type_id)])
-    heading = typeNames[Number(self.type_id)] ?? `#${self.type_id}`
+    const typeName = typeNames[Number(self.type_id)] ?? `#${self.type_id}`
+    heading = self.name && self.name !== typeName ? `${self.name} (${typeName})` : typeName
     if (self.location_id != null) {
       backHref = `/assets/${self.location_id}`
       backLabel = 'Back'
@@ -124,6 +127,7 @@ const AssetLocationPage = async ({ params }: { params: Promise<{ locationId: str
       itemId: String(a.item_id),
       characterId: a.character_id,
       typeId: Number(a.type_id),
+      name: a.name,
       quantity: a.quantity,
       isSingleton: a.is_singleton,
       flag: a.location_flag,

--- a/src/app/typeName.tsx
+++ b/src/app/typeName.tsx
@@ -5,19 +5,29 @@ import { Suspense, use } from 'react'
 type TypeNameProps = {
   id: number
   promise: Promise<Record<number, string>>
+  // Optional player-assigned name (e.g. a ship/container's custom name). When it
+  // differs from the type name, both are shown: "Custom Name (Type)".
+  name?: string | null
 }
 
-const Resolved = ({ id, promise }: TypeNameProps) => {
+const Resolved = ({ id, promise, name }: TypeNameProps) => {
   const names = use(promise)
-  return <>{names[id] ?? `#${id}`}</>
+  const type = names[id] ?? `#${id}`
+  if (name && name !== type)
+    return (
+      <>
+        {name} <span style={{ color: 'var(--ink-faint)' }}>({type})</span>
+      </>
+    )
+  return <>{type}</>
 }
 
-export const TypeName = ({ id, promise }: TypeNameProps) => (
+export const TypeName = ({ id, promise, name }: TypeNameProps) => (
   // A type/item name is always dynamic, item-specific text, so it owns the serif
   // face (see globals.css) rather than relying on each caller to add it.
   <span className="serif">
-    <Suspense fallback={`#${id}`}>
-      <Resolved id={id} promise={promise} />
+    <Suspense fallback={name ?? `#${id}`}>
+      <Resolved id={id} promise={promise} name={name} />
     </Suspense>
   </span>
 )

--- a/src/assets.js
+++ b/src/assets.js
@@ -86,14 +86,32 @@ const fetchAssets = async (access_token, characterID) => {
 const reconcile = async (character_id, fetched, hasName) => {
   const baseCols =
     'id, item_id, type_id, location_id, location_flag, location_type, quantity, is_singleton, is_blueprint_copy'
-  const { data: current, error } = await sudoSupabase
-    .from('asset_over_time')
-    .select(hasName ? `${baseCols}, name` : baseCols)
-    .eq('character_id', character_id)
-    .eq('is_current', true)
-  if (error) throw error
+  // Page through every open row: PostgREST caps a select at the API "Max rows"
+  // limit (1000), but a character can hold tens of thousands of items. Reading a
+  // truncated set makes the un-read items look new, so they'd be re-inserted and
+  // collide with their existing current row on asset_over_time_current_item_idx.
+  const PAGE = 1000
+  const current = []
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await sudoSupabase
+      .from('asset_over_time')
+      .select(hasName ? `${baseCols}, name` : baseCols)
+      .eq('character_id', character_id)
+      .eq('is_current', true)
+      .order('id', { ascending: true })
+      .range(from, from + PAGE - 1)
+    if (error) throw error
+    if (!data || data.length === 0) break
+    current.push(...data)
+    if (data.length < PAGE) break
+  }
 
-  const currentByItem = new Map((current ?? []).map((r) => [Number(r.item_id), r]))
+  const currentByItem = new Map(current.map((r) => [Number(r.item_id), r]))
+
+  // ESI can return the same item twice across pages if assets shift mid-fetch;
+  // collapse to one entry per item so we never queue two inserts for it.
+  const fetchedByItem = new Map(fetched.map((a) => [Number(a.item_id), a]))
+  fetched = [...fetchedByItem.values()]
 
   const now = new Date().toISOString()
   const touchIds = [] // unchanged: bump last_seen_at on the open row

--- a/src/assets.js
+++ b/src/assets.js
@@ -1,4 +1,4 @@
-import { assets, userAgent } from './esi.js'
+import { assets, assetNames, userAgent } from './esi.js'
 import SingleSignOn from 'eve-sso'
 import { sudoSupabase } from './supabase.js'
 
@@ -28,7 +28,26 @@ const signature = (a) =>
     a.quantity == null ? null : Number(a.quantity),
     a.is_singleton ?? null,
     !!a.is_blueprint_copy,
+    a.name ?? null,
   ])
+
+// ESI only names singleton items (assembled ships, containers). Resolve them in
+// chunks (the names endpoint caps at 1000 ids) into a Map item_id → name. Best
+// effort: a failed chunk just leaves those items unnamed this run.
+const fetchNames = async (access_token, characterID, fetched) => {
+  const ids = fetched.filter((a) => a.is_singleton).map((a) => Number(a.item_id))
+  const names = new Map()
+  for (const part of chunk(ids, 1000)) {
+    if (part.length === 0) continue
+    try {
+      const rows = await assetNames(access_token, characterID, part)
+      for (const r of rows ?? []) names.set(Number(r.item_id), r.name ?? null)
+    } catch (e) {
+      console.error(`[assets] assetNames failed for ${characterID}: ${e?.message}`)
+    }
+  }
+  return names
+}
 
 const refreshToken = async (tokenRow) => {
   const refreshed = await sso.getAccessToken(tokenRow.refresh_token, true)
@@ -64,12 +83,12 @@ const fetchAssets = async (access_token, characterID) => {
 // Reconcile the freshly fetched assets against the character's current (open)
 // rows: unchanged items get their last_seen_at extended, changed items have
 // their old row closed and a new one inserted, and vanished items are closed.
-const reconcile = async (character_id, fetched) => {
+const reconcile = async (character_id, fetched, hasName) => {
+  const baseCols =
+    'id, item_id, type_id, location_id, location_flag, location_type, quantity, is_singleton, is_blueprint_copy'
   const { data: current, error } = await sudoSupabase
     .from('asset_over_time')
-    .select(
-      'id, item_id, type_id, location_id, location_flag, location_type, quantity, is_singleton, is_blueprint_copy'
-    )
+    .select(hasName ? `${baseCols}, name` : baseCols)
     .eq('character_id', character_id)
     .eq('is_current', true)
   if (error) throw error
@@ -99,6 +118,7 @@ const reconcile = async (character_id, fetched) => {
         is_singleton: a.is_singleton ?? null,
         is_blueprint_copy: !!a.is_blueprint_copy,
         last_seen_at: now,
+        ...(hasName ? { name: a.name ?? null } : {}),
       })
     }
     currentByItem.delete(Number(a.item_id))
@@ -141,6 +161,12 @@ const execute = async () => {
     process.exit(1)
   }
 
+  // Tolerate the name column not existing yet (migration not applied): probe it
+  // once and skip name fetching/storage entirely until it's present.
+  const { error: probeError } = await sudoSupabase.from('asset_over_time').select('name').limit(1)
+  const hasName = !probeError
+  if (!hasName) console.log('[assets] name column absent; skipping asset names (apply the migration to enable)')
+
   console.log(`[assets] found ${tokens?.length ?? 0} token(s) with ${ASSETS_SCOPE}`)
 
   for (const tokenRow of tokens ?? []) {
@@ -155,7 +181,11 @@ const execute = async () => {
       }
 
       const { all, totalPages } = await fetchAssets(access_token, characterID)
-      const { touched, opened, closed } = await reconcile(tokenRow.character_id, all)
+      if (hasName) {
+        const names = await fetchNames(access_token, characterID, all)
+        for (const a of all) a.name = names.get(Number(a.item_id)) ?? null
+      }
+      const { touched, opened, closed } = await reconcile(tokenRow.character_id, all, hasName)
 
       const dt = Date.now() - t0
       console.log(

--- a/supabase/migrations/20260602000000_add_asset_name.sql
+++ b/supabase/migrations/20260602000000_add_asset_name.sql
@@ -1,0 +1,9 @@
+-- Store the player-assigned name of an asset (ship / container custom name).
+-- Populated by the assets cron from ESI's /characters/{id}/assets/names/ for
+-- singleton items; null for everything else.
+alter table public.asset_over_time add column if not exists name text;
+
+-- The asset view's `select *` was expanded into explicit columns at creation,
+-- so recreate it to pick up the new column.
+create or replace view public.asset with (security_invoker = on) as
+  select * from public.asset_over_time where is_current;


### PR DESCRIPTION
## Problem

The `Migrate` workflow failed before applying anything:

```
Access token not provided. Supply an access token by running supabase login or
setting the SUPABASE_ACCESS_TOKEN environment variable.
```

It used `supabase link`, which requires a `SUPABASE_ACCESS_TOKEN` secret that isn't configured.

## Fix

Drop `supabase link` (and the access token) and push straight to the database with `supabase db push --db-url`, built from the **`SUPABASE_DB_PASSWORD` secret and `SUPABASE_PROJECT_REF` var we already store** — no new secret needed.

- The password is **URL-encoded** (it may contain reserved characters that would break the connection URL) and **masked** with `::add-mask::` so it never appears in logs.
- Connection target is the direct connection `db.<ref>.supabase.co:5432`.

## Heads-up

If the runner can't reach `db.<ref>.supabase.co` (Supabase direct connections are IPv6-only without the IPv4 add-on, and GitHub-hosted runners are IPv4-only), the push will fail to connect. In that case the fix is to point `--db-url` at the Supavisor pooler (`aws-0-<region>.pooler.supabase.com`, user `postgres.<ref>`), which is IPv4 — that needs your project region, so tell me and I'll switch it.

Once this is on `main`, re-run **Migrate** to apply the pending `20260602000000_add_asset_name.sql`.

https://claude.ai/code/session_01GoGDdqs8zUt3jJ56ZbX1eF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoGDdqs8zUt3jJ56ZbX1eF)_