### PR TITLE
Auto-refresh ESI for a newly added character

### DIFF
--- a/src/app/character/actions.ts
+++ b/src/app/character/actions.ts
@@ -1,18 +1,12 @@
 'use server'
 
-import { randomUUID } from 'node:crypto'
-
 import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
 
+import { dispatchRefresh } from './dispatchRefresh'
 import { sso } from './sso'
 import { getEnabledScopes } from './userScopes'
-
-// The per-character ESI extracts a "Refresh ESI" run fans out, one queue message
-// per character each. `daily` is account-wide (it resolves affiliations for every
-// registration at once), so it's dispatched once with no character.
-const PER_CHARACTER_JOBS = ['assets', 'hourly', 'structures', 'orders'] as const
 
 export const register = async (formData: FormData) => {
   const supabase = await createClient()
@@ -37,11 +31,7 @@ export const register = async (formData: FormData) => {
 }
 
 // Run every scheduled ESI extract on demand for just the signed-in player's
-// characters, then send them to /characters/refresh to watch it. Each unit of work
-// (a per-character job for one character, or the account-wide daily job) becomes a
-// refresh_task row and a matching Vercel queue message; the consumer flips each
-// row's status as it runs. RLS scopes the registration read to the caller, so we
-// only refresh ids the user owns; the inserts/enqueues use the service role.
+// characters, then send them to /characters/refresh to watch it.
 export const refreshEsi = async () => {
   const supabase = await createClient()
 
@@ -52,39 +42,9 @@ export const refreshEsi = async () => {
     redirect('/account/login')
   }
 
+  // RLS scopes the registration read to the caller, so we only refresh ids the user owns.
   const { data: characters } = await supabase.from('registration').select('id, name')
-  const chars = characters ?? []
-
-  const batchId = randomUUID()
-  const tasks = [
-    ...PER_CHARACTER_JOBS.flatMap((job) =>
-      chars.map((c) => ({
-        batch_id: batchId,
-        user_id: user.id,
-        job,
-        character_id: c.id,
-        character_name: c.name,
-      }))
-    ),
-    // Account-wide, no character.
-    { batch_id: batchId, user_id: user.id, job: 'daily', character_id: null, character_name: null },
-  ]
-
-  // Imported lazily so loading the page (and `next build`) never pulls the service
-  // client / queue setup into the page bundle.
-  const { sudoSupabase } = await import('@/supabase.js')
-  const { data: inserted, error } = await sudoSupabase
-    .from('refresh_task')
-    .insert(tasks)
-    .select('id, job, character_id')
-  if (error) {
-    throw error
-  }
-
-  const { send } = await import('@vercel/queue')
-  await Promise.all(
-    (inserted ?? []).map((t) => send('jobs', { job: t.job, characterId: t.character_id ?? undefined, taskId: t.id }))
-  )
+  const batchId = await dispatchRefresh(user.id, characters ?? [])
 
   redirect(`/characters/refresh?batch=${batchId}`)
 }

--- a/src/app/character/callback/route.ts
+++ b/src/app/character/callback/route.ts
@@ -5,6 +5,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { createClient } from '@/utils/supabase/server'
 
+import { dispatchRefresh } from '../dispatchRefresh'
 import { sso } from '../sso'
 
 const upsertCharacter =
@@ -55,7 +56,7 @@ export const GET = async (request: NextRequest) => {
   await sso.getAccessToken(refresh_token, true)
 
   const character_id = await upsertCharacter(supabase)({ user_id, owner, name, character_id: eve_character_id })
-  const token_id = await upsertToken(supabase)({
+  await upsertToken(supabase)({
     user_id,
     character_id,
     access_token,
@@ -65,7 +66,12 @@ export const GET = async (request: NextRequest) => {
     scope: [scp].flat(),
   })
 
+  // Pull this character's ESI data right away so it's populated by the time the
+  // user looks, and drop them on the status page to watch it land.
+  const batchId = await dispatchRefresh(user_id, [{ id: character_id, name }])
+
   const redirectTo = request.nextUrl.clone()
-  redirectTo.pathname = '/character'
+  redirectTo.pathname = '/characters/refresh'
+  redirectTo.search = `?batch=${batchId}`
   return NextResponse.redirect(redirectTo)
 }

--- a/src/app/character/dispatchRefresh.ts
+++ b/src/app/character/dispatchRefresh.ts
@@ -1,0 +1,48 @@
+import { randomUUID } from 'node:crypto'
+
+// The per-character ESI extracts a refresh fans out, one queue message per
+// character each. `daily` is account-wide (it resolves affiliations for every
+// registration at once), so it's dispatched once with no character.
+const PER_CHARACTER_JOBS = ['assets', 'hourly', 'structures', 'orders'] as const
+
+type Character = { id: string; name: string | null }
+
+// Run every scheduled ESI extract on demand for the given characters: insert a
+// refresh_task row per unit of work (a per-character job for one character, or the
+// account-wide daily job) and enqueue a matching Vercel queue message tagged with
+// that row's id, which the consumer flips running -> done/error. Returns the batch
+// id so callers can link to /characters/refresh?batch=<id>. Uses the service role,
+// so callers must pass a userId they've already authorized.
+export const dispatchRefresh = async (userId: string, characters: Character[]): Promise<string> => {
+  const batchId = randomUUID()
+  const tasks = [
+    ...PER_CHARACTER_JOBS.flatMap((job) =>
+      characters.map((c) => ({
+        batch_id: batchId,
+        user_id: userId,
+        job,
+        character_id: c.id,
+        character_name: c.name,
+      }))
+    ),
+    { batch_id: batchId, user_id: userId, job: 'daily', character_id: null, character_name: null },
+  ]
+
+  // Imported lazily so importing this module never pulls the service client / queue
+  // setup into a page bundle or `next build`.
+  const { sudoSupabase } = await import('@/supabase.js')
+  const { data: inserted, error } = await sudoSupabase
+    .from('refresh_task')
+    .insert(tasks)
+    .select('id, job, character_id')
+  if (error) {
+    throw error
+  }
+
+  const { send } = await import('@vercel/queue')
+  await Promise.all(
+    (inserted ?? []).map((t) => send('jobs', { job: t.job, characterId: t.character_id ?? undefined, taskId: t.id }))
+  )
+
+  return batchId
+}


### PR DESCRIPTION
## What

When a character is added via EVE SSO, immediately dispatch all the refresh jobs for that character (assets, hourly, structures, orders, plus the account-wide daily), so its data starts populating right away — and drop the user on `/characters/refresh` to watch it land instead of the plain character list.

## How

- Extracts the refresh dispatch (insert `refresh_task` rows + enqueue the matching Vercel queue messages) from the `refreshEsi` action into a shared **`dispatchRefresh(userId, characters)`** helper.
- `refreshEsi` (the "Refresh ESI" button) now calls the helper for all the user's characters — behaviour unchanged.
- The `/character/callback` route calls it for the just-added character (`[{ id, name }]`) after upserting the registration/token, then redirects to `/characters/refresh?batch=<id>`.

Builds on the `refresh_task` table + queue tracking from #403 (already merged and migrated). No schema change here.

## Notes

- Re-adding an existing character (the upsert is idempotent) will also re-dispatch — harmless, the extracts are idempotent.
- Also removed a now-unused `token_id` variable in the callback (clears a lint warning).
- The post-add redirect now goes to the refresh status page rather than `/character`; the status page has a "← Back to Characters" link. Easy to revert to `/character` if you'd rather not change that flow.

## Verification

- `npm run lint` (only the pre-existing `register` `formData` warning) and `npm run build` pass; `/character/callback` and `/characters/refresh` compile.
- No migration; ships with the production redeploy on merge. After merge, adding a character should land on the status matrix with that character's jobs running.

https://claude.ai/code/session_01NejxJRVWRMAcrpULY15f6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01NejxJRVWRMAcrpULY15f6Q)_