### PR TITLE
Fix sparkline max/min excluding the displayed current value

### DIFF
--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -296,11 +296,20 @@ const StructuresPage = async () => {
                         {indexActivities.map((activity) => {
                           const cost = systemIndexes?.get(activity)
                           const series = systemHistory?.get(activity)
+                          const historyValues = series?.values ?? []
+                          // cost and series come from separate DB queries and can diverge (race
+                          // with a cron insert). Append cost when it differs from the last history
+                          // point so the sparkline's max/min always spans the displayed value.
+                          const sparklineValues =
+                            cost != null &&
+                            (historyValues.length === 0 || historyValues[historyValues.length - 1] !== cost)
+                              ? [...historyValues, cost]
+                              : historyValues
                           return (
                             <li key={`idx-${s.structure_id}-${activity}`} className={styles.indexRow}>
                               <span className={styles.indexLabel}>{INDEX_ACTIVITY_LABELS[activity]}</span>
                               <Sparkline
-                                values={series?.values ?? []}
+                                values={sparklineValues}
                                 updatedAt={series?.updatedAt}
                                 label={INDEX_ACTIVITY_LABELS[activity]}
                               />


### PR DESCRIPTION
## Summary

- The current index value and sparkline history come from two independent DB queries (`fetchLatestSystemIndexes` and `fetchSystemIndexHistory`). If a cron job inserts new rows between these two queries, the current value can be newer/higher than anything in the history array.
- The sparkline computed its max/min solely from the history values, so it was possible to display a "high" that was lower than the current value shown right next to it (e.g. 5.25% current, 4.72% high).
- Fix: append `cost` to the values passed to `<Sparkline>` when it differs from the last history point, so the sparkline's max/min always spans the value being displayed.

## Test plan

- [ ] Deploy and visit `/structures` — confirm the sparkline high is always ≥ the index value shown to its right
- [ ] When no race condition is active (history already ends at the current value), sparkline is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrMJ13m3PswS2AX9zRvfqf

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrMJ13m3PswS2AX9zRvfqf)_