### PR TITLE
Group asset quantities with commas, copy raw digits

### DIFF
--- a/src/app/assets/[locationId]/locationAssets.tsx
+++ b/src/app/assets/[locationId]/locationAssets.tsx
@@ -6,6 +6,7 @@ import retro from '../../retro.module.css'
 import { TypeName } from '../../typeName'
 import styles from '../assets.module.css'
 import { ALL_CHARACTERS, CharacterFilter, useCharacterFilter, type Character } from '../characterFilter'
+import { Quantity } from './quantity'
 
 export type ItemRow = {
   itemId: string
@@ -69,7 +70,7 @@ export const LocationAssets = ({ rows, characters, typeNamesPromise }: LocationA
                     <TypeName id={row.typeId} name={row.name} promise={typeNamesPromise} />
                   )}
                 </td>
-                <td className={retro.num}>{row.isSingleton ? '—' : (row.quantity ?? 1)}</td>
+                <td className={retro.num}>{row.isSingleton ? '—' : <Quantity value={row.quantity} />}</td>
                 <td>{row.flag ?? '—'}</td>
                 <td className={retro.num}>{row.contents > 0 ? row.contents : '—'}</td>
               </tr>

--- a/src/app/assets/[locationId]/quantity.module.css
+++ b/src/app/assets/[locationId]/quantity.module.css
@@ -1,0 +1,25 @@
+/*
+ * Quantity: shown grouped with thousands separators, copied raw.
+ *
+ * The visible, comma-grouped text comes from generated content (::after), which
+ * browsers leave out of the clipboard. The raw, separator-free digits live in a
+ * real — but visually hidden — text node, so a select-and-copy grabs the plain
+ * number (e.g. 123456789) instead of the grouped display (123,456,789).
+ */
+.quantity {
+  position: relative;
+}
+
+.quantity::after {
+  content: attr(data-grouped);
+}
+
+/* Visually hidden, yet still part of the DOM selection so it copies cleanly. */
+.raw {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}

--- a/src/app/assets/[locationId]/quantity.tsx
+++ b/src/app/assets/[locationId]/quantity.tsx
@@ -1,0 +1,16 @@
+import styles from './quantity.module.css'
+
+// Renders a stack size grouped with thousands separators (123,456,789) for
+// display, while keeping the raw digits (123456789) as the text that actually
+// lands on the clipboard when the cell is highlighted and copied. Non-numeric
+// values fall through unchanged.
+export const Quantity = ({ value }: { value: number | string | null }) => {
+  const n = Number(value ?? 1)
+  if (!Number.isFinite(n)) return <>{value ?? 1}</>
+
+  return (
+    <span className={styles.quantity} data-grouped={n.toLocaleString('en-US')}>
+      <span className={styles.raw}>{n}</span>
+    </span>
+  )
+}


### PR DESCRIPTION
## What

In the assets viewer, hangar stacks can run into the hundreds of millions, making the bare quantity hard to read. This formats the **Quantity** column with thousands separators (e.g. `123,456,789`) — but keeps the **raw, separator-free** number on the clipboard when you highlight and copy it (`123456789`), so it pastes cleanly into spreadsheets and the like.

## How

A new `Quantity` component renders the grouped value via a CSS generated-content pseudo-element (`::after` with `content: attr(data-grouped)`). Browsers exclude generated content from the clipboard, so it never gets copied. The raw digits live in a visually-hidden — but still selectable — real text node, which is what actually lands on the clipboard.

- `src/app/assets/[locationId]/quantity.tsx` — the component (non-numeric values pass through unchanged).
- `src/app/assets/[locationId]/quantity.module.css` — grouped display + visually-hidden raw node.
- `src/app/assets/[locationId]/locationAssets.tsx` — render `<Quantity value={row.quantity} />` in the Quantity cell (singletons still show `—`).

## Notes

No DB/schema changes; purely a display-layer tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMiDvND3ZfF6G6L42qYmxz)_