### PR TITLE
Fix duplicate market sales from corp-attributed transactions

### DIFF
--- a/src/app/market/page.tsx
+++ b/src/app/market/page.tsx
@@ -51,12 +51,16 @@ const MarketPage = async () => {
   // the whole lookback span. Personal and corp sales live in separate tables (corp
   // transactions have no owning character); RLS scopes each to what the user may
   // see, and transaction_ids never collide across the two, so the union is a plain
-  // concatenation.
+  // concatenation. ESI's character wallet/transactions endpoint also reports trades
+  // the character made on behalf of their corp (is_personal: false) — those are
+  // already captured via corp_market_transaction, so exclude them here to avoid
+  // double-counting the same sale.
   const personal = await fetchAllRows<Sale>((from, to) =>
     supabase
       .from('market_transaction')
       .select('transaction_id, character_id, date, type_id, quantity, unit_price, seen_at')
       .eq('is_buy', false)
+      .eq('is_personal', true)
       .gte('date', since)
       .order('date', { ascending: false })
       .range(from, to)


### PR DESCRIPTION
## Summary

- A character's personal `wallet/transactions/` feed from ESI includes trades made on behalf of their corporation (flagged `is_personal: false`), not just true personal trades.
- `src/app/market/page.tsx` unioned all rows from `market_transaction` with `corp_market_transaction` without filtering on `is_personal`, so any corp-attributed sale was counted twice: once via the character's personal feed and again via the corp feed.
- This only surfaces for characters who also hold the corp wallet scope, which matches the report of a user seeing duplicated sales tied to their corp wallet.
- Fix: filter the personal `market_transaction` query in the market page to `is_personal = true`, excluding rows already captured via `corp_market_transaction`.

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [ ] Manually verify on an account with corp wallet scope that previously-duplicated sales now appear once


---
_Generated by [Claude Code](https://claude.ai/code/session_01LyggFHx9zE4sgQTaq446pR)_