### PR TITLE
Fix queue trigger path so Vercel actually binds the consumer

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "functions": {
-    "src/app/api/queue/jobs/route.ts": {
+    "app/api/queue/jobs/route.ts": {
       "maxDuration": 60,
       "experimentalTriggers": [
         {


### PR DESCRIPTION
## Summary

- `vercel.json` keyed the queue consumer function at `src/app/api/queue/jobs/route.ts`, but Vercel matches `functions` patterns against the canonical route path (`app/api/...`), not the on-disk source location. The pattern silently no-matched, so the `experimentalTriggers` binding for the `jobs` topic never registered.
- Result: refresh messages enqueued fine (visible in the Queues dashboard) but `/api/queue/jobs` was never invoked — refresh_task rows stayed pending forever.
- Drop the `src/` prefix so the pattern matches and the consumer gets wired up.

## Test plan

- [ ] After deploy, hit "Refresh ESI" from `/character` and watch `refresh_task` rows flip `pending → running → done` on `/characters/refresh`.
- [ ] Confirm Vercel runtime logs now show `/api/queue/jobs` invocations.
- [ ] Confirm the Queues dashboard backlog drains.

https://claude.ai/code/session_011696GpDqtVFc4ATkRminjR

---
_Generated by [Claude Code](https://claude.ai/code/session_011696GpDqtVFc4ATkRminjR)_