### PR TITLE
Resolve system names from eve_name cache on /structures

### DIFF
--- a/src/app/systemNames.ts
+++ b/src/app/systemNames.ts
@@ -1,30 +1,21 @@
-// Resolve solar-system names from eve-build-calculator, mirroring the type
-// lookup in typeNames.ts. Unresolved ids are simply omitted so callers can fall
-// back to showing the raw id (never read the evesde SDE).
-const cache = new Map<number, Promise<string | null>>()
-
-const fetchOne = (systemID: number): Promise<string | null> =>
-  fetch(`https://sde.edencom.link/api/system/${systemID}`)
-    .then((res) => (res.ok ? res.json() : null))
-    .then((system: { name?: { en?: string } | string } | null) => {
-      if (!system) return null
-      return typeof system.name === 'string' ? system.name : (system.name?.en ?? null)
-    })
-    .catch(() => null)
-
-const lookup = (systemID: number): Promise<string | null> => {
-  const cached = cache.get(systemID)
-  if (cached) return cached
-  const promise = fetchOne(systemID)
-  cache.set(systemID, promise)
-  promise.then((name) => {
-    if (name === null) cache.delete(systemID)
-  })
-  return promise
-}
+// Resolve solar-system names from the local eve_name cache, which the structures
+// job keeps populated for every system we hold a structure in (and for systems
+// referenced by other resolved-name pulls). Unresolved ids are simply omitted
+// so callers can fall back to showing the raw id (never read the evesde SDE).
+import { createClient } from '@/utils/supabase/server'
 
 export const fetchSystemNames = async (systemIDs: Iterable<number>): Promise<Record<number, string>> => {
   const ids = Array.from(new Set([...systemIDs].filter((n) => Number.isFinite(n))))
-  const pairs = await Promise.all(ids.map(async (id) => [id, await lookup(id)] as const))
-  return Object.fromEntries(pairs.filter(([, name]) => name !== null) as [number, string][])
+  if (ids.length === 0) return {}
+  const supabase = await createClient()
+  const { data } = await supabase
+    .from('eve_name')
+    .select('id, name')
+    .eq('category', 'solar_system')
+    .in('id', ids)
+  const result: Record<number, string> = {}
+  for (const r of (data ?? []) as Array<{ id: number | string; name: string }>) {
+    result[Number(r.id)] = r.name
+  }
+  return result
 }

--- a/src/jobs/structures.js
+++ b/src/jobs/structures.js
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url'
 import { pullCorpWalletJournals } from '../corpWalletJournal.js'
 import { character as fetchCharacter, corpAssets, corpStructures, universeNames } from '../esi.js'
 import { pullIndustryIndexes } from '../industryIndexes.js'
-import { resolveCorpJournalNames } from '../resolveNames.js'
+import { resolveCorpJournalNames, resolveCorpStructureSystemNames } from '../resolveNames.js'
 import { resolveStructureNames } from '../structureNames.js'
 import { sudoSupabase } from '../supabase.js'
 import { refreshAccessToken } from '../tokenRefresh.js'
@@ -266,6 +266,14 @@ export const runStructures = async ({ characterIds } = {}) => {
     await resolveStructureNames()
   } catch (e) {
     console.error(`[structures] structure-name resolution FAILED name=${e?.name} message=${e?.message}`)
+  }
+
+  // Name the solar systems our corp structures sit in, so the structures page can
+  // label each tile's system instead of falling back to a raw system_id.
+  try {
+    await resolveCorpStructureSystemNames()
+  } catch (e) {
+    console.error(`[structures] system-name resolution FAILED name=${e?.name} message=${e?.message}`)
   }
 
   // Snapshot the industry cost indices for every system we have a structure in,

--- a/src/resolveNames.js
+++ b/src/resolveNames.js
@@ -67,3 +67,45 @@ export const resolveCorpJournalNames = async () => {
   const characterCount = rows.filter((r) => r.category === 'character').length
   console.log(`[names] upserted ${rows.length} name(s) (${characterCount} character)`)
 }
+
+// Cache (in eve_name) the name of every solar system we currently have a corp
+// structure in. Only resolves ids missing from eve_name, so steady-state runs do
+// nothing. The structures page reads eve_name to label each tile's system instead
+// of falling back to a raw system_id.
+export const resolveCorpStructureSystemNames = async () => {
+  const { data: structures, error: structuresErr } = await sudoSupabase.from('corp_structure').select('system_id')
+  if (structuresErr) throw structuresErr
+
+  const ids = new Set()
+  for (const r of structures ?? []) {
+    if (r.system_id != null) ids.add(Number(r.system_id))
+  }
+
+  const { data: known, error: knownErr } = await sudoSupabase
+    .from('eve_name')
+    .select('id')
+    .eq('category', 'solar_system')
+  if (knownErr) throw knownErr
+  for (const k of known ?? []) ids.delete(Number(k.id))
+
+  const toResolve = [...ids].filter((n) => Number.isFinite(n) && n > 0)
+  console.log(`[names] corp structure systems: ${toResolve.length} to resolve`)
+  if (toResolve.length === 0) return
+
+  const resolved = []
+  for (let i = 0; i < toResolve.length; i += BATCH_SIZE) {
+    const batch = toResolve.slice(i, i + BATCH_SIZE)
+    const names = await resolveBatch(batch)
+    resolved.push(...names)
+  }
+
+  if (resolved.length === 0) {
+    console.log('[names] no system names resolved')
+    return
+  }
+
+  const rows = resolved.map((n) => ({ id: n.id, name: n.name, category: n.category }))
+  const { error: upErr } = await sudoSupabase.from('eve_name').upsert(rows, { onConflict: 'id' })
+  if (upErr) throw upErr
+  console.log(`[names] upserted ${rows.length} system name(s)`)
+}


### PR DESCRIPTION
Structure tiles were showing `#30000740` instead of `EKPB-3` because `fetchSystemNames` called `sde.edencom.link/api/system/{id}` — an endpoint the SDE service doesn't expose (it only ships `/api/type/{id}`), so every lookup 404'd and the page fell back to the raw id.

## Fix

- **`src/app/systemNames.ts`** — read from the local `eve_name` cache via Supabase instead of the missing SDE endpoint. The signature is unchanged so the other pages that call it (`/assets`, `/structures/[id]`) pick up the fix automatically.
- **`src/resolveNames.js`** — add `resolveCorpStructureSystemNames`, which pulls every distinct `corp_structure.system_id` and resolves the missing ones through ESI `/universe/names/`, upserting into `eve_name` with `category = 'solar_system'`. Steady-state runs do nothing.
- **`src/jobs/structures.js`** — call the resolver at the end of each run, alongside the existing journal-party and structure-name resolvers.

Names will start populating at the next hourly structures run. Existing structures get backfilled the first time the new job runs; anything anchored after that is picked up on the next pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVxCmNeDAG9XtpCnHYbYWr)_