### PR TITLE
Fix vercel.json functions path to include src/ prefix

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "functions": {
-    "app/api/queue/jobs/route.ts": {
+    "src/app/api/queue/jobs/route.ts": {
       "maxDuration": 60,
       "experimentalTriggers": [
         {


### PR DESCRIPTION
## Summary

- Fix `vercel.json` `functions` key: `app/api/queue/jobs/route.ts` → `src/app/api/queue/jobs/route.ts`
- Vercel documentation explicitly states: *"You must prefix functions in the src directory with /src/"*
- Without the `src/` prefix, Vercel silently skips binding the `experimentalTriggers` queue consumer, so dispatched jobs never fire

## Test plan

- [ ] Deploy to Vercel preview and verify queue consumer binding appears in function logs
- [ ] Trigger a character refresh and confirm job tasks transition from `pending` → `running` → `done`

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrMJ13m3PswS2AX9zRvfqf)_