### PR TITLE
Refresh matrix: show last successful run for un-queued jobs

### DIFF
--- a/src/app/characters/refresh/page.tsx
+++ b/src/app/characters/refresh/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
 
+import { DateTime } from '../../DateTime'
 import { RefreshPoller } from './poller'
 import styles from './refresh.module.css'
 
@@ -31,11 +32,25 @@ const STATUS_LABEL: Record<string, string> = {
   pending: '· pending',
 }
 
-const StatusCell = ({ task }: { task?: Task }) => {
-  const status = task?.status ?? 'pending'
+const StatusCell = ({ task, lastSuccessAt }: { task?: Task; lastSuccessAt?: string | null }) => {
+  // No task means this job wasn't queued in this refresh — fall back to when it
+  // last completed successfully for this character (across earlier refreshes).
+  if (!task) {
+    return (
+      <span className={styles.status} data-status="idle">
+        {lastSuccessAt ? (
+          <>
+            last ✓ <DateTime value={lastSuccessAt} />
+          </>
+        ) : (
+          'never run'
+        )}
+      </span>
+    )
+  }
   return (
-    <span className={styles.status} data-status={status} title={task?.error ?? undefined}>
-      {STATUS_LABEL[status] ?? status}
+    <span className={styles.status} data-status={task.status} title={task.error ?? undefined}>
+      {STATUS_LABEL[task.status] ?? task.status}
     </span>
   )
 }
@@ -98,6 +113,23 @@ const RefreshPage = async ({ searchParams }: { searchParams: Promise<{ batch?: s
     )
   }
 
+  // For matrix cells with no task in this batch, look up the last successful run
+  // of that job for the character (any earlier refresh). One query for all of the
+  // batch's characters, reduced to the most recent `done` per character+job.
+  const charIds = [...characters.keys()]
+  const lastSuccess = new Map<string, string>()
+  const { data: doneData } = await supabase
+    .from('refresh_task')
+    .select('character_id, job, ended_at')
+    .eq('status', 'done')
+    .in('character_id', charIds)
+    .not('ended_at', 'is', null)
+    .order('ended_at', { ascending: false })
+  for (const r of doneData ?? []) {
+    const key = `${r.character_id}:${r.job}`
+    if (!lastSuccess.has(key)) lastSuccess.set(key, r.ended_at) // first seen = most recent
+  }
+
   return (
     <>
       <h1>Refresh ESI</h1>
@@ -124,7 +156,7 @@ const RefreshPage = async ({ searchParams }: { searchParams: Promise<{ batch?: s
               <td>{name}</td>
               {JOBS.map((job) => (
                 <td key={job}>
-                  <StatusCell task={byCharJob.get(`${id}:${job}`)} />
+                  <StatusCell task={byCharJob.get(`${id}:${job}`)} lastSuccessAt={lastSuccess.get(`${id}:${job}`)} />
                 </td>
               ))}
             </tr>

--- a/src/app/characters/refresh/refresh.module.css
+++ b/src/app/characters/refresh/refresh.module.css
@@ -29,3 +29,7 @@
 .status[data-status='pending'] {
   color: #888;
 }
+
+.status[data-status='idle'] {
+  color: #888;
+}


### PR DESCRIPTION
## What

In the **Refresh ESI** job matrix (`/characters/refresh`), a cell with no task in the current batch previously rendered a misleading `· pending` — a state it would never leave, since nothing was queued for it. Now, when a job isn't queued for a character, the cell shows **the last time that job ran successfully for that character** (`last ✓ <timestamp>`), or `never run` if it never has.

## How

- `StatusCell` takes an optional `lastSuccessAt`. When there's no task for the cell, it renders the last-success timestamp instead of a fake pending state. Cells that *do* have a task in the batch are unchanged (live `pending`/`running`/`done`/`error`).
- One query fetches the most recent `done` `refresh_task` per character+job for the batch's characters (RLS already scopes `refresh_task` to the owner), reduced client-side to the latest per `character_id:job`.
- Added a muted `idle` status style for the fallback cell.

## Notes

- "Last successful run" is sourced from `refresh_task`, which only records on-demand Refresh ESI runs (the scheduled GitHub Actions crons don't write to it), so a character/job that has only ever been refreshed by cron will read `never run` here.
- With the current dispatch (every refresh queues all four per-character jobs), this fallback mainly surfaces for future conditional dispatch, but it removes the stuck-`pending` cell whenever a job is genuinely absent from a batch.

## Testing

- `npm run build` — succeeds.
- `npm run lint` — clean (one pre-existing unrelated warning).

https://claude.ai/code/session_018cieuTtxCvTLkCt5Mg52Lg

---
_Generated by [Claude Code](https://claude.ai/code/session_018cieuTtxCvTLkCt5Mg52Lg)_