### PR TITLE
Add manual search button to blueprint search

### DIFF
--- a/src/app/blueprint/typeSearch.tsx
+++ b/src/app/blueprint/typeSearch.tsx
@@ -10,36 +10,67 @@ const MAX_RESULTS = 8
 export const TypeSearch = () => {
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<[typeID: string, name: string][]>([])
+  const [searching, setSearching] = useState(false)
+  const [searched, setSearched] = useState(false)
   const timeoutRef = useRef<number | undefined>(undefined)
+  // Tracks the latest issued query so a slow response can't clobber a newer one.
+  const latestRef = useRef('')
 
+  const runSearch = (term: string) => {
+    const trimmed = term.trim()
+    if (trimmed === '') {
+      latestRef.current = ''
+      setResults([])
+      setSearched(false)
+      setSearching(false)
+      return
+    }
+    latestRef.current = trimmed
+    setSearching(true)
+    searchType(trimmed).then((found) => {
+      if (latestRef.current !== trimmed) return
+      setResults(found)
+      setSearching(false)
+      setSearched(true)
+    })
+  }
+
+  // Debounced autocomplete: fires on its own a short while after typing stops.
   useEffect(() => {
     if (timeoutRef.current) window.clearTimeout(timeoutRef.current)
     if (query.trim() === '') {
-      setResults([])
+      runSearch('')
       return
     }
-    // Snapshot the in-flight query so a slow response can't clobber a newer one.
-    const current = query
-    timeoutRef.current = window.setTimeout(() => {
-      searchType(current).then((found) => {
-        setQuery((latest) => {
-          if (latest === current) setResults(found)
-          return latest
-        })
-      })
-    }, DEBOUNCE_MS)
+    timeoutRef.current = window.setTimeout(() => runSearch(query), DEBOUNCE_MS)
     return () => window.clearTimeout(timeoutRef.current)
   }, [query])
 
+  // Manual trigger (button / Enter) for when the autocomplete didn't fire or came back empty.
+  const onManualSearch = () => {
+    if (timeoutRef.current) window.clearTimeout(timeoutRef.current)
+    runSearch(query)
+  }
+
   return (
     <>
-      <input
-        type="text"
-        value={query}
-        placeholder="Blueprint name…"
-        onChange={(e) => setQuery(e.target.value)}
-        autoFocus
-      />
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          onManualSearch()
+        }}
+      >
+        <input
+          type="text"
+          value={query}
+          placeholder="Blueprint name…"
+          onChange={(e) => setQuery(e.target.value)}
+          autoFocus
+        />
+        <button type="submit" disabled={query.trim() === '' || searching}>
+          {searching ? 'Searching…' : 'Search'}
+        </button>
+      </form>
       <ul>
         {results.slice(0, MAX_RESULTS).map(([typeID, name]) => (
           <li key={typeID}>
@@ -48,6 +79,7 @@ export const TypeSearch = () => {
         ))}
         {results.length > MAX_RESULTS && <li>…</li>}
       </ul>
+      {searched && !searching && results.length === 0 && <p>No blueprints found.</p>}
     </>
   )
 }


### PR DESCRIPTION
## What

The blueprint search only ran via the debounced autocomplete, so when it didn't fire (or came back empty) there was no way to retry it and no visible feedback. This adds a **Search** button (also triggered by pressing Enter) that runs the search on demand, plus `searching` / no-results states so an empty result is distinguishable from an idle box.

## Heads up — root cause of "nothing comes up"

While investigating I found the actual reason `beacon` (and everything else) returns nothing: the upstream SDE search endpoint is **down**, not the autocomplete.

```
GET https://sde.edencom.link/api/type/search?q=rifter        → 404 "not found"
GET https://sde.edencom.link/api/type/587                    → 200 (lookup by ID still works)
```

`searchBlueprints` calls `/api/type/search`, and `search()` swallows non-OK responses (`if (!res.ok) return []`), so the UI silently shows nothing for any query. **This button makes the search retriable and surfaces the empty state, but it can't restore results on its own** — the `/api/type/search` endpoint needs to be brought back on the `sde.edencom.link` service for matches to return.

## Changes

- `src/app/blueprint/typeSearch.tsx`: add Search button + Enter-to-search, `searching` indicator, and a "No blueprints found." message. Staleness guard switched from a `setQuery` functional update to a `latestRef` so both the debounce and the manual trigger share it.

https://claude.ai/code/session_01BdgzQLrw2hup55p2bJqQLd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdgzQLrw2hup55p2bJqQLd)_