### PR TITLE
Resolve player structure names on each asset fetch

### DIFF
--- a/src/jobs/assets.js
+++ b/src/jobs/assets.js
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url'
 import { assets, assetNames, userAgent } from '../esi.js'
 import SingleSignOn from '@philihp/eve-sso'
 import { sudoSupabase } from '../supabase.js'
+import { resolveStructureNames } from '../structureNames.js'
 
 const EVE_CLIENT_ID = process.env.EVE_CLIENT_ID
 const EVE_SECRET_KEY = process.env.EVE_SECRET_KEY
@@ -222,6 +223,15 @@ export const runAssets = async ({ characterIds } = {}) => {
       const dt = Date.now() - t0
       console.error(`[assets] ${ctx}: FAILED after ${dt}ms name=${e?.name} message=${e?.message}\n${e?.stack ?? e}`)
     }
+  }
+
+  // Resolve player structure names so the assets page can label them.
+  // This runs every hour alongside asset fetches, so newly discovered
+  // structures get named quickly rather than waiting for the daily job.
+  try {
+    await resolveStructureNames()
+  } catch (e) {
+    console.error(`[assets] structure-name resolution FAILED name=${e?.name} message=${e?.message}`)
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes asset location 1050038310811 (and other player structures) not being resolved to their names when characters fetch assets.

**The problem:** Asset fetches run hourly, but structure name resolution only ran daily. This created a gap where newly discovered structures sat unresolved for up to 24 hours.

**The fix:** `resolveStructureNames()` is now called at the end of each hourly asset fetch, so structures get labeled immediately when they appear in asset data.

## Details

- The assets job runs every hour at :26 and pulls all character assets
- Character assets can reference player Upwell structures via location_id
- Previously only the daily structures job (09:17 UTC) called `resolveStructureNames()`
- Now it's also called after each hourly asset fetch
- Structure resolution tries to resolve via ESI for any character with `esi-universe.read_structures.v1` scope
- Once resolved, the `structure` table caches the name/system_id, so subsequent calls are cheap

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nt9rdVSA1oAD6mYzR2jiLG)_