### PR TITLE
Add missing user_settings migration so scope checkboxes persist

### DIFF
--- a/supabase/migrations/20260602110000_add_user_settings.sql
+++ b/supabase/migrations/20260602110000_add_user_settings.sql
@@ -1,0 +1,26 @@
+-- Per-user preferences backing the ESI scope checkboxes on the settings page.
+-- This table was added to schema.sql in #349 but never shipped as an incremental
+-- migration, so databases updated via `supabase db push` (rather than a full,
+-- destructive schema.sql reset) never got it. Without the table, getEnabledScopes
+-- silently fell back to "request everything" (every box checked) and saving
+-- preferences failed, so the settings checkboxes never reflected what the user
+-- had chosen. Mirrors the definition in schema.sql, written idempotently so it is
+-- safe to apply to databases that already have the table.
+create table if not exists public.user_settings (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  enabled_scopes text[] not null default '{}',
+  updated_at timestamptz not null default now()
+);
+
+alter table public.user_settings enable row level security;
+
+drop policy if exists "Users manage own settings" on public.user_settings;
+create policy "Users manage own settings"
+  on public.user_settings
+  for all
+  to authenticated
+  using (user_id = (select auth.uid()))
+  with check (user_id = (select auth.uid()));
+
+grant select, insert, update, delete on public.user_settings to authenticated;
+grant all                            on public.user_settings to service_role;


### PR DESCRIPTION
## Problem

The ESI scope checkboxes on the settings page don't reflect the user's saved preferences.

## Root cause

The `user_settings` table — which backs those checkboxes — was added to `schema.sql` in #349 but **never shipped as an incremental migration**. Per the project workflow (`CLAUDE.md`), every schema change must live in `schema.sql` *and* in `supabase/migrations/`, because the `Migrate` workflow rolls out changes to existing databases via `supabase db push` (it never runs the destructive `schema.sql` reset).

Because no migration creates `public.user_settings`, databases updated through migrations never got the table. The symptom follows directly:

- `getEnabledScopes` does `const { data } = await supabase.from('user_settings')…` and **ignores the error**. With no table, `data` is `null`, so it falls back to `defaultScopes` — i.e. *every box checked*, regardless of what the user saved.
- `saveScopePreferences` upserts into the missing table and fails, so preferences never persist.

The React component (`scopeSettings.tsx`) and the read/write logic are all correct; they just had no table to talk to.

## Fix

Add `supabase/migrations/20260602110000_add_user_settings.sql`, mirroring the definition in `schema.sql` (table, RLS policy, grants) and written idempotently (`create table if not exists`, `drop policy if exists` before `create policy`) so it's safe to apply to databases that already have the table.

## Notes

- No UI/code changes were needed — this is a data-layer rollout gap.
- The error-swallowing in `getEnabledScopes` (`const { data } = …`) is what made this invisible: a missing table looked identical to a brand-new user. Left as-is since defaulting to "request everything" is intentional for genuinely new users, but flagging it.

https://claude.ai/code/session_01JXdnnnQm2GM2iSKN1xk6Fy

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXdnnnQm2GM2iSKN1xk6Fy)_