### PR TITLE
Drop type-name lookup from /api/assets for speed

### DIFF
--- a/src/app/api/assets/route.ts
+++ b/src/app/api/assets/route.ts
@@ -1,18 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-import { fetchTypeNames } from '@/app/typeNames'
 import { createServiceClient } from '@/utils/supabase/service'
 
 // Public JSON endpoint for Google Sheets =ImportJSON(): the player's total asset
 // inventory, summed by item type, as of an optional timestamp. Authenticated by
 // the per-user api_token in the query string (Sheets carries no session cookie),
-// so it always recomputes — no caching.
+// so it always recomputes — no caching. Returns raw type ids; the sheet resolves
+// names itself, which keeps the response fast (no external lookups per type).
 export const dynamic = 'force-dynamic'
-// Headroom over Vercel's default function timeout; the work is one aggregation
-// query plus best-effort type-name lookups, but a large inventory needs room.
+// Headroom over Vercel's default function timeout for a large inventory.
 export const maxDuration = 60
 
-type Row = { typeId: number; typeName: string; quantity: number }
+type Row = { typeId: number; quantity: number }
 
 export const GET = async (request: NextRequest): Promise<NextResponse> => {
   const { searchParams } = new URL(request.url)
@@ -76,15 +75,8 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
   }
   const inventory = (totals ?? []) as { type_id: number; quantity: number }[]
 
-  // Best-effort names: fetchTypeNames caps each lookup with a timeout and falls
-  // back to the raw id, so a slow/missing name never stalls the response.
-  const names = await fetchTypeNames(inventory.map((r) => Number(r.type_id)))
   const rows: Row[] = inventory
-    .map(({ type_id, quantity }) => ({
-      typeId: Number(type_id),
-      typeName: names[Number(type_id)] ?? String(type_id),
-      quantity: Number(quantity),
-    }))
+    .map(({ type_id, quantity }) => ({ typeId: Number(type_id), quantity: Number(quantity) }))
     .sort((a, b) => b.quantity - a.quantity)
 
   return NextResponse.json(rows)

--- a/src/app/typeNames.ts
+++ b/src/app/typeNames.ts
@@ -1,10 +1,7 @@
 const cache = new Map<number, Promise<string | null>>()
 
 const fetchOne = (typeID: number): Promise<string | null> =>
-  // Cap each lookup so one slow/hung request can't stall a caller that awaits the
-  // whole batch (e.g. the /api/assets endpoint); on timeout fetch rejects and we
-  // fall back to null (the caller shows the raw id).
-  fetch(`https://eve-build-calculator.philihp.com/api/type/${typeID}`, { signal: AbortSignal.timeout(5000) })
+  fetch(`https://eve-build-calculator.philihp.com/api/type/${typeID}`)
     .then((res) => (res.ok ? res.json() : null))
     .then((type: { name?: { en?: string } | string } | null) => {
       if (!type) return null


### PR DESCRIPTION
## What

`/api/assets` resolved a human-readable name per `typeId` (one external request each to eve-build-calculator) before responding. This removes that step — the endpoint now returns just `{ typeId, quantity }`, sorted by quantity desc. The spreadsheet can resolve names on its own.

## Why

The name resolution was the only remaining per-type external fan-out in the request path. Dropping it makes the response purely the Postgres aggregation (`asset_inventory_at`) — faster and with no dependency on a second external API.

Also reverts the 5s per-request timeout that had been added to `fetchTypeNames` solely to keep this endpoint from hanging on name lookups — it's no longer needed here, and the UI's behaviour returns to what it was.

## Notes

- No schema change. The `asset_inventory_at` function (from #392) is unchanged.
- Verified post-#392 that the endpoint already returns 200 with correct quantities in production; this just trims the output to ids + quantities.

https://claude.ai/code/session_01NejxJRVWRMAcrpULY15f6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01NejxJRVWRMAcrpULY15f6Q)_