### PR TITLE
Pin Vercel Queue region so refresh jobs actually get consumed

### DIFF
--- a/src/app/api/queue/jobs/route.ts
+++ b/src/app/api/queue/jobs/route.ts
@@ -1,6 +1,6 @@
 import { randomInt } from 'node:crypto'
 
-import { handleCallback } from '@vercel/queue'
+import { handleCallback } from '@/utils/queue'
 
 export const runtime = 'nodejs'
 // 60s is the max the current Vercel plan allows. Per-character fan-out keeps each
@@ -22,6 +22,7 @@ type Msg = {
 // (per retryAfterSeconds in vercel.json).
 export const POST = handleCallback(async (message: Msg) => {
   const { job, characterId, taskId } = message
+  console.log(`[queue/jobs] consume job=${job} characterId=${characterId ?? '-'} taskId=${taskId ?? '-'}`)
   const ids = characterId != null ? { characterIds: [characterId] } : undefined
 
   // Imported lazily so loading the route (and `next build`) never runs the job

--- a/src/app/character/dispatchRefresh.ts
+++ b/src/app/character/dispatchRefresh.ts
@@ -39,10 +39,11 @@ export const dispatchRefresh = async (userId: string, characters: Character[]): 
     throw error
   }
 
-  const { send } = await import('@vercel/queue')
-  await Promise.all(
+  const { send } = await import('@/utils/queue')
+  const sent = await Promise.all(
     (inserted ?? []).map((t) => send('jobs', { job: t.job, characterId: t.character_id ?? undefined, taskId: t.id }))
   )
+  console.log(`[dispatchRefresh] enqueued ${sent.length} jobs to topic "jobs" region=${process.env.QUEUE_REGION ?? 'sfo1'}`)
 
   return batchId
 }

--- a/src/utils/queue.ts
+++ b/src/utils/queue.ts
@@ -1,0 +1,19 @@
+import { QueueClient } from '@vercel/queue'
+
+// Vercel Queues are region-scoped: a message published to a topic in one region is
+// only delivered to a consumer watching that same region's topic. The push consumer
+// (wired up in vercel.json via experimentalTriggers) runs in the deployment's
+// region, so the producer must publish to that same region.
+//
+// Left to the default, @vercel/queue keys the region off VERCEL_REGION and silently
+// falls back to "iad1" when it isn't set — so a `send` from a runtime without
+// VERCEL_REGION lands in the iad1 topic while the consumer watches the deployment's
+// region (sfo1), and the message is never consumed. That was the bug behind refreshes
+// looking "stuck in the queue": rows were enqueued but nothing ever picked them up.
+//
+// Pin the region explicitly so producer and consumer always agree. Defaults to the
+// project's deployment region (sfo1); override with QUEUE_REGION if the project moves.
+const region = process.env.QUEUE_REGION ?? 'sfo1'
+
+export const queue = new QueueClient({ region })
+export const { send, handleCallback } = queue


### PR DESCRIPTION
## Problem

Hitting **Refresh ESI** enqueues `refresh_task` rows and calls `send('jobs', …)`, but the jobs sit in the queue forever — the `/characters/refresh` matrix stays on `· pending`.

## Diagnosis

Pulled the live Vercel logs for the production deployment:

- `/characters/refresh` route: **3016** runtime hits over the window.
- `/api/queue/jobs` (the consumer): **0** hits — *across both* the `app/...` and `src/app/...` `vercel.json` path variants that PRs #451 and #453 tried. So the trigger **path was never the problem.**
- The producer side works: rows get inserted and `send` doesn't throw (the user reaches `/characters/refresh`), so messages *are* being published.

The build logs show the smoking gun:

```
[QueueClient] Region not detected — defaulting to "iad1".
On Vercel this is set automatically via VERCEL_REGION.
```

Vercel Queues are **region-scoped** — a message published to a topic in one region is only delivered to a consumer watching that *same* region's topic. `@vercel/queue` derives the region from `VERCEL_REGION` and silently falls back to `iad1` when it's unset. This deployment runs in **`sfo1`**, so a producer that fell back to `iad1` published into a topic the `sfo1` push consumer never watches: the messages were enqueued but orphaned.

## Fix

- Add a shared, region-pinned `QueueClient` (`src/utils/queue.ts`), defaulting to `sfo1` and overridable via a `QUEUE_REGION` env var.
- Use it for **both** the producer (`dispatchRefresh`) and the consumer (`/api/queue/jobs/route.ts`) so they always agree on the region (and the build-time warning goes away).
- Add an enqueue/consume `console.log` on each side so a refresh can be verified end-to-end in the runtime logs.

## Verifying after deploy

1. Deploy, then hit **Refresh ESI** for an account.
2. Runtime logs should now show `[dispatchRefresh] enqueued N jobs …` immediately followed by `[queue/jobs] consume job=… ` lines, and the matrix should move `pending → running → done`.

> Note: if jobs are *still* not consumed after this deploy, that rules region out and points at the `queue/v2beta` push trigger not registering under the Turbopack build / Queues beta — the next step would be to confirm Queues push mode is enabled for the project. The added logging will make that determination unambiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016P7eNt2cV9R99Ks8fkBq2A)_