### PR TITLE
Add /api/orders CSV endpoint for open market orders

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -395,6 +395,46 @@ create policy "Users read own orders"
 grant select on public.market_order to authenticated;
 grant all    on public.market_order to service_role;
 
+-- /api/orders IMPORTDATA endpoint: the player's open market orders across all of
+-- their characters, with the owning character's name. Returns the whole result as
+-- a single json array (json, not jsonb, so json_build_object's key order is
+-- preserved for the sheet's columns) and sidesteps PostgREST's max-rows cap. The
+-- stored `is_buy` flag is exposed as `is_buy_order` to match ESI's field name.
+create or replace function public.market_orders(character_ids uuid[])
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'duration',       o.duration,
+        'escrow',         o.escrow,
+        'is_buy_order',   o.is_buy,
+        'is_corporation', o.is_corporation,
+        'issued',         o.issued,
+        'location_id',    o.location_id,
+        'min_volume',     o.min_volume,
+        'order_id',       o.order_id,
+        'price',          o.price,
+        'range',          o.range,
+        'region_id',      o.region_id,
+        'type_id',        o.type_id,
+        'volume_remain',  o.volume_remain,
+        'volume_total',   o.volume_total,
+        'character_name', r.name
+      )
+      order by o.issued desc
+    ),
+    '[]'::json
+  )
+  from public.market_order o
+  join public.registration r on r.id = o.character_id
+  where o.character_id = any(character_ids);
+$$;
+
+grant execute on function public.market_orders(uuid[]) to service_role;
+
 -- ── industry_job ──────────────────────────────────────────────────────────
 create table public.industry_job (
   job_id bigint primary key,

--- a/src/app/account/settings/apiToken.tsx
+++ b/src/app/account/settings/apiToken.tsx
@@ -28,6 +28,7 @@ const ApiToken = ({ initialToken }: { initialToken: string | null }) => {
 
   const assetsUrl = token ? `${origin}/api/assets?token=${token}` : null
   const industryUrl = token ? `${origin}/api/industry?token=${token}` : null
+  const ordersUrl = token ? `${origin}/api/orders?token=${token}` : null
 
   return (
     <>
@@ -36,13 +37,16 @@ const ApiToken = ({ initialToken }: { initialToken: string | null }) => {
         Pull your data into a spreadsheet with <code>=IMPORTDATA(url)</code> (the first row is the column
         headers):
       </p>
-      {assetsUrl && industryUrl && (
+      {assetsUrl && industryUrl && ordersUrl && (
         <ul>
           <li>
             Assets (one row per item stack): <code>=IMPORTDATA(&quot;{assetsUrl}&quot;)</code>
           </li>
           <li>
             Industry jobs: <code>=IMPORTDATA(&quot;{industryUrl}&quot;)</code>
+          </li>
+          <li>
+            Market orders (open): <code>=IMPORTDATA(&quot;{ordersUrl}&quot;)</code>
           </li>
         </ul>
       )}

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { resolvePlayer } from '@/utils/apiToken'
+import { toCsv } from '@/utils/csv'
+
+// Public CSV endpoint for Google Sheets =IMPORTDATA(): the player's open market
+// orders across all of their characters, with the owning character's name. The
+// first row is the column headers. Authenticated by the per-user api_token in the
+// query string (Sheets carries no session cookie), so it always recomputes — no
+// caching.
+export const dynamic = 'force-dynamic'
+// Headroom over Vercel's default function timeout.
+export const maxDuration = 60
+
+export const GET = async (request: NextRequest): Promise<NextResponse> => {
+  const { searchParams } = new URL(request.url)
+
+  const player = await resolvePlayer(searchParams.get('token')?.trim())
+  if (!player.ok) {
+    return NextResponse.json({ error: player.error }, { status: player.status })
+  }
+
+  // Built and returned as one json array by Postgres (market_orders), which keeps
+  // the field order for the sheet's columns and sidesteps PostgREST's max-rows cap.
+  const { data: rows, error: rowsError } = await player.supabase.rpc('market_orders', {
+    character_ids: player.characterIds,
+  })
+  if (rowsError) {
+    return NextResponse.json({ error: 'Query failed' }, { status: 500 })
+  }
+
+  return new NextResponse(toCsv(rows ?? []), {
+    headers: { 'Content-Type': 'text/csv; charset=utf-8' },
+  })
+}

--- a/supabase/migrations/20260608090000_market_orders.sql
+++ b/supabase/migrations/20260608090000_market_orders.sql
@@ -1,0 +1,40 @@
+-- /api/orders IMPORTDATA endpoint: the player's open market orders across all of
+-- their characters, with the owning character's name. Returns the whole result as
+-- a single json array (json, not jsonb, so json_build_object's key order is
+-- preserved for the sheet's columns) and sidesteps PostgREST's max-rows cap. The
+-- stored `is_buy` flag is exposed as `is_buy_order` to match ESI's field name.
+-- Called with the service role over the caller's own registration ids.
+create or replace function public.market_orders(character_ids uuid[])
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'duration',       o.duration,
+        'escrow',         o.escrow,
+        'is_buy_order',   o.is_buy,
+        'is_corporation', o.is_corporation,
+        'issued',         o.issued,
+        'location_id',    o.location_id,
+        'min_volume',     o.min_volume,
+        'order_id',       o.order_id,
+        'price',          o.price,
+        'range',          o.range,
+        'region_id',      o.region_id,
+        'type_id',        o.type_id,
+        'volume_remain',  o.volume_remain,
+        'volume_total',   o.volume_total,
+        'character_name', r.name
+      )
+      order by o.issued desc
+    ),
+    '[]'::json
+  )
+  from public.market_order o
+  join public.registration r on r.id = o.character_id
+  where o.character_id = any(character_ids);
+$$;
+
+grant execute on function public.market_orders(uuid[]) to service_role;


### PR DESCRIPTION
## What

Adds a `/api/orders` CSV endpoint (Google Sheets `=IMPORTDATA(url)`) for each player's **open market orders**, alongside the existing `/api/assets` and `/api/industry` endpoints.

We already had all the data: `src/jobs/orders.js` fetches open orders from ESI hourly into the `market_order` table. This PR just exposes it.

## Fields

First row is headers, in this order (matching the request):

`duration, escrow, is_buy_order, is_corporation, issued, location_id, min_volume, order_id, price, range, region_id, type_id, volume_remain, volume_total, character_name`

- The table stores the buy flag as `is_buy`; it's surfaced as `is_buy_order` to match ESI's field name.
- `character_name` comes from the `registration` join, like the industry endpoint.

## Changes

- `src/app/api/orders/route.ts` — new route, modeled on `/api/industry` (CSV via shared `toCsv`, `resolvePlayer` auth).
- New `public.market_orders(uuid[])` Postgres function in `schema.sql` + a non-destructive migration (`supabase/migrations/20260608090000_market_orders.sql`).
- Account settings UI now lists the orders `=IMPORTDATA(...)` URL.

https://claude.ai/code/session_015DzGVbd41WdgPGU7RBFobf

---
_Generated by [Claude Code](https://claude.ai/code/session_015DzGVbd41WdgPGU7RBFobf)_