### PR TITLE
Return raw asset rows with character name from /api/assets

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -14,6 +14,8 @@ drop schema if exists hangar cascade;
 
 drop function if exists public.asset_location_summary()        cascade;
 drop function if exists public.asset_location_contents(bigint) cascade;
+drop function if exists public.asset_inventory_at(uuid[], timestamptz) cascade;
+drop function if exists public.asset_snapshot_at(uuid[], timestamptz)  cascade;
 drop view  if exists public.asset                cascade;
 drop table if exists public.asset_over_time      cascade;
 drop table if exists public.wallet               cascade;
@@ -221,29 +223,46 @@ $$;
 grant execute on function public.asset_location_summary()        to authenticated;
 grant execute on function public.asset_location_contents(bigint) to authenticated;
 
--- /api/assets ImportJSON endpoint: the player's total inventory summed by item
--- type as of `at`, reconstructed from the SCD-2 history. A row counts when it had
--- started by `at` and was either still open then or is the current version (its
--- state extends forward past last_seen_at to now); a later version of an item
--- always starts after the prior one's last_seen_at, so at most one version per
--- item matches — no double counting. Aggregating in Postgres avoids paging tens
--- of thousands of raw rows into the serverless function (which timed it out). The
--- route calls this with the service role over the caller's own registration ids,
--- so it takes them as a parameter rather than leaning on RLS.
-create or replace function public.asset_inventory_at(character_ids uuid[], as_of timestamptz)
-returns table (type_id bigint, quantity bigint)
+-- /api/assets ImportJSON endpoint: the player's raw asset rows (one per item
+-- stack), with the owning character's name, as of `as_of`, reconstructed from the
+-- SCD-2 history. A row counts when it had started by `as_of` and was either still
+-- open then or is the current version (its state extends forward past
+-- last_seen_at to now); a later version of an item always starts after the prior
+-- one's last_seen_at, so at most one version per item matches. Returns the whole
+-- result as a single jsonb array so PostgREST's max-rows cap never truncates it
+-- and the function (not the serverless route) pages the table — what kept the
+-- endpoint under Vercel's timeout. Called with the service role over the caller's
+-- own registration ids, so it takes them as a parameter rather than leaning on RLS.
+create or replace function public.asset_snapshot_at(character_ids uuid[], as_of timestamptz)
+returns jsonb
 language sql
 stable
 as $$
-  select a.type_id, sum(coalesce(a.quantity, 1))::bigint as quantity
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'is_blueprint_copy', a.is_blueprint_copy,
+        'is_singleton',      a.is_singleton,
+        'item_id',           a.item_id,
+        'location_flag',     a.location_flag,
+        'location_id',       a.location_id,
+        'location_type',     a.location_type,
+        'quantity',          a.quantity,
+        'type_id',           a.type_id,
+        'character_name',    r.name
+      )
+      order by a.item_id
+    ),
+    '[]'::jsonb
+  )
   from public.asset_over_time a
+  join public.registration r on r.id = a.character_id
   where a.character_id = any(character_ids)
     and a.first_seen_at <= as_of
-    and (a.last_seen_at >= as_of or a.is_current)
-  group by a.type_id;
+    and (a.last_seen_at >= as_of or a.is_current);
 $$;
 
-grant execute on function public.asset_inventory_at(uuid[], timestamptz) to service_role;
+grant execute on function public.asset_snapshot_at(uuid[], timestamptz) to service_role;
 
 -- ── heartbeat ─────────────────────────────────────────────────────────────
 -- One row per scheduled-job run. Workflows write a 'start' step (stamps

--- a/src/app/api/assets/route.ts
+++ b/src/app/api/assets/route.ts
@@ -2,16 +2,13 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { createServiceClient } from '@/utils/supabase/service'
 
-// Public JSON endpoint for Google Sheets =ImportJSON(): the player's total asset
-// inventory, summed by item type, as of an optional timestamp. Authenticated by
-// the per-user api_token in the query string (Sheets carries no session cookie),
-// so it always recomputes — no caching. Returns raw type ids; the sheet resolves
-// names itself, which keeps the response fast (no external lookups per type).
+// Public JSON endpoint for Google Sheets =ImportJSON(): the player's raw asset
+// rows (one per item stack) with the owning character's name, as of an optional
+// timestamp. Authenticated by the per-user api_token in the query string (Sheets
+// carries no session cookie), so it always recomputes — no caching.
 export const dynamic = 'force-dynamic'
 // Headroom over Vercel's default function timeout for a large inventory.
 export const maxDuration = 60
-
-type Row = { typeId: number; quantity: number }
 
 export const GET = async (request: NextRequest): Promise<NextResponse> => {
   const { searchParams } = new URL(request.url)
@@ -62,22 +59,17 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
     return NextResponse.json([])
   }
 
-  // Sum quantity per type across every version that was live at `at`. The rollup
-  // runs in Postgres (asset_inventory_at) rather than paging every raw row into
-  // this function — a full inventory is tens of thousands of rows, and shipping
-  // them here timed the request out. Returns one row per type id.
-  const { data: totals, error: totalsError } = await supabase.rpc('asset_inventory_at', {
+  // The raw rows live at `at`, with character_name, built and returned as one
+  // jsonb array by Postgres (asset_snapshot_at) — keeping the rollup/paging out of
+  // this function is what kept the endpoint under Vercel's timeout, and a single
+  // jsonb scalar sidesteps PostgREST's max-rows cap.
+  const { data: rows, error: rowsError } = await supabase.rpc('asset_snapshot_at', {
     character_ids: characterIds,
     as_of: atIso,
   })
-  if (totalsError) {
+  if (rowsError) {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
-  const inventory = (totals ?? []) as { type_id: number; quantity: number }[]
 
-  const rows: Row[] = inventory
-    .map(({ type_id, quantity }) => ({ typeId: Number(type_id), quantity: Number(quantity) }))
-    .sort((a, b) => b.quantity - a.quantity)
-
-  return NextResponse.json(rows)
+  return NextResponse.json(rows ?? [])
 }

--- a/supabase/migrations/20260604073000_asset_snapshot_at.sql
+++ b/supabase/migrations/20260604073000_asset_snapshot_at.sql
@@ -1,0 +1,38 @@
+-- The /api/assets ImportJSON endpoint now returns the raw asset rows (one per
+-- item stack) with the owning character's name, instead of a by-type total.
+-- asset_snapshot_at supersedes asset_inventory_at: it reconstructs the SCD-2
+-- snapshot as of `as_of` and returns the whole result as a single jsonb array, so
+-- PostgREST's max-rows cap never truncates it and the rollup/paging stays in
+-- Postgres (what keeps the endpoint under Vercel's timeout).
+drop function if exists public.asset_inventory_at(uuid[], timestamptz);
+
+create or replace function public.asset_snapshot_at(character_ids uuid[], as_of timestamptz)
+returns jsonb
+language sql
+stable
+as $$
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'is_blueprint_copy', a.is_blueprint_copy,
+        'is_singleton',      a.is_singleton,
+        'item_id',           a.item_id,
+        'location_flag',     a.location_flag,
+        'location_id',       a.location_id,
+        'location_type',     a.location_type,
+        'quantity',          a.quantity,
+        'type_id',           a.type_id,
+        'character_name',    r.name
+      )
+      order by a.item_id
+    ),
+    '[]'::jsonb
+  )
+  from public.asset_over_time a
+  join public.registration r on r.id = a.character_id
+  where a.character_id = any(character_ids)
+    and a.first_seen_at <= as_of
+    and (a.last_seen_at >= as_of or a.is_current);
+$$;
+
+grant execute on function public.asset_snapshot_at(uuid[], timestamptz) to service_role;


### PR DESCRIPTION
## What

Changes `/api/assets` from a by-type total to **one row per item stack**, exposing exactly the fields the spreadsheet wants:

```
is_blueprint_copy, is_singleton, item_id, location_flag, location_id,
location_type, quantity, type_id, character_name
```

`character_name` comes from joining `registration` on the owning `character_id`.

## How

New `asset_snapshot_at(character_ids, as_of)` SQL function (schema + migration `20260604073000_asset_snapshot_at.sql`) supersedes `asset_inventory_at`:
- Reconstructs the same SCD-2 snapshot as of `as_of` (`first_seen_at <= as_of AND (last_seen_at >= as_of OR is_current)`).
- Joins `registration` for the character name.
- Returns the **entire result as a single `jsonb` array**. Two reasons: PostgREST's max-rows cap (1000) would otherwise truncate a large inventory, and returning one scalar keeps the rollup/paging inside Postgres — which is what kept this endpoint under Vercel's timeout in the first place. The route just hands the array straight back.

The migration drops the now-superseded `asset_inventory_at`.

## Notes

- `item_id` / `location_id` are EVE ids well under 2^53, so JSON number precision is fine.
- Ships via the `Migrate` workflow on merge (touches `supabase/migrations/**`); the endpoint depends on `asset_snapshot_at` existing, so it starts returning the new shape once that runs.

## Verification

- `npm run lint` (pre-existing warnings only) and `npm run build` pass.
- Post-merge I'll hit the live URL and confirm the rows carry all nine fields.

https://claude.ai/code/session_01NejxJRVWRMAcrpULY15f6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01NejxJRVWRMAcrpULY15f6Q)_