### PR TITLE
Preserve asset column order in /api/assets (json, not jsonb)

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -229,18 +229,20 @@ grant execute on function public.asset_location_contents(bigint) to authenticate
 -- open then or is the current version (its state extends forward past
 -- last_seen_at to now); a later version of an item always starts after the prior
 -- one's last_seen_at, so at most one version per item matches. Returns the whole
--- result as a single jsonb array so PostgREST's max-rows cap never truncates it
+-- result as a single json array so PostgREST's max-rows cap never truncates it
 -- and the function (not the serverless route) pages the table — what kept the
--- endpoint under Vercel's timeout. Called with the service role over the caller's
--- own registration ids, so it takes them as a parameter rather than leaning on RLS.
+-- endpoint under Vercel's timeout. Uses json (not jsonb), which preserves the
+-- object key order below so the sheet's columns come out in that exact order.
+-- Called with the service role over the caller's own registration ids, so it
+-- takes them as a parameter rather than leaning on RLS.
 create or replace function public.asset_snapshot_at(character_ids uuid[], as_of timestamptz)
-returns jsonb
+returns json
 language sql
 stable
 as $$
   select coalesce(
-    jsonb_agg(
-      jsonb_build_object(
+    json_agg(
+      json_build_object(
         'is_blueprint_copy', a.is_blueprint_copy,
         'is_singleton',      a.is_singleton,
         'item_id',           a.item_id,
@@ -253,7 +255,7 @@ as $$
       )
       order by a.item_id
     ),
-    '[]'::jsonb
+    '[]'::json
   )
   from public.asset_over_time a
   join public.registration r on r.id = a.character_id

--- a/supabase/migrations/20260604080000_asset_snapshot_at_json_order.sql
+++ b/supabase/migrations/20260604080000_asset_snapshot_at_json_order.sql
@@ -1,0 +1,36 @@
+-- ImportJSON renders the sheet's columns in the order the JSON keys appear, but
+-- jsonb normalizes (reorders) object keys, so the columns came out scrambled.
+-- Switch asset_snapshot_at to the json type, which preserves the key order in
+-- json_build_object below. Changing a function's return type needs a drop first.
+drop function if exists public.asset_snapshot_at(uuid[], timestamptz);
+
+create or replace function public.asset_snapshot_at(character_ids uuid[], as_of timestamptz)
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'is_blueprint_copy', a.is_blueprint_copy,
+        'is_singleton',      a.is_singleton,
+        'item_id',           a.item_id,
+        'location_flag',     a.location_flag,
+        'location_id',       a.location_id,
+        'location_type',     a.location_type,
+        'quantity',          a.quantity,
+        'type_id',           a.type_id,
+        'character_name',    r.name
+      )
+      order by a.item_id
+    ),
+    '[]'::json
+  )
+  from public.asset_over_time a
+  join public.registration r on r.id = a.character_id
+  where a.character_id = any(character_ids)
+    and a.first_seen_at <= as_of
+    and (a.last_seen_at >= as_of or a.is_current);
+$$;
+
+grant execute on function public.asset_snapshot_at(uuid[], timestamptz) to service_role;


### PR DESCRIPTION
## Problem

The `/api/assets` rows came back with their keys scrambled (`item_id, type_id, quantity, …` instead of the requested order). ImportJSON renders sheet columns in JSON key order, so the columns were out of order.

Cause: `asset_snapshot_at` built the array with `jsonb`, and **Postgres `jsonb` normalizes object keys** (orders them by length, then bytes) — it does not preserve insertion order.

## Fix

Switch the function to the **`json`** type (`json_agg` / `json_build_object`), which preserves the key order exactly as written. The keys now come out in the requested order:

```
is_blueprint_copy, is_singleton, item_id, location_flag, location_id,
location_type, quantity, type_id, character_name
```

JS object key order and `NextResponse.json` preserve that through the route, so the response — and the sheet columns — match.

Migration `20260604080000_asset_snapshot_at_json_order.sql` drops and recreates the function (changing a return type requires a drop). No route/TS change.

## Verification

- Ships via the `Migrate` workflow on merge. I'll hit the live URL afterward and confirm the keys appear in the exact order above.

https://claude.ai/code/session_01NejxJRVWRMAcrpULY15f6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01NejxJRVWRMAcrpULY15f6Q)_