### PR TITLE
Fix Refresh ESI 500: fall back to NEXT_PUBLIC Supabase vars on Vercel

### DIFF
--- a/src/supabase.js
+++ b/src/supabase.js
@@ -1,7 +1,13 @@
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = process.env.SUPABASE_URL
-const supabaseKey = process.env.SUPABASE_KEY
+// The cron/GitHub Actions environment sets SUPABASE_URL / SUPABASE_KEY, but the
+// Vercel runtime only exposes the NEXT_PUBLIC_* vars (same project). This module
+// is imported in both — by the GitHub Actions jobs and by the Vercel queue
+// consumer / the "Refresh ESI" server action via dispatchRefresh — so fall back
+// to the public vars to keep createClient from throwing "supabaseUrl is required"
+// on Vercel. The service key has no public equivalent and is set in both.
+const supabaseUrl = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseKey = process.env.SUPABASE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_KEY
 const supabaseUsername = process.env.SUPABASE_USERNAME
 const supabasePassword = process.env.SUPABASE_PASSWORD


### PR DESCRIPTION
## Problem

Hitting the **Refresh ESI** button returned a 500. Production runtime logs show:

```
POST /character 500 — Error: supabaseUrl is required
```

## Root cause

`src/supabase.js` initializes its clients at module load from `SUPABASE_URL` / `SUPABASE_KEY`:

```js
const supabaseUrl = process.env.SUPABASE_URL
export const sudoSupabase = createClient(supabaseUrl, supabaseServiceKey, …)
```

Those vars are set in the **GitHub Actions cron** environment but **not in the Vercel runtime**, which only exposes the `NEXT_PUBLIC_*` vars (this is exactly why `src/utils/supabase/service.ts` already uses `NEXT_PUBLIC_SUPABASE_URL`). The Refresh ESI button (`refreshEsi` → `dispatchRefresh`) lazily imports `@/supabase.js`, so `createClient` throws `supabaseUrl is required` and the server action 500s. The same module is imported by the Vercel queue consumer (`/api/queue/jobs` → `@/jobs/*`), so the on-demand jobs were affected too. This predates the invite-code work — it shipped with the Refresh ESI button in #406.

## Fix

Fall back to the public vars so the module loads in the Vercel runtime:

```js
const supabaseUrl = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL
const supabaseKey = process.env.SUPABASE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
```

- In GitHub Actions, `SUPABASE_URL` / `SUPABASE_KEY` are set, so the fallback is never used — **cron behavior is unchanged**.
- The service-role key (`SUPABASE_SERVICE_KEY`) has no public equivalent and is already present in both environments; the Vercel-side code paths (`dispatchRefresh`, the job modules) only use the service-role client.

## Testing

- `npm run build` — succeeds.
- `npm run lint` — clean (one pre-existing unrelated warning).

https://claude.ai/code/session_018cieuTtxCvTLkCt5Mg52Lg

---
_Generated by [Claude Code](https://claude.ai/code/session_018cieuTtxCvTLkCt5Mg52Lg)_