### PR TITLE
Union corp wallet market sales into the Market tab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ EVE Online hangar/wallet/industry tracker. Package name `edencom-link` (private)
 ## Layout
 
 - `src/app/` — Next.js App Router. Page routes: `account/`, `assets/`, `character/`, `industry/`, `market/`, `structures/`, plus `theme/`, `layout/` (Header/Footer), `private/`. Shared helpers at top level: `typeNames.ts`/`typeName.tsx`, `systemNames.ts`, `stationNames.ts`, `isk.ts`, `DateTime.tsx`.
-- `src/` (Node cron/scripts): `esi.js` (ESI API wrapper), `supabase.js` (clients — anon + `sudoSupabase` service role that bypasses RLS), `corpWalletJournal.js`, `resolveNames.js`, `structureNames.js`, `tokenRefresh.js`/`refresh.js`, `proxy.ts`, `utils/`. The scheduled job entry points live under `src/jobs/`: `hourly.js`, `daily.js`, `assets.js`, `structures.js` — each exports a `run*` function (callable from the Vercel queue consumer) and self-runs as a CLI when invoked directly (`node src/jobs/<job>.js`).
+- `src/` (Node cron/scripts): `esi.js` (ESI API wrapper), `supabase.js` (clients — anon + `sudoSupabase` service role that bypasses RLS), `corpWalletJournal.js`, `corpMarketTransactions.js`, `resolveNames.js`, `structureNames.js`, `tokenRefresh.js`/`refresh.js`, `proxy.ts`, `utils/`. The scheduled job entry points live under `src/jobs/`: `hourly.js`, `daily.js`, `assets.js`, `structures.js` — each exports a `run*` function (callable from the Vercel queue consumer) and self-runs as a CLI when invoked directly (`node src/jobs/<job>.js`).
 - `schema.sql` — the single source of truth for the Supabase schema (in the default `public` schema). It's a full reset: it DROPs the app's tables and recreates them, so re-running wipes data — never run it against a database with data you want to keep. To change the schema, edit this file (so a fresh reset stays correct) **and** add a non-destructive incremental migration under `supabase/migrations/` (Supabase CLI format, applied with `supabase db push`) so the change can be rolled out to existing databases without wiping data.
 - `.github/workflows/` — `hourly.yml`, `daily.yml`, `assets.yml`, `structures.yml`, `heartbeat.yml` (each a scheduled cron + manual dispatch); `migrate.yml` (applies Supabase migrations on push to `main`).
 
@@ -61,6 +61,7 @@ All functions take `(characterId, accessToken)` unless noted. Returns raw ESI re
 - `corpStructures(corpId, token)` — corporation Upwell structures
 - `corpAssets(corpId, token)` — corporation assets
 - `corpWalletJournal(corpId, division, token)` — corp wallet journal by division
+- `corpTransactions(token, corpId, division)` — corp wallet market transactions for one division
 - `assetNames(characterId, token, itemIds[])` — player-assigned names for specific item IDs
 - `industrySystems()` — public industry system cost indices (no auth)
 - `universeNames(ids[])` — bulk id→name resolution (no auth)
@@ -85,7 +86,11 @@ All functions take `(characterId, accessToken)` unless noted. Returns raw ESI re
 ### `src/resolveNames.js`
 - `resolveBatch(ids[])` — bulk ESI `universeNames` with bisect-on-error fallback; upserts to `eve_name`
 - `resolveCorpJournalNames(entries[])` — extract and resolve first/second party IDs from journal rows
+- `resolveCorpNames(corporationIds[])` — resolve+cache corp names (for labelling corp market sales)
 - `resolveCorpStructureSystemNames(structures[])` — resolve system IDs for structures
+
+### `src/corpMarketTransactions.js`
+- `pullCorpMarketTransactions({ access_token, corporation_id, ... })` — fetch all 7 divisions' market transactions, upsert to `corp_market_transaction`
 
 ### `src/structureNames.js`
 - `resolveStructureNames(structureIds[])` — fetch structure info from ESI using a scoped token, upsert to `structure` table
@@ -158,6 +163,7 @@ Each job exports its `run*()` function (consumed by Vercel queue at `/api/queue/
 | `corp_structure` | Corp Upwell structures | `structure_id`, `corporation_id`, `type_id`, `system_id`, `name`, `state`, `fuel_expires`, `services` (jsonb) |
 | `corp_structure_rig` | Rigs on structures | `structure_id`, `location_flag`, `type_id`, `corporation_id` |
 | `corp_wallet_journal` | Corp transaction log | `corporation_id`, `division`, `entry_id`, `ref_type`, `amount`, `date` |
+| `corp_market_transaction` | Corp market buys/sells (unioned into market page) | `transaction_id`, `corporation_id`, `division`, `type_id`, `unit_price`, `quantity`, `is_buy`, `date` |
 | `industry_system_index` | Cost index history (append-only) | `system_id`, `activity`, `cost_index`, `recorded_at` |
 | `eve_name` | Cached id→name | `id` (bigint PK), `name`, `category` |
 | `character_corp` | Character→Corp mapping | `character_id`, `corporation_id` |

--- a/schema.sql
+++ b/schema.sql
@@ -27,6 +27,7 @@ drop table if exists public.industry_system_index cascade;
 drop table if exists public.corp_structure_rig   cascade;
 drop table if exists public.corp_structure       cascade;
 drop table if exists public.corp_wallet_journal  cascade;
+drop table if exists public.corp_market_transaction cascade;
 drop table if exists public.eve_name             cascade;
 drop table if exists public.character_corp       cascade;
 drop table if exists public.structure            cascade;
@@ -656,6 +657,46 @@ create policy "Users read journal for own corps"
 
 grant select on public.corp_wallet_journal to authenticated;
 grant all    on public.corp_wallet_journal to service_role;
+
+-- ── corp_market_transaction ───────────────────────────────────────────────
+-- Market transactions (buys and sells) pulled from corporation wallet divisions
+-- (esi-wallet.read_corporation_wallets.v1), unioned into the market page beside
+-- the per-character market_transaction rows. `character_id` is the registration
+-- whose token scanned the row; RLS scopes reads to that character's owner, so a
+-- corp transaction is only visible to the player who pulled it (like personal
+-- transactions). transaction_id is globally unique in EVE, so it keys the table
+-- and dedupes across divisions and re-scans (first scanner wins attribution).
+-- Corp transactions have no is_personal flag.
+create table public.corp_market_transaction (
+  transaction_id bigint primary key,
+  character_id uuid not null references public.registration(id) on delete cascade,
+  corporation_id bigint not null,
+  division smallint not null,
+  date timestamptz not null,
+  type_id bigint not null,
+  quantity bigint not null,
+  unit_price numeric(20, 2) not null,
+  is_buy boolean not null,
+  client_id bigint not null,
+  location_id bigint not null,
+  journal_ref_id bigint not null,
+  seen_at timestamptz not null default now()
+);
+create index corp_market_transaction_character_id_date_idx on public.corp_market_transaction (character_id, date desc);
+
+alter table public.corp_market_transaction enable row level security;
+create policy "Users read own corp transactions"
+  on public.corp_market_transaction
+  for select
+  to authenticated
+  using (
+    character_id in (
+      select id from public.registration where user_id = (select auth.uid())
+    )
+  );
+
+grant select on public.corp_market_transaction to authenticated;
+grant all    on public.corp_market_transaction to service_role;
 
 -- ── eve_name ──────────────────────────────────────────────────────────────
 -- Cache of resolved EVE id -> name/category lookups.

--- a/src/app/market/marketView.tsx
+++ b/src/app/market/marketView.tsx
@@ -17,13 +17,15 @@ type MarketViewProps = {
   now: string
   sales: Sale[]
   characters: Character[]
+  // corporation_id → name, for labelling corp sales in the Recent Sales table.
+  corpNames: Record<number, string>
   typeNamesPromise: Promise<Record<number, string>>
 }
 
 // Owns the page-level time window. The dropdown floats to the right of the
 // "Market" title and re-scopes both the overview tiles and the Recent Sales
 // table below.
-export const MarketView = ({ now, sales, characters, typeNamesPromise }: MarketViewProps) => {
+export const MarketView = ({ now, sales, characters, corpNames, typeNamesPromise }: MarketViewProps) => {
   const nowMs = Date.parse(now)
 
   const [windowDays, setWindowDays] = usePersist<number>(WINDOW_STORAGE_KEY, DEFAULT_WINDOW_DAYS, (raw) => {
@@ -51,6 +53,7 @@ export const MarketView = ({ now, sales, characters, typeNamesPromise }: MarketV
         now={nowMs}
         sales={sales}
         characters={characters}
+        corpNames={corpNames}
         typeNamesPromise={typeNamesPromise}
         windowDays={windowDays}
       />

--- a/src/app/market/page.tsx
+++ b/src/app/market/page.tsx
@@ -8,6 +8,31 @@ import { LOOKBACK_DAYS } from './windows'
 
 const PAGE_SIZE = 1000
 
+// Page through a select past PostgREST's max_rows (1000) cap until a short page
+// signals the end (cf. src/jobs/assets.js).
+const fetchAllRows = async <T,>(
+  build: (from: number, to: number) => PromiseLike<{ data: T[] | null; error: unknown }>
+): Promise<T[]> => {
+  const rows: T[] = []
+  for (let from = 0; ; from += PAGE_SIZE) {
+    const { data, error } = await build(from, from + PAGE_SIZE - 1)
+    if (error || !data || data.length === 0) break
+    rows.push(...data)
+    if (data.length < PAGE_SIZE) break
+  }
+  return rows
+}
+
+type CorpRow = {
+  transaction_id: number | string
+  corporation_id: number | string
+  date: string
+  type_id: number | string
+  quantity: number | string
+  unit_price: number | string
+  seen_at: string
+}
+
 const MarketPage = async () => {
   const supabase = await createClient()
 
@@ -22,21 +47,51 @@ const MarketPage = async () => {
   const now = new Date()
   const since = new Date(now.getTime() - LOOKBACK_DAYS * 24 * 60 * 60 * 1000).toISOString()
 
-  // Sales over the whole lookback span — the overview's prior-period tile reaches
-  // back two windows past `now`. PostgREST caps a response at max_rows (1000), so
-  // page through until a short page signals the end (cf. src/jobs/assets.js).
-  const sales: Sale[] = []
-  for (let from = 0; ; from += PAGE_SIZE) {
-    const { data: page, error } = await supabase
+  // The overview's prior-period tile reaches back two windows past `now`, so fetch
+  // the whole lookback span. Personal and corp sales live in separate tables (corp
+  // transactions have no owning character); RLS scopes each to what the user may
+  // see, and transaction_ids never collide across the two, so the union is a plain
+  // concatenation.
+  const personal = await fetchAllRows<Sale>((from, to) =>
+    supabase
       .from('market_transaction')
       .select('transaction_id, character_id, date, type_id, quantity, unit_price, seen_at')
       .eq('is_buy', false)
       .gte('date', since)
       .order('date', { ascending: false })
-      .range(from, from + PAGE_SIZE - 1)
-    if (error || !page || page.length === 0) break
-    sales.push(...(page as Sale[]))
-    if (page.length < PAGE_SIZE) break
+      .range(from, to)
+  )
+
+  const corpRows = await fetchAllRows<CorpRow>((from, to) =>
+    supabase
+      .from('corp_market_transaction')
+      .select('transaction_id, corporation_id, date, type_id, quantity, unit_price, seen_at')
+      .eq('is_buy', false)
+      .gte('date', since)
+      .order('date', { ascending: false })
+      .range(from, to)
+  )
+
+  const corpSales: Sale[] = corpRows.map((r) => ({
+    transaction_id: r.transaction_id,
+    character_id: null,
+    corporation_id: r.corporation_id,
+    date: r.date,
+    type_id: r.type_id,
+    quantity: r.quantity,
+    unit_price: r.unit_price,
+    seen_at: r.seen_at,
+  }))
+
+  const sales: Sale[] = [...personal, ...corpSales]
+
+  // Resolve corp names from eve_name (kept populated by the hourly job) to label
+  // corp sales; unresolved ids fall back to a raw id in the table.
+  const corpIds = [...new Set(corpSales.map((s) => Number(s.corporation_id)))]
+  let corpNames: Record<number, string> = {}
+  if (corpIds.length > 0) {
+    const { data: nameRows } = await supabase.from('eve_name').select('id, name').in('id', corpIds)
+    corpNames = Object.fromEntries((nameRows ?? []).map((r) => [Number(r.id), r.name as string]))
   }
 
   const typeNamesPromise = fetchTypeNames(sales.map((s) => Number(s.type_id)))
@@ -46,6 +101,7 @@ const MarketPage = async () => {
       now={now.toISOString()}
       sales={sales}
       characters={sortedCharacters}
+      corpNames={corpNames}
       typeNamesPromise={typeNamesPromise}
     />
   )

--- a/src/app/market/recentSales.tsx
+++ b/src/app/market/recentSales.tsx
@@ -2,14 +2,17 @@
 
 import { DateTime } from '../DateTime'
 import { formatMiskValue } from '../isk'
-import { CharacterName } from '../names'
+import { Name } from '../names'
 import { TypeName } from '../typeName'
 import styles from './market.module.css'
 import { usePersist } from './usePersist'
 
 export type Sale = {
   transaction_id: string | number
-  character_id: string
+  // Personal sales carry the owning character; corp sales have no character and
+  // carry a corporation_id instead.
+  character_id: string | null
+  corporation_id?: number | string | null
   date: string
   type_id: number | string
   quantity: number | string
@@ -28,9 +31,13 @@ type RecentSalesProps = {
   now: number
   sales: Sale[]
   characters: Character[]
+  // corporation_id → name, for labelling corp sales (falls back to a raw id).
+  corpNames: Record<number, string>
   typeNamesPromise: Promise<Record<number, string>>
   windowDays: number
 }
+
+const CORP_PREFIX = 'corp:'
 
 const DAY_MS = 24 * 60 * 60 * 1000
 
@@ -43,28 +50,48 @@ const THRESHOLDS: Array<{ label: string; value: number }> = [
 ]
 
 const THRESHOLD_STORAGE_KEY = 'market.recentSales.threshold'
-const CHARACTER_STORAGE_KEY = 'market.recentSales.characterId'
-const ALL_CHARACTERS = ''
+const SELLER_STORAGE_KEY = 'market.recentSales.characterId'
+const ALL_SELLERS = ''
 
-export const RecentSales = ({ now, sales, characters, typeNamesPromise, windowDays }: RecentSalesProps) => {
+export const RecentSales = ({ now, sales, characters, corpNames, typeNamesPromise, windowDays }: RecentSalesProps) => {
   const characterName: Record<string, string> = Object.fromEntries(characters.map((c) => [c.id, c.name]))
   const windowStart = now - windowDays * DAY_MS
   const windowLabel = `${windowDays} day${windowDays === 1 ? '' : 's'}`
+
+  // Corporations that actually appear in the sales, for the seller filter.
+  const corpName = (id: number) => corpNames[id] ?? `Corp #${id}`
+  const corpIds = [...new Set(sales.filter((s) => s.corporation_id != null).map((s) => Number(s.corporation_id)))].sort(
+    (a, b) => corpName(a).localeCompare(corpName(b))
+  )
+
+  const sellerLabel = (s: Sale): string | null => {
+    if (s.character_id) return characterName[s.character_id] ?? null
+    if (s.corporation_id != null) return corpName(Number(s.corporation_id))
+    return null
+  }
 
   const [threshold, setThreshold] = usePersist(THRESHOLD_STORAGE_KEY, 0, (raw) => {
     const parsed = Number(raw)
     return THRESHOLDS.some((t) => t.value === parsed) ? parsed : undefined
   })
 
-  const [characterId, setCharacterId] = usePersist<string>(CHARACTER_STORAGE_KEY, ALL_CHARACTERS, (raw) =>
-    raw === ALL_CHARACTERS || characters.some((c) => c.id === raw) ? raw : undefined
-  )
+  const [sellerId, setSellerId] = usePersist<string>(SELLER_STORAGE_KEY, ALL_SELLERS, (raw) => {
+    if (raw === ALL_SELLERS || characters.some((c) => c.id === raw)) return raw
+    if (raw.startsWith(CORP_PREFIX) && corpIds.includes(Number(raw.slice(CORP_PREFIX.length)))) return raw
+    return undefined
+  })
+
+  const matchesSeller = (s: Sale) => {
+    if (sellerId === ALL_SELLERS) return true
+    if (sellerId.startsWith(CORP_PREFIX)) return String(s.corporation_id ?? '') === sellerId.slice(CORP_PREFIX.length)
+    return s.character_id === sellerId
+  }
 
   const filtered = sales.filter(
     (s) =>
       Date.parse(s.date) >= windowStart &&
       Number(s.unit_price) * Number(s.quantity) >= threshold &&
-      (characterId === ALL_CHARACTERS || s.character_id === characterId)
+      matchesSeller(s)
   )
 
   return (
@@ -73,14 +100,25 @@ export const RecentSales = ({ now, sales, characters, typeNamesPromise, windowDa
         <h2>Recent Sales (last {windowLabel})</h2>
         <div className={styles.salesFilters}>
           <label className={styles.salesFilter}>
-            Character:&nbsp;
-            <select value={characterId} onChange={(e) => setCharacterId(e.target.value)}>
-              <option value={ALL_CHARACTERS}>All characters</option>
-              {characters.map((c) => (
-                <option key={c.id} value={c.id}>
-                  {c.name}
-                </option>
-              ))}
+            Seller:&nbsp;
+            <select value={sellerId} onChange={(e) => setSellerId(e.target.value)}>
+              <option value={ALL_SELLERS}>All sellers</option>
+              <optgroup label="Characters">
+                {characters.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                  </option>
+                ))}
+              </optgroup>
+              {corpIds.length > 0 && (
+                <optgroup label="Corporations">
+                  {corpIds.map((id) => (
+                    <option key={id} value={`${CORP_PREFIX}${id}`}>
+                      {corpName(id)}
+                    </option>
+                  ))}
+                </optgroup>
+              )}
             </select>
           </label>
           <label className={styles.salesFilter}>
@@ -99,7 +137,7 @@ export const RecentSales = ({ now, sales, characters, typeNamesPromise, windowDa
         <table className={styles.sales}>
           <thead>
             <tr>
-              <th>Character</th>
+              <th>Seller</th>
               <th>Type</th>
               <th>Qty</th>
               <th>Unit (mISK)</th>
@@ -112,7 +150,7 @@ export const RecentSales = ({ now, sales, characters, typeNamesPromise, windowDa
             {filtered.map((s) => (
               <tr key={`sale-${s.transaction_id}`}>
                 <td>
-                  <CharacterName name={characterName[s.character_id]} />
+                  <Name name={sellerLabel(s)} />
                 </td>
                 <td>
                   <TypeName id={Number(s.type_id)} promise={typeNamesPromise} />

--- a/src/corpMarketTransactions.js
+++ b/src/corpMarketTransactions.js
@@ -1,0 +1,50 @@
+import { corpTransactions } from './esi.js'
+import { sudoSupabase } from './supabase.js'
+
+const WALLET_DIVISIONS = [1, 2, 3, 4, 5, 6, 7]
+
+// Pull market transactions from every wallet division of one corporation and
+// store them in corp_market_transaction, tagged with `character_id` — the
+// registration whose token scanned them — so RLS only shows each row to that
+// character's owner. The market page unions these with the per-character
+// market_transaction rows. transaction_id is globally unique in EVE, so the
+// upsert dedupes across divisions and re-scans. Each division is isolated: one
+// division failing (e.g. a permissions edge) doesn't abort the others.
+export const pullCorpMarketTransactions = async ({
+  access_token,
+  corporation_id,
+  character_id,
+  ctx,
+  corpLabel = corporation_id,
+}) => {
+  for (const division of WALLET_DIVISIONS) {
+    try {
+      const txns = await corpTransactions(access_token, corporation_id, division)
+      if (!Array.isArray(txns) || txns.length === 0) {
+        console.log(`[corp-market] ${ctx}: corp ${corpLabel} div ${division} 0 transactions`)
+        continue
+      }
+      const rows = txns.map((t) => ({
+        transaction_id: t.transaction_id,
+        character_id,
+        corporation_id,
+        division,
+        date: t.date,
+        type_id: t.type_id,
+        quantity: t.quantity,
+        unit_price: t.unit_price,
+        is_buy: t.is_buy,
+        client_id: t.client_id,
+        location_id: t.location_id,
+        journal_ref_id: t.journal_ref_id,
+      }))
+      const { error } = await sudoSupabase
+        .from('corp_market_transaction')
+        .upsert(rows, { onConflict: 'transaction_id', ignoreDuplicates: true })
+      if (error) throw error
+      console.log(`[corp-market] ${ctx}: corp ${corpLabel} div ${division} ${rows.length} transactions`)
+    } catch (e) {
+      console.error(`[corp-market] ${ctx}: corp ${corpLabel} div ${division} FAILED message=${e?.message}`)
+    }
+  }
+}

--- a/src/esi.js
+++ b/src/esi.js
@@ -89,6 +89,16 @@ export const corpWalletJournal = (access_token, corporationID, division, page = 
     label: `corpWalletJournal ${corporationID} div=${division} page=${page}`,
   })
 
+// A corp wallet division's market transactions (buys and sells). Like the
+// character endpoint it is not page-numbered — ESI returns the most recent batch
+// in one response (older history is reachable via from_id, which we don't need
+// for an hourly sync). Requires the Accountant or Junior Accountant role in game.
+export const corpTransactions = (access_token, corporationID, division) =>
+  esiJson(`/corporations/${corporationID}/wallets/${division}/transactions/`, {
+    access_token,
+    label: `corpTransactions ${corporationID} div=${division}`,
+  })
+
 export const assetNames = (access_token, characterID, ids) =>
   esiJson(`/characters/${characterID}/assets/names/`, {
     access_token,

--- a/src/jobs/hourly.js
+++ b/src/jobs/hourly.js
@@ -1,10 +1,13 @@
 import { fileURLToPath } from 'node:url'
 
-import { industryJobs, transactions, wallet } from '../esi.js'
+import { pullCorpMarketTransactions } from '../corpMarketTransactions.js'
+import { character as fetchCharacter, industryJobs, transactions, wallet } from '../esi.js'
+import { resolveCorpNames } from '../resolveNames.js'
 import { sudoSupabase } from '../supabase.js'
 import { refreshAccessToken } from '../tokenRefresh.js'
 
 const WALLET_SCOPE = 'esi-wallet.read_character_wallet.v1'
+const CORP_WALLET_SCOPE = 'esi-wallet.read_corporation_wallets.v1'
 const INDUSTRY_SCOPE = 'esi-industry.read_character_jobs.v1'
 
 // Pull wallet/transactions and industry jobs for tokens carrying the relevant
@@ -64,6 +67,56 @@ export const runHourly = async ({ characterIds } = {}) => {
     } catch (e) {
       console.error(`refresh failed for ${name} ${tokenRow.character_id}:`, e)
     }
+  }
+
+  // Corp market transactions: union into the market page alongside the personal
+  // sales above. Driven off the corp-wallet scope (already used for journals), and
+  // deduped per corporation so two characters in the same corp don't both pull it.
+  let corpQuery = sudoSupabase
+    .from('token')
+    .select('id, character_id, refresh_token')
+    .contains('scope', [CORP_WALLET_SCOPE])
+  if (characterIds) corpQuery = corpQuery.in('character_id', characterIds)
+  const { data: corpTokens, error: corpTokensError } = await corpQuery
+
+  if (corpTokensError) {
+    console.error(corpTokensError)
+    throw corpTokensError
+  }
+
+  const seenCorps = new Set()
+  for (const tokenRow of corpTokens ?? []) {
+    const name = characterName.get(tokenRow.character_id) ?? '?'
+    const ctx = `${name} ${tokenRow.character_id}`
+    try {
+      const { access_token, characterID, scope } = await refreshAccessToken(tokenRow)
+      if (!scope.includes(CORP_WALLET_SCOPE)) continue
+      const info = await fetchCharacter(access_token, characterID)
+      const corporation_id = info?.corporation_id
+      if (!corporation_id) {
+        console.error(`[corp-market] ${ctx}: character payload missing corporation_id`)
+        continue
+      }
+      if (seenCorps.has(corporation_id)) continue
+      seenCorps.add(corporation_id)
+      await pullCorpMarketTransactions({
+        access_token,
+        corporation_id,
+        character_id: tokenRow.character_id,
+        ctx,
+        corpLabel: corporation_id,
+      })
+    } catch (e) {
+      console.error(`[corp-market] ${ctx}: FAILED message=${e?.message}`)
+    }
+  }
+
+  // Cache the names of the corps we pulled so the market page can label corp sales
+  // by name rather than a raw id. Only resolves ids missing from eve_name.
+  try {
+    await resolveCorpNames([...seenCorps])
+  } catch (e) {
+    console.error(`[corp-market] corp name resolution FAILED message=${e?.message}`)
   }
 
   let industryQuery = sudoSupabase

--- a/src/resolveNames.js
+++ b/src/resolveNames.js
@@ -68,6 +68,33 @@ export const resolveCorpJournalNames = async () => {
   console.log(`[names] upserted ${rows.length} name(s) (${characterCount} character)`)
 }
 
+// Resolve and cache (in eve_name) the names of the given corporation ids that we
+// don't already have. The market page reads eve_name to label corp market sales
+// by corporation name instead of a raw id. Only resolves missing ids, so
+// steady-state runs do nothing.
+export const resolveCorpNames = async (corporationIds) => {
+  const ids = [...new Set((corporationIds ?? []).map(Number).filter((n) => Number.isFinite(n) && n > 0))]
+  if (ids.length === 0) return
+
+  const { data: known, error: knownErr } = await sudoSupabase.from('eve_name').select('id').in('id', ids)
+  if (knownErr) throw knownErr
+  const knownIds = new Set((known ?? []).map((k) => Number(k.id)))
+  const toResolve = ids.filter((id) => !knownIds.has(id))
+  if (toResolve.length === 0) return
+
+  const resolved = []
+  for (let i = 0; i < toResolve.length; i += BATCH_SIZE) {
+    const names = await resolveBatch(toResolve.slice(i, i + BATCH_SIZE))
+    resolved.push(...names)
+  }
+  if (resolved.length === 0) return
+
+  const rows = resolved.map((n) => ({ id: n.id, name: n.name, category: n.category }))
+  const { error: upErr } = await sudoSupabase.from('eve_name').upsert(rows, { onConflict: 'id' })
+  if (upErr) throw upErr
+  console.log(`[names] upserted ${rows.length} corp name(s)`)
+}
+
 // Cache (in eve_name) the name of every solar system we currently have a corp
 // structure in. Only resolves ids missing from eve_name, so steady-state runs do
 // nothing. The structures page reads eve_name to label each tile's system instead

--- a/supabase/migrations/20260616010000_add_corp_market_transaction.sql
+++ b/supabase/migrations/20260616010000_add_corp_market_transaction.sql
@@ -1,0 +1,40 @@
+-- Corp market transactions: the market buys/sells pulled from corporation wallet
+-- divisions (esi-wallet.read_corporation_wallets.v1), unioned into the market page
+-- alongside the per-character market_transaction rows. `character_id` records the
+-- registration whose token scanned the row; RLS scopes reads to that character's
+-- owner, so a corp transaction is only visible to the player who pulled it (like
+-- personal transactions). Keyed by the globally-unique transaction_id so it dedupes
+-- across divisions and re-scans (first scanner wins attribution).
+create table if not exists public.corp_market_transaction (
+  transaction_id bigint primary key,
+  character_id uuid not null references public.registration(id) on delete cascade,
+  corporation_id bigint not null,
+  division smallint not null,
+  date timestamptz not null,
+  type_id bigint not null,
+  quantity bigint not null,
+  unit_price numeric(20, 2) not null,
+  is_buy boolean not null,
+  client_id bigint not null,
+  location_id bigint not null,
+  journal_ref_id bigint not null,
+  seen_at timestamptz not null default now()
+);
+create index if not exists corp_market_transaction_character_id_date_idx
+  on public.corp_market_transaction (character_id, date desc);
+
+alter table public.corp_market_transaction enable row level security;
+
+drop policy if exists "Users read own corp transactions" on public.corp_market_transaction;
+create policy "Users read own corp transactions"
+  on public.corp_market_transaction
+  for select
+  to authenticated
+  using (
+    character_id in (
+      select id from public.registration where user_id = (select auth.uid())
+    )
+  );
+
+grant select on public.corp_market_transaction to authenticated;
+grant all    on public.corp_market_transaction to service_role;


### PR DESCRIPTION
## What

The Market tab now shows the **union of personal character sales and corporation wallet sales**. Corp market transactions are pulled from every corp wallet division and folded into the overview tiles (top sellers, bar chart, prior period) and the Recent Sales table.

No new ESI scope was needed — `esi-wallet.read_corporation_wallets.v1` already exists (used today for corp wallet journals); this just adds the corp **transactions** endpoint.

## How

**Ingestion (hourly job — where personal wallet/transactions are already pulled)**
- `esi.js`: add `corpTransactions(token, corpId, division)`.
- `corpMarketTransactions.js` (new): `pullCorpMarketTransactions()` fetches all 7 divisions and upserts to `corp_market_transaction`.
- `hourly.js`: for tokens carrying the corp-wallet scope, resolve the corp (via character sheet) and pull its transactions, **deduped per corporation** so two characters in one corp don't both pull it.
- `resolveNames.js`: `resolveCorpNames()` caches corp names in `eve_name` so corp sales can be labeled by name.

**Database** — new `corp_market_transaction` table (corp txns have no owning character, so they can't live in `market_transaction`):
- Keyed by the globally-unique `transaction_id` (dedupes across divisions / re-scans).
- Tagged with the **scanning `character_id`**, and **RLS scopes reads to that character's owner** — so a corp transaction is only visible to the player who pulled it, exactly like personal `market_transaction`.
- `schema.sql` updated + non-destructive migration `20260616010000_add_corp_market_transaction.sql` (the `Migrate` workflow applies it on merge to `main`).

**UI (`src/app/market`)**
- `page.tsx` pages through `corp_market_transaction` (past the 1000-row cap), normalizes, and unions into the sales feed. The overview tiles aggregate by type/value/time, so corp sales fold in with **no change to the aggregation code**.
- Corp rows are labeled by **corp name** in Recent Sales; the old "Character" filter becomes a **"Seller"** filter that groups Characters and Corporations.

## Notes / decisions
- "Sales" = `is_buy = false`, consistent with the existing personal-sales filter.
- Per-corp dedup + first-scanner attribution means, in a multi-user corp, corp sales are owned by whichever linked character scanned first. For a single-account tracker this is moot; flag it if multi-user corp visibility matters and I'll key per `(transaction_id, character_id)` instead.

## Verification
- `npx tsc --noEmit` — clean
- `npm run lint` — clean (only a pre-existing unrelated warning)
- `npm run build` — succeeds; `/market` compiles as a dynamic route
- `node --check` on changed cron scripts — clean

https://claude.ai/code/session_01SirPTxSz3K8ewwVLFbMJ3v

---
_Generated by [Claude Code](https://claude.ai/code/session_01SirPTxSz3K8ewwVLFbMJ3v)_