### PR TITLE
Add Refresh Assets button to character screen

### DIFF
--- a/src/app/character/actions.ts
+++ b/src/app/character/actions.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { redirect } from 'next/navigation'
+import { revalidatePath } from 'next/cache'
 
 import { createClient } from '@/utils/supabase/server'
 
@@ -31,4 +32,32 @@ export const register = async (formData: FormData) => {
 
   const scopes = await getEnabledScopes(supabase, user.id)
   redirect(sso.getRedirectUrl('state', scopes))
+}
+
+// Refresh assets for just the signed-in player's characters, on demand. This
+// runs the same extract as the scheduled Assets workflow (src/assets.js) but
+// scoped to the characters this user owns. RLS scopes the registration read to
+// the caller; the extract itself writes with the service role, so we only hand
+// it the ids the user is actually allowed to refresh.
+export const refreshAssets = async () => {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user?.id) {
+    redirect('/account/login')
+  }
+
+  const { data: characters } = await supabase.from('registration').select('id')
+  const characterIds = (characters ?? []).map((c) => c.id)
+
+  if (characterIds.length > 0) {
+    // Imported lazily so loading the page (and `next build`) never pulls in the
+    // ESI/service-role module or runs its top-level client setup.
+    const { runAssets } = await import('@/assets.js')
+    await runAssets({ characterIds })
+  }
+
+  revalidatePath('/character')
 }

--- a/src/app/character/character.module.css
+++ b/src/app/character/character.module.css
@@ -60,6 +60,12 @@
   margin-right: 4pt;
 }
 
+.actions {
+  display: flex;
+  gap: 8pt;
+  flex-wrap: wrap;
+}
+
 .warning {
   margin: 12pt 0;
   padding: 10pt 12pt;

--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
-import { register } from './actions'
+import { register, refreshAssets } from './actions'
 import { requiredScopes } from './scopes'
 import { getEnabledScopes } from './userScopes'
 import styles from './character.module.css'
@@ -87,8 +87,11 @@ const CharacterPage = async () => {
           <pre>{JSON.stringify(error, undefined, 2)}</pre>
         </>
       )}
-      <form>
+      <form className={styles.actions}>
         <button formAction={register}>Add Character</button>
+        <button formAction={refreshAssets} disabled={!characters?.length}>
+          Refresh Assets
+        </button>
       </form>
     </>
   )

--- a/src/assets.js
+++ b/src/assets.js
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url'
+
 import { assets, assetNames, userAgent } from './esi.js'
 import SingleSignOn from 'eve-sso'
 import { sudoSupabase } from './supabase.js'
@@ -164,22 +166,26 @@ const reconcile = async (character_id, fetched, hasName) => {
   return { touched: touchIds.length, opened: inserts.length, closed: closeIds.length }
 }
 
-const execute = async () => {
+// Refresh assets for tokens carrying the assets scope. Pass `characterIds` to
+// scope the run to a specific set of registrations (e.g. a single player's
+// characters, triggered from the UI); omit it to refresh everyone, as the
+// scheduled workflow does. Throws on a fatal lookup failure so callers — the
+// CLI wrapper or a server action — can decide how to surface it.
+export const runAssets = async ({ characterIds } = {}) => {
   const { data: characters, error: charactersError } = await sudoSupabase.from('registration').select('id, name')
   if (charactersError) {
     console.error('[assets] character lookup failed:', charactersError)
-    process.exit(1)
+    throw charactersError
   }
   const characterName = new Map((characters ?? []).map((c) => [c.id, c.name]))
 
-  const { data: tokens, error } = await sudoSupabase
-    .from('token')
-    .select('id, character_id, refresh_token')
-    .contains('scope', [ASSETS_SCOPE])
+  let tokenQuery = sudoSupabase.from('token').select('id, character_id, refresh_token').contains('scope', [ASSETS_SCOPE])
+  if (characterIds) tokenQuery = tokenQuery.in('character_id', characterIds)
+  const { data: tokens, error } = await tokenQuery
 
   if (error) {
     console.error('[assets] token lookup failed:', error)
-    process.exit(1)
+    throw error
   }
 
   // Tolerate the name column not existing yet (migration not applied): probe it
@@ -219,4 +225,17 @@ const execute = async () => {
   }
 }
 
-execute()
+const execute = async () => {
+  try {
+    await runAssets()
+  } catch {
+    process.exit(1)
+  }
+}
+
+// Only run as a CLI (npm run assets / the scheduled workflow) when invoked
+// directly. When imported by the Next.js app to refresh one player's assets,
+// the side-effecting top-level run must not fire.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  execute()
+}


### PR DESCRIPTION
## What

Adds a **Refresh Assets** button at the bottom of the character screen, beside **Add Character**. It kicks off an on-demand asset refresh for *just the signed-in player's* characters — the same extract the scheduled `Assets` workflow runs for everyone, but scoped to the registrations this user owns.

## How

- **`src/assets.js`** — extracted the run body into an exported `runAssets({ characterIds })`. Passing `characterIds` filters the token lookup with `.in('character_id', …)`; omitting it refreshes everyone as before. The top-level run is now guarded so it only fires when the file is invoked directly as a CLI (`npm run assets` / the workflow), not when the app imports it. Fatal lookup failures now `throw` instead of `process.exit(1)` so the server-action caller can surface them; the CLI wrapper still exits non-zero.
- **`src/app/character/actions.ts`** — new `refreshAssets` server action: resolves the caller's own `registration` ids (RLS scopes the read to the user), then lazily `import()`s `runAssets` and hands it those ids. Lazy import keeps the ESI/service-role module (and its top-level client setup) out of page render and `next build`. Revalidates `/character` afterward.
- **`src/app/character/page.tsx`** + **`character.module.css`** — render the button (disabled when the user has no characters) in a small flex `actions` row.

## Note on environment

Because `asset_over_time` only grants writes to the `service_role`, this runs the extract with the service-role client (`sudoSupabase`). For the button to work in the deployed app, the Vercel environment needs `SUPABASE_URL` and `SUPABASE_SERVICE_KEY` available to the server runtime (today these are only used by the GitHub Actions crons). `EVE_CLIENT_ID` / `EVE_SECRET_KEY` are already present for SSO.

As discussed, this runs inline in a server action rather than dispatching the workflow, so very large accounts could approach Vercel's function timeout.

## Verification

- `npm run lint` — clean (only the two pre-existing unused-var warnings)
- `npm run build` — succeeds

https://claude.ai/code/session_01XkE1P2ygcqFVmUWFarevRZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkE1P2ygcqFVmUWFarevRZ)_