### PR TITLE
Inline Renovate config (drop @philihp preset)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,12 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "@philihp",
-    ":dependencyDashboard",
-    ":semanticCommits",
-    "helpers:pinGitHubActionDigests",
-    "schedule:weekly"
-  ],
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "schedule": ["every weekend"],
+  "semanticCommits": "enabled",
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "Independency Dashboard",
+  "transitiveRemediation": true,
   "labels": ["dependencies"],
   "prConcurrentLimit": 10,
   "lockFileMaintenance": {
@@ -14,9 +13,13 @@
   },
   "packageRules": [
     {
-      "description": "Automerge non-major devDependency updates",
+      "description": "Automerge minor, patch, pin, and digest updates",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "description": "Automerge all devDependency updates",
       "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     },
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,34 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["@philihp"]
+  "extends": [
+    "@philihp",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    "helpers:pinGitHubActionDigests",
+    "schedule:weekly"
+  ],
+  "labels": ["dependencies"],
+  "prConcurrentLimit": 10,
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "description": "Automerge non-major devDependency updates",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
+      "description": "Group and automerge GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions",
+      "automerge": true
+    },
+    {
+      "description": "Group type definition packages together",
+      "matchPackageNames": ["/^@types//"],
+      "groupName": "type definitions"
+    }
+  ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,4 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["@philihp"]
 }


### PR DESCRIPTION
## What

Makes `.github/renovate.json` self-contained: drops the external `@philihp/renovate-config` shared preset and inlines its settings directly, alongside a few additional modern conventions.

## Inlined from `@philihp/renovate-config@1.2.0`

The preset's `default` config was:

```json
{
  "extends": ["config:base"],
  "schedule": ["every weekend"],
  "dependencyDashboard": true,
  "dependencyDashboardTitle": "Independency Dashboard",
  "transitiveRemediation": true,
  "packageRules": [
    { "semanticCommits": "enabled" },
    { "updateTypes": ["minor", "patch", "pin", "digest"], "automerge": true },
    { "depTypeList": ["devDependencies"], "automerge": true }
  ]
}
```

All of it is now inlined, with deprecated field names modernized:
- `config:base` → `config:recommended`
- `updateTypes` → `matchUpdateTypes`
- `depTypeList` → `matchDepTypes`
- the no-matcher `{ "semanticCommits": "enabled" }` rule → top-level `semanticCommits`

## Also retained (added earlier on this branch)

- `$schema` for editor validation/autocomplete
- `helpers:pinGitHubActionDigests` — SHA-pin GitHub Actions
- `lockFileMaintenance` enabled
- `labels: ["dependencies"]` and `prConcurrentLimit: 10`
- grouping for GitHub Actions and `@types/*` packages

## Notes

Behavior is equivalent to the previous `@philihp`-based setup, just without the external config dependency. Config only — no application code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)