### PR TITLE
Treat ESI "None" asset name sentinel as unnamed

### DIFF
--- a/src/app/typeName.tsx
+++ b/src/app/typeName.tsx
@@ -13,7 +13,10 @@ type TypeNameProps = {
 const Resolved = ({ id, promise, name }: TypeNameProps) => {
   const names = use(promise)
   const type = names[id] ?? `#${id}`
-  if (name && name !== type)
+  // ESI uses the literal string "None" for singletons with no player-assigned
+  // name (e.g. blueprints); don't show it as a prefix. Guards rows already
+  // stored before fetchNames filtered it out.
+  if (name && name !== 'None' && name !== type)
     return (
       <>
         {name} <span style={{ color: 'var(--ink-faint)' }}>({type})</span>
@@ -26,7 +29,7 @@ export const TypeName = ({ id, promise, name }: TypeNameProps) => (
   // A type/item name is always dynamic, item-specific text, so it owns the serif
   // face (see globals.css) rather than relying on each caller to add it.
   <span className="serif">
-    <Suspense fallback={name ?? `#${id}`}>
+    <Suspense fallback={name && name !== 'None' ? name : `#${id}`}>
       <Resolved id={id} promise={promise} name={name} />
     </Suspense>
   </span>

--- a/src/assets.js
+++ b/src/assets.js
@@ -34,6 +34,9 @@ const signature = (a) =>
 // ESI only names singleton items (assembled ships, containers). Resolve them in
 // chunks (the names endpoint caps at 1000 ids) into a Map item_id → name. Best
 // effort: a failed chunk just leaves those items unnamed this run.
+//
+// ESI returns the literal string "None" for singletons with no player-assigned
+// name (e.g. blueprints), so treat that sentinel as "no name" rather than text.
 const fetchNames = async (access_token, characterID, fetched) => {
   const ids = fetched.filter((a) => a.is_singleton).map((a) => Number(a.item_id))
   const names = new Map()
@@ -41,7 +44,7 @@ const fetchNames = async (access_token, characterID, fetched) => {
     if (part.length === 0) continue
     try {
       const rows = await assetNames(access_token, characterID, part)
-      for (const r of rows ?? []) names.set(Number(r.item_id), r.name ?? null)
+      for (const r of rows ?? []) names.set(Number(r.item_id), r.name && r.name !== 'None' ? r.name : null)
     } catch (e) {
       console.error(`[assets] assetNames failed for ${characterID}: ${e?.message}`)
     }


### PR DESCRIPTION
## Problem

Some assets render as `None (Merlin Blueprint)`. ESI's `assetNames` endpoint returns the literal string `"None"` as the name for singleton items that have no player-assigned name (e.g. blueprints). That sentinel was stored in the DB and then displayed as a prefix.

## Fix

- **`src/assets.js`** — in `fetchNames`, treat the `"None"` sentinel as no name (store `null`) instead of the literal string. New cron runs stop persisting it, and existing rows self-heal on the next run (the name is part of the SCD signature, so a changed name opens a fresh version).
- **`src/app/typeName.tsx`** — guard the render and the `Suspense` fallback so rows already stored as `"None"` display just the type name (e.g. `Merlin Blueprint`) without waiting for the next cron.

## Notes

A container a player literally named "None" is the only false positive; ESI uses "None" as its unnamed sentinel, so this is the correct tradeoff.

https://claude.ai/code/session_01Wbi2qKpTmzWR4xGCkRRKgi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wbi2qKpTmzWR4xGCkRRKgi)_