### PR TITLE
Resolve NPC station names from the eve_name cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ All functions take `(characterId, accessToken)` unless noted. Returns raw ESI re
 - `resolveCorpJournalNames(entries[])` — extract and resolve first/second party IDs from journal rows
 - `resolveCorpNames(corporationIds[])` — resolve+cache corp names (for labelling corp market sales)
 - `resolveCorpStructureSystemNames(structures[])` — resolve system IDs for structures
+- `resolveAssetStationNames()` — resolve+cache NPC station names (location_type 'station' in assets) into `eve_name`
 
 ### `src/corpMarketTransactions.js`
 - `pullCorpMarketTransactions({ access_token, corporation_id, ... })` — fetch all 7 divisions' market transactions, upsert to `corp_market_transaction`

--- a/src/app/stationNames.ts
+++ b/src/app/stationNames.ts
@@ -1,54 +1,25 @@
-// Resolve station details from eve-build-calculator, mirroring the system lookup
-// in systemNames.ts. Unresolved ids are simply omitted so callers can fall back
-// to showing the raw id (never read the evesde SDE).
-type Station = { name: string | null; solarSystemId: number | null }
+// Resolve NPC station names from the local eve_name cache, which the structures
+// job keeps populated (via ESI universe/names, category 'station') for every NPC
+// station we currently hold assets in. Mirrors the solar-system lookup in
+// systemNames.ts. Unresolved ids are simply omitted so callers can fall back to
+// showing the raw id (never read the evesde SDE). Player Upwell structures are
+// resolved separately from corp_structure/structure.
+import { createClient } from '@/utils/supabase/server'
 
-type StationResponse = {
-  name?: { en?: string } | string
-  // The calculator exposes the station's solar system so callers can resolve its
-  // name via /api/system/{id}; tolerate either casing the API might return.
-  solarSystemId?: number
-  solarSystemID?: number
-}
-
-const cache = new Map<number, Promise<Station | null>>()
-
-const fetchOne = (stationID: number): Promise<Station | null> =>
-  fetch(`https://sde.edencom.link/api/station/${stationID}`)
-    .then((res) => (res.ok ? res.json() : null))
-    .then((station: StationResponse | null) => {
-      if (!station) return null
-      const name = typeof station.name === 'string' ? station.name : (station.name?.en ?? null)
-      const solarSystemId = station.solarSystemId ?? station.solarSystemID ?? null
-      return { name, solarSystemId }
-    })
-    .catch(() => null)
-
-const lookup = (stationID: number): Promise<Station | null> => {
-  const cached = cache.get(stationID)
-  if (cached) return cached
-  const promise = fetchOne(stationID)
-  cache.set(stationID, promise)
-  promise.then((station) => {
-    if (station === null) cache.delete(stationID)
-  })
-  return promise
-}
-
-const resolve = async <T>(stationIDs: Iterable<number>, pick: (s: Station) => T | null): Promise<Record<number, T>> => {
+export const fetchStationNames = async (stationIDs: Iterable<number>): Promise<Record<number, string>> => {
   const ids = Array.from(new Set([...stationIDs].filter((n) => Number.isFinite(n))))
-  const pairs = await Promise.all(
-    ids.map(async (id) => {
-      const station = await lookup(id)
-      return [id, station ? pick(station) : null] as const
-    }),
-  )
-  return Object.fromEntries(pairs.filter(([, value]) => value !== null) as [number, T][])
+  if (ids.length === 0) return {}
+  const supabase = await createClient()
+  const { data } = await supabase.from('eve_name').select('id, name').eq('category', 'station').in('id', ids)
+  const result: Record<number, string> = {}
+  for (const r of (data ?? []) as Array<{ id: number | string; name: string }>) {
+    result[Number(r.id)] = r.name
+  }
+  return result
 }
 
-export const fetchStationNames = (stationIDs: Iterable<number>): Promise<Record<number, string>> =>
-  resolve(stationIDs, (s) => s.name)
-
-// stationID → solarSystemID, for resolving the system an NPC station sits in.
-export const fetchStationSystems = (stationIDs: Iterable<number>): Promise<Record<number, number>> =>
-  resolve(stationIDs, (s) => s.solarSystemId)
+// universe/names doesn't return a station's solar system, so we don't cache it.
+// The NPC station name already embeds the system (e.g. "Podion VIII - Moon 15 -
+// …"), so the assets page falls back to that rather than a separate system label.
+// Kept as a stub so callers don't have to special-case NPC stations.
+export const fetchStationSystems = async (_stationIDs: Iterable<number>): Promise<Record<number, number>> => ({})

--- a/src/jobs/structures.js
+++ b/src/jobs/structures.js
@@ -2,7 +2,7 @@ import { fileURLToPath } from 'node:url'
 
 import { pullCorpWalletJournals } from '../corpWalletJournal.js'
 import { character as fetchCharacter, corpAssets, corpStructures, universeNames } from '../esi.js'
-import { resolveCorpJournalNames, resolveCorpStructureSystemNames } from '../resolveNames.js'
+import { resolveAssetStationNames, resolveCorpJournalNames, resolveCorpStructureSystemNames } from '../resolveNames.js'
 import { resolveStructureNames } from '../structureNames.js'
 import { sudoSupabase } from '../supabase.js'
 import { refreshAccessToken } from '../tokenRefresh.js'
@@ -265,6 +265,14 @@ export const runStructures = async ({ characterIds } = {}) => {
     await resolveStructureNames()
   } catch (e) {
     console.error(`[structures] structure-name resolution FAILED name=${e?.name} message=${e?.message}`)
+  }
+
+  // Name the NPC stations characters hold assets in, so the assets page can label
+  // them instead of showing a raw station id (player structures are named above).
+  try {
+    await resolveAssetStationNames()
+  } catch (e) {
+    console.error(`[structures] station-name resolution FAILED name=${e?.name} message=${e?.message}`)
   }
 
   // Name the solar systems our corp structures sit in, so the structures page can

--- a/src/resolveNames.js
+++ b/src/resolveNames.js
@@ -95,6 +95,56 @@ export const resolveCorpNames = async (corporationIds) => {
   console.log(`[names] upserted ${rows.length} corp name(s)`)
 }
 
+// Cache (in eve_name) the name of every NPC station that currently holds one of
+// our assets. ESI marks those asset rows with location_type 'station', and their
+// names resolve via universe/names (category 'station') — no docking token
+// needed, unlike player Upwell structures (handled by resolveStructureNames).
+// Only resolves ids missing from eve_name, so steady-state runs do nothing. The
+// assets page reads eve_name to label NPC station locations instead of a raw id.
+export const resolveAssetStationNames = async () => {
+  // Page through live asset rows located directly in an NPC station. Order by the
+  // primary key so range paging is stable (an unordered .range() can skip rows).
+  const PAGE = 1000
+  const ids = new Set()
+  for (let from = 0; ; from += PAGE) {
+    const { data: rows, error } = await sudoSupabase
+      .from('asset_over_time')
+      .select('location_id')
+      .eq('is_current', true)
+      .eq('location_type', 'station')
+      .order('id', { ascending: true })
+      .range(from, from + PAGE - 1)
+    if (error) throw error
+    if (!rows || rows.length === 0) break
+    for (const r of rows) if (r.location_id != null) ids.add(Number(r.location_id))
+    if (rows.length < PAGE) break
+  }
+
+  const { data: known, error: knownErr } = await sudoSupabase.from('eve_name').select('id').eq('category', 'station')
+  if (knownErr) throw knownErr
+  for (const k of known ?? []) ids.delete(Number(k.id))
+
+  const toResolve = [...ids].filter((n) => Number.isFinite(n) && n > 0)
+  console.log(`[names] asset stations: ${toResolve.length} to resolve`)
+  if (toResolve.length === 0) return
+
+  const resolved = []
+  for (let i = 0; i < toResolve.length; i += BATCH_SIZE) {
+    const names = await resolveBatch(toResolve.slice(i, i + BATCH_SIZE))
+    resolved.push(...names)
+  }
+
+  if (resolved.length === 0) {
+    console.log('[names] no station names resolved')
+    return
+  }
+
+  const rows = resolved.map((n) => ({ id: n.id, name: n.name, category: n.category }))
+  const { error: upErr } = await sudoSupabase.from('eve_name').upsert(rows, { onConflict: 'id' })
+  if (upErr) throw upErr
+  console.log(`[names] upserted ${rows.length} station name(s)`)
+}
+
 // Cache (in eve_name) the name of every solar system we currently have a corp
 // structure in. Only resolves ids missing from eve_name, so steady-state runs do
 // nothing. The structures page reads eve_name to label each tile's system instead


### PR DESCRIPTION
## Summary

NPC station locations (e.g. `60013867`) were rendering as raw `Station #id` on the assets page while player structures resolved fine.

**Root cause:** `stationNames.ts` fetched NPC station details client-side from `https://sde.edencom.link/api/station/{id}`, which now returns **404** — that service only serves `/api/type/` today. (`systemNames.ts` had already been migrated off the same service to the `eve_name` DB cache for this reason; station resolution was the last thing still pointing at the dead endpoint.) Confirmed in production: all 136 distinct NPC stations held across accounts had no cached name.

## Fix

Resolve NPC station names through the normal **cron → DB → UI** path instead of from the UI:

- **`resolveNames.js`** — new `resolveAssetStationNames()`: pools the `location_id`s of live assets ESI marks with `location_type = 'station'`, resolves the ones missing from `eve_name` via `universe/names` (category `station`, no docking token needed), and upserts them. Only resolves missing ids, so steady-state runs do nothing.
- **`structures.js`** — runs it alongside the other name resolvers (`resolveStructureNames`, `resolveCorpStructureSystemNames`, …).
- **`stationNames.ts`** — `fetchStationNames` now reads from `eve_name` (category `station`), mirroring `systemNames.ts`. No more SDE dependency.

## Notes / scope

- `universe/names` doesn't return a station's solar system, so the separate **system label** for NPC stations is dropped. It was already broken (it came from the same dead SDE endpoint), and the NPC station name embeds the system anyway ("Podion VIII - Moon 15 - …"), so this is a strict improvement, not a regression.
- No DB schema change — `eve_name` already has the `(id, name, category)` shape and an upsert conflict target.
- Names populate on the next **structures** job run (daily 09:17 UTC, or trigger it via manual workflow dispatch to backfill immediately). Verified `tsc --noEmit` and `eslint` are clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nt9rdVSA1oAD6mYzR2jiLG)_