### PR TITLE
Disable "Set as Main" until a different character is picked

### DIFF
--- a/src/app/character/mainCharacterForm.tsx
+++ b/src/app/character/mainCharacterForm.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useState } from 'react'
+
+// Wraps the character list's radios and the "Set as Main" button. The button
+// stays disabled until the player picks a character other than their current
+// main (`mainId`, null when none is set yet). The radios are server-rendered as
+// `children`; their change events bubble to the form, where we re-read the
+// selected value from the form data.
+const MainCharacterForm = ({
+  mainId,
+  hasCharacters,
+  action,
+  children,
+}: {
+  mainId: string | null
+  hasCharacters: boolean
+  action: (formData: FormData) => void | Promise<void>
+  children: React.ReactNode
+}) => {
+  const [selectedId, setSelectedId] = useState<string | null>(mainId)
+
+  const onChange = (e: React.FormEvent<HTMLFormElement>) => {
+    const value = new FormData(e.currentTarget).get('main')
+    setSelectedId(typeof value === 'string' ? value : null)
+  }
+
+  return (
+    <form onChange={onChange}>
+      {children}
+      {hasCharacters && (
+        <button formAction={action} disabled={selectedId === mainId}>
+          Set as Main
+        </button>
+      )}
+    </form>
+  )
+}
+
+export default MainCharacterForm

--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
 import { register, refreshEsi, setMainCharacter } from './actions'
+import MainCharacterForm from './mainCharacterForm'
 import { requiredScopes } from './scopes'
 import { getEnabledScopes } from './userScopes'
 import styles from './character.module.css'
@@ -34,6 +35,8 @@ const CharacterPage = async () => {
   const enabledScopes = await getEnabledScopes(supabase, data.user.id)
   const hasNoOptionalScopes = enabledScopes.every((scope) => requiredScopes.includes(scope))
 
+  const mainId = characters?.find((c) => c.is_main)?.id ?? null
+
   return (
     <>
       <h1>Characters</h1>
@@ -47,7 +50,7 @@ const CharacterPage = async () => {
           </p>
         </div>
       )}
-      <form>
+      <MainCharacterForm mainId={mainId} hasCharacters={!!characters?.length} action={setMainCharacter}>
         <ul className={styles.grid}>
           {characters?.map((c) => (
             <li key={`character-${c.id}`} className={styles.tile}>
@@ -79,8 +82,7 @@ const CharacterPage = async () => {
             </li>
           ))}
         </ul>
-        {characters?.length ? <button formAction={setMainCharacter}>Set as Main</button> : null}
-      </form>
+      </MainCharacterForm>
       {error && (
         <>
           <strong>


### PR DESCRIPTION
Makes the **Set as Main** button on `/character` disabled until the player selects a character *other than* their current main — so it never submits a no-op.

- The character list's radios and submit button move into a small client component (`mainCharacterForm.tsx`). Radio change events bubble to the form, where the selected value is re-read from the form data.
- The button is disabled when the selection equals the current main (`mainId`). When no main is set yet, it stays disabled until any character is selected. After a successful "Set as Main", the page revalidates and the button returns to disabled for the new main.
- No schema or server-action changes; `setMainCharacter` is passed to the client component as a prop.

`npm run lint` (only the unrelated pre-existing `register` warning) and `npm run build` both pass.

https://claude.ai/code/session_01Gn4y21uZSaJ7ygPyrts9MZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gn4y21uZSaJ7ygPyrts9MZ)_