### PR TITLE
Show relevant industry cost indices per structure

### DIFF
--- a/src/app/structures/[structureId]/page.tsx
+++ b/src/app/structures/[structureId]/page.tsx
@@ -7,6 +7,12 @@ import { ACTIVITY_NAMES } from '../../industry/jobFields'
 import { CharacterName, Name, SystemName } from '../../names'
 import { fetchSystemNames } from '../../systemNames'
 import { fetchTypeNames } from '../../typeNames'
+import {
+  fetchLatestSystemIndexes,
+  formatIndex,
+  INDEX_ACTIVITY_LABELS,
+  structureIndexActivities,
+} from '../industryIndex'
 import retro from '../../retro.module.css'
 
 type Structure = {
@@ -129,6 +135,12 @@ const StructurePage = async ({ params }: StructureParams) => {
   const typeName = typeNames[Number(s.type_id)]
   const systemName = systemNames[Number(s.system_id)]
 
+  // Industry cost indices relevant to this structure (those its fitted service
+  // modules enable), pulled from the latest snapshot for its system.
+  const indexActivities = structureIndexActivities(s.services)
+  const indexesBySystem = await fetchLatestSystemIndexes(supabase, [Number(s.system_id)])
+  const systemIndexes = indexesBySystem.get(Number(s.system_id))
+
   return (
     <>
       <h1 className="serif">{s.name ?? `Structure #${s.structure_id}`}</h1>
@@ -200,6 +212,19 @@ const StructurePage = async ({ params }: StructureParams) => {
             <th>Rigs</th>
             <td>
               {rigs.length > 0 ? rigs.map((r) => typeNames[Number(r.type_id)] ?? `#${r.type_id}`).join(', ') : '—'}
+            </td>
+          </tr>
+          <tr>
+            <th>Industry Indexes</th>
+            <td>
+              {indexActivities.length > 0
+                ? indexActivities
+                    .map((activity) => {
+                      const cost = systemIndexes?.get(activity)
+                      return `${INDEX_ACTIVITY_LABELS[activity]} ${cost != null ? formatIndex(cost) : '—'}`
+                    })
+                    .join(', ')
+                : '—'}
             </td>
           </tr>
           <tr>

--- a/src/app/structures/industryIndex.ts
+++ b/src/app/structures/industryIndex.ts
@@ -1,0 +1,123 @@
+import type { createClient } from '@/utils/supabase/server'
+
+// Per-structure industry cost indices. EVE's /industry/systems/ endpoint reports
+// a cost index per solar system for each industry activity; the structures job
+// snapshots them into industry_system_index. Here we decide which of those
+// indices are *relevant* to a given structure based on the service modules it has
+// fitted (corp_structure.services), and read back the latest snapshot per system.
+
+type Supabase = Awaited<ReturnType<typeof createClient>>
+
+// Activity strings exactly as ESI returns them in cost_indices[].activity (and as
+// stored in industry_system_index.activity).
+export type Activity =
+  | 'manufacturing'
+  | 'researching_time_efficiency'
+  | 'researching_material_efficiency'
+  | 'copying'
+  | 'invention'
+  | 'reaction'
+
+// Human-readable labels for each activity.
+export const INDEX_ACTIVITY_LABELS: Record<Activity, string> = {
+  manufacturing: 'Manufacturing',
+  reaction: 'Reaction',
+  researching_material_efficiency: 'Research ME',
+  researching_time_efficiency: 'Research TE',
+  copying: 'Copying',
+  invention: 'Invention',
+}
+
+// The order indices are rendered in, regardless of which modules surfaced them.
+const ACTIVITY_ORDER: Activity[] = [
+  'manufacturing',
+  'reaction',
+  'researching_material_efficiency',
+  'researching_time_efficiency',
+  'copying',
+  'invention',
+]
+
+// Which cost-index activities a single service module enables. Matched on
+// keywords (case-insensitive) so it holds whether ESI returns the full module
+// name ("Standup Manufacturing Plant I") or a shortened service label, and across
+// module tiers (e.g. the Hyasyoda Research Lab, capital/supercapital shipyards).
+const serviceActivities = (serviceName: string): Activity[] => {
+  const n = serviceName.toLowerCase()
+  // Reactor modules (Composite/Hybrid/Biochemical) are the only thing that lets a
+  // refinery run reactions; the reaction rig is just a bonus, not a requirement.
+  if (n.includes('reactor') || n.includes('reaction')) return ['reaction']
+  // The Invention Lab is a distinct module from the Research Lab — check it first
+  // so it isn't swallowed by a broader research match.
+  if (n.includes('invention')) return ['invention']
+  // The Research Lab covers ME research, TE research and blueprint copying.
+  if (n.includes('research')) {
+    return ['researching_material_efficiency', 'researching_time_efficiency', 'copying']
+  }
+  // Manufacturing plants and capital/supercapital shipyards all manufacture.
+  if (n.includes('manufactur') || n.includes('shipyard')) return ['manufacturing']
+  return []
+}
+
+// The distinct industry activities relevant to a structure, given its fitted
+// service modules, in display order. Offline modules count too — we surface what
+// the structure is set up to do, not only what is powered on right now.
+export const structureIndexActivities = (
+  services: Array<{ name: string; state: string }> | null | undefined
+): Activity[] => {
+  const set = new Set<Activity>()
+  for (const svc of services ?? []) {
+    if (!svc?.name) continue
+    for (const activity of serviceActivities(svc.name)) set.add(activity)
+  }
+  return ACTIVITY_ORDER.filter((a) => set.has(a))
+}
+
+// Cost indices are fractions (0.0432 → 4.32%); EVE shows them as a percentage.
+export const formatIndex = (cost: number): string => `${(cost * 100).toFixed(2)}%`
+
+type IndexRow = {
+  system_id: number | string
+  activity: string
+  cost_index: number | string | null
+}
+
+// Latest cost index per system per activity, keyed system_id → activity → index.
+// The pull job stamps every row in a run with one recorded_at and snapshots every
+// system holding a structure, so the most recent recorded_at identifies the latest
+// complete snapshot — fetch just those rows.
+export const fetchLatestSystemIndexes = async (
+  supabase: Supabase,
+  systemIds: Iterable<number>
+): Promise<Map<number, Map<Activity, number>>> => {
+  const result = new Map<number, Map<Activity, number>>()
+  const ids = [...new Set([...systemIds].filter((n) => Number.isFinite(n)))]
+  if (ids.length === 0) return result
+
+  const { data: latest } = await supabase
+    .from('industry_system_index')
+    .select('recorded_at')
+    .order('recorded_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  if (!latest?.recorded_at) return result
+
+  const { data: rows } = await supabase
+    .from('industry_system_index')
+    .select('system_id, activity, cost_index')
+    .eq('recorded_at', latest.recorded_at)
+    .in('system_id', ids)
+
+  for (const r of (rows ?? []) as IndexRow[]) {
+    const cost = r.cost_index == null ? null : Number(r.cost_index)
+    if (cost == null || !Number.isFinite(cost)) continue
+    const system = Number(r.system_id)
+    let byActivity = result.get(system)
+    if (!byActivity) {
+      byActivity = new Map()
+      result.set(system, byActivity)
+    }
+    byActivity.set(r.activity as Activity, cost)
+  }
+  return result
+}

--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -6,6 +6,7 @@ import { formatMisk } from '../isk'
 import { Name, SystemName } from '../names'
 import { fetchSystemNames } from '../systemNames'
 import { fetchTypeNames } from '../typeNames'
+import { fetchLatestSystemIndexes, formatIndex, INDEX_ACTIVITY_LABELS, structureIndexActivities } from './industryIndex'
 import { StructureSilhouette } from './silhouette'
 import styles from './structures.module.css'
 
@@ -100,6 +101,13 @@ const StructuresPage = async () => {
 
   const systemNames = await fetchSystemNames(list.map((s) => Number(s.system_id)))
   const structureTypeNames = await fetchTypeNames(list.map((s) => Number(s.type_id)))
+
+  // Latest industry cost indices for the systems we hold structures in. We only
+  // show, per structure, the activities its fitted service modules enable.
+  const indexesBySystem = await fetchLatestSystemIndexes(
+    supabase,
+    list.map((s) => Number(s.system_id))
+  )
 
   const { data: journal } = await supabase
     .from('corp_wallet_journal')
@@ -205,6 +213,8 @@ const StructuresPage = async () => {
             {list.map((s) => {
               const rigs = rigsByStructure.get(String(s.structure_id)) ?? []
               const services = s.services?.map((svc) => svc.name) ?? []
+              const indexActivities = structureIndexActivities(s.services)
+              const systemIndexes = indexesBySystem.get(Number(s.system_id))
               return (
                 <li key={`structure-${s.structure_id}`} className={styles.tile}>
                   <StructureSilhouette typeId={s.type_id} className={styles.silhouette} />
@@ -261,6 +271,25 @@ const StructuresPage = async () => {
                             {rig}
                           </li>
                         ))}
+                      </ul>
+                    ) : (
+                      <span className={styles.empty}>—</span>
+                    )}
+                  </div>
+
+                  <div className={styles.section}>
+                    <span className={styles.sectionLabel}>Industry Indexes</span>
+                    {indexActivities.length > 0 ? (
+                      <ul className={styles.indexes}>
+                        {indexActivities.map((activity) => {
+                          const cost = systemIndexes?.get(activity)
+                          return (
+                            <li key={`idx-${s.structure_id}-${activity}`} className={styles.indexRow}>
+                              <span className={styles.indexLabel}>{INDEX_ACTIVITY_LABELS[activity]}</span>
+                              <span className={styles.indexValue}>{cost != null ? formatIndex(cost) : '—'}</span>
+                            </li>
+                          )
+                        })}
                       </ul>
                     ) : (
                       <span className={styles.empty}>—</span>

--- a/src/app/structures/structures.module.css
+++ b/src/app/structures/structures.module.css
@@ -139,6 +139,33 @@
   overflow-wrap: anywhere;
 }
 
+/* Industry cost indices: a label / percentage grid, like the fields block. */
+.indexes {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 12px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-size: 12px;
+}
+
+/* Each row spreads its label and value across the parent grid's two columns. */
+.indexRow {
+  display: contents;
+}
+
+.indexLabel {
+  color: var(--ink-faint);
+  white-space: nowrap;
+}
+
+.indexValue {
+  text-align: right;
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+}
+
 .footer {
   display: grid;
   grid-template-columns: auto auto;


### PR DESCRIPTION
## What

On the Structures page (list + detail), each structure now shows the EVE industry **cost indices** relevant to it, derived from its fitted service modules.

Mapping (service module → index activity):

| Service module | Indices shown |
| --- | --- |
| Manufacturing Plant / Capital & Supercapital Shipyard | Manufacturing |
| Research Lab | Research ME, Research TE, Copying |
| Invention Lab | Invention |
| Reactor (Composite / Hybrid / Biochemical) | Reaction |

A structure can show many indices, or none — e.g. one with only a clone bay shows nothing. Indices are looked up per the structure's solar system.

## How

- New helper `src/app/structures/industryIndex.ts`:
  - `structureIndexActivities(services)` — maps `corp_structure.services` (the `{name,state}` JSONB from ESI) to the set of relevant activities. Matching is keyword-based (case-insensitive) so it works whether ESI returns the full module name (`Standup Manufacturing Plant I`) or a shortened label, and across module tiers.
  - `fetchLatestSystemIndexes(supabase, systemIds)` — reads the latest snapshot from the existing `industry_system_index` table (the pull job stamps every row in a run with one `recorded_at` covering all systems, so the max timestamp is the latest complete snapshot).
  - `INDEX_ACTIVITY_LABELS` / `formatIndex` — labels and percentage formatting (`0.0432` → `4.32%`).
- `src/app/structures/page.tsx` — new "Industry Indexes" section on each tile (label/percentage grid).
- `src/app/structures/[structureId]/page.tsx` — new "Industry Indexes" row in the detail table.

No schema or data-pipeline changes — `industry_system_index` is already populated by the structures cron job; this only reads it.

## Notes / decisions

- **Reaction** keys on the reactor service module alone (the rig is just a bonus, not required to run reactions).
- **Offline modules count** — we surface what the structure is set up to do, not only what is currently powered on.
- If the latest snapshot lacks an activity for a system, that row shows `—`.

## Verification

- `npm run lint` — clean (one pre-existing unrelated warning).
- `npm run build` — type-checks and compiles, both `/structures` routes build.

https://claude.ai/code/session_016UU4iipAmkVDxQKKbpa9ku

---
_Generated by [Claude Code](https://claude.ai/code/session_016UU4iipAmkVDxQKKbpa9ku)_