### PR TITLE
Bridge snapshot gaps when rolling assets up to their structure

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -178,7 +178,21 @@ returns table (location_id bigint, location_type text, character_id uuid, stacks
 language sql
 stable
 as $$
-  with recursive walk as (
+  with recursive parent_of as (
+    -- One best-known parent per item the caller can see: the live row if there is
+    -- one, otherwise the most recent historical sighting. The walk climbs through
+    -- this rather than the live-only asset view so it can bridge a container or
+    -- ship that has momentarily dropped out of the current snapshot — e.g. one
+    -- handed between the player's own characters, whose per-character extracts run
+    -- at different times — and still roll its contents up to the enclosing
+    -- structure instead of stranding them on the bare item id. RLS keeps
+    -- asset_over_time scoped to the caller's own characters, so a container owned
+    -- by someone else (a corpmate's) still can't be bridged.
+    select distinct on (item_id) item_id, location_id, location_type
+    from public.asset_over_time
+    order by item_id, is_current desc, last_seen_at desc
+  ),
+  walk as (
     select
       a.item_id       as start_item,
       a.character_id  as character_id,
@@ -194,7 +208,7 @@ as $$
       p.location_type,
       w.depth + 1
     from walk w
-    join public.asset p on p.item_id = w.location_id
+    join parent_of p on p.item_id = w.location_id
     where w.depth < 64
   )
   select
@@ -204,7 +218,7 @@ as $$
     count(*) as stacks
   from walk w
   where w.location_id is not null
-    and not exists (select 1 from public.asset o where o.item_id = w.location_id)
+    and not exists (select 1 from parent_of o where o.item_id = w.location_id)
   group by w.location_id, w.location_type, w.character_id;
 $$;
 

--- a/supabase/migrations/20260630193000_asset_location_summary_bridge_gaps.sql
+++ b/supabase/migrations/20260630193000_asset_location_summary_bridge_gaps.sql
@@ -1,0 +1,53 @@
+-- asset_location_summary() climbed each item up its location_id chain through
+-- the live `asset` view only, so when an intermediate container or ship was
+-- momentarily absent from the current snapshot — e.g. handed between the
+-- player's own characters, whose per-character extracts run at different times —
+-- the walk stranded that item's contents on the bare container/ship id, which
+-- the assets page then rendered as a raw "Location #<id>" instead of folding it
+-- into the enclosing structure.
+--
+-- Climb through a best-known-parent CTE (the live row per item if present, else
+-- the most recent historical sighting) so the chain can bridge that gap and roll
+-- the contents up to the structure. RLS still scopes asset_over_time to the
+-- caller's own characters, so a container owned by someone else can't be bridged.
+create or replace function public.asset_location_summary()
+returns table (location_id bigint, location_type text, character_id uuid, stacks bigint)
+language sql
+stable
+as $$
+  with recursive parent_of as (
+    select distinct on (item_id) item_id, location_id, location_type
+    from public.asset_over_time
+    order by item_id, is_current desc, last_seen_at desc
+  ),
+  walk as (
+    select
+      a.item_id       as start_item,
+      a.character_id  as character_id,
+      a.location_id   as location_id,
+      a.location_type as location_type,
+      1               as depth
+    from public.asset a
+    union all
+    select
+      w.start_item,
+      w.character_id,
+      p.location_id,
+      p.location_type,
+      w.depth + 1
+    from walk w
+    join parent_of p on p.item_id = w.location_id
+    where w.depth < 64
+  )
+  select
+    w.location_id,
+    w.location_type,
+    w.character_id,
+    count(*) as stacks
+  from walk w
+  where w.location_id is not null
+    and not exists (select 1 from parent_of o where o.item_id = w.location_id)
+  group by w.location_id, w.location_type, w.character_id;
+$$;
+
+grant execute on function public.asset_location_summary() to authenticated;


### PR DESCRIPTION
## Summary

The assets page groups items by their root location using `asset_location_summary()`, which climbs each item up its `location_id` chain to the first thing that isn't one of our own items (a station, structure, or solar system). That climb only hopped through the **live** `asset` view.

So when an intermediate container or ship was momentarily absent from the current snapshot, the walk stranded that item's contents on the bare container/ship id — and the page rendered it as a raw `Location #<id>` instead of folding it into the enclosing structure. This is the most common reason items in a known structure show up "unresolved."

The usual trigger: a container handed between the player's **own** characters. Each character's asset extract runs at a different time, so there's a window where the container's row isn't `is_current` for anyone, and its contents have no visible parent to climb through.

## Fix

Climb through a `parent_of` CTE — one best-known parent per item the caller can see: the live row if present, otherwise the most recent historical sighting (`distinct on (item_id) ... order by item_id, is_current desc, last_seen_at desc`). That lets the chain bridge the gap and roll the contents up to the structure.

RLS still scopes `asset_over_time` to the caller's own characters, so a container owned by **someone else** (a corpmate's) genuinely can't be bridged — those stay as-is. Foreign structures nobody can dock at are also unaffected (separate concern).

## Changes

- `schema.sql` — updated `asset_location_summary()` (the full-reset source of truth).
- `supabase/migrations/20260630193000_asset_location_summary_bridge_gaps.sql` — non-destructive `create or replace` migration so existing databases pick up the change without a wipe.

## Verification

Replayed the new logic against production data for an affected account (read-only, scoped to mimic RLS): **18 previously-stranded stacks now roll up into resolved structures**, with no stack counts increasing anywhere and no new stranded roots introduced. The orphaned-container example folded into its structure as expected; asset-safety (`2004`) correctly stays separate.

## Note

This is one of two PRs from the same investigation. The other (#470) hardens `resolveStructureNames()` pagination. This PR is the assets-page roll-up half.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nt9rdVSA1oAD6mYzR2jiLG)_