### PR TITLE
Take structures off the refresh fan-out; split out hourly industry_index job

### DIFF
--- a/.github/workflows/industry_index.yml
+++ b/.github/workflows/industry_index.yml
@@ -1,9 +1,9 @@
-name: Structures
+name: Industry Index
 
 on:
   workflow_dispatch:
   schedule:
-    - cron: '17 9 * * *'
+    - cron: '10 * * * *'
 
 jobs:
   refresh:
@@ -17,20 +17,18 @@ jobs:
           cache-dependency-path: package-lock.json
       - run: npm install
       - name: Heartbeat start
-        run: npm run heartbeat -- structures start
+        run: npm run heartbeat -- industry_index start
         env:
           SUPABASE_URL: ${{ vars.SUPABASE_URL }}
           SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
-      - run: npm run structures
+      - run: npm run industry-index
         env:
-          EVE_CLIENT_ID: ${{ vars.EVE_CLIENT_ID }}
-          EVE_SECRET_KEY: ${{ secrets.EVE_SECRET_KEY }}
           SUPABASE_URL: ${{ vars.SUPABASE_URL }}
           SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
       - name: Heartbeat end
-        run: npm run heartbeat -- structures end
+        run: npm run heartbeat -- industry_index end
         env:
           SUPABASE_URL: ${{ vars.SUPABASE_URL }}
           SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ EVE Online hangar/wallet/industry tracker. Package name `edencom-link` (private)
 - `npm run pretty` — `prettier --write src/` (config: `@philihp/prettier-config`).
 - **No test runner / no `test` script** — there are no automated tests. No `typecheck` script (rely on `next build` / editor).
 - Pre-commit: husky + lint-staged auto-format & `eslint --fix` staged files.
-- Cron scripts (run via GitHub Actions, see below): `npm run hourly` / `daily` / `assets` / `structures` / `heartbeat`. `connect`, `ping`, `refresh` are DB/token utilities.
+- Cron scripts (run via GitHub Actions, see below): `npm run hourly` / `daily` / `assets` / `structures` / `industry-index` / `heartbeat`. `connect`, `ping`, `refresh` are DB/token utilities.
 - DB migrations (Supabase CLI, configured by `supabase/config.toml`): `npm run db:new <name>` scaffolds a migration under `supabase/migrations/`; `npm run db:push` applies pending migrations to the linked project (`supabase link --project-ref <ref>` first). On push to `main` that touches `supabase/migrations/**`, the `Migrate` workflow runs `supabase db push` automatically (also manually dispatchable).
 
 ## Layout
@@ -22,7 +22,7 @@ EVE Online hangar/wallet/industry tracker. Package name `edencom-link` (private)
 - `src/app/` — Next.js App Router. Page routes: `account/`, `assets/`, `character/`, `industry/`, `market/`, `structures/`, plus `theme/`, `layout/` (Header/Footer), `private/`. Shared helpers at top level: `typeNames.ts`/`typeName.tsx`, `systemNames.ts`, `stationNames.ts`, `isk.ts`, `DateTime.tsx`.
 - `src/` (Node cron/scripts): `esi.js` (ESI API wrapper), `supabase.js` (clients — anon + `sudoSupabase` service role that bypasses RLS), `corpWalletJournal.js`, `corpMarketTransactions.js`, `resolveNames.js`, `structureNames.js`, `tokenRefresh.js`/`refresh.js`, `proxy.ts`, `utils/`. The scheduled job entry points live under `src/jobs/`: `hourly.js`, `daily.js`, `assets.js`, `structures.js` — each exports a `run*` function (callable from the Vercel queue consumer) and self-runs as a CLI when invoked directly (`node src/jobs/<job>.js`).
 - `schema.sql` — the single source of truth for the Supabase schema (in the default `public` schema). It's a full reset: it DROPs the app's tables and recreates them, so re-running wipes data — never run it against a database with data you want to keep. To change the schema, edit this file (so a fresh reset stays correct) **and** add a non-destructive incremental migration under `supabase/migrations/` (Supabase CLI format, applied with `supabase db push`) so the change can be rolled out to existing databases without wiping data.
-- `.github/workflows/` — `hourly.yml`, `daily.yml`, `assets.yml`, `structures.yml`, `heartbeat.yml` (each a scheduled cron + manual dispatch); `migrate.yml` (applies Supabase migrations on push to `main`).
+- `.github/workflows/` — `hourly.yml`, `daily.yml`, `assets.yml`, `structures.yml`, `industry_index.yml`, `heartbeat.yml` (each a scheduled cron + manual dispatch); `migrate.yml` (applies Supabase migrations on push to `main`).
 
 ## Database & ESI
 
@@ -99,7 +99,7 @@ All functions take `(characterId, accessToken)` unless noted. Returns raw ESI re
 - `pullCorpWalletJournals(corpId, token)` — fetch all 7 divisions, upsert to `corp_wallet_journal`
 
 ### `src/industryIndexes.js`
-- `pullIndustryIndexes()` — fetch public industry cost indices from ESI, insert rows to `industry_system_index`
+- `pullIndustryIndexes()` — fetch public industry cost indices from ESI, insert rows to `industry_system_index` (run by the `industry-index` cron job, `src/jobs/industryIndex.js`)
 
 ### `src/utils/apiToken.ts`
 - `resolvePlayer(token: string)` — look up `user_settings.api_token`, return `{ supabase, characterIds }` for Sheets API endpoints
@@ -143,10 +143,11 @@ Shared UI helpers: `src/app/isk.ts` (ISK formatting), `src/app/DateTime.tsx`, `s
 | `hourly` | `src/jobs/hourly.js` → `runHourly()` | `hourly.yml` | every hour `:44` |
 | `daily` | `src/jobs/daily.js` → `runDaily()` | `daily.yml` | 11:41 UTC |
 | `assets` | `src/jobs/assets.js` → `runAssets()` | `assets.yml` | every hour `:26` |
-| `structures` | `src/jobs/structures.js` → `runStructures()` | `structures.yml` | every hour `:17` |
+| `structures` | `src/jobs/structures.js` → `runStructures()` | `structures.yml` | 09:17 UTC daily |
+| `industry-index` | `src/jobs/industryIndex.js` → `runIndustryIndex()` | `industry_index.yml` | every hour `:10` |
 | `heartbeat` | `src/heartbeat.js` | `heartbeat.yml` | 10:55 UTC daily |
 
-Each job exports its `run*()` function (consumed by Vercel queue at `/api/queue/jobs`) and self-invokes as CLI when run directly.
+Each job exports its `run*()` function and self-invokes as CLI when run directly. The per-character jobs (`assets`, `hourly`, `orders`) plus the account-wide `daily` are also dispatched on demand via the Vercel queue at `/api/queue/jobs` (the "Refresh ESI" flow). `structures` and `industry-index` are cron-only — they do whole-corp/whole-universe work that isn't character-scoped, so they're not fanned out per character.
 
 ## Database tables (quick reference)
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dev": "next dev",
     "heartbeat": "node src/heartbeat.js",
     "hourly": "node src/jobs/hourly.js",
+    "industry-index": "node src/jobs/industryIndex.js",
     "orders": "node src/jobs/orders.js",
     "structures": "node src/jobs/structures.js",
     "refresh": "node src/refresh.js",

--- a/src/app/character/dispatchRefresh.ts
+++ b/src/app/character/dispatchRefresh.ts
@@ -3,7 +3,13 @@ import { randomUUID } from 'node:crypto'
 // The per-character ESI extracts a refresh fans out, one queue message per
 // character each. `daily` is account-wide (it resolves affiliations for every
 // registration at once), so it's dispatched once with no character.
-const PER_CHARACTER_JOBS = ['assets', 'hourly', 'structures', 'orders'] as const
+//
+// `structures` is deliberately NOT here: it does whole-corp/whole-universe work
+// (notably pulling the full EVE industry cost index) that isn't scoped per
+// character, so fanning it out made every message redo the same heavy pull and
+// blow past the 60s queue function limit. It runs on its own daily GitHub Actions
+// cron (structures.yml) instead.
+const PER_CHARACTER_JOBS = ['assets', 'hourly', 'orders'] as const
 
 type Character = { id: string; name: string | null }
 

--- a/src/app/characters/refresh/page.tsx
+++ b/src/app/characters/refresh/page.tsx
@@ -8,7 +8,9 @@ import { RefreshPoller } from './poller'
 import styles from './refresh.module.css'
 
 // Matches the per-character jobs the Refresh ESI action fans out, in column order.
-const JOBS = ['assets', 'hourly', 'structures', 'orders'] as const
+// `structures` isn't fanned out per character (it runs on a daily cron), so it's
+// not a column here.
+const JOBS = ['assets', 'hourly', 'orders'] as const
 
 // Always read fresh — the poller re-requests this server component every couple of
 // seconds while a refresh is in flight.

--- a/src/industryIndexes.js
+++ b/src/industryIndexes.js
@@ -28,7 +28,7 @@ export const pullIndustryIndexes = async () => {
     if (rows.length < SYSTEM_PAGE) break
   }
 
-  console.log(`[structures] industry indexes: ${systemIds.size} system(s) with structures`)
+  console.log(`[industry_index] ${systemIds.size} system(s) with structures`)
   if (systemIds.size === 0) return
 
   const systems = await industrySystems()
@@ -49,14 +49,14 @@ export const pullIndustryIndexes = async () => {
   }
 
   if (rows.length === 0) {
-    console.log('[structures] industry indexes: no matching systems returned by ESI, nothing to record')
+    console.log('[industry_index] no matching systems returned by ESI, nothing to record')
     return
   }
 
   const { error: insertErr } = await sudoSupabase.from('industry_system_index').insert(rows)
   if (insertErr) {
-    console.error(`[structures] industry index insert FAILED: ${insertErr.message}`)
+    console.error(`[industry_index] insert FAILED: ${insertErr.message}`)
     throw insertErr
   }
-  console.log(`[structures] recorded ${rows.length} industry index row(s)`)
+  console.log(`[industry_index] recorded ${rows.length} industry index row(s)`)
 }

--- a/src/jobs/industryIndex.js
+++ b/src/jobs/industryIndex.js
@@ -1,0 +1,29 @@
+import { fileURLToPath } from 'node:url'
+
+import { pullIndustryIndexes } from '../industryIndexes.js'
+
+// Snapshot the public industry cost indices for every system we hold a structure
+// in, building a history of how those indices drift over time. The ESI endpoint is
+// public (no token) and the work is account-wide — it reads corp_structure and the
+// global /industry/systems/ feed — so this job takes no character/user scope and
+// runs for everyone at once on its own hourly cron (industry_index.yml). It was
+// pulled out of the structures job, where running it per-character fanout blew past
+// the 60s queue limit.
+export const runIndustryIndex = async () => {
+  await pullIndustryIndexes()
+}
+
+const execute = async () => {
+  try {
+    await runIndustryIndex()
+  } catch (e) {
+    console.error('[industry_index] FAILED', e)
+    process.exit(1)
+  }
+}
+
+// Only run as a CLI (npm run industry-index / the scheduled workflow) when invoked
+// directly. When imported elsewhere, the top-level run must not fire.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  execute()
+}

--- a/src/jobs/structures.js
+++ b/src/jobs/structures.js
@@ -2,7 +2,6 @@ import { fileURLToPath } from 'node:url'
 
 import { pullCorpWalletJournals } from '../corpWalletJournal.js'
 import { character as fetchCharacter, corpAssets, corpStructures, universeNames } from '../esi.js'
-import { pullIndustryIndexes } from '../industryIndexes.js'
 import { resolveCorpJournalNames, resolveCorpStructureSystemNames } from '../resolveNames.js'
 import { resolveStructureNames } from '../structureNames.js'
 import { sudoSupabase } from '../supabase.js'
@@ -274,15 +273,6 @@ export const runStructures = async ({ characterIds } = {}) => {
     await resolveCorpStructureSystemNames()
   } catch (e) {
     console.error(`[structures] system-name resolution FAILED name=${e?.name} message=${e?.message}`)
-  }
-
-  // Snapshot the industry cost indices for every system we have a structure in,
-  // building a history of how those indices move over time. Public ESI data, so
-  // it runs regardless of which scopes the linked tokens carry.
-  try {
-    await pullIndustryIndexes()
-  } catch (e) {
-    console.error(`[structures] industry index pull FAILED name=${e?.name} message=${e?.message}`)
   }
 }
 


### PR DESCRIPTION
## Why

After the region fix (#454), the production logs showed the queue consumer retrying in a loop: 42 `Vercel Runtime Timeout Error: Task timed out after 60 seconds` on `/api/queue/jobs`, and every consume line around them was `job=structures` with the **same taskIds redelivered over and over**.

Root cause: `structures` does whole-corp/whole-universe work that isn't character-scoped, yet it was fanned out one queue message per character. Every message redid the same heavy pull — worst of all `pullIndustryIndexes()`, which snapshots the **entire** EVE industry cost index and trips ESI's `420` rate limit when several characters fire at once. Each attempt blew past the 60s function limit → killed → never acked → Vercel redelivered every 60s.

## Changes

**Structures off the on-demand path:**
- Removed `structures` from the per-character refresh fan-out (`dispatchRefresh`) and from the `/characters/refresh` status matrix columns.
- It now runs **only** on its GitHub Actions cron, moved from hourly → **daily** (`09:17` UTC). The CLI run has no 60s cap, which is the right place for this heavy whole-account work.

**New standalone `industry_index` job:**
- Extracted `pullIndustryIndexes()` into its own job: `src/jobs/industryIndex.js` (`runIndustryIndex()`) + `industry_index.yml`, running **every hour at `:10`**.
- It takes **no character/user scope** — the ESI feed is public and the work is account-wide — so one run covers everyone.
- Added `npm run industry-index`; relabelled its logs `[structures]` → `[industry_index]`; updated CLAUDE.md.

## Net effect

No more per-character `structures` queue messages, so the 60s timeout/retry loop is gone. Industry indices keep refreshing hourly (better than the old per-refresh cadence), and full structure data refreshes daily.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016P7eNt2cV9R99Ks8fkBq2A)_