### PR TITLE
Refresh ESI: dispatch all jobs and track them on /characters/refresh

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -31,6 +31,7 @@ drop table if exists public.eve_name             cascade;
 drop table if exists public.character_corp       cascade;
 drop table if exists public.structure            cascade;
 drop table if exists public.user_settings        cascade;
+drop table if exists public.refresh_task         cascade;
 drop table if exists public.heartbeat            cascade;
 drop table if exists public.token                cascade;
 drop table if exists public.registration         cascade;
@@ -699,3 +700,37 @@ create policy "Users manage own settings"
 
 grant select, insert, update, delete on public.user_settings to authenticated;
 grant all                            on public.user_settings to service_role;
+
+-- ── refresh_task ──────────────────────────────────────────────────────────
+-- Tracks an on-demand "Refresh ESI" run (the button on /character). One row per
+-- dispatched unit of work: per character for the per-character jobs (assets,
+-- hourly, structures, orders) and one account-wide row for daily. The server
+-- action inserts these (status 'pending') and enqueues a matching queue message;
+-- the queue consumer flips each to 'running' then 'done'/'error'. The
+-- /characters/refresh page reads them (scoped to the owner) to show live status.
+create table public.refresh_task (
+  id uuid primary key default gen_random_uuid(),
+  batch_id uuid not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  job text not null,
+  character_id uuid references public.registration(id) on delete cascade,
+  character_name text,
+  status text not null default 'pending',
+  started_at timestamptz,
+  ended_at timestamptz,
+  error text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index refresh_task_batch_id_idx on public.refresh_task (batch_id);
+create index refresh_task_user_id_created_at_idx on public.refresh_task (user_id, created_at desc);
+
+alter table public.refresh_task enable row level security;
+create policy "Users read own refresh tasks"
+  on public.refresh_task
+  for select
+  to authenticated
+  using (user_id = (select auth.uid()));
+
+grant select on public.refresh_task to authenticated;
+grant all    on public.refresh_task to service_role;

--- a/src/app/api/queue/jobs/route.ts
+++ b/src/app/api/queue/jobs/route.ts
@@ -8,53 +8,95 @@ export const runtime = 'nodejs'
 // GitHub Actions remains the safety net if it ever exceeds this on large datasets.
 export const maxDuration = 60
 
-type Msg = { job: 'hourly' | 'assets' | 'structures' | 'daily' | 'orders'; characterId?: number }
+// characterId is a registration uuid (per-character fan-out); absent runs the job
+// for everyone. taskId, when present, is a refresh_task row the "Refresh ESI" flow
+// tracks — the consumer flips it running -> done/error so /characters/refresh can
+// show live status.
+type Msg = {
+  job: 'hourly' | 'assets' | 'structures' | 'daily' | 'orders'
+  characterId?: string
+  taskId?: string
+}
 
 // A thrown error fails the callback, so the Vercel queue retries the message
 // (per retryAfterSeconds in vercel.json).
 export const POST = handleCallback(async (message: Msg) => {
-  const { job, characterId } = message
+  const { job, characterId, taskId } = message
   const ids = characterId != null ? { characterIds: [characterId] } : undefined
 
   // Imported lazily so loading the route (and `next build`) never runs the job
   // modules' top-level supabase service-client setup, which needs env vars absent
   // at build time.
-  switch (job) {
-    case 'hourly': {
-      const { runHourly } = await import('@/jobs/hourly.js')
-      await runHourly(ids)
-      return
-    }
-    case 'assets': {
-      const { runAssets } = await import('@/jobs/assets.js')
-      await runAssets(ids)
-      return
-    }
-    case 'structures': {
-      const { runStructures } = await import('@/jobs/structures.js')
-      await runStructures(ids)
-      return
-    }
-    case 'orders': {
-      const { runOrders } = await import('@/jobs/orders.js')
-      await runOrders(ids)
-      return
-    }
-    case 'daily': {
-      // Daily is a single whole-job message, so the consumer records its heartbeat
-      // (the per-character producers record their own at enqueue time).
-      const { runDaily } = await import('@/jobs/daily.js')
-      const { recordHeartbeat } = await import('@/supabase.js')
-      const runId = randomInt(1, 2 ** 48)
-      await recordHeartbeat('daily', 'start', { runId, source: 'vercel' })
-      try {
-        await runDaily()
-      } finally {
-        await recordHeartbeat('daily', 'end', { runId, source: 'vercel' })
+  const runJob = async () => {
+    switch (job) {
+      case 'hourly': {
+        const { runHourly } = await import('@/jobs/hourly.js')
+        await runHourly(ids)
+        return
       }
-      return
+      case 'assets': {
+        const { runAssets } = await import('@/jobs/assets.js')
+        await runAssets(ids)
+        return
+      }
+      case 'structures': {
+        const { runStructures } = await import('@/jobs/structures.js')
+        await runStructures(ids)
+        return
+      }
+      case 'orders': {
+        const { runOrders } = await import('@/jobs/orders.js')
+        await runOrders(ids)
+        return
+      }
+      case 'daily': {
+        // Daily is a single whole-job message, so the consumer records its heartbeat
+        // (the per-character producers record their own at enqueue time).
+        const { runDaily } = await import('@/jobs/daily.js')
+        const { recordHeartbeat } = await import('@/supabase.js')
+        const runId = randomInt(1, 2 ** 48)
+        await recordHeartbeat('daily', 'start', { runId, source: 'vercel' })
+        try {
+          await runDaily()
+        } finally {
+          await recordHeartbeat('daily', 'end', { runId, source: 'vercel' })
+        }
+        return
+      }
+      default:
+        throw new Error(`unknown job: ${String(job)}`)
     }
-    default:
-      throw new Error(`unknown job: ${String(job)}`)
+  }
+
+  // Not part of a tracked "Refresh ESI" run: just run it, letting a throw retry.
+  if (taskId == null) {
+    await runJob()
+    return
+  }
+
+  // Tracked: record status on the refresh_task row. Best-effort — a failure is
+  // recorded and swallowed rather than rethrown, so the queue doesn't retry it and
+  // the page settles on a terminal state the user can see.
+  const { sudoSupabase } = await import('@/supabase.js')
+  await sudoSupabase
+    .from('refresh_task')
+    .update({ status: 'running', started_at: new Date().toISOString(), updated_at: new Date().toISOString() })
+    .eq('id', taskId)
+  try {
+    await runJob()
+    await sudoSupabase
+      .from('refresh_task')
+      .update({ status: 'done', ended_at: new Date().toISOString(), updated_at: new Date().toISOString() })
+      .eq('id', taskId)
+  } catch (e) {
+    await sudoSupabase
+      .from('refresh_task')
+      .update({
+        status: 'error',
+        ended_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        error: String(e instanceof Error ? e.message : e).slice(0, 500),
+      })
+      .eq('id', taskId)
   }
 })

--- a/src/app/character/actions.ts
+++ b/src/app/character/actions.ts
@@ -1,12 +1,18 @@
 'use server'
 
+import { randomUUID } from 'node:crypto'
+
 import { redirect } from 'next/navigation'
-import { revalidatePath } from 'next/cache'
 
 import { createClient } from '@/utils/supabase/server'
 
 import { sso } from './sso'
 import { getEnabledScopes } from './userScopes'
+
+// The per-character ESI extracts a "Refresh ESI" run fans out, one queue message
+// per character each. `daily` is account-wide (it resolves affiliations for every
+// registration at once), so it's dispatched once with no character.
+const PER_CHARACTER_JOBS = ['assets', 'hourly', 'structures', 'orders'] as const
 
 export const register = async (formData: FormData) => {
   const supabase = await createClient()
@@ -21,11 +27,7 @@ export const register = async (formData: FormData) => {
   // A brand new player (no characters yet and no saved grant preferences) is sent
   // to choose what to share before we send them on to EVE SSO.
   const { count } = await supabase.from('registration').select('id', { count: 'exact', head: true })
-  const { data: settings } = await supabase
-    .from('user_settings')
-    .select('user_id')
-    .eq('user_id', user.id)
-    .maybeSingle()
+  const { data: settings } = await supabase.from('user_settings').select('user_id').eq('user_id', user.id).maybeSingle()
   if ((count ?? 0) === 0 && !settings) {
     redirect('/settings/grants?from=characters')
   }
@@ -34,13 +36,13 @@ export const register = async (formData: FormData) => {
   redirect(sso.getRedirectUrl('state', scopes))
 }
 
-// Refresh assets for just the signed-in player's characters, on demand. This
-// enqueues the same extract the scheduled Assets workflow runs (src/jobs/assets.js)
-// onto the Vercel queue — one message per character, so the consumer runs them in
-// the background and retries per character. RLS scopes the registration read to the
-// caller, so we only enqueue the ids the user is actually allowed to refresh; the
-// consumer's extract writes with the service role.
-export const refreshAssets = async () => {
+// Run every scheduled ESI extract on demand for just the signed-in player's
+// characters, then send them to /characters/refresh to watch it. Each unit of work
+// (a per-character job for one character, or the account-wide daily job) becomes a
+// refresh_task row and a matching Vercel queue message; the consumer flips each
+// row's status as it runs. RLS scopes the registration read to the caller, so we
+// only refresh ids the user owns; the inserts/enqueues use the service role.
+export const refreshEsi = async () => {
   const supabase = await createClient()
 
   const {
@@ -50,15 +52,39 @@ export const refreshAssets = async () => {
     redirect('/account/login')
   }
 
-  const { data: characters } = await supabase.from('registration').select('id')
-  const characterIds = (characters ?? []).map((c) => c.id)
+  const { data: characters } = await supabase.from('registration').select('id, name')
+  const chars = characters ?? []
 
-  if (characterIds.length > 0) {
-    // Imported lazily so loading the page (and `next build`) never pulls the queue
-    // client into the page bundle or runs its top-level setup.
-    const { send } = await import('@vercel/queue')
-    await Promise.all(characterIds.map((characterId) => send('jobs', { job: 'assets', characterId })))
+  const batchId = randomUUID()
+  const tasks = [
+    ...PER_CHARACTER_JOBS.flatMap((job) =>
+      chars.map((c) => ({
+        batch_id: batchId,
+        user_id: user.id,
+        job,
+        character_id: c.id,
+        character_name: c.name,
+      }))
+    ),
+    // Account-wide, no character.
+    { batch_id: batchId, user_id: user.id, job: 'daily', character_id: null, character_name: null },
+  ]
+
+  // Imported lazily so loading the page (and `next build`) never pulls the service
+  // client / queue setup into the page bundle.
+  const { sudoSupabase } = await import('@/supabase.js')
+  const { data: inserted, error } = await sudoSupabase
+    .from('refresh_task')
+    .insert(tasks)
+    .select('id, job, character_id')
+  if (error) {
+    throw error
   }
 
-  revalidatePath('/character')
+  const { send } = await import('@vercel/queue')
+  await Promise.all(
+    (inserted ?? []).map((t) => send('jobs', { job: t.job, characterId: t.character_id ?? undefined, taskId: t.id }))
+  )
+
+  redirect(`/characters/refresh?batch=${batchId}`)
 }

--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
-import { register, refreshAssets } from './actions'
+import { register, refreshEsi } from './actions'
 import { requiredScopes } from './scopes'
 import { getEnabledScopes } from './userScopes'
 import styles from './character.module.css'
@@ -89,8 +89,8 @@ const CharacterPage = async () => {
       )}
       <form className={styles.actions}>
         <button formAction={register}>Add Character</button>
-        <button formAction={refreshAssets} disabled={!characters?.length}>
-          Refresh Assets
+        <button formAction={refreshEsi} disabled={!characters?.length}>
+          Refresh ESI
         </button>
       </form>
     </>

--- a/src/app/characters/refresh/page.tsx
+++ b/src/app/characters/refresh/page.tsx
@@ -1,0 +1,144 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+
+import { createClient } from '@/utils/supabase/server'
+
+import { RefreshPoller } from './poller'
+import styles from './refresh.module.css'
+
+// Matches the per-character jobs the Refresh ESI action fans out, in column order.
+const JOBS = ['assets', 'hourly', 'structures', 'orders'] as const
+
+// Always read fresh — the poller re-requests this server component every couple of
+// seconds while a refresh is in flight.
+export const dynamic = 'force-dynamic'
+
+type Task = {
+  id: string
+  job: string
+  character_id: string | null
+  character_name: string | null
+  status: string
+  started_at: string | null
+  ended_at: string | null
+  error: string | null
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  done: '✓ done',
+  running: '● running',
+  error: '✗ error',
+  pending: '· pending',
+}
+
+const StatusCell = ({ task }: { task?: Task }) => {
+  const status = task?.status ?? 'pending'
+  return (
+    <span className={styles.status} data-status={status} title={task?.error ?? undefined}>
+      {STATUS_LABEL[status] ?? status}
+    </span>
+  )
+}
+
+const RefreshPage = async ({ searchParams }: { searchParams: Promise<{ batch?: string }> }) => {
+  const { batch } = await searchParams
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user?.id) {
+    redirect('/account/login')
+  }
+
+  if (!batch) {
+    return (
+      <>
+        <h1>Refresh ESI</h1>
+        <p>
+          No refresh in progress. Start one from the <Link href="/character">Characters</Link> page.
+        </p>
+      </>
+    )
+  }
+
+  const { data: tasksData } = await supabase
+    .from('refresh_task')
+    .select('id, job, character_id, character_name, status, started_at, ended_at, error')
+    .eq('batch_id', batch)
+    .order('created_at', { ascending: true })
+  const tasks = (tasksData ?? []) as Task[]
+
+  // Index the per-character tasks by character+job for the matrix; the daily task
+  // is account-wide so it stands on its own.
+  const byCharJob = new Map<string, Task>()
+  const characters = new Map<string, string>()
+  let daily: Task | undefined
+  for (const t of tasks) {
+    if (t.character_id) {
+      byCharJob.set(`${t.character_id}:${t.job}`, t)
+      characters.set(t.character_id, t.character_name ?? t.character_id)
+    } else if (t.job === 'daily') {
+      daily = t
+    }
+  }
+
+  const isTerminal = (status: string) => status === 'done' || status === 'error'
+  const allDone = tasks.length > 0 && tasks.every((t) => isTerminal(t.status))
+
+  if (tasks.length === 0) {
+    return (
+      <>
+        <h1>Refresh ESI</h1>
+        <p>No tasks found for this refresh.</p>
+        <p>
+          <Link href="/character">← Back to Characters</Link>
+        </p>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <h1>Refresh ESI</h1>
+      <p>{allDone ? 'All jobs finished.' : 'Refreshing… this page updates automatically.'}</p>
+
+      {daily && (
+        <p>
+          Account-wide <strong>daily</strong>: <StatusCell task={daily} />
+        </p>
+      )}
+
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>Character</th>
+            {JOBS.map((job) => (
+              <th key={job}>{job}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {[...characters.entries()].map(([id, name]) => (
+            <tr key={id}>
+              <td>{name}</td>
+              {JOBS.map((job) => (
+                <td key={job}>
+                  <StatusCell task={byCharJob.get(`${id}:${job}`)} />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <p>
+        <Link href="/character">← Back to Characters</Link>
+      </p>
+
+      <RefreshPoller done={allDone} />
+    </>
+  )
+}
+
+export default RefreshPage

--- a/src/app/characters/refresh/poller.tsx
+++ b/src/app/characters/refresh/poller.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+
+// Re-render the server page on an interval until every task has reached a terminal
+// state, so the matrix updates live without a manual reload.
+export const RefreshPoller = ({ done }: { done: boolean }) => {
+  const router = useRouter()
+  useEffect(() => {
+    if (done) return
+    const id = setInterval(() => router.refresh(), 2000)
+    return () => clearInterval(id)
+  }, [done, router])
+  return null
+}

--- a/src/app/characters/refresh/refresh.module.css
+++ b/src/app/characters/refresh/refresh.module.css
@@ -1,0 +1,31 @@
+.table {
+  border-collapse: collapse;
+  margin: 1rem 0;
+}
+
+.table th,
+.table td {
+  border: 1px solid var(--border, #444);
+  padding: 0.35rem 0.75rem;
+  text-align: left;
+}
+
+.status {
+  white-space: nowrap;
+}
+
+.status[data-status='done'] {
+  color: #00af00;
+}
+
+.status[data-status='running'] {
+  color: #d8a800;
+}
+
+.status[data-status='error'] {
+  color: #ff4040;
+}
+
+.status[data-status='pending'] {
+  color: #888;
+}

--- a/supabase/migrations/20260606060000_refresh_task.sql
+++ b/supabase/migrations/20260606060000_refresh_task.sql
@@ -1,0 +1,32 @@
+-- Tracks an on-demand "Refresh ESI" run (the button on /character). One row per
+-- dispatched unit of work: per character for the per-character jobs (assets,
+-- hourly, structures, orders) and one account-wide row for daily. The server
+-- action inserts these (status 'pending') and enqueues a matching queue message;
+-- the queue consumer flips each to 'running' then 'done'/'error'. The
+-- /characters/refresh page reads them (scoped to the owner) to show live status.
+create table if not exists public.refresh_task (
+  id uuid primary key default gen_random_uuid(),
+  batch_id uuid not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  job text not null,
+  character_id uuid references public.registration(id) on delete cascade,
+  character_name text,
+  status text not null default 'pending',
+  started_at timestamptz,
+  ended_at timestamptz,
+  error text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index if not exists refresh_task_batch_id_idx on public.refresh_task (batch_id);
+create index if not exists refresh_task_user_id_created_at_idx on public.refresh_task (user_id, created_at desc);
+
+alter table public.refresh_task enable row level security;
+create policy "Users read own refresh tasks"
+  on public.refresh_task
+  for select
+  to authenticated
+  using (user_id = (select auth.uid()));
+
+grant select on public.refresh_task to authenticated;
+grant all    on public.refresh_task to service_role;


### PR DESCRIPTION
## What

Renames the character page's **Refresh Assets** button to **Refresh ESI**. Clicking it now runs *every* scheduled ESI extract on demand for the signed-in player's characters (not just assets), and navigates to a new **/characters/refresh** page that tracks each job's status live.

## How it works

**Dispatch** (`refreshEsi` server action) — for the signed-in user's characters:
- Fans out one Vercel queue message **per character** for the per-character jobs: `assets`, `hourly`, `structures`, `orders`.
- Sends one **account-wide** `daily` message (daily resolves affiliations for everyone at once, so it isn't per-character).
- Each unit of work is recorded as a `refresh_task` row (status `pending`), then enqueued with its `taskId`. Redirects to `/characters/refresh?batch=<id>`.

**Tracking** (queue consumer, `src/app/api/queue/jobs/route.ts`):
- When a message carries a `taskId`, the consumer flips its `refresh_task` row `running` → `done`/`error` around the run. This path is **best-effort** (a failure is recorded and swallowed, not rethrown) so the queue doesn't retry and the page settles on a terminal state.
- Messages without a `taskId` (e.g. future producers) keep the old retry-on-throw behaviour.
- `characterId` is now correctly typed as the registration `uuid` (it always was one at runtime).

**Status page** (`/characters/refresh`) — a matrix of **character × job** (assets/hourly/structures/orders) plus the account-wide **daily** row, each cell showing `pending → running → done/error` (errors surface on hover). A small client poller calls `router.refresh()` every 2s until every task is terminal, then stops.

**Schema**: new `refresh_task` table (schema.sql + migration `20260606060000_refresh_task.sql`) with per-user RLS (`Users read own refresh tasks`); the action/consumer write with the service role.

## Notes

- A character's `assets` stays one-message-per-character — that's the existing pattern that keeps each queue invocation under the 60s `maxDuration`.
- Jobs only do work for characters whose token carries the relevant ESI scope (e.g. `orders` needs `esi-markets.read_character_orders.v1`); a task with no matching scope still shows `done` (the extract no-ops for it).
- The new page lives at `/characters/refresh` (plural) as requested; the existing characters page remains `/character`.

## Verification

- `npm run lint` (pre-existing warnings only) and `npm run build` pass; `/characters/refresh` and `/api/queue/jobs` both compile.
- `refresh_task` ships via the `Migrate` workflow on merge. After merge I can click Refresh ESI and confirm the matrix fills in, or smoke-test by watching the rows.

https://claude.ai/code/session_01NejxJRVWRMAcrpULY15f6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01NejxJRVWRMAcrpULY15f6Q)_