### PR TITLE
Add market orders extract job, table, and workflow

### DIFF
--- a/.github/workflows/orders.yml
+++ b/.github/workflows/orders.yml
@@ -1,0 +1,37 @@
+name: Orders
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '24 * * * *'
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm install
+      - name: Heartbeat start
+        run: npm run heartbeat -- orders start
+        env:
+          SUPABASE_URL: ${{ vars.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+      - run: npm run orders
+        env:
+          EVE_CLIENT_ID: ${{ vars.EVE_CLIENT_ID }}
+          EVE_SECRET_KEY: ${{ secrets.EVE_SECRET_KEY }}
+          SUPABASE_URL: ${{ vars.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+      - name: Heartbeat end
+        run: npm run heartbeat -- orders end
+        env:
+          SUPABASE_URL: ${{ vars.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dev": "next dev",
     "heartbeat": "node src/heartbeat.js",
     "hourly": "node src/jobs/hourly.js",
+    "orders": "node src/jobs/orders.js",
     "structures": "node src/jobs/structures.js",
     "refresh": "node src/refresh.js",
     "lint": "eslint .",

--- a/schema.sql
+++ b/schema.sql
@@ -21,6 +21,7 @@ drop view  if exists public.asset                cascade;
 drop table if exists public.asset_over_time      cascade;
 drop table if exists public.wallet               cascade;
 drop table if exists public.market_transaction   cascade;
+drop table if exists public.market_order         cascade;
 drop table if exists public.industry_job         cascade;
 drop table if exists public.industry_system_index cascade;
 drop table if exists public.corp_structure_rig   cascade;
@@ -351,6 +352,46 @@ create policy "Users read own transactions"
 
 grant select on public.market_transaction to authenticated;
 grant all    on public.market_transaction to service_role;
+
+-- ── market_order ──────────────────────────────────────────────────────────
+-- A character's currently open market orders (ESI /characters/{id}/orders/).
+-- The orders job keeps this a live snapshot: each run upserts every open order
+-- and sweeps away that character's rows it didn't see, which have since filled,
+-- expired or been cancelled. is_buy is false for sell orders (ESI omits
+-- is_buy_order on those); escrow/min_volume are buy-order-only, hence nullable.
+create table public.market_order (
+  order_id bigint primary key,
+  character_id uuid not null references public.registration(id) on delete cascade,
+  type_id bigint not null,
+  region_id bigint not null,
+  location_id bigint not null,
+  range text not null,
+  is_buy boolean not null,
+  is_corporation boolean not null,
+  price numeric(20, 2) not null,
+  volume_total bigint not null,
+  volume_remain bigint not null,
+  min_volume bigint,
+  escrow numeric(20, 2),
+  duration integer not null,
+  issued timestamptz not null,
+  seen_at timestamptz not null default now()
+);
+create index market_order_character_id_issued_idx on public.market_order (character_id, issued desc);
+
+alter table public.market_order enable row level security;
+create policy "Users read own orders"
+  on public.market_order
+  for select
+  to authenticated
+  using (
+    character_id in (
+      select id from public.registration where user_id = (select auth.uid())
+    )
+  );
+
+grant select on public.market_order to authenticated;
+grant all    on public.market_order to service_role;
 
 -- ── industry_job ──────────────────────────────────────────────────────────
 create table public.industry_job (

--- a/src/app/api/queue/jobs/route.ts
+++ b/src/app/api/queue/jobs/route.ts
@@ -8,7 +8,7 @@ export const runtime = 'nodejs'
 // GitHub Actions remains the safety net if it ever exceeds this on large datasets.
 export const maxDuration = 60
 
-type Msg = { job: 'hourly' | 'assets' | 'structures' | 'daily'; characterId?: number }
+type Msg = { job: 'hourly' | 'assets' | 'structures' | 'daily' | 'orders'; characterId?: number }
 
 // A thrown error fails the callback, so the Vercel queue retries the message
 // (per retryAfterSeconds in vercel.json).
@@ -33,6 +33,11 @@ export const POST = handleCallback(async (message: Msg) => {
     case 'structures': {
       const { runStructures } = await import('@/jobs/structures.js')
       await runStructures(ids)
+      return
+    }
+    case 'orders': {
+      const { runOrders } = await import('@/jobs/orders.js')
+      await runOrders(ids)
       return
     }
     case 'daily': {

--- a/src/esi.js
+++ b/src/esi.js
@@ -54,6 +54,14 @@ export const wallet = (access_token, characterID) =>
     label: `wallet ${characterID}`,
   })
 
+// A character's open market orders (buy and sell). Not paginated — ESI returns
+// every open order in one response.
+export const orders = (access_token, characterID) =>
+  esiJson(`/characters/${characterID}/orders/`, {
+    access_token,
+    label: `orders ${characterID}`,
+  })
+
 export const character = (access_token, characterID) =>
   esiJson(`/characters/${characterID}/`, {
     access_token,

--- a/src/jobs/orders.js
+++ b/src/jobs/orders.js
@@ -1,0 +1,98 @@
+import { fileURLToPath } from 'node:url'
+
+import { orders } from '../esi.js'
+import { sudoSupabase } from '../supabase.js'
+import { refreshAccessToken } from '../tokenRefresh.js'
+
+const ORDERS_SCOPE = 'esi-markets.read_character_orders.v1'
+
+// Pull each character's open market orders into market_order. ESI's open-orders
+// endpoint is a full snapshot, so this mirrors it: upsert everything fetched with
+// a fresh seen_at, then drop that character's rows left with an older seen_at —
+// those orders have filled, expired or been cancelled, so they're no longer open.
+//
+// Pass `characterIds` to scope the run to specific registrations (e.g. a single
+// character fanned out from the Vercel queue); omit it to refresh everyone, as the
+// scheduled workflow does. Throws on a fatal lookup failure so callers — the CLI
+// wrapper or the queue consumer — can decide how to surface it.
+export const runOrders = async ({ characterIds } = {}) => {
+  const { data: characters, error: charactersError } = await sudoSupabase.from('registration').select('id, name')
+  if (charactersError) {
+    console.error(charactersError)
+    throw charactersError
+  }
+  const characterName = new Map((characters ?? []).map((c) => [c.id, c.name]))
+
+  let tokenQuery = sudoSupabase
+    .from('token')
+    .select('id, character_id, refresh_token')
+    .contains('scope', [ORDERS_SCOPE])
+  if (characterIds) tokenQuery = tokenQuery.in('character_id', characterIds)
+  const { data: tokens, error } = await tokenQuery
+
+  if (error) {
+    console.error(error)
+    throw error
+  }
+
+  for (const tokenRow of tokens ?? []) {
+    const name = characterName.get(tokenRow.character_id) ?? '?'
+    try {
+      const { access_token, characterID } = await refreshAccessToken(tokenRow)
+      // One timestamp for the whole character so the stale sweep below is exact.
+      const seen_at = new Date().toISOString()
+      const fetched = await orders(access_token, characterID)
+
+      if (fetched.length > 0) {
+        const rows = fetched.map((o) => ({
+          order_id: o.order_id,
+          character_id: tokenRow.character_id,
+          type_id: o.type_id,
+          region_id: o.region_id,
+          location_id: o.location_id,
+          range: o.range,
+          // is_buy_order is present (true) only on buy orders; absent means a sell.
+          is_buy: o.is_buy_order ?? false,
+          is_corporation: o.is_corporation ?? false,
+          price: o.price,
+          volume_total: o.volume_total,
+          volume_remain: o.volume_remain,
+          min_volume: o.min_volume ?? null,
+          escrow: o.escrow ?? null,
+          duration: o.duration,
+          issued: o.issued,
+          seen_at,
+        }))
+        const { error: upsertError } = await sudoSupabase.from('market_order').upsert(rows, { onConflict: 'order_id' })
+        if (upsertError) throw upsertError
+      }
+
+      // Anything for this character not refreshed this run is no longer open.
+      const { error: sweepError } = await sudoSupabase
+        .from('market_order')
+        .delete()
+        .eq('character_id', tokenRow.character_id)
+        .lt('seen_at', seen_at)
+      if (sweepError) throw sweepError
+
+      console.log(`orders ${name} ${tokenRow.character_id} (${characterID}): ${fetched.length} open`)
+    } catch (e) {
+      console.error(`orders refresh failed for ${name} ${tokenRow.character_id}:`, e)
+    }
+  }
+}
+
+const execute = async () => {
+  try {
+    await runOrders()
+  } catch (e) {
+    console.error('[orders] FAILED', e)
+    process.exit(1)
+  }
+}
+
+// Only run as a CLI (npm run orders / the scheduled workflow) when invoked directly.
+// When imported by the Next.js queue consumer, the top-level run must not fire.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  execute()
+}

--- a/supabase/migrations/20260604140000_market_order.sql
+++ b/supabase/migrations/20260604140000_market_order.sql
@@ -1,0 +1,38 @@
+-- A character's currently open market orders (ESI /characters/{id}/orders/),
+-- populated by the orders job. It keeps this a live snapshot: each run upserts
+-- every open order and sweeps away that character's rows it didn't see (filled,
+-- expired or cancelled). is_buy is false for sell orders (ESI omits is_buy_order
+-- on those); escrow/min_volume are buy-order-only, hence nullable.
+create table if not exists public.market_order (
+  order_id bigint primary key,
+  character_id uuid not null references public.registration(id) on delete cascade,
+  type_id bigint not null,
+  region_id bigint not null,
+  location_id bigint not null,
+  range text not null,
+  is_buy boolean not null,
+  is_corporation boolean not null,
+  price numeric(20, 2) not null,
+  volume_total bigint not null,
+  volume_remain bigint not null,
+  min_volume bigint,
+  escrow numeric(20, 2),
+  duration integer not null,
+  issued timestamptz not null,
+  seen_at timestamptz not null default now()
+);
+create index if not exists market_order_character_id_issued_idx on public.market_order (character_id, issued desc);
+
+alter table public.market_order enable row level security;
+create policy "Users read own orders"
+  on public.market_order
+  for select
+  to authenticated
+  using (
+    character_id in (
+      select id from public.registration where user_id = (select auth.uid())
+    )
+  );
+
+grant select on public.market_order to authenticated;
+grant all    on public.market_order to service_role;


### PR DESCRIPTION
## What

A new scheduled pipeline that pulls each character's **open market orders** from ESI into a `market_order` table — the buy/sell orders themselves, distinct from the existing `market_transaction` table (completed trades).

## Pieces (mirrors the existing hourly/assets/structures conventions)

- **ESI fetch** (`src/esi.js`): `orders(access_token, characterID)` → `/characters/{id}/orders/` (not paginated; ESI returns all open orders in one response).
- **Extract** (`src/jobs/orders.js`): `runOrders({ characterIds })` — for every token carrying the `esi-markets.read_character_orders.v1` scope, refresh it, fetch open orders, **upsert** them with a fresh `seen_at`, then **sweep** that character's rows it didn't see this run (filled/expired/cancelled) so the table stays a live snapshot of what's currently open. Same `run*` export + CLI self-run guard as the other jobs; per-character errors are logged and don't stop the loop.
- **Schema** (`schema.sql` + migration `20260604140000_market_order.sql`): `market_order` table (PK `order_id`, `character_id` → `registration.id`), RLS (`Users read own orders`) and grants matching the other per-character tables. `is_buy` is `false` for sells (ESI omits `is_buy_order` on those); `escrow`/`min_volume` are buy-only, hence nullable.
- **Scheduling**: `orders` npm script + `.github/workflows/orders.yml` (cron `24 * * * *`, heartbeat start/end, same env wiring as `hourly.yml`).
- **Queue**: `orders` added to the consumer's `Msg` union + switch, so it can be fanned out per character like `assets`.

## Notes / follow-ups

- This is the **extract only**, as requested — no ImportJSON endpoint yet. A `/api/orders` (or `/api/market`) reader in the same ordered-`json` style would be a natural next step if you want orders in the sheet.
- It only pulls for characters whose token has `esi-markets.read_character_orders.v1`; if that scope isn't enabled yet, the job no-ops for them until it's granted.
- `market_order` ships via the `Migrate` workflow on merge (touches `supabase/migrations/**`).

## Verification

- `node --check` on the new JS, `npm run lint` (pre-existing warnings only), and `npm run build` all pass; `/api/queue/jobs` still compiles.
- The scheduled workflow can be smoke-tested via **workflow_dispatch** after merge; I can also confirm rows land by checking the table once it's run.

https://claude.ai/code/session_01NejxJRVWRMAcrpULY15f6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01NejxJRVWRMAcrpULY15f6Q)_