### PR TITLE
Fix /api/assets timeout by aggregating inventory in Postgres

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -221,6 +221,30 @@ $$;
 grant execute on function public.asset_location_summary()        to authenticated;
 grant execute on function public.asset_location_contents(bigint) to authenticated;
 
+-- /api/assets ImportJSON endpoint: the player's total inventory summed by item
+-- type as of `at`, reconstructed from the SCD-2 history. A row counts when it had
+-- started by `at` and was either still open then or is the current version (its
+-- state extends forward past last_seen_at to now); a later version of an item
+-- always starts after the prior one's last_seen_at, so at most one version per
+-- item matches — no double counting. Aggregating in Postgres avoids paging tens
+-- of thousands of raw rows into the serverless function (which timed it out). The
+-- route calls this with the service role over the caller's own registration ids,
+-- so it takes them as a parameter rather than leaning on RLS.
+create or replace function public.asset_inventory_at(character_ids uuid[], as_of timestamptz)
+returns table (type_id bigint, quantity bigint)
+language sql
+stable
+as $$
+  select a.type_id, sum(coalesce(a.quantity, 1))::bigint as quantity
+  from public.asset_over_time a
+  where a.character_id = any(character_ids)
+    and a.first_seen_at <= as_of
+    and (a.last_seen_at >= as_of or a.is_current)
+  group by a.type_id;
+$$;
+
+grant execute on function public.asset_inventory_at(uuid[], timestamptz) to service_role;
+
 -- ── heartbeat ─────────────────────────────────────────────────────────────
 -- One row per scheduled-job run. Workflows write a 'start' step (stamps
 -- started_at) and an 'end' step (stamps ended_at), both keyed on the GitHub

--- a/src/app/api/assets/route.ts
+++ b/src/app/api/assets/route.ts
@@ -8,8 +8,9 @@ import { createServiceClient } from '@/utils/supabase/service'
 // the per-user api_token in the query string (Sheets carries no session cookie),
 // so it always recomputes — no caching.
 export const dynamic = 'force-dynamic'
-
-const PAGE = 1000
+// Headroom over Vercel's default function timeout; the work is one aggregation
+// query plus best-effort type-name lookups, but a large inventory needs room.
+export const maxDuration = 60
 
 type Row = { typeId: number; typeName: string; quantity: number }
 
@@ -62,38 +63,28 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
     return NextResponse.json([])
   }
 
-  // Sum quantity per type across every version that was live at `at`: a row is
-  // valid when it had started by then and either was still open at then or is the
-  // current version (its state extends forward past its last_seen_at to now).
-  // A later version of an item always starts after the prior version's
-  // last_seen_at, so at most one version of any item matches — no double counting.
-  // Page in 1000-row chunks: a character can hold tens of thousands of rows and
-  // PostgREST caps a select at 1000 (same constraint src/assets.js pages around).
-  const totals = new Map<number, number>()
-  for (let from = 0; ; from += PAGE) {
-    const { data, error } = await supabase
-      .from('asset_over_time')
-      .select('type_id, quantity')
-      .in('character_id', characterIds)
-      .lte('first_seen_at', atIso)
-      .or(`last_seen_at.gte.${atIso},is_current.is.true`)
-      .order('id', { ascending: true })
-      .range(from, from + PAGE - 1)
-    if (error) {
-      return NextResponse.json({ error: 'Query failed' }, { status: 500 })
-    }
-    if (!data || data.length === 0) break
-    for (const a of data) {
-      const typeId = Number(a.type_id)
-      // Singleton items (ships, containers) store a null quantity = one item.
-      totals.set(typeId, (totals.get(typeId) ?? 0) + (a.quantity == null ? 1 : Number(a.quantity)))
-    }
-    if (data.length < PAGE) break
+  // Sum quantity per type across every version that was live at `at`. The rollup
+  // runs in Postgres (asset_inventory_at) rather than paging every raw row into
+  // this function — a full inventory is tens of thousands of rows, and shipping
+  // them here timed the request out. Returns one row per type id.
+  const { data: totals, error: totalsError } = await supabase.rpc('asset_inventory_at', {
+    character_ids: characterIds,
+    as_of: atIso,
+  })
+  if (totalsError) {
+    return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
+  const inventory = (totals ?? []) as { type_id: number; quantity: number }[]
 
-  const names = await fetchTypeNames(totals.keys())
-  const rows: Row[] = [...totals.entries()]
-    .map(([typeId, quantity]) => ({ typeId, typeName: names[typeId] ?? String(typeId), quantity }))
+  // Best-effort names: fetchTypeNames caps each lookup with a timeout and falls
+  // back to the raw id, so a slow/missing name never stalls the response.
+  const names = await fetchTypeNames(inventory.map((r) => Number(r.type_id)))
+  const rows: Row[] = inventory
+    .map(({ type_id, quantity }) => ({
+      typeId: Number(type_id),
+      typeName: names[Number(type_id)] ?? String(type_id),
+      quantity: Number(quantity),
+    }))
     .sort((a, b) => b.quantity - a.quantity)
 
   return NextResponse.json(rows)

--- a/src/app/typeNames.ts
+++ b/src/app/typeNames.ts
@@ -1,7 +1,10 @@
 const cache = new Map<number, Promise<string | null>>()
 
 const fetchOne = (typeID: number): Promise<string | null> =>
-  fetch(`https://eve-build-calculator.philihp.com/api/type/${typeID}`)
+  // Cap each lookup so one slow/hung request can't stall a caller that awaits the
+  // whole batch (e.g. the /api/assets endpoint); on timeout fetch rejects and we
+  // fall back to null (the caller shows the raw id).
+  fetch(`https://eve-build-calculator.philihp.com/api/type/${typeID}`, { signal: AbortSignal.timeout(5000) })
     .then((res) => (res.ok ? res.json() : null))
     .then((type: { name?: { en?: string } | string } | null) => {
       if (!type) return null

--- a/supabase/migrations/20260604070000_add_asset_inventory_at.sql
+++ b/supabase/migrations/20260604070000_add_asset_inventory_at.sql
@@ -1,0 +1,19 @@
+-- Postgres-side aggregation for the /api/assets ImportJSON endpoint: the player's
+-- total inventory summed by item type as of `at`, reconstructed from the SCD-2
+-- history in asset_over_time. Doing the rollup here (instead of paging every raw
+-- row into the serverless function) is what keeps the endpoint under Vercel's
+-- timeout. Called with the service role over the caller's own registration ids.
+create or replace function public.asset_inventory_at(character_ids uuid[], as_of timestamptz)
+returns table (type_id bigint, quantity bigint)
+language sql
+stable
+as $$
+  select a.type_id, sum(coalesce(a.quantity, 1))::bigint as quantity
+  from public.asset_over_time a
+  where a.character_id = any(character_ids)
+    and a.first_seen_at <= as_of
+    and (a.last_seen_at >= as_of or a.is_current)
+  group by a.type_id;
+$$;
+
+grant execute on function public.asset_inventory_at(uuid[], timestamptz) to service_role;


### PR DESCRIPTION
## Problem

`GET /api/assets` returns `504 FUNCTION_INVOCATION_TIMEOUT` against production. Runtime logs confirm every `/api/assets` request times out, while the `/assets` UI pages (which aggregate in Postgres and *stream* type names) return 200.

The endpoint was doing two expensive things synchronously that no 200 page does:
1. **Paging every raw `asset_over_time` row** for all of the player's characters into the function (a full inventory is tens of thousands of rows = dozens of round trips).
2. **Awaiting `fetchTypeNames`**, which fires one external HTTP request per type with **no timeout** — a single hung request stalls the whole function until it times out.

## Fix

- **Aggregate in Postgres.** New `asset_inventory_at(character_ids, as_of)` SQL function (in `schema.sql` + migration `20260604070000_add_asset_inventory_at.sql`) sums `quantity` per `type_id` for the SCD-2 snapshot, mirroring the existing `asset_location_summary` RPC. The route now does one RPC call returning one row per type instead of paging the raw rows.
- **Bound name resolution.** `fetchTypeNames` now caps each lookup with a `5s` `AbortSignal.timeout`, falling back to the raw id — so a slow/missing name can't stall the batch. (Also benefits the UI.)
- **Headroom.** Added `export const maxDuration = 60` to the route.

The SCD-2 "valid at `as_of`" semantics are unchanged (`first_seen_at <= as_of AND (last_seen_at >= as_of OR is_current)`), just moved into SQL.

## Deploy note

The new function ships via the `Migrate` workflow on merge to `main` (the PR touches `supabase/migrations/**`). The endpoint depends on `asset_inventory_at` existing in the DB, so it'll start working once that migration runs.

## Verification

- `npm run lint` (only pre-existing warnings) and `npm run build` pass; `/api/assets` still compiles as a dynamic route.
- Post-merge, re-hit the failing URL — expect a JSON array of `{ typeId, typeName, quantity }` instead of a 504. I can confirm via Vercel runtime logs once it deploys.

https://claude.ai/code/session_01NejxJRVWRMAcrpULY15f6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01NejxJRVWRMAcrpULY15f6Q)_