### PR TITLE
Add 7-day sparklines next to structure industry indexes

### DIFF
--- a/src/app/structures/industryIndex.ts
+++ b/src/app/structures/industryIndex.ts
@@ -118,3 +118,46 @@ export const fetchLatestSystemIndexes = async (
   }
   return result
 }
+
+type HistoryRow = IndexRow & { recorded_at: string }
+
+// 7-day cost-index history per system per activity, in chronological order. Used
+// to draw sparklines next to each index. We pull the raw snapshots and bucket
+// them by recorded_at; a daily bucket would smooth them more but the structures
+// job runs a handful of times a day so the raw points already make a reasonable
+// shape.
+export const fetchSystemIndexHistory = async (
+  supabase: Supabase,
+  systemIds: Iterable<number>
+): Promise<Map<number, Map<Activity, number[]>>> => {
+  const result = new Map<number, Map<Activity, number[]>>()
+  const ids = [...new Set([...systemIds].filter((n) => Number.isFinite(n)))]
+  if (ids.length === 0) return result
+
+  const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
+  const { data: rows } = await supabase
+    .from('industry_system_index')
+    .select('system_id, activity, cost_index, recorded_at')
+    .gte('recorded_at', since)
+    .in('system_id', ids)
+    .order('recorded_at', { ascending: true })
+
+  for (const r of (rows ?? []) as HistoryRow[]) {
+    const cost = r.cost_index == null ? null : Number(r.cost_index)
+    if (cost == null || !Number.isFinite(cost)) continue
+    const system = Number(r.system_id)
+    let byActivity = result.get(system)
+    if (!byActivity) {
+      byActivity = new Map()
+      result.set(system, byActivity)
+    }
+    const activity = r.activity as Activity
+    let series = byActivity.get(activity)
+    if (!series) {
+      series = []
+      byActivity.set(activity, series)
+    }
+    series.push(cost)
+  }
+  return result
+}

--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -6,8 +6,15 @@ import { formatMisk } from '../isk'
 import { Name, SystemName } from '../names'
 import { fetchSystemNames } from '../systemNames'
 import { fetchTypeNames } from '../typeNames'
-import { fetchLatestSystemIndexes, formatIndex, INDEX_ACTIVITY_LABELS, structureIndexActivities } from './industryIndex'
+import {
+  fetchLatestSystemIndexes,
+  fetchSystemIndexHistory,
+  formatIndex,
+  INDEX_ACTIVITY_LABELS,
+  structureIndexActivities,
+} from './industryIndex'
 import { StructureSilhouette } from './silhouette'
+import { Sparkline } from './sparkline'
 import styles from './structures.module.css'
 
 type Structure = {
@@ -105,6 +112,10 @@ const StructuresPage = async () => {
   // Latest industry cost indices for the systems we hold structures in. We only
   // show, per structure, the activities its fitted service modules enable.
   const indexesBySystem = await fetchLatestSystemIndexes(
+    supabase,
+    list.map((s) => Number(s.system_id))
+  )
+  const indexHistoryBySystem = await fetchSystemIndexHistory(
     supabase,
     list.map((s) => Number(s.system_id))
   )
@@ -215,6 +226,7 @@ const StructuresPage = async () => {
               const services = s.services?.map((svc) => svc.name) ?? []
               const indexActivities = structureIndexActivities(s.services)
               const systemIndexes = indexesBySystem.get(Number(s.system_id))
+              const systemHistory = indexHistoryBySystem.get(Number(s.system_id))
               return (
                 <li key={`structure-${s.structure_id}`} className={styles.tile}>
                   <StructureSilhouette typeId={s.type_id} className={styles.silhouette} />
@@ -283,9 +295,11 @@ const StructuresPage = async () => {
                       <ul className={styles.indexes}>
                         {indexActivities.map((activity) => {
                           const cost = systemIndexes?.get(activity)
+                          const history = systemHistory?.get(activity) ?? []
                           return (
                             <li key={`idx-${s.structure_id}-${activity}`} className={styles.indexRow}>
                               <span className={styles.indexLabel}>{INDEX_ACTIVITY_LABELS[activity]}</span>
+                              <Sparkline values={history} label={INDEX_ACTIVITY_LABELS[activity]} />
                               <span className={styles.indexValue}>{cost != null ? formatIndex(cost) : '—'}</span>
                             </li>
                           )

--- a/src/app/structures/sparkline.tsx
+++ b/src/app/structures/sparkline.tsx
@@ -1,0 +1,42 @@
+import styles from './structures.module.css'
+
+type SparklineProps = {
+  values: number[]
+  label?: string
+}
+
+// Tiny line chart for the 7-day cost-index history. Sized in CSS to 100px wide
+// and one line-height tall; the viewBox uses a fixed coordinate space and the
+// path scales (preserveAspectRatio="none") so it stretches to whatever line
+// height the surrounding text resolves to.
+export const Sparkline = ({ values, label }: SparklineProps) => {
+  if (values.length < 2) return <span className={styles.sparkline} aria-hidden />
+
+  const w = 100
+  const h = 20
+  const pad = 1
+  const min = Math.min(...values)
+  const max = Math.max(...values)
+  const range = max - min || 1
+  const step = (w - pad * 2) / (values.length - 1)
+  const points = values
+    .map((v, i) => {
+      const x = pad + i * step
+      const y = pad + (1 - (v - min) / range) * (h - pad * 2)
+      return `${x.toFixed(2)},${y.toFixed(2)}`
+    })
+    .join(' ')
+  const trend = values[values.length - 1] >= values[0] ? 'rising' : 'falling'
+
+  return (
+    <svg
+      className={styles.sparkline}
+      viewBox={`0 0 ${w} ${h}`}
+      preserveAspectRatio="none"
+      role="img"
+      aria-label={label ? `${label}, ${trend}` : trend}
+    >
+      <polyline points={points} fill="none" stroke="currentColor" strokeWidth={1.5} vectorEffect="non-scaling-stroke" />
+    </svg>
+  )
+}

--- a/src/app/structures/structures.module.css
+++ b/src/app/structures/structures.module.css
@@ -139,18 +139,19 @@
   overflow-wrap: anywhere;
 }
 
-/* Industry cost indices: a label / percentage grid, like the fields block. */
+/* Industry cost indices: label / sparkline / percentage. The sparkline column
+ * is sized to the SVG (100px) so the percentages still align across rows. */
 .indexes {
   display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 4px 12px;
+  grid-template-columns: auto 1fr auto;
+  gap: 4px 8px;
   list-style: none;
   padding: 0;
   margin: 0;
   font-size: 12px;
 }
 
-/* Each row spreads its label and value across the parent grid's two columns. */
+/* Each row spreads its three cells across the parent grid's columns. */
 .indexRow {
   display: contents;
 }
@@ -164,6 +165,17 @@
   text-align: right;
   font-family: var(--mono);
   font-variant-numeric: tabular-nums;
+}
+
+/* Sparkline sits between the label and percentage; sized to one line-height
+ * tall so it slots into the existing row rhythm without changing it. */
+.sparkline {
+  width: 100px;
+  height: 1lh;
+  justify-self: end;
+  align-self: center;
+  color: var(--ink-soft);
+  overflow: visible;
 }
 
 .footer {


### PR DESCRIPTION
For each industry index shown on a structure tile, this pulls the last seven days of `industry_system_index` snapshots and draws an SVG sparkline between the activity label and the current percentage.

## Details

- `fetchSystemIndexHistory` in `industryIndex.ts` returns 7d of cost-index points per system per activity, grouped chronologically.
- New `Sparkline` component renders a `<polyline>` in a 100×20 viewBox with `preserveAspectRatio="none"` and `vectorEffect="non-scaling-stroke"` so the line scales but the stroke stays crisp.
- The `.indexes` grid grew a third column; sparkline cell is sized to `100px` wide and `1lh` tall so it slots into the existing row rhythm.
- Color is `--ink-soft` — neutral, since for industry costs "up" isn't unambiguously good or bad. The shape itself communicates direction, with an `aria-label` of "rising" / "falling" for screen readers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVxCmNeDAG9XtpCnHYbYWr)_