### PR TITLE
Add Market overview tiles with a page-level time window

### DIFF
--- a/src/app/market/aggregate.ts
+++ b/src/app/market/aggregate.ts
@@ -1,0 +1,43 @@
+import type { Sale } from './recentSales'
+
+// Sale value in raw ISK. "Total sales" everywhere on this page means summed ISK
+// turnover (unit price × quantity), not transaction count or unit quantity.
+const value = (s: Sale) => Number(s.unit_price) * Number(s.quantity)
+
+export type TypeTotal = { typeId: number; total: number }
+
+// Top-N type_ids by summed ISK value of sales whose date falls in [start, end).
+export const topTypesByValue = (sales: Sale[], start: number, end: number, limit: number): TypeTotal[] => {
+  const totals = new Map<number, number>()
+  for (const s of sales) {
+    const t = Date.parse(s.date)
+    if (t < start || t >= end) continue
+    const typeId = Number(s.type_id)
+    totals.set(typeId, (totals.get(typeId) ?? 0) + value(s))
+  }
+  return [...totals.entries()]
+    .map(([typeId, total]) => ({ typeId, total }))
+    .sort((a, b) => b.total - a.total)
+    .slice(0, limit)
+}
+
+export type Bucket = { start: number; end: number; total: number }
+
+// Bucketed ISK totals across [start, end) in fixed-width slices. The window
+// always divides evenly by the bucket width (see WINDOW_OPTIONS), so the
+// right-most bucket ends exactly at `end` (= now).
+export const bucketSales = (sales: Sale[], start: number, end: number, bucketMs: number): Bucket[] => {
+  const count = Math.max(1, Math.round((end - start) / bucketMs))
+  const buckets: Bucket[] = Array.from({ length: count }, (_, i) => ({
+    start: start + i * bucketMs,
+    end: start + (i + 1) * bucketMs,
+    total: 0,
+  }))
+  for (const s of sales) {
+    const t = Date.parse(s.date)
+    if (t < start || t >= end) continue
+    const idx = Math.min(count - 1, Math.floor((t - start) / bucketMs))
+    buckets[idx].total += value(s)
+  }
+  return buckets
+}

--- a/src/app/market/market.module.css
+++ b/src/app/market/market.module.css
@@ -1,3 +1,168 @@
+/* Page title row: "Market" on the left, the window dropdown floated right. It
+ * governs both the overview tiles and the Recent Sales table below. */
+.pageHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12pt;
+}
+
+.pageHeader h1 {
+  margin: 0;
+}
+
+.windowSelect {
+  font-size: 10pt;
+  color: var(--ink-soft);
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Four equal columns: the "Top sellers" tile spans two (50%), the bar chart and
+ * the prior-period tile take one each (25%). Collapses to a single column on
+ * narrow screens. */
+.overview {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12pt;
+  margin: 16pt 0;
+}
+
+.tileWide {
+  grid-column: span 2;
+}
+
+@media (max-width: 720px) {
+  .overview {
+    grid-template-columns: 1fr;
+  }
+
+  .tileWide {
+    grid-column: auto;
+  }
+}
+
+.tile {
+  display: flex;
+  flex-direction: column;
+  gap: 8pt;
+  padding: 12pt;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper-raised);
+  min-width: 0;
+}
+
+.tileHead {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8pt;
+}
+
+.tileTitle {
+  margin: 0;
+  font-size: 13pt;
+}
+
+.tileSub {
+  font-size: 9pt;
+  color: var(--ink-faint);
+  white-space: nowrap;
+}
+
+/* Ranked "rank · name · value" rows. Names wrap rather than truncate so long
+ * EVE item names stay legible in the narrow 25% tiles. */
+.topList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.topRow {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: baseline;
+  gap: 8pt;
+  padding: 3pt 0;
+  border-bottom: 1px solid var(--line-soft);
+  font-size: 10pt;
+}
+
+.topRow:last-child {
+  border-bottom: none;
+}
+
+.topRank {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 9pt;
+  color: var(--ink-faint);
+  text-align: right;
+  min-width: 1.4em;
+}
+
+.topName {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.topValue {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  color: var(--ink-soft);
+}
+
+.empty {
+  margin: 0;
+  font-size: 10pt;
+  color: var(--ink-faint);
+}
+
+/* Total-sales bar chart. Bars fill the tile height (stretching to match the
+ * neighbouring list tiles) and grow up from a shared baseline. */
+.bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 1px;
+  flex: 1 1 auto;
+  min-height: 160px;
+  width: 100%;
+}
+
+.barCol {
+  display: flex;
+  align-items: flex-end;
+  flex: 1 1 0;
+  min-width: 0;
+  height: 100%;
+}
+
+.bar {
+  width: 100%;
+  min-height: 0;
+  background: var(--accent);
+  border-radius: 1px 1px 0 0;
+  transition: height 0.12s ease;
+}
+
+.barCol:hover .bar {
+  background: var(--accent-strong);
+}
+
 .salesHeader {
   display: flex;
   align-items: center;

--- a/src/app/market/marketOverview.tsx
+++ b/src/app/market/marketOverview.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import { useMemo } from 'react'
+
+import { formatMisk, formatMiskValue } from '../isk'
+import { TypeName } from '../typeName'
+import { bucketSales, topTypesByValue, type Bucket, type TypeTotal } from './aggregate'
+import type { Sale } from './recentSales'
+import { windowOption } from './windows'
+import styles from './market.module.css'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const HOUR_MS = 60 * 60 * 1000
+const TOP_N = 16
+
+type MarketOverviewProps = {
+  // Server-anchored "now" (epoch ms) so window math agrees across SSR/hydration.
+  now: number
+  sales: Sale[]
+  windowDays: number
+  typeNamesPromise: Promise<Record<number, string>>
+}
+
+// A titled card. The "Top sellers" tile is wide (spans two of the four columns,
+// = 50%); the bar chart and the prior-period tile are one column each (= 25%).
+const TopItems = ({
+  title,
+  subtitle,
+  items,
+  typeNamesPromise,
+  wide = false,
+}: {
+  title: string
+  subtitle: string
+  items: TypeTotal[]
+  typeNamesPromise: Promise<Record<number, string>>
+  wide?: boolean
+}) => (
+  <div className={wide ? `${styles.tile} ${styles.tileWide}` : styles.tile}>
+    <div className={styles.tileHead}>
+      <h2 className={styles.tileTitle}>{title}</h2>
+      <span className={styles.tileSub}>{subtitle}</span>
+    </div>
+    {items.length > 0 ? (
+      <ol className={styles.topList}>
+        {items.map((it, i) => (
+          <li key={it.typeId} className={styles.topRow}>
+            <span className={styles.topRank}>{i + 1}</span>
+            <span className={styles.topName}>
+              <TypeName id={it.typeId} promise={typeNamesPromise} />
+            </span>
+            <span className={styles.topValue} title={formatMisk(it.total)}>
+              {formatMiskValue(it.total)}
+            </span>
+          </li>
+        ))}
+      </ol>
+    ) : (
+      <p className={styles.empty}>No sales in this period.</p>
+    )}
+  </div>
+)
+
+const granularityLabel = (bucketHours: number) =>
+  bucketHours === 1 ? 'hourly' : bucketHours < 24 ? `${bucketHours}-hour` : 'daily'
+
+const bucketTip = (b: Bucket, bucketHours: number) => {
+  const start = new Date(b.start)
+  // Sub-day buckets need the hour to disambiguate; daily buckets just the date.
+  const when =
+    bucketHours < 24
+      ? start.toISOString().slice(0, 16).replace('T', ' ')
+      : start.toISOString().slice(0, 10)
+  return `${when} — ${formatMisk(b.total)}`
+}
+
+const SalesBars = ({ buckets, bucketHours }: { buckets: Bucket[]; bucketHours: number }) => {
+  const max = Math.max(1, ...buckets.map((b) => b.total))
+  return (
+    <div className={styles.tile}>
+      <div className={styles.tileHead}>
+        <h2 className={styles.tileTitle}>Sales over time</h2>
+        <span className={styles.tileSub}>{granularityLabel(bucketHours)}</span>
+      </div>
+      <div className={styles.bars} role="img" aria-label={`Total sales per ${granularityLabel(bucketHours)} period`}>
+        {buckets.map((b) => (
+          <div key={b.start} className={styles.barCol} title={bucketTip(b, bucketHours)}>
+            <div className={styles.bar} style={{ height: `${(b.total / max) * 100}%` }} />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export const MarketOverview = ({ now, sales, windowDays, typeNamesPromise }: MarketOverviewProps) => {
+  const opt = windowOption(windowDays)
+
+  const { current, previous, buckets } = useMemo(() => {
+    const currentStart = now - windowDays * DAY_MS
+    const previousStart = now - 2 * windowDays * DAY_MS
+    return {
+      current: topTypesByValue(sales, currentStart, now, TOP_N),
+      previous: topTypesByValue(sales, previousStart, currentStart, TOP_N),
+      buckets: bucketSales(sales, currentStart, now, opt.bucketHours * HOUR_MS),
+    }
+  }, [sales, now, windowDays, opt.bucketHours])
+
+  return (
+    <section className={styles.overview}>
+      <TopItems
+        wide
+        title="Top sellers"
+        subtitle={`last ${opt.label}`}
+        items={current}
+        typeNamesPromise={typeNamesPromise}
+      />
+      <SalesBars buckets={buckets} bucketHours={opt.bucketHours} />
+      <TopItems
+        title="Previous period"
+        subtitle={`prior ${opt.label}`}
+        items={previous}
+        typeNamesPromise={typeNamesPromise}
+      />
+    </section>
+  )
+}

--- a/src/app/market/marketView.tsx
+++ b/src/app/market/marketView.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { MarketOverview } from './marketOverview'
+import { RecentSales, type Sale } from './recentSales'
+import { usePersist } from './usePersist'
+import { DEFAULT_WINDOW_DAYS, WINDOW_OPTIONS, WINDOW_STORAGE_KEY } from './windows'
+import styles from './market.module.css'
+
+type Character = {
+  id: string
+  name: string
+}
+
+type MarketViewProps = {
+  // Server-anchored "now" (ISO) so every window calculation is stable across the
+  // SSR/hydration boundary instead of drifting with each client render.
+  now: string
+  sales: Sale[]
+  characters: Character[]
+  typeNamesPromise: Promise<Record<number, string>>
+}
+
+// Owns the page-level time window. The dropdown floats to the right of the
+// "Market" title and re-scopes both the overview tiles and the Recent Sales
+// table below.
+export const MarketView = ({ now, sales, characters, typeNamesPromise }: MarketViewProps) => {
+  const nowMs = Date.parse(now)
+
+  const [windowDays, setWindowDays] = usePersist<number>(WINDOW_STORAGE_KEY, DEFAULT_WINDOW_DAYS, (raw) => {
+    const parsed = Number(raw)
+    return WINDOW_OPTIONS.some((o) => o.days === parsed) ? parsed : undefined
+  })
+
+  return (
+    <>
+      <div className={styles.pageHeader}>
+        <h1>Market</h1>
+        <label className={styles.windowSelect}>
+          <span className={styles.srOnly}>Window</span>
+          <select value={windowDays} onChange={(e) => setWindowDays(Number(e.target.value))}>
+            {WINDOW_OPTIONS.map((o) => (
+              <option key={o.days} value={o.days}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <MarketOverview now={nowMs} sales={sales} windowDays={windowDays} typeNamesPromise={typeNamesPromise} />
+      <RecentSales
+        now={nowMs}
+        sales={sales}
+        characters={characters}
+        typeNamesPromise={typeNamesPromise}
+        windowDays={windowDays}
+      />
+    </>
+  )
+}

--- a/src/app/market/page.tsx
+++ b/src/app/market/page.tsx
@@ -2,7 +2,11 @@ import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
 import { fetchTypeNames } from '../typeNames'
-import { RecentSales } from './recentSales'
+import { MarketView } from './marketView'
+import type { Sale } from './recentSales'
+import { LOOKBACK_DAYS } from './windows'
+
+const PAGE_SIZE = 1000
 
 const MarketPage = async () => {
   const supabase = await createClient()
@@ -13,24 +17,37 @@ const MarketPage = async () => {
   }
 
   const { data: characters } = await supabase.from('registration').select('id, name')
-
-  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
-  const { data: sales } = await supabase
-    .from('market_transaction')
-    .select('transaction_id, character_id, date, type_id, quantity, unit_price, seen_at')
-    .eq('is_buy', false)
-    .gte('date', sevenDaysAgo)
-    .order('date', { ascending: false })
-
   const sortedCharacters = [...(characters ?? [])].sort((a, b) => a.name.localeCompare(b.name))
 
-  const typeNamesPromise = fetchTypeNames((sales ?? []).map((s) => Number(s.type_id)))
+  const now = new Date()
+  const since = new Date(now.getTime() - LOOKBACK_DAYS * 24 * 60 * 60 * 1000).toISOString()
+
+  // Sales over the whole lookback span — the overview's prior-period tile reaches
+  // back two windows past `now`. PostgREST caps a response at max_rows (1000), so
+  // page through until a short page signals the end (cf. src/jobs/assets.js).
+  const sales: Sale[] = []
+  for (let from = 0; ; from += PAGE_SIZE) {
+    const { data: page, error } = await supabase
+      .from('market_transaction')
+      .select('transaction_id, character_id, date, type_id, quantity, unit_price, seen_at')
+      .eq('is_buy', false)
+      .gte('date', since)
+      .order('date', { ascending: false })
+      .range(from, from + PAGE_SIZE - 1)
+    if (error || !page || page.length === 0) break
+    sales.push(...(page as Sale[]))
+    if (page.length < PAGE_SIZE) break
+  }
+
+  const typeNamesPromise = fetchTypeNames(sales.map((s) => Number(s.type_id)))
 
   return (
-    <>
-      <h1>Market</h1>
-      <RecentSales sales={sales ?? []} characters={sortedCharacters} typeNamesPromise={typeNamesPromise} />
-    </>
+    <MarketView
+      now={now.toISOString()}
+      sales={sales}
+      characters={sortedCharacters}
+      typeNamesPromise={typeNamesPromise}
+    />
   )
 }
 export default MarketPage

--- a/src/app/market/recentSales.tsx
+++ b/src/app/market/recentSales.tsx
@@ -23,10 +23,16 @@ type Character = {
 }
 
 type RecentSalesProps = {
+  // Server-anchored "now" (epoch ms) shared with the overview, so the table and
+  // the tiles cover exactly the same window.
+  now: number
   sales: Sale[]
   characters: Character[]
   typeNamesPromise: Promise<Record<number, string>>
+  windowDays: number
 }
+
+const DAY_MS = 24 * 60 * 60 * 1000
 
 const THRESHOLDS: Array<{ label: string; value: number }> = [
   { label: 'All', value: 0 },
@@ -40,8 +46,10 @@ const THRESHOLD_STORAGE_KEY = 'market.recentSales.threshold'
 const CHARACTER_STORAGE_KEY = 'market.recentSales.characterId'
 const ALL_CHARACTERS = ''
 
-export const RecentSales = ({ sales, characters, typeNamesPromise }: RecentSalesProps) => {
+export const RecentSales = ({ now, sales, characters, typeNamesPromise, windowDays }: RecentSalesProps) => {
   const characterName: Record<string, string> = Object.fromEntries(characters.map((c) => [c.id, c.name]))
+  const windowStart = now - windowDays * DAY_MS
+  const windowLabel = `${windowDays} day${windowDays === 1 ? '' : 's'}`
 
   const [threshold, setThreshold] = usePersist(THRESHOLD_STORAGE_KEY, 0, (raw) => {
     const parsed = Number(raw)
@@ -54,6 +62,7 @@ export const RecentSales = ({ sales, characters, typeNamesPromise }: RecentSales
 
   const filtered = sales.filter(
     (s) =>
+      Date.parse(s.date) >= windowStart &&
       Number(s.unit_price) * Number(s.quantity) >= threshold &&
       (characterId === ALL_CHARACTERS || s.character_id === characterId)
   )
@@ -61,7 +70,7 @@ export const RecentSales = ({ sales, characters, typeNamesPromise }: RecentSales
   return (
     <section>
       <div className={styles.salesHeader}>
-        <h2>Recent Sales (last 7 days)</h2>
+        <h2>Recent Sales (last {windowLabel})</h2>
         <div className={styles.salesFilters}>
           <label className={styles.salesFilter}>
             Character:&nbsp;

--- a/src/app/market/windows.ts
+++ b/src/app/market/windows.ts
@@ -1,0 +1,34 @@
+// The Market page's time window. A single page-level control (see MarketView)
+// drives every tile and the Recent Sales table off this. The chosen window also
+// dictates the bar-chart bucket granularity:
+//   1 day        → hourly bars (24)
+//   3 days       → 6-hour bars (12)
+//   7/30/90 days → daily bars (7/30/90)
+export type WindowOption = {
+  label: string
+  days: number
+  // Width of each bar-chart bucket, in hours.
+  bucketHours: number
+}
+
+export const WINDOW_OPTIONS: WindowOption[] = [
+  { label: '1 day', days: 1, bucketHours: 1 },
+  { label: '3 days', days: 3, bucketHours: 6 },
+  { label: '7 days', days: 7, bucketHours: 24 },
+  { label: '30 days', days: 30, bucketHours: 24 },
+  { label: '90 days', days: 90, bucketHours: 24 },
+]
+
+export const DEFAULT_WINDOW_DAYS = 7
+export const WINDOW_STORAGE_KEY = 'market.window.days'
+
+// The longest span we ever need rows for: the selected window plus an equal
+// preceding window (the right-most tile compares against the prior period), so
+// twice the largest option.
+export const MAX_WINDOW_DAYS = Math.max(...WINDOW_OPTIONS.map((o) => o.days))
+export const LOOKBACK_DAYS = MAX_WINDOW_DAYS * 2
+
+const fallback = WINDOW_OPTIONS.find((o) => o.days === DEFAULT_WINDOW_DAYS) ?? WINDOW_OPTIONS[0]
+
+export const windowOption = (days: number): WindowOption =>
+  WINDOW_OPTIONS.find((o) => o.days === days) ?? fallback


### PR DESCRIPTION
## What

Adds a sales overview to the top of the **Market** tab, above Recent Sales, driven by a single page-level time-window control.

### Window dropdown
A `1 / 3 / 7 / 30 / 90 days` dropdown floats to the right of the **Market** title and re-scopes the whole page — both the new overview tiles and the existing Recent Sales table (its heading updates to match, e.g. "Recent Sales (last 30 days)"). Selection persists to `localStorage`. Default is 7 days, so default behavior is unchanged.

### Four-column overview grid
| Tile | Width | Contents |
|---|---|---|
| **Top sellers** | 50% (spans 2 cols) | Top 16 items in the current window, ranked by total ISK turnover |
| **Sales over time** | 25% | Bar chart of total ISK sales, bucketed by the window: `1d` → hourly, `3d` → 6-hour, `7/30/90d` → daily bars |
| **Previous period** | 25% | Top 16 items of the equal-length *preceding* window, ranked by that window's ISK turnover |

Collapses to a single column on narrow screens.

## How

- `page.tsx` now fetches sales over a **two-window lookback** (180 days = 2 × the 90-day max, so the prior-period tile has data), **paginating past the PostgREST `max_rows` (1000) cap** the same way `src/jobs/assets.js` does.
- A server-anchored `now` timestamp is threaded through so all window math is stable across the SSR/hydration boundary.
- Aggregation is done client-side (`aggregate.ts`) so switching the window is instant — no refetch.
- New files: `windows.ts` (window options + bucket config), `aggregate.ts` (pure top-N / bucketing helpers), `marketView.tsx` (window state + header), `marketOverview.tsx` (the tiles).

## Interpretation notes
- "Total sales" / "sales volume" → **ISK turnover** (`unit_price × quantity`), consistent across all tiles and matching the app's mISK convention.
- "Control the entire dashboard" → the window also re-scopes Recent Sales. Easy to limit to just the overview if that's preferred.

## Verification
- `npx tsc --noEmit` — clean
- `npm run lint` — clean (only a pre-existing unrelated warning)
- `npm run build` — succeeds; `/market` compiles as a dynamic route

https://claude.ai/code/session_01SirPTxSz3K8ewwVLFbMJ3v

---
_Generated by [Claude Code](https://claude.ai/code/session_01SirPTxSz3K8ewwVLFbMJ3v)_