### PR TITLE
Pad partial `at` timestamps in /api/assets

### DIFF
--- a/src/app/api/assets/route.ts
+++ b/src/app/api/assets/route.ts
@@ -10,6 +10,18 @@ export const dynamic = 'force-dynamic'
 // Headroom over Vercel's default function timeout for a large inventory.
 export const maxDuration = 60
 
+// Pad a partial ISO date/time out to a full UTC timestamp so callers can pass
+// just the precision they care about: 2026 → 2026-01-01T00:00:00Z, 2026-05 →
+// 2026-05-01T00:00:00Z, 2026-05-30T18 → 2026-05-30T18:00:00Z, etc. Inputs that
+// already carry fractional seconds or a timezone (e.g. a full toISOString) don't
+// match the bare-prefix pattern and are returned untouched for Date to parse.
+const completePartialAt = (value: string): string => {
+  const m = /^(\d{4})(?:-(\d{2}))?(?:-(\d{2}))?(?:[T ](\d{2}))?(?::(\d{2}))?(?::(\d{2}))?$/.exec(value)
+  if (!m) return value
+  const [, year, month = '01', day = '01', hour = '00', minute = '00', second = '00'] = m
+  return `${year}-${month}-${day}T${hour}:${minute}:${second}Z`
+}
+
 export const GET = async (request: NextRequest): Promise<NextResponse> => {
   const { searchParams } = new URL(request.url)
 
@@ -21,7 +33,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
   // `at` is the moment to reconstruct the inventory at; default to now (the live
   // inventory). asset_over_time keeps full SCD-2 history, so any past time works.
   const atParam = searchParams.get('at')
-  const at = atParam ? new Date(atParam) : new Date()
+  const at = atParam ? new Date(completePartialAt(atParam.trim())) : new Date()
   if (Number.isNaN(at.getTime())) {
     return NextResponse.json(
       { error: 'Invalid `at` timestamp; use ISO 8601 (e.g. 2026-06-01T00:00:00Z)' },


### PR DESCRIPTION
## What

`/api/assets` now accepts a partial `at` value and pads it out to a full UTC timestamp before reconstructing the snapshot:

| Input | Used as |
| --- | --- |
| `2026` | `2026-01-01T00:00:00Z` |
| `2026-05` | `2026-05-01T00:00:00Z` |
| `2026-05-30` | `2026-05-30T00:00:00Z` |
| `2026-05-30T18` | `2026-05-30T18:00:00Z` |
| `2026-05-30T18:30` | `2026-05-30T18:30:00Z` |

Full timestamps (with fractional seconds or a timezone, e.g. the settings-page `toISOString()` URL) don't match the bare-prefix pattern and pass through unchanged. Unparseable values still return `400`.

## How

A small `completePartialAt` helper in the route: a regex captures whatever leading components are present (`YYYY`, then optional month/day/hour/minute/second), defaults the missing ones (`01` for month/day, `00` for time), and appends `Z`. Pure string change ahead of the existing `new Date(...)` parse — no schema/migration.

Verified the mapping for all the cases above (and that full ISO strings pass through) with a quick script before wiring it in.

https://claude.ai/code/session_01NejxJRVWRMAcrpULY15f6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01NejxJRVWRMAcrpULY15f6Q)_