### PR TITLE
Record industry cost indices for systems with structures

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -19,6 +19,7 @@ drop table if exists public.asset_over_time      cascade;
 drop table if exists public.wallet               cascade;
 drop table if exists public.market_transaction   cascade;
 drop table if exists public.industry_job         cascade;
+drop table if exists public.industry_system_index cascade;
 drop table if exists public.corp_structure_rig   cascade;
 drop table if exists public.corp_structure       cascade;
 drop table if exists public.corp_wallet_journal  cascade;
@@ -413,6 +414,33 @@ create policy "Users read structure rigs for own corps"
 
 grant select on public.corp_structure_rig to authenticated;
 grant all    on public.corp_structure_rig to service_role;
+
+-- ── industry_system_index ─────────────────────────────────────────────────
+-- History of EVE's per-system industry cost indices, snapshotted each structures
+-- run for every solar system we have a structure anchored in. Public ESI data
+-- (/industry/systems/), so it's readable by everyone. Each row is one system /
+-- activity (manufacturing, reaction, copying, invention, ...) and the recorded
+-- cost index at recorded_at; the table is append-only so the indices' drift over
+-- time can be charted.
+create table public.industry_system_index (
+  id bigint generated always as identity primary key,
+  system_id bigint not null,
+  activity text not null,
+  cost_index real not null,
+  recorded_at timestamptz not null default now()
+);
+create index industry_system_index_system_activity_idx
+  on public.industry_system_index (system_id, activity, recorded_at desc);
+
+alter table public.industry_system_index enable row level security;
+create policy "Everyone reads industry indexes"
+  on public.industry_system_index
+  for select
+  to anon, authenticated
+  using (true);
+
+grant select on public.industry_system_index to anon, authenticated;
+grant all    on public.industry_system_index to service_role;
 
 -- ── corp_wallet_journal ───────────────────────────────────────────────────
 create table public.corp_wallet_journal (

--- a/src/esi.js
+++ b/src/esi.js
@@ -89,6 +89,13 @@ export const assetNames = (access_token, characterID, ids) =>
     label: `assetNames ${characterID}`,
   })
 
+// Public (no token): per-solar-system industry cost indices for every system
+// with activity in it. Each entry is { solar_system_id, cost_indices: [{ activity, cost_index }] }.
+export const industrySystems = () =>
+  esiJson(`/industry/systems/`, {
+    label: `industrySystems`,
+  })
+
 export const universeNames = (ids) =>
   esiJson(`/universe/names/`, {
     method: 'POST',

--- a/src/industryIndexes.js
+++ b/src/industryIndexes.js
@@ -1,0 +1,62 @@
+import { industrySystems } from './esi.js'
+import { sudoSupabase } from './supabase.js'
+
+// PostgREST caps a single select; page through corp_structure so a large number
+// of structures doesn't silently truncate the set of systems we care about.
+const SYSTEM_PAGE = 1000
+
+// Record a snapshot of the industry cost indices for every solar system we have a
+// structure anchored in. The /industry/systems/ endpoint is public and returns
+// the indices for *all* systems in one shot, so we fetch it once and keep only
+// the systems that appear in corp_structure. Each run appends a fresh set of
+// rows to industry_system_index, building a history of how the indices drift.
+export const pullIndustryIndexes = async () => {
+  // Distinct systems we hold structures in. Read corp_structure (the base table
+  // service_role can reach) paged so a large fleet isn't truncated.
+  const systemIds = new Set()
+  for (let from = 0; ; from += SYSTEM_PAGE) {
+    const { data: rows, error } = await sudoSupabase
+      .from('corp_structure')
+      .select('system_id')
+      .range(from, from + SYSTEM_PAGE - 1)
+    if (error) throw error
+    if (!rows || rows.length === 0) break
+    for (const r of rows) {
+      const id = Number(r.system_id)
+      if (Number.isFinite(id)) systemIds.add(id)
+    }
+    if (rows.length < SYSTEM_PAGE) break
+  }
+
+  console.log(`[structures] industry indexes: ${systemIds.size} system(s) with structures`)
+  if (systemIds.size === 0) return
+
+  const systems = await industrySystems()
+  const recorded_at = new Date().toISOString()
+  const rows = []
+  for (const s of systems ?? []) {
+    const system_id = Number(s?.solar_system_id)
+    if (!systemIds.has(system_id)) continue
+    for (const ci of s?.cost_indices ?? []) {
+      if (!ci?.activity) continue
+      rows.push({
+        system_id,
+        activity: ci.activity,
+        cost_index: ci.cost_index ?? null,
+        recorded_at,
+      })
+    }
+  }
+
+  if (rows.length === 0) {
+    console.log('[structures] industry indexes: no matching systems returned by ESI, nothing to record')
+    return
+  }
+
+  const { error: insertErr } = await sudoSupabase.from('industry_system_index').insert(rows)
+  if (insertErr) {
+    console.error(`[structures] industry index insert FAILED: ${insertErr.message}`)
+    throw insertErr
+  }
+  console.log(`[structures] recorded ${rows.length} industry index row(s)`)
+}

--- a/src/structures.js
+++ b/src/structures.js
@@ -1,5 +1,6 @@
 import { pullCorpWalletJournals } from './corpWalletJournal.js'
 import { character as fetchCharacter, corpAssets, corpStructures, universeNames } from './esi.js'
+import { pullIndustryIndexes } from './industryIndexes.js'
 import { resolveCorpJournalNames } from './resolveNames.js'
 import { resolveStructureNames } from './structureNames.js'
 import { sudoSupabase } from './supabase.js'
@@ -254,6 +255,15 @@ const execute = async () => {
     await resolveStructureNames()
   } catch (e) {
     console.error(`[structures] structure-name resolution FAILED name=${e?.name} message=${e?.message}`)
+  }
+
+  // Snapshot the industry cost indices for every system we have a structure in,
+  // building a history of how those indices move over time. Public ESI data, so
+  // it runs regardless of which scopes the linked tokens carry.
+  try {
+    await pullIndustryIndexes()
+  } catch (e) {
+    console.error(`[structures] industry index pull FAILED name=${e?.name} message=${e?.message}`)
   }
 }
 

--- a/supabase/migrations/20260603000000_add_industry_system_index.sql
+++ b/supabase/migrations/20260603000000_add_industry_system_index.sql
@@ -1,0 +1,26 @@
+-- History of EVE's per-system industry cost indices, snapshotted each structures
+-- run for every solar system we have a structure anchored in. Public ESI data
+-- (/industry/systems/), so it's readable by everyone. Append-only so the indices'
+-- drift over time can be charted. Mirrors the definition in schema.sql, written
+-- idempotently so it is safe to apply to databases that already have the table.
+create table if not exists public.industry_system_index (
+  id bigint generated always as identity primary key,
+  system_id bigint not null,
+  activity text not null,
+  cost_index real not null,
+  recorded_at timestamptz not null default now()
+);
+create index if not exists industry_system_index_system_activity_idx
+  on public.industry_system_index (system_id, activity, recorded_at desc);
+
+alter table public.industry_system_index enable row level security;
+
+drop policy if exists "Everyone reads industry indexes" on public.industry_system_index;
+create policy "Everyone reads industry indexes"
+  on public.industry_system_index
+  for select
+  to anon, authenticated
+  using (true);
+
+grant select on public.industry_system_index to anon, authenticated;
+grant all    on public.industry_system_index to service_role;


### PR DESCRIPTION
## What

The structures job now also snapshots EVE's per-system **industry cost indices** for every solar system we have a structure anchored in, storing the history in a new table.

## Changes

- **`src/esi.js`** — new `industrySystems()` helper for the public `/industry/systems/` ESI endpoint (no token required).
- **`src/industryIndexes.js`** — new `pullIndustryIndexes()` module: reads the distinct `system_id`s from `corp_structure`, fetches the cost indices for all systems in one shot, keeps only the systems we have structures in, and appends a snapshot to the new table.
- **`src/structures.js`** — runs `pullIndustryIndexes()` at the end of the structures job (after structure/name resolution). It's public data, so it runs regardless of which scopes the linked tokens carry; failures are logged and don't abort the run.
- **`schema.sql`** + **`supabase/migrations/20260603000000_add_industry_system_index.sql`** — new `industry_system_index` table.

## New table: `industry_system_index`

Append-only history, one row per system / activity / snapshot:

| column | type | notes |
| --- | --- | --- |
| `id` | bigint identity | pk |
| `system_id` | bigint | the solar system |
| `activity` | text | index type — `manufacturing`, `reaction`, `copying`, `invention`, ... |
| `cost_index` | real | the recorded cost index for that activity |
| `recorded_at` | timestamptz | snapshot time |

Indexed on `(system_id, activity, recorded_at desc)` for charting drift over time. **Readable by everyone** (`anon` + `authenticated`, RLS `using (true)`); writes are service-role only.

## Notes

- Followed the repo convention: schema.sql (full-reset source of truth) updated **and** a non-destructive idempotent migration added so existing databases get the table via `supabase db push`.
- Data is sourced from the public ESI endpoint per the project's data-flow rule (ESI → DB → UI); no SDE schema involved.
- No tests in this repo; verified with `eslint` (clean) and `node --check` on the changed files.

https://claude.ai/code/session_01BTm2YqiH8Qw53GBusN45AY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTm2YqiH8Qw53GBusN45AY)_