### PR TITLE
Remove sparkline debug readout below each industry index

### DIFF
--- a/src/app/structures/page.tsx
+++ b/src/app/structures/page.tsx
@@ -298,8 +298,6 @@ const StructuresPage = async () => {
                           const cost = systemIndexes?.get(activity)
                           const series = systemHistory?.get(activity)
                           const values = series?.values ?? []
-                          const histMin = values.length > 0 ? Math.min(...values) : null
-                          const histMax = values.length > 0 ? Math.max(...values) : null
                           return (
                             <li key={`idx-${s.structure_id}-${activity}`} className={styles.indexRow}>
                               <span className={styles.indexLabel}>{INDEX_ACTIVITY_LABELS[activity]}</span>
@@ -310,10 +308,6 @@ const StructuresPage = async () => {
                                 label={INDEX_ACTIVITY_LABELS[activity]}
                               />
                               <span className={styles.indexValue}>{cost != null ? formatIndex(cost) : '—'}</span>
-                              <ul style={{gridColumn:'1/-1',fontSize:'0.7em',fontFamily:'monospace',margin:'2px 0 4px',padding:'0',listStyle:'none'}}>
-                                <li>values ({values.length}): [{values.map((v) => formatIndex(v)).join(', ')}]</li>
-                                <li>min: {histMin != null ? formatIndex(histMin) : '—'} | max: {histMax != null ? formatIndex(histMax) : '—'} | current: {cost != null ? formatIndex(cost) : '—'}</li>
-                              </ul>
                             </li>
                           )
                         })}


### PR DESCRIPTION
The sparkline numbers are correct now, so this drops the temporary debug list that was rendered under each industry-index sparkline — the raw `values (N): [...]` line and the `min | max | current` line (added in the "sparkline debug" commit). Also removes the now-unused `histMin`/`histMax` locals.

Sparkline, the current value, and the activity label are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016P7eNt2cV9R99Ks8fkBq2A)_