### PR TITLE
Extend index sparklines to 30 days with last-updated tooltip

### DIFF
--- a/src/app/structures/industryIndex.ts
+++ b/src/app/structures/industryIndex.ts
@@ -121,20 +121,27 @@ export const fetchLatestSystemIndexes = async (
 
 type HistoryRow = IndexRow & { recorded_at: string }
 
-// 7-day cost-index history per system per activity, in chronological order. Used
-// to draw sparklines next to each index. We pull the raw snapshots and bucket
-// them by recorded_at; a daily bucket would smooth them more but the structures
-// job runs a handful of times a day so the raw points already make a reasonable
-// shape.
+export type IndexSeries = {
+  values: number[]
+  // recorded_at of the most recent point in `values`, ISO 8601.
+  updatedAt: string
+}
+
+// 30-day cost-index history per system per activity, in chronological order.
+// Used to draw sparklines next to each index. We pull the raw snapshots and
+// keep them in `recorded_at` order; a daily bucket would smooth them more but
+// the structures job runs a handful of times a day so the raw points already
+// make a reasonable shape. Returning `updatedAt` alongside the values lets the
+// sparkline surface "last updated" in a tooltip without a second lookup.
 export const fetchSystemIndexHistory = async (
   supabase: Supabase,
   systemIds: Iterable<number>
-): Promise<Map<number, Map<Activity, number[]>>> => {
-  const result = new Map<number, Map<Activity, number[]>>()
+): Promise<Map<number, Map<Activity, IndexSeries>>> => {
+  const result = new Map<number, Map<Activity, IndexSeries>>()
   const ids = [...new Set([...systemIds].filter((n) => Number.isFinite(n)))]
   if (ids.length === 0) return result
 
-  const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
+  const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
   const { data: rows } = await supabase
     .from('industry_system_index')
     .select('system_id, activity, cost_index, recorded_at')
@@ -154,10 +161,12 @@ export const fetchSystemIndexHistory = async (
     const activity = r.activity as Activity
     let series = byActivity.get(activity)
     if (!series) {
-      series = []
+      series = { values: [], updatedAt: r.recorded_at }
       byActivity.set(activity, series)
     }
-    series.push(cost)
+    series.values.push(cost)
+    // Rows arrive in ascending recorded_at, so the last write wins as the latest.
+    series.updatedAt = r.recorded_at
   }
   return result
 }

--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -295,11 +295,15 @@ const StructuresPage = async () => {
                       <ul className={styles.indexes}>
                         {indexActivities.map((activity) => {
                           const cost = systemIndexes?.get(activity)
-                          const history = systemHistory?.get(activity) ?? []
+                          const series = systemHistory?.get(activity)
                           return (
                             <li key={`idx-${s.structure_id}-${activity}`} className={styles.indexRow}>
                               <span className={styles.indexLabel}>{INDEX_ACTIVITY_LABELS[activity]}</span>
-                              <Sparkline values={history} label={INDEX_ACTIVITY_LABELS[activity]} />
+                              <Sparkline
+                                values={series?.values ?? []}
+                                updatedAt={series?.updatedAt}
+                                label={INDEX_ACTIVITY_LABELS[activity]}
+                              />
                               <span className={styles.indexValue}>{cost != null ? formatIndex(cost) : '—'}</span>
                             </li>
                           )

--- a/src/app/structures/sparkline.tsx
+++ b/src/app/structures/sparkline.tsx
@@ -4,17 +4,40 @@ import styles from './structures.module.css'
 type SparklineProps = {
   values: number[]
   label?: string
+  // ISO 8601 of the most recent data point — surfaced in the hover tooltip.
+  updatedAt?: string
 }
 
-// Tiny line chart for the 7-day cost-index history. The SVG is sized in CSS to
-// 100px wide and one line-height tall; the viewBox uses a fixed coordinate
+// Format an ISO timestamp for the title-attribute tooltip. Matches the
+// YYYY-MM-DD HH:MM, 24-hour format the DateTime component uses elsewhere so
+// timestamps read the same in chips and tooltips.
+const tooltipFormatter = new Intl.DateTimeFormat('sv-SE', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+})
+
+const formatUpdatedAt = (iso?: string): string | undefined => {
+  if (!iso) return undefined
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return undefined
+  return `Last updated ${tooltipFormatter.format(d)}`
+}
+
+// Tiny line chart for the 30-day cost-index history. The SVG is sized in CSS
+// to 100px wide and one line-height tall; the viewBox uses a fixed coordinate
 // space and the path scales (preserveAspectRatio="none") so the line stretches
 // to whatever line height the surrounding text resolves to. To the left of the
 // chart we stack the range it covers — max as a superscript on top, min as a
 // subscript on the bottom — so the reader can read the absolute scale without
 // having to look up at the current % to know roughly where the line sits.
-export const Sparkline = ({ values, label }: SparklineProps) => {
-  if (values.length < 2) return <span className={styles.sparklineCell} aria-hidden />
+export const Sparkline = ({ values, label, updatedAt }: SparklineProps) => {
+  const tooltip = formatUpdatedAt(updatedAt)
+
+  if (values.length < 2) return <span className={styles.sparklineCell} title={tooltip} aria-hidden />
 
   const w = 100
   const h = 20
@@ -33,7 +56,7 @@ export const Sparkline = ({ values, label }: SparklineProps) => {
   const trend = values[values.length - 1] >= values[0] ? 'rising' : 'falling'
 
   return (
-    <span className={styles.sparklineCell}>
+    <span className={styles.sparklineCell} title={tooltip}>
       <span className={styles.sparklineRange} aria-hidden>
         <sup className={styles.sparklineMax}>{formatIndex(max)}</sup>
         <sub className={styles.sparklineMin}>{formatIndex(min)}</sub>


### PR DESCRIPTION
## Changes

- **30-day window** — `fetchSystemIndexHistory` now pulls 30 days of `industry_system_index` snapshots instead of 7, so the sparkline shape shows monthly drift rather than a noisy week.
- **Last-updated tooltip** — the fetcher now returns `{ values, updatedAt }` per series (the latest `recorded_at` it saw), and the `Sparkline` carries it as a native `title="Last updated YYYY-MM-DD HH:MM"` tooltip on the sparkline cell so hovering surfaces when the chart's most recent point was captured.

Same `Intl.DateTimeFormat('sv-SE', ...)` config the `DateTime` component uses elsewhere, so timestamps read the same in tooltips as in chips.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVxCmNeDAG9XtpCnHYbYWr)_