### PR TITLE
Show units sold and #-prefix the rank in Market top-seller tiles

### DIFF
--- a/src/app/market/aggregate.ts
+++ b/src/app/market/aggregate.ts
@@ -4,19 +4,23 @@ import type { Sale } from './recentSales'
 // turnover (unit price × quantity), not transaction count or unit quantity.
 const value = (s: Sale) => Number(s.unit_price) * Number(s.quantity)
 
-export type TypeTotal = { typeId: number; total: number }
+export type TypeTotal = { typeId: number; total: number; quantity: number }
 
 // Top-N type_ids by summed ISK value of sales whose date falls in [start, end).
+// Also carries the summed unit quantity sold in the same window.
 export const topTypesByValue = (sales: Sale[], start: number, end: number, limit: number): TypeTotal[] => {
-  const totals = new Map<number, number>()
+  const agg = new Map<number, { total: number; quantity: number }>()
   for (const s of sales) {
     const t = Date.parse(s.date)
     if (t < start || t >= end) continue
     const typeId = Number(s.type_id)
-    totals.set(typeId, (totals.get(typeId) ?? 0) + value(s))
+    const cur = agg.get(typeId) ?? { total: 0, quantity: 0 }
+    cur.total += value(s)
+    cur.quantity += Number(s.quantity)
+    agg.set(typeId, cur)
   }
-  return [...totals.entries()]
-    .map(([typeId, total]) => ({ typeId, total }))
+  return [...agg.entries()]
+    .map(([typeId, { total, quantity }]) => ({ typeId, total, quantity }))
     .sort((a, b) => b.total - a.total)
     .slice(0, limit)
 }

--- a/src/app/market/market.module.css
+++ b/src/app/market/market.module.css
@@ -93,7 +93,7 @@
 
 .topRow {
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto 1fr auto auto;
   align-items: baseline;
   gap: 8pt;
   padding: 3pt 0;
@@ -117,6 +117,16 @@
 .topName {
   min-width: 0;
   overflow-wrap: anywhere;
+}
+
+/* Units sold in the window — de-emphasised (like the rank) so the ISK value
+ * stays the row's focus. */
+.topQty {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 9pt;
+  text-align: right;
+  color: var(--ink-faint);
 }
 
 .topValue {

--- a/src/app/market/marketOverview.tsx
+++ b/src/app/market/marketOverview.tsx
@@ -45,9 +45,12 @@ const TopItems = ({
       <ol className={styles.topList}>
         {items.map((it, i) => (
           <li key={it.typeId} className={styles.topRow}>
-            <span className={styles.topRank}>{i + 1}</span>
+            <span className={styles.topRank}>#{i + 1}</span>
             <span className={styles.topName}>
               <TypeName id={it.typeId} promise={typeNamesPromise} />
+            </span>
+            <span className={styles.topQty} title={`${it.quantity.toLocaleString('en-US')} sold`}>
+              ×{it.quantity.toLocaleString('en-US')}
             </span>
             <span className={styles.topValue} title={formatMisk(it.total)}>
               {formatMiskValue(it.total)}


### PR DESCRIPTION
## What

Two small tweaks to the **top-seller tiles** (tile 1 "Top sellers" and tile 3 "Previous period") in the Market overview:

1. Each row now shows the **quantity sold** in the selected window, rendered in the same faint colour as the rank so the ISK value stays the row's focus (e.g. `×1,234`).
2. The rank number is now **`#`-prefixed** (`#1`, `#2`, …).

## How
- `aggregate.ts`: `topTypesByValue` now also sums unit quantity per type (`TypeTotal` gains `quantity`).
- `marketOverview.tsx`: render `#{rank}` and a new lighter `×{quantity}` cell.
- `market.module.css`: top rows go from a 3- to 4-column grid; new `.topQty` uses `--ink-faint` (matching `.topRank`).

The bar chart and Recent Sales are unchanged.

## Verification
- `npx tsc --noEmit` — clean
- `npm run lint` — clean (only a pre-existing unrelated warning)
- `npm run build` — succeeds; `/market` compiles

https://claude.ai/code/session_01SirPTxSz3K8ewwVLFbMJ3v

---
_Generated by [Claude Code](https://claude.ai/code/session_01SirPTxSz3K8ewwVLFbMJ3v)_