### PR TITLE
Wrap industry index sparklines to full-width row on mobile

### DIFF
--- a/src/app/structures/structures.module.css
+++ b/src/app/structures/structures.module.css
@@ -208,6 +208,43 @@
   overflow: visible;
 }
 
+/* On narrow phones the tiles are half-screen wide, so the 3-column label /
+ * sparkline / value layout overflows. Instead, stack label+value on the first
+ * row and let the sparkline take the full width on the second row. */
+@media (max-width: 639px) {
+  .indexes {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .indexRow {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0 8px;
+  }
+
+  /* Value jumps to row 1 col 2 (next to the label). */
+  .indexValue {
+    grid-row: 1;
+    grid-column: 2;
+  }
+
+  /* Sparkline wraps to row 2 and stretches to fill both columns. */
+  .sparklineCell {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    justify-self: stretch;
+    display: flex;
+  }
+
+  /* SVG grows to fill the flex container instead of the fixed 100px. */
+  .sparkline {
+    flex: 1;
+    width: auto;
+  }
+}
+
 .footer {
   display: grid;
   grid-template-columns: auto auto;


### PR DESCRIPTION
## Summary

- On phones (< 640 px), structure tiles are half-screen wide, so the 3-column label / sparkline / value row overflows the tile boundary
- Added a `@media (max-width: 639px)` block that switches each index row to a 2-row grid: label + current value on the first row, sparkline spanning full tile width on the second row
- The sparkline SVG now grows with `flex: 1` instead of the fixed 100 px, so it fills whatever space is available

## Test plan

- [ ] Open the Structures page on a narrow phone (portrait mode) — industry index rows should show label + % on one line, sparkline below spanning the full tile width with no overflow
- [ ] On desktop / tablet (≥ 640 px) the original 3-column inline layout is unchanged

https://claude.ai/code/session_01BsSQ56RoYZfDkQRMTAZMR5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BsSQ56RoYZfDkQRMTAZMR5)_