### PR TITLE
Serve Sheets data as CSV (=IMPORTDATA) instead of JSON

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -227,7 +227,7 @@ $$;
 grant execute on function public.asset_location_summary()        to authenticated;
 grant execute on function public.asset_location_contents(bigint) to authenticated;
 
--- /api/assets ImportJSON endpoint: the player's raw asset rows (one per item
+-- /api/assets IMPORTDATA endpoint: the player's raw asset rows (one per item
 -- stack), with the owning character's name, as of `as_of`, reconstructed from the
 -- SCD-2 history. A row counts when it had started by `as_of` and was either still
 -- open then or is the current version (its state extends forward past
@@ -438,7 +438,7 @@ create policy "Users read own industry jobs"
 grant select on public.industry_job to authenticated;
 grant all    on public.industry_job to service_role;
 
--- /api/industry ImportJSON endpoint: the player's industry jobs across all of
+-- /api/industry IMPORTDATA endpoint: the player's industry jobs across all of
 -- their characters, with the owning character's name. Returns the whole result
 -- as a single json array (json, not jsonb, so json_build_object's key order is
 -- preserved for the sheet's columns; one scalar also sidesteps PostgREST's
@@ -680,7 +680,7 @@ grant all    on public.structure to service_role;
 -- Per-user preferences. `enabled_scopes` is the set of ESI OAuth scopes the
 -- user has opted into requesting when they add a character; an absent row means
 -- "request everything" (see src/app/character/userScopes.ts).
--- `api_token` is an opaque per-user secret the Google Sheets ImportJSON endpoint
+-- `api_token` is an opaque per-user secret the Google Sheets IMPORTDATA endpoint
 -- (/api/assets) authenticates with — that request carries no Supabase session,
 -- so the route looks the user up by this token (service role) and scopes the
 -- results to their characters. Null until the user generates one in settings.

--- a/src/app/account/settings/actions.ts
+++ b/src/app/account/settings/actions.ts
@@ -34,7 +34,7 @@ export const changePassword = async (formData: FormData) => {
   }
 }
 
-// Mint (or rotate) the user's api_token — the secret the /api/assets ImportJSON
+// Mint (or rotate) the user's api_token — the secret the /api/assets IMPORTDATA
 // endpoint authenticates with. Upsert keeps any existing enabled_scopes intact.
 // Returns { token } on success or { error } on failure.
 export const generateApiToken = async (): Promise<{ token?: string; error?: string }> => {

--- a/src/app/account/settings/apiToken.tsx
+++ b/src/app/account/settings/apiToken.tsx
@@ -33,15 +33,16 @@ const ApiToken = ({ initialToken }: { initialToken: string | null }) => {
     <>
       <h2>API Access (Google Sheets)</h2>
       <p>
-        Pull your data into a spreadsheet with <code>=ImportJSON(url)</code>:
+        Pull your data into a spreadsheet with <code>=IMPORTDATA(url)</code> (the first row is the column
+        headers):
       </p>
       {assetsUrl && industryUrl && (
         <ul>
           <li>
-            Assets (one row per item stack): <code>=ImportJSON(&quot;{assetsUrl}&quot;)</code>
+            Assets (one row per item stack): <code>=IMPORTDATA(&quot;{assetsUrl}&quot;)</code>
           </li>
           <li>
-            Industry jobs: <code>=ImportJSON(&quot;{industryUrl}&quot;)</code>
+            Industry jobs: <code>=IMPORTDATA(&quot;{industryUrl}&quot;)</code>
           </li>
         </ul>
       )}

--- a/src/app/api/assets/route.ts
+++ b/src/app/api/assets/route.ts
@@ -1,11 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { resolvePlayer } from '@/utils/apiToken'
+import { toCsv } from '@/utils/csv'
 
-// Public JSON endpoint for Google Sheets =ImportJSON(): the player's raw asset
+// Public CSV endpoint for Google Sheets =IMPORTDATA(): the player's raw asset
 // rows (one per item stack) with the owning character's name, as of an optional
-// timestamp. Authenticated by the per-user api_token in the query string (Sheets
-// carries no session cookie), so it always recomputes — no caching.
+// timestamp. The first row is the column headers. Authenticated by the per-user
+// api_token in the query string (Sheets carries no session cookie), so it always
+// recomputes — no caching.
 export const dynamic = 'force-dynamic'
 // Headroom over Vercel's default function timeout for a large inventory.
 export const maxDuration = 60
@@ -54,5 +56,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
 
-  return NextResponse.json(rows ?? [])
+  return new NextResponse(toCsv(rows ?? []), {
+    headers: { 'Content-Type': 'text/csv; charset=utf-8' },
+  })
 }

--- a/src/app/api/industry/route.ts
+++ b/src/app/api/industry/route.ts
@@ -1,11 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { resolvePlayer } from '@/utils/apiToken'
+import { toCsv } from '@/utils/csv'
 
-// Public JSON endpoint for Google Sheets =ImportJSON(): the player's industry jobs
-// across all of their characters, with the owning character's name. Authenticated
-// by the per-user api_token in the query string (Sheets carries no session
-// cookie), so it always recomputes — no caching.
+// Public CSV endpoint for Google Sheets =IMPORTDATA(): the player's industry jobs
+// across all of their characters, with the owning character's name. The first row
+// is the column headers. Authenticated by the per-user api_token in the query
+// string (Sheets carries no session cookie), so it always recomputes — no caching.
 export const dynamic = 'force-dynamic'
 // Headroom over Vercel's default function timeout.
 export const maxDuration = 60
@@ -27,5 +28,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
 
-  return NextResponse.json(rows ?? [])
+  return new NextResponse(toCsv(rows ?? []), {
+    headers: { 'Content-Type': 'text/csv; charset=utf-8' },
+  })
 }

--- a/src/utils/apiToken.ts
+++ b/src/utils/apiToken.ts
@@ -4,7 +4,7 @@ type Resolved =
   | { ok: true; supabase: ReturnType<typeof createServiceClient>; characterIds: string[] }
   | { ok: false; status: number; error: string }
 
-// Resolve a per-user api_token (from the ImportJSON query string) to the owner's
+// Resolve a per-user api_token (from the IMPORTDATA query string) to the owner's
 // registration ids. The request carries no Supabase session, so this uses the
 // service role and scopes by the resolved user_id. Returns a discriminated result
 // the caller turns straight into a JSON response. Shared by the /api/* endpoints.

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,0 +1,22 @@
+// Serialize an array of flat row objects to CSV text for Google Sheets
+// =IMPORTDATA(). The first row is the header (the keys of the first object, in
+// the order Postgres returned them); every subsequent row is a record. Values
+// that aren't primitives are JSON-stringified so nested json columns still land
+// in a single cell.
+const formatValue = (value: unknown): string => {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'object') return JSON.stringify(value)
+  return String(value)
+}
+
+// Quote a field per RFC 4180 when it contains a comma, quote, or newline,
+// doubling any embedded quotes.
+const escapeField = (value: string): string =>
+  /[",\r\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value
+
+export const toCsv = (rows: Record<string, unknown>[]): string => {
+  if (rows.length === 0) return ''
+  const headers = Object.keys(rows[0])
+  const lines = [headers, ...rows.map((row) => headers.map((h) => row[h]))]
+  return lines.map((line) => line.map((cell) => escapeField(formatValue(cell))).join(',')).join('\r\n')
+}

--- a/src/utils/supabase/service.ts
+++ b/src/utils/supabase/service.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@supabase/supabase-js'
 
 // Service-role Supabase client for server-only code paths that can't rely on the
-// caller's session — notably the /api/assets ImportJSON endpoint, which is
+// caller's session — notably the /api/assets IMPORTDATA endpoint, which is
 // authenticated by an opaque api_token rather than a Supabase auth cookie. It
 // bypasses RLS, so callers MUST scope every query to the resolved user_id
 // themselves. Mirrors `sudoSupabase` in src/supabase.js but uses the Next public


### PR DESCRIPTION
## Why

`ImportJSON` isn't a built-in Google Sheets function (it requires a custom Apps Script), so the documented `=ImportJSON(url)` workflow doesn't work out of the box. Google Sheets *does* ship `=IMPORTDATA(url)`, which fetches and parses CSV from a URL.

## What

- `/api/assets` and `/api/industry` now respond with `text/csv` instead of JSON.
- The **first row is the column headers** (the keys of the returned rows, in the order Postgres returns them); each subsequent row is a record.
- Added `src/utils/csv.ts` — a small RFC 4180 serializer (quotes fields containing commas/quotes/newlines, JSON-stringifies nested json columns into a single cell).
- Updated the account settings UI to show `=IMPORTDATA(...)` and note that the first row is headers.
- Refreshed the now-stale `ImportJSON` references in comments and `schema.sql`.

https://claude.ai/code/session_015DzGVbd41WdgPGU7RBFobf

---
_Generated by [Claude Code](https://claude.ai/code/session_015DzGVbd41WdgPGU7RBFobf)_