### PR TITLE
Remove stale token-refresh call from OAuth callback

### DIFF
--- a/src/app/character/callback/route.ts
+++ b/src/app/character/callback/route.ts
@@ -52,9 +52,6 @@ export const GET = async (request: NextRequest) => {
   const expires_at = new Date(exp * 1000).toISOString()
   const eve_character_id = Number(sub.split(':')[2])
 
-  // why are we doing this, again? can this be deleted?
-  await sso.getAccessToken(refresh_token, true)
-
   const character_id = await upsertCharacter(supabase)({ user_id, owner, name, character_id: eve_character_id })
   await upsertToken(supabase)({
     user_id,


### PR DESCRIPTION
## Summary

- The `callback/route.ts` was calling `sso.getAccessToken(refresh_token, true)` immediately after the initial authorization-code exchange — and discarding the result.
- EVE SSO rotates refresh tokens on use (you can see `refreshAccessToken` in `tokenRefresh.js` always saves the new refresh_token it gets back). So this call consumed the just-stored `refresh_token`, leaving an invalid one in the DB.
- When the dispatched jobs ran (often just seconds later via the queue), `refreshAccessToken` tried to use the stale token, got an auth error from EVE SSO, and silently skipped the character. Tasks showed `done` but nothing was actually fetched — jobs appeared to not be working after a new character was registered.
- The code even had a comment: `// why are we doing this, again? can this be deleted?` The answer is yes.

## Test plan

- [ ] Register a new character via EVE SSO
- [ ] Confirm you land on `/characters/refresh` and jobs complete with data actually appearing (wallet, assets, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrMJ13m3PswS2AX9zRvfqf

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrMJ13m3PswS2AX9zRvfqf)_