### PR TITLE
Stabilize structure-name candidate paging with an explicit order

### DIFF
--- a/src/structureNames.js
+++ b/src/structureNames.js
@@ -45,10 +45,15 @@ export const resolveStructureNames = async () => {
   const itemIds = new Set()
   const locationIds = new Set()
   for (let from = 0; ; from += ASSET_PAGE) {
+    // Order by the primary key so range paging is stable: PostgREST gives no row
+    // order without an explicit sort, so an unordered .range() can skip or repeat
+    // rows across pages and silently drop a structure from the candidate set. The
+    // assets extract pages the same table and orders by id for exactly this reason.
     const { data: rows, error: assetsErr } = await sudoSupabase
       .from('asset_over_time')
       .select('item_id, location_id')
       .eq('is_current', true)
+      .order('id', { ascending: true })
       .range(from, from + ASSET_PAGE - 1)
     if (assetsErr) throw assetsErr
     if (!rows || rows.length === 0) break


### PR DESCRIPTION
## Summary

`resolveStructureNames()` pools the player-structure `location_id`s it needs to resolve by paging through every `is_current` row of `asset_over_time`. That pagination used `.range()` **with no `ORDER BY`**.

PostgREST guarantees no row ordering without an explicit sort, so across the ~22 pages of a 20k+ row table a given structure's `location_id` could be skipped (or repeated) between pages — and a skipped one is silently dropped from the candidate set, leaving that structure unresolved until some later run happened to page it in. This is a plausible contributor to "some structures aren't being resolved."

## Fix

Order the page query by the primary key (`id`) so paging is stable and every `is_current` row is seen exactly once. The assets extract (`src/jobs/assets.js`) already orders its identical paging by `id` for precisely this reason.

## Notes

- One-line change plus an explanatory comment; no behavior change beyond making the candidate set complete and deterministic.
- This does **not** fix foreign structures that no linked character can dock at (ESI returns 403 on those), nor the assets-page roll-up of items whose container isn't in the viewer's current snapshot — that roll-up is handled in a separate PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nt9rdVSA1oAD6mYzR2jiLG)_