### PR TITLE
Show sparkline min/max as sup/sub next to industry indexes

### DIFF
--- a/src/app/structures/sparkline.tsx
+++ b/src/app/structures/sparkline.tsx
@@ -1,3 +1,4 @@
+import { formatIndex } from './industryIndex'
 import styles from './structures.module.css'
 
 type SparklineProps = {
@@ -5,12 +6,15 @@ type SparklineProps = {
   label?: string
 }
 
-// Tiny line chart for the 7-day cost-index history. Sized in CSS to 100px wide
-// and one line-height tall; the viewBox uses a fixed coordinate space and the
-// path scales (preserveAspectRatio="none") so it stretches to whatever line
-// height the surrounding text resolves to.
+// Tiny line chart for the 7-day cost-index history. The SVG is sized in CSS to
+// 100px wide and one line-height tall; the viewBox uses a fixed coordinate
+// space and the path scales (preserveAspectRatio="none") so the line stretches
+// to whatever line height the surrounding text resolves to. To the left of the
+// chart we stack the range it covers — max as a superscript on top, min as a
+// subscript on the bottom — so the reader can read the absolute scale without
+// having to look up at the current % to know roughly where the line sits.
 export const Sparkline = ({ values, label }: SparklineProps) => {
-  if (values.length < 2) return <span className={styles.sparkline} aria-hidden />
+  if (values.length < 2) return <span className={styles.sparklineCell} aria-hidden />
 
   const w = 100
   const h = 20
@@ -29,14 +33,20 @@ export const Sparkline = ({ values, label }: SparklineProps) => {
   const trend = values[values.length - 1] >= values[0] ? 'rising' : 'falling'
 
   return (
-    <svg
-      className={styles.sparkline}
-      viewBox={`0 0 ${w} ${h}`}
-      preserveAspectRatio="none"
-      role="img"
-      aria-label={label ? `${label}, ${trend}` : trend}
-    >
-      <polyline points={points} fill="none" stroke="currentColor" strokeWidth={1.5} vectorEffect="non-scaling-stroke" />
-    </svg>
+    <span className={styles.sparklineCell}>
+      <span className={styles.sparklineRange} aria-hidden>
+        <sup className={styles.sparklineMax}>{formatIndex(max)}</sup>
+        <sub className={styles.sparklineMin}>{formatIndex(min)}</sub>
+      </span>
+      <svg
+        className={styles.sparkline}
+        viewBox={`0 0 ${w} ${h}`}
+        preserveAspectRatio="none"
+        role="img"
+        aria-label={label ? `${label}, ${trend}` : trend}
+      >
+        <polyline points={points} fill="none" stroke="currentColor" strokeWidth={1.5} vectorEffect="non-scaling-stroke" />
+      </svg>
+    </span>
   )
 }

--- a/src/app/structures/structures.module.css
+++ b/src/app/structures/structures.module.css
@@ -167,13 +167,43 @@
   font-variant-numeric: tabular-nums;
 }
 
+/* Sparkline cell: tiny min/max range column to the left, line chart on the
+ * right. The whole cell aligns to the right edge of the column so the chart
+ * stays flush against the current % to its right. */
+.sparklineCell {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  justify-self: end;
+}
+
+.sparklineRange {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: center;
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 8px;
+  line-height: 1;
+  color: var(--ink-faint);
+  height: 1lh;
+}
+
+.sparklineMax,
+.sparklineMin {
+  font-size: inherit;
+  line-height: 1;
+  vertical-align: baseline;
+  top: 0;
+  bottom: 0;
+}
+
 /* Sparkline sits between the label and percentage; sized to one line-height
  * tall so it slots into the existing row rhythm without changing it. */
 .sparkline {
   width: 100px;
   height: 1lh;
-  justify-self: end;
-  align-self: center;
   color: var(--ink-soft);
   overflow: visible;
 }


### PR DESCRIPTION
Each sparkline auto-scales to its own seven-day window, so the chart's vertical range had no absolute scale on it. This stacks the window's high (as a `<sup>`) and low (as a `<sub>`) just left of the sparkline so you can read the range without having to look up at the current %.

- New `.sparklineCell` wraps the min/max pair and the SVG in an `inline-flex` row, aligned to the right edge of the column.
- Range labels use the same mono font as the percentage, sized down to 8px and stacked with no leading so they fit inside one line-height.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVxCmNeDAG9XtpCnHYbYWr)_