### PR TITLE
Add /api/industry endpoint for industry jobs

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -16,6 +16,7 @@ drop function if exists public.asset_location_summary()        cascade;
 drop function if exists public.asset_location_contents(bigint) cascade;
 drop function if exists public.asset_inventory_at(uuid[], timestamptz) cascade;
 drop function if exists public.asset_snapshot_at(uuid[], timestamptz)  cascade;
+drop function if exists public.industry_jobs(uuid[])                   cascade;
 drop view  if exists public.asset                cascade;
 drop table if exists public.asset_over_time      cascade;
 drop table if exists public.wallet               cascade;
@@ -393,6 +394,55 @@ create policy "Users read own industry jobs"
 
 grant select on public.industry_job to authenticated;
 grant all    on public.industry_job to service_role;
+
+-- /api/industry ImportJSON endpoint: the player's industry jobs across all of
+-- their characters, with the owning character's name. Returns the whole result
+-- as a single json array (json, not jsonb, so json_build_object's key order is
+-- preserved for the sheet's columns; one scalar also sidesteps PostgREST's
+-- max-rows cap). Called with the service role over the caller's own registration
+-- ids, so it takes them as a parameter rather than leaning on RLS.
+create or replace function public.industry_jobs(character_ids uuid[])
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'activity_id',            j.activity_id,
+        'blueprint_id',           j.blueprint_id,
+        'blueprint_location_id',  j.blueprint_location_id,
+        'blueprint_type_id',      j.blueprint_type_id,
+        'completed_character_id', j.completed_character_id,
+        'completed_date',         j.completed_date,
+        'cost',                   j.cost,
+        'duration',               j.duration,
+        'end_date',               j.end_date,
+        'facility_id',            j.facility_id,
+        'installer_id',           j.installer_id,
+        'job_id',                 j.job_id,
+        'licensed_runs',          j.licensed_runs,
+        'output_location_id',     j.output_location_id,
+        'pause_date',             j.pause_date,
+        'probability',            j.probability,
+        'product_type_id',        j.product_type_id,
+        'runs',                   j.runs,
+        'start_date',             j.start_date,
+        'station_id',             j.station_id,
+        'status',                 j.status,
+        'successful_runs',        j.successful_runs,
+        'character_name',         r.name
+      )
+      order by j.start_date desc
+    ),
+    '[]'::json
+  )
+  from public.industry_job j
+  join public.registration r on r.id = j.character_id
+  where j.character_id = any(character_ids);
+$$;
+
+grant execute on function public.industry_jobs(uuid[]) to service_role;
 
 -- ── corp_structure ────────────────────────────────────────────────────────
 create table public.corp_structure (

--- a/src/app/account/settings/apiToken.tsx
+++ b/src/app/account/settings/apiToken.tsx
@@ -26,21 +26,29 @@ const ApiToken = ({ initialToken }: { initialToken: string | null }) => {
     setResponse(initialToken ? 'Token regenerated — update your sheet' : 'Token generated')
   }
 
-  const url = token ? `${origin}/api/assets?token=${token}&at=${new Date().toISOString()}` : null
+  const assetsUrl = token ? `${origin}/api/assets?token=${token}` : null
+  const industryUrl = token ? `${origin}/api/industry?token=${token}` : null
 
   return (
     <>
       <h2>API Access (Google Sheets)</h2>
       <p>
-        Pull your total asset inventory into a spreadsheet with <code>=ImportJSON(url)</code>. The optional{' '}
-        <code>at</code> timestamp (ISO 8601) reconstructs your inventory as it was at that moment; omit it for the
-        current inventory.
+        Pull your data into a spreadsheet with <code>=ImportJSON(url)</code>:
       </p>
-      {url && (
-        <p>
-          <code>=ImportJSON(&quot;{url}&quot;)</code>
-        </p>
+      {assetsUrl && industryUrl && (
+        <ul>
+          <li>
+            Assets (one row per item stack): <code>=ImportJSON(&quot;{assetsUrl}&quot;)</code>
+          </li>
+          <li>
+            Industry jobs: <code>=ImportJSON(&quot;{industryUrl}&quot;)</code>
+          </li>
+        </ul>
       )}
+      <p>
+        The assets URL accepts an optional <code>at</code> timestamp (e.g. <code>&amp;at=2026-05-30</code>) to
+        reconstruct your inventory as it was at that moment; omit it for the current inventory.
+      </p>
       <form>
         <button formAction={generate}>{token ? 'Regenerate API token' : 'Generate API token'}</button>
       </form>

--- a/src/app/api/assets/route.ts
+++ b/src/app/api/assets/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-import { createServiceClient } from '@/utils/supabase/service'
+import { resolvePlayer } from '@/utils/apiToken'
 
 // Public JSON endpoint for Google Sheets =ImportJSON(): the player's raw asset
 // rows (one per item stack) with the owning character's name, as of an optional
@@ -25,11 +25,6 @@ const completePartialAt = (value: string): string => {
 export const GET = async (request: NextRequest): Promise<NextResponse> => {
   const { searchParams } = new URL(request.url)
 
-  const token = searchParams.get('token')?.trim()
-  if (!token) {
-    return NextResponse.json({ error: 'Missing api token' }, { status: 401 })
-  }
-
   // `at` is the moment to reconstruct the inventory at; default to now (the live
   // inventory). asset_over_time keeps full SCD-2 history, so any past time works.
   const atParam = searchParams.get('at')
@@ -42,41 +37,17 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
   }
   const atIso = at.toISOString()
 
-  const supabase = createServiceClient()
-
-  // Resolve the token to its owner. Service role bypasses RLS, so we scope every
-  // subsequent query to this user_id ourselves.
-  const { data: settings, error: settingsError } = await supabase
-    .from('user_settings')
-    .select('user_id')
-    .eq('api_token', token)
-    .maybeSingle()
-  if (settingsError) {
-    return NextResponse.json({ error: 'Lookup failed' }, { status: 500 })
-  }
-  if (!settings) {
-    return NextResponse.json({ error: 'Invalid api token' }, { status: 401 })
+  const player = await resolvePlayer(searchParams.get('token')?.trim())
+  if (!player.ok) {
+    return NextResponse.json({ error: player.error }, { status: player.status })
   }
 
-  // The player's characters.
-  const { data: characters, error: charactersError } = await supabase
-    .from('registration')
-    .select('id')
-    .eq('user_id', settings.user_id)
-  if (charactersError) {
-    return NextResponse.json({ error: 'Lookup failed' }, { status: 500 })
-  }
-  const characterIds = (characters ?? []).map((c) => c.id)
-  if (characterIds.length === 0) {
-    return NextResponse.json([])
-  }
-
-  // The raw rows live at `at`, with character_name, built and returned as one
-  // jsonb array by Postgres (asset_snapshot_at) — keeping the rollup/paging out of
-  // this function is what kept the endpoint under Vercel's timeout, and a single
-  // jsonb scalar sidesteps PostgREST's max-rows cap.
-  const { data: rows, error: rowsError } = await supabase.rpc('asset_snapshot_at', {
-    character_ids: characterIds,
+  // The raw rows live at `at`, with character_name, built and returned as one json
+  // array by Postgres (asset_snapshot_at) — keeping the rollup/paging out of this
+  // function is what kept the endpoint under Vercel's timeout, and a single json
+  // scalar sidesteps PostgREST's max-rows cap.
+  const { data: rows, error: rowsError } = await player.supabase.rpc('asset_snapshot_at', {
+    character_ids: player.characterIds,
     as_of: atIso,
   })
   if (rowsError) {

--- a/src/app/api/industry/route.ts
+++ b/src/app/api/industry/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { resolvePlayer } from '@/utils/apiToken'
+
+// Public JSON endpoint for Google Sheets =ImportJSON(): the player's industry jobs
+// across all of their characters, with the owning character's name. Authenticated
+// by the per-user api_token in the query string (Sheets carries no session
+// cookie), so it always recomputes — no caching.
+export const dynamic = 'force-dynamic'
+// Headroom over Vercel's default function timeout.
+export const maxDuration = 60
+
+export const GET = async (request: NextRequest): Promise<NextResponse> => {
+  const { searchParams } = new URL(request.url)
+
+  const player = await resolvePlayer(searchParams.get('token')?.trim())
+  if (!player.ok) {
+    return NextResponse.json({ error: player.error }, { status: player.status })
+  }
+
+  // Built and returned as one json array by Postgres (industry_jobs), which keeps
+  // the field order for the sheet's columns and sidesteps PostgREST's max-rows cap.
+  const { data: rows, error: rowsError } = await player.supabase.rpc('industry_jobs', {
+    character_ids: player.characterIds,
+  })
+  if (rowsError) {
+    return NextResponse.json({ error: 'Query failed' }, { status: 500 })
+  }
+
+  return NextResponse.json(rows ?? [])
+}

--- a/src/utils/apiToken.ts
+++ b/src/utils/apiToken.ts
@@ -1,0 +1,39 @@
+import { createServiceClient } from '@/utils/supabase/service'
+
+type Resolved =
+  | { ok: true; supabase: ReturnType<typeof createServiceClient>; characterIds: string[] }
+  | { ok: false; status: number; error: string }
+
+// Resolve a per-user api_token (from the ImportJSON query string) to the owner's
+// registration ids. The request carries no Supabase session, so this uses the
+// service role and scopes by the resolved user_id. Returns a discriminated result
+// the caller turns straight into a JSON response. Shared by the /api/* endpoints.
+export const resolvePlayer = async (token: string | undefined): Promise<Resolved> => {
+  if (!token) {
+    return { ok: false, status: 401, error: 'Missing api token' }
+  }
+
+  const supabase = createServiceClient()
+
+  const { data: settings, error: settingsError } = await supabase
+    .from('user_settings')
+    .select('user_id')
+    .eq('api_token', token)
+    .maybeSingle()
+  if (settingsError) {
+    return { ok: false, status: 500, error: 'Lookup failed' }
+  }
+  if (!settings) {
+    return { ok: false, status: 401, error: 'Invalid api token' }
+  }
+
+  const { data: characters, error: charactersError } = await supabase
+    .from('registration')
+    .select('id')
+    .eq('user_id', settings.user_id)
+  if (charactersError) {
+    return { ok: false, status: 500, error: 'Lookup failed' }
+  }
+
+  return { ok: true, supabase, characterIds: (characters ?? []).map((c) => c.id) }
+}

--- a/supabase/migrations/20260604120000_industry_jobs.sql
+++ b/supabase/migrations/20260604120000_industry_jobs.sql
@@ -1,0 +1,47 @@
+-- /api/industry ImportJSON endpoint: the player's industry jobs across all of
+-- their characters, with the owning character's name. Returns the whole result
+-- as a single json array (json, not jsonb, to preserve json_build_object's key
+-- order for the sheet's columns, and to sidestep PostgREST's max-rows cap).
+-- Called with the service role over the caller's own registration ids.
+create or replace function public.industry_jobs(character_ids uuid[])
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'activity_id',            j.activity_id,
+        'blueprint_id',           j.blueprint_id,
+        'blueprint_location_id',  j.blueprint_location_id,
+        'blueprint_type_id',      j.blueprint_type_id,
+        'completed_character_id', j.completed_character_id,
+        'completed_date',         j.completed_date,
+        'cost',                   j.cost,
+        'duration',               j.duration,
+        'end_date',               j.end_date,
+        'facility_id',            j.facility_id,
+        'installer_id',           j.installer_id,
+        'job_id',                 j.job_id,
+        'licensed_runs',          j.licensed_runs,
+        'output_location_id',     j.output_location_id,
+        'pause_date',             j.pause_date,
+        'probability',            j.probability,
+        'product_type_id',        j.product_type_id,
+        'runs',                   j.runs,
+        'start_date',             j.start_date,
+        'station_id',             j.station_id,
+        'status',                 j.status,
+        'successful_runs',        j.successful_runs,
+        'character_name',         r.name
+      )
+      order by j.start_date desc
+    ),
+    '[]'::json
+  )
+  from public.industry_job j
+  join public.registration r on r.id = j.character_id
+  where j.character_id = any(character_ids);
+$$;
+
+grant execute on function public.industry_jobs(uuid[]) to service_role;


### PR DESCRIPTION
## What

New `/api/industry` ImportJSON endpoint returning the player's industry jobs across all characters — one row per job, with the fields in the requested order plus `character_name`:

```
activity_id, blueprint_id, blueprint_location_id, blueprint_type_id,
completed_character_id, completed_date, cost, duration, end_date,
facility_id, installer_id, job_id, licensed_runs, output_location_id,
pause_date, probability, product_type_id, runs, start_date, station_id,
status, successful_runs, character_name
```

No `at`/time-travel — `industry_job` isn't a versioned (SCD) table, so this returns the current set of jobs (ordered by `start_date` desc).

## How

- **`industry_jobs(character_ids)` SQL function** (schema + migration `20260604120000_industry_jobs.sql`): same approach as `asset_snapshot_at` — builds the whole result as one `json` array (`json`, not `jsonb`, so `json_build_object`'s key order is preserved for the sheet's columns, and one scalar sidesteps PostgREST's 1000-row cap), joining `registration` for `character_name`.
- **Shared `resolvePlayer` helper** (`src/utils/apiToken.ts`): extracts the token → user → character-ids lookup that `/api/assets` and `/api/industry` both need. Refactored `/api/assets` onto it (behaviour unchanged; the empty-characters case now flows through the RPC, which already returns `[]`).
- **Settings page**: now lists both ImportJSON URLs, and per request **neither includes the `&at=` timestamp**. The `at` note remains, described as assets-only and optional.

## Deploy note

The endpoint depends on the `industry_jobs` function, which ships via the `Migrate` workflow on merge (touches `supabase/migrations/**`).

## Verification

- `npm run lint` (pre-existing warnings only) and `npm run build` pass; both `/api/assets` and `/api/industry` register as dynamic routes.
- Post-merge I'll hit `/api/industry?token=…` and confirm the rows carry all fields in the order above.

https://claude.ai/code/session_01NejxJRVWRMAcrpULY15f6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01NejxJRVWRMAcrpULY15f6Q)_