### PR TITLE
Simplify imperative loops with map/reduce and a ramda lens

### DIFF
--- a/src/app/account/chancellor/page.tsx
+++ b/src/app/account/chancellor/page.tsx
@@ -42,10 +42,10 @@ const ChancellorPage = async () => {
         .order('created_at', { ascending: true })
     : { data: [] }
 
-  const namesByUser = new Map<string, string[]>()
-  for (const r of regs ?? []) {
-    namesByUser.set(r.user_id, [...(namesByUser.get(r.user_id) ?? []), r.name])
-  }
+  const namesByUser = (regs ?? []).reduce((acc, r) => {
+    acc.set(r.user_id, [...(acc.get(r.user_id) ?? []), r.name])
+    return acc
+  }, new Map<string, string[]>())
 
   const emailByUser = new Map<string, string>()
   for (const id of ids) {

--- a/src/app/account/chancellor/page.tsx
+++ b/src/app/account/chancellor/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
+import { pluck, reduce, uniq } from 'ramda'
 
 import { createServiceClient } from '@/utils/supabase/service'
 import { createClient } from '@/utils/supabase/server'
@@ -30,7 +31,7 @@ const ChancellorPage = async () => {
     .select('redeemed_by')
     .eq('is_chancellor', true)
     .not('redeemed_by', 'is', null)
-  const ids = [...new Set((rows ?? []).map((r) => r.redeemed_by as string))]
+  const ids = uniq(pluck('redeemed_by', rows ?? []) as string[])
 
   // Display each Chancellor by their character names; fall back to the account
   // email (then the raw id) for accounts that haven't linked a character yet.
@@ -42,10 +43,11 @@ const ChancellorPage = async () => {
         .order('created_at', { ascending: true })
     : { data: [] }
 
-  const namesByUser = (regs ?? []).reduce((acc, r) => {
-    acc.set(r.user_id, [...(acc.get(r.user_id) ?? []), r.name])
-    return acc
-  }, new Map<string, string[]>())
+  const namesByUser = reduce(
+    (acc, r) => acc.set(r.user_id, [...(acc.get(r.user_id) ?? []), r.name]),
+    new Map<string, string[]>(),
+    regs ?? []
+  )
 
   const emailByUser = new Map<string, string>()
   for (const id of ids) {

--- a/src/app/assets/page.tsx
+++ b/src/app/assets/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from 'next/navigation'
 import { Suspense } from 'react'
+import { chain } from 'ramda'
 
 import { createClient } from '@/utils/supabase/server'
 import { DateTime } from '../DateTime'
@@ -71,13 +72,13 @@ const Locations = async () => {
 
   // Tally stacks per location, split by the character that owns each stack so
   // the client can filter by character.
-  const byLocation = new Map<string, { root: Root; counts: Map<string, number> }>()
-  for (const row of (summary ?? []) as SummaryRow[]) {
+  const byLocation = ((summary ?? []) as SummaryRow[]).reduce((acc, row) => {
     const id = String(row.location_id)
-    const entry = byLocation.get(id) ?? { root: { id, type: row.location_type }, counts: new Map<string, number>() }
+    const entry = acc.get(id) ?? { root: { id, type: row.location_type }, counts: new Map<string, number>() }
     entry.counts.set(row.character_id, (entry.counts.get(row.character_id) ?? 0) + Number(row.stacks))
-    byLocation.set(id, entry)
-  }
+    acc.set(id, entry)
+    return acc
+  }, new Map<string, { root: Root; counts: Map<string, number> }>())
 
   // Structure names + systems come from two caches: our own corp's structures
   // (corp_structure) and foreign player structures characters hold assets in,
@@ -90,27 +91,39 @@ const Locations = async () => {
     ? await supabase.from('structure').select('structure_id, name, system_id').in('structure_id', locationIds)
     : { data: [] }
 
-  const structureById = new Map<string, Structure>()
-  for (const s of (playerStructures ?? []) as Structure[]) structureById.set(String(s.structure_id), s)
-  // Own-corp structures override the ESI-resolved cache.
-  for (const s of (corpStructures ?? []) as Structure[]) structureById.set(String(s.structure_id), s)
+  // Own-corp structures override the ESI-resolved cache (later entries win).
+  const structureById = new Map<string, Structure>(
+    [...((playerStructures ?? []) as Structure[]), ...((corpStructures ?? []) as Structure[])].map((s) => [
+      String(s.structure_id),
+      s,
+    ])
+  )
 
   // NPC station names come from the eve_name DB cache; player structures aren't
   // there, so those still resolve via corp_structure above.
   const stationIds = [...byLocation.values()]
     .filter(({ root }) => root.type === 'station')
     .map(({ root }) => Number(root.id))
-  const [stationNames, stationSystems] = await Promise.all([fetchStationNames(stationIds), fetchStationSystems(stationIds)])
+  const [stationNames, stationSystems] = await Promise.all([
+    fetchStationNames(stationIds),
+    fetchStationSystems(stationIds),
+  ])
 
-  const systemIds = new Set<number>()
-  for (const { root } of byLocation.values()) {
-    if (root.type === 'solar_system') systemIds.add(Number(root.id))
-    const structure = structureById.get(root.id)
-    if (structure?.system_id != null) systemIds.add(Number(structure.system_id))
-    // NPC stations aren't in corp_structure/structure; their system comes from
-    // the calculator's station lookup above.
-    if (root.type === 'station' && stationSystems[Number(root.id)] != null) systemIds.add(stationSystems[Number(root.id)])
-  }
+  const systemIds = new Set<number>(
+    chain(
+      ({ root }) => {
+        const structure = structureById.get(root.id)
+        return [
+          root.type === 'solar_system' ? Number(root.id) : null,
+          structure?.system_id != null ? Number(structure.system_id) : null,
+          // NPC stations aren't in corp_structure/structure; their system comes from
+          // the calculator's station lookup above.
+          root.type === 'station' ? (stationSystems[Number(root.id)] ?? null) : null,
+        ].filter((id): id is number => id != null)
+      },
+      [...byLocation.values()]
+    )
+  )
   const systemNames = await fetchSystemNames(systemIds)
 
   const labelFor = (loc: Root): string => {

--- a/src/app/assets/page.tsx
+++ b/src/app/assets/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from 'next/navigation'
 import { Suspense } from 'react'
-import { chain } from 'ramda'
+import { chain, filter, map, pipe, reduce } from 'ramda'
 
 import { createClient } from '@/utils/supabase/server'
 import { DateTime } from '../DateTime'
@@ -72,19 +72,22 @@ const Locations = async () => {
 
   // Tally stacks per location, split by the character that owns each stack so
   // the client can filter by character.
-  const byLocation = ((summary ?? []) as SummaryRow[]).reduce((acc, row) => {
-    const id = String(row.location_id)
-    const entry = acc.get(id) ?? { root: { id, type: row.location_type }, counts: new Map<string, number>() }
-    entry.counts.set(row.character_id, (entry.counts.get(row.character_id) ?? 0) + Number(row.stacks))
-    acc.set(id, entry)
-    return acc
-  }, new Map<string, { root: Root; counts: Map<string, number> }>())
+  const byLocation = reduce(
+    (acc, row) => {
+      const id = String(row.location_id)
+      const entry = acc.get(id) ?? { root: { id, type: row.location_type }, counts: new Map<string, number>() }
+      entry.counts.set(row.character_id, (entry.counts.get(row.character_id) ?? 0) + Number(row.stacks))
+      return acc.set(id, entry)
+    },
+    new Map<string, { root: Root; counts: Map<string, number> }>(),
+    (summary ?? []) as SummaryRow[]
+  )
 
   // Structure names + systems come from two caches: our own corp's structures
   // (corp_structure) and foreign player structures characters hold assets in,
   // resolved from ESI by the structures job (public.structure). Own-corp entries
   // win on overlap. In-space `solar_system` locations are the system itself.
-  const locationIds = [...byLocation.keys()].map(Number).filter((n) => Number.isFinite(n))
+  const locationIds = filter(Number.isFinite, map(Number, [...byLocation.keys()]))
 
   const { data: corpStructures } = await supabase.from('corp_structure').select('structure_id, name, system_id')
   const { data: playerStructures } = locationIds.length
@@ -92,18 +95,18 @@ const Locations = async () => {
     : { data: [] }
 
   // Own-corp structures override the ESI-resolved cache (later entries win).
-  const structureById = new Map<string, Structure>(
-    [...((playerStructures ?? []) as Structure[]), ...((corpStructures ?? []) as Structure[])].map((s) => [
-      String(s.structure_id),
-      s,
-    ])
-  )
+  const byStructureId = (list: Structure[]): [string, Structure][] => map((s) => [String(s.structure_id), s], list)
+  const structureById = new Map<string, Structure>([
+    ...byStructureId((playerStructures ?? []) as Structure[]),
+    ...byStructureId((corpStructures ?? []) as Structure[]),
+  ])
 
   // NPC station names come from the eve_name DB cache; player structures aren't
   // there, so those still resolve via corp_structure above.
-  const stationIds = [...byLocation.values()]
-    .filter(({ root }) => root.type === 'station')
-    .map(({ root }) => Number(root.id))
+  const stationIds = pipe(
+    filter(({ root }: { root: Root }) => root.type === 'station'),
+    map(({ root }: { root: Root }) => Number(root.id))
+  )([...byLocation.values()])
   const [stationNames, stationSystems] = await Promise.all([
     fetchStationNames(stationIds),
     fetchStationSystems(stationIds),
@@ -145,12 +148,15 @@ const Locations = async () => {
     return undefined
   }
 
-  const locations: Location[] = [...byLocation.values()].map(({ root, counts }) => ({
-    id: root.id,
-    name: labelFor(root),
-    system: systemFor(root) ?? null,
-    counts: Object.fromEntries(counts),
-  }))
+  const locations: Location[] = map(
+    ({ root, counts }) => ({
+      id: root.id,
+      name: labelFor(root),
+      system: systemFor(root) ?? null,
+      counts: Object.fromEntries(counts),
+    }),
+    [...byLocation.values()]
+  )
 
   // When the Assets background job last finished. Each scheduled run writes a
   // public.heartbeat row stamped with ended_at and a link to the workflow run; we

--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
+import { reduce } from 'ramda'
 
 import { createClient } from '@/utils/supabase/server'
 import { register, refreshEsi, setMainCharacter } from './actions'
@@ -23,10 +24,11 @@ const CharacterPage = async () => {
     .select('character_id, balance, recorded_at')
     .order('recorded_at', { ascending: false })
 
-  const latestBalance = (wallets ?? []).reduce((acc, w) => {
-    if (!acc.has(w.character_id)) acc.set(w.character_id, w.balance)
-    return acc
-  }, new Map<string, string>())
+  const latestBalance = reduce(
+    (acc, w) => (acc.has(w.character_id) ? acc : acc.set(w.character_id, w.balance)),
+    new Map<string, string>(),
+    wallets ?? []
+  )
   const formatIsk = (raw: string | number) =>
     new Intl.NumberFormat('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(Number(raw))
 

--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -23,10 +23,10 @@ const CharacterPage = async () => {
     .select('character_id, balance, recorded_at')
     .order('recorded_at', { ascending: false })
 
-  const latestBalance = new Map<string, string>()
-  for (const w of wallets ?? []) {
-    if (!latestBalance.has(w.character_id)) latestBalance.set(w.character_id, w.balance)
-  }
+  const latestBalance = (wallets ?? []).reduce((acc, w) => {
+    if (!acc.has(w.character_id)) acc.set(w.character_id, w.balance)
+    return acc
+  }, new Map<string, string>())
   const formatIsk = (raw: string | number) =>
     new Intl.NumberFormat('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(Number(raw))
 

--- a/src/app/characters/refresh/page.tsx
+++ b/src/app/characters/refresh/page.tsx
@@ -88,17 +88,18 @@ const RefreshPage = async ({ searchParams }: { searchParams: Promise<{ batch?: s
 
   // Index the per-character tasks by character+job for the matrix; the daily task
   // is account-wide so it stands on its own.
-  const byCharJob = new Map<string, Task>()
-  const characters = new Map<string, string>()
-  let daily: Task | undefined
-  for (const t of tasks) {
-    if (t.character_id) {
-      byCharJob.set(`${t.character_id}:${t.job}`, t)
-      characters.set(t.character_id, t.character_name ?? t.character_id)
-    } else if (t.job === 'daily') {
-      daily = t
-    }
-  }
+  const { byCharJob, characters, daily } = tasks.reduce(
+    (acc, t) => {
+      if (t.character_id) {
+        acc.byCharJob.set(`${t.character_id}:${t.job}`, t)
+        acc.characters.set(t.character_id, t.character_name ?? t.character_id)
+      } else if (t.job === 'daily') {
+        acc.daily = t
+      }
+      return acc
+    },
+    { byCharJob: new Map<string, Task>(), characters: new Map<string, string>(), daily: undefined as Task | undefined }
+  )
 
   const isTerminal = (status: string) => status === 'done' || status === 'error'
   const allDone = tasks.length > 0 && tasks.every((t) => isTerminal(t.status))
@@ -119,7 +120,6 @@ const RefreshPage = async ({ searchParams }: { searchParams: Promise<{ batch?: s
   // of that job for the character (any earlier refresh). One query for all of the
   // batch's characters, reduced to the most recent `done` per character+job.
   const charIds = [...characters.keys()]
-  const lastSuccess = new Map<string, string>()
   const { data: doneData } = await supabase
     .from('refresh_task')
     .select('character_id, job, ended_at')
@@ -127,10 +127,11 @@ const RefreshPage = async ({ searchParams }: { searchParams: Promise<{ batch?: s
     .in('character_id', charIds)
     .not('ended_at', 'is', null)
     .order('ended_at', { ascending: false })
-  for (const r of doneData ?? []) {
+  const lastSuccess = (doneData ?? []).reduce((acc, r) => {
     const key = `${r.character_id}:${r.job}`
-    if (!lastSuccess.has(key)) lastSuccess.set(key, r.ended_at) // first seen = most recent
-  }
+    if (!acc.has(key)) acc.set(key, r.ended_at) // first seen = most recent
+    return acc
+  }, new Map<string, string>())
 
   return (
     <>

--- a/src/app/characters/refresh/page.tsx
+++ b/src/app/characters/refresh/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
+import { reduce } from 'ramda'
 
 import { createClient } from '@/utils/supabase/server'
 
@@ -88,7 +89,7 @@ const RefreshPage = async ({ searchParams }: { searchParams: Promise<{ batch?: s
 
   // Index the per-character tasks by character+job for the matrix; the daily task
   // is account-wide so it stands on its own.
-  const { byCharJob, characters, daily } = tasks.reduce(
+  const { byCharJob, characters, daily } = reduce(
     (acc, t) => {
       if (t.character_id) {
         acc.byCharJob.set(`${t.character_id}:${t.job}`, t)
@@ -98,7 +99,8 @@ const RefreshPage = async ({ searchParams }: { searchParams: Promise<{ batch?: s
       }
       return acc
     },
-    { byCharJob: new Map<string, Task>(), characters: new Map<string, string>(), daily: undefined as Task | undefined }
+    { byCharJob: new Map<string, Task>(), characters: new Map<string, string>(), daily: undefined as Task | undefined },
+    tasks
   )
 
   const isTerminal = (status: string) => status === 'done' || status === 'error'
@@ -127,11 +129,12 @@ const RefreshPage = async ({ searchParams }: { searchParams: Promise<{ batch?: s
     .in('character_id', charIds)
     .not('ended_at', 'is', null)
     .order('ended_at', { ascending: false })
-  const lastSuccess = (doneData ?? []).reduce((acc, r) => {
-    const key = `${r.character_id}:${r.job}`
-    if (!acc.has(key)) acc.set(key, r.ended_at) // first seen = most recent
-    return acc
-  }, new Map<string, string>())
+  const lastSuccess = reduce(
+    // first seen for a key = most recent ended_at, since doneData is ordered descending
+    (acc, r) => (acc.has(`${r.character_id}:${r.job}`) ? acc : acc.set(`${r.character_id}:${r.job}`, r.ended_at)),
+    new Map<string, string>(),
+    doneData ?? []
+  )
 
   return (
     <>

--- a/src/app/market/aggregate.ts
+++ b/src/app/market/aggregate.ts
@@ -1,29 +1,29 @@
+import { filter, map, reduce, sortBy } from 'ramda'
 import type { Sale } from './recentSales'
 
 // Sale value in raw ISK. "Total sales" everywhere on this page means summed ISK
 // turnover (unit price × quantity), not transaction count or unit quantity.
 const value = (s: Sale) => Number(s.unit_price) * Number(s.quantity)
+const saleTime = (s: Sale) => Date.parse(s.date)
+const inWindow = (start: number, end: number) => (s: Sale) => saleTime(s) >= start && saleTime(s) < end
 
 export type TypeTotal = { typeId: number; total: number; quantity: number }
 
 // Top-N type_ids by summed ISK value of sales whose date falls in [start, end).
 // Also carries the summed unit quantity sold in the same window.
 export const topTypesByValue = (sales: Sale[], start: number, end: number, limit: number): TypeTotal[] => {
-  const agg = sales
-    .filter((s) => {
-      const t = Date.parse(s.date)
-      return t >= start && t < end
-    })
-    .reduce((agg, s) => {
+  const agg = reduce(
+    (agg: Map<number, { total: number; quantity: number }>, s: Sale) => {
       const typeId = Number(s.type_id)
       const cur = agg.get(typeId) ?? { total: 0, quantity: 0 }
       agg.set(typeId, { total: cur.total + value(s), quantity: cur.quantity + Number(s.quantity) })
       return agg
-    }, new Map<number, { total: number; quantity: number }>())
-  return [...agg.entries()]
-    .map(([typeId, { total, quantity }]) => ({ typeId, total, quantity }))
-    .sort((a, b) => b.total - a.total)
-    .slice(0, limit)
+    },
+    new Map<number, { total: number; quantity: number }>(),
+    filter(inWindow(start, end), sales)
+  )
+  const totals: TypeTotal[] = map(([typeId, { total, quantity }]) => ({ typeId, total, quantity }), [...agg.entries()])
+  return sortBy((t) => -t.total, totals).slice(0, limit)
 }
 
 export type Bucket = { start: number; end: number; total: number }
@@ -38,11 +38,13 @@ export const bucketSales = (sales: Sale[], start: number, end: number, bucketMs:
     end: start + (i + 1) * bucketMs,
     total: 0,
   }))
-  return sales.reduce((buckets, s) => {
-    const t = Date.parse(s.date)
-    if (t < start || t >= end) return buckets
-    const idx = Math.min(count - 1, Math.floor((t - start) / bucketMs))
-    buckets[idx].total += value(s)
-    return buckets
-  }, buckets)
+  return reduce(
+    (buckets: Bucket[], s: Sale) => {
+      const idx = Math.min(count - 1, Math.floor((saleTime(s) - start) / bucketMs))
+      buckets[idx].total += value(s)
+      return buckets
+    },
+    buckets,
+    filter(inWindow(start, end), sales)
+  )
 }

--- a/src/app/market/aggregate.ts
+++ b/src/app/market/aggregate.ts
@@ -9,16 +9,17 @@ export type TypeTotal = { typeId: number; total: number; quantity: number }
 // Top-N type_ids by summed ISK value of sales whose date falls in [start, end).
 // Also carries the summed unit quantity sold in the same window.
 export const topTypesByValue = (sales: Sale[], start: number, end: number, limit: number): TypeTotal[] => {
-  const agg = new Map<number, { total: number; quantity: number }>()
-  for (const s of sales) {
-    const t = Date.parse(s.date)
-    if (t < start || t >= end) continue
-    const typeId = Number(s.type_id)
-    const cur = agg.get(typeId) ?? { total: 0, quantity: 0 }
-    cur.total += value(s)
-    cur.quantity += Number(s.quantity)
-    agg.set(typeId, cur)
-  }
+  const agg = sales
+    .filter((s) => {
+      const t = Date.parse(s.date)
+      return t >= start && t < end
+    })
+    .reduce((agg, s) => {
+      const typeId = Number(s.type_id)
+      const cur = agg.get(typeId) ?? { total: 0, quantity: 0 }
+      agg.set(typeId, { total: cur.total + value(s), quantity: cur.quantity + Number(s.quantity) })
+      return agg
+    }, new Map<number, { total: number; quantity: number }>())
   return [...agg.entries()]
     .map(([typeId, { total, quantity }]) => ({ typeId, total, quantity }))
     .sort((a, b) => b.total - a.total)
@@ -37,11 +38,11 @@ export const bucketSales = (sales: Sale[], start: number, end: number, bucketMs:
     end: start + (i + 1) * bucketMs,
     total: 0,
   }))
-  for (const s of sales) {
+  return sales.reduce((buckets, s) => {
     const t = Date.parse(s.date)
-    if (t < start || t >= end) continue
+    if (t < start || t >= end) return buckets
     const idx = Math.min(count - 1, Math.floor((t - start) / bucketMs))
     buckets[idx].total += value(s)
-  }
-  return buckets
+    return buckets
+  }, buckets)
 }

--- a/src/app/settings/grants/grants.tsx
+++ b/src/app/settings/grants/grants.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { lensProp, not, over } from 'ramda'
+import { fromPairs, lensProp, map, not, over } from 'ramda'
 
 import type { EsiScope } from '@/app/character/scopes'
 import Dot from '@/app/account/settings/dot'
@@ -17,16 +17,16 @@ type GrantsProps = {
 
 const Grants = ({ scopes, enabled, from }: GrantsProps) => {
   const [checked, setChecked] = useState<Record<string, boolean>>(() =>
-    Object.fromEntries(scopes.map((s) => [s.scope, Boolean(s.required) || enabled.includes(s.scope)]))
+    fromPairs(map((s) => [s.scope, Boolean(s.required) || enabled.includes(s.scope)], scopes))
   )
   const [response, setResponse] = useState('')
 
   const toggle = (scope: string) => setChecked(over(lensProp(scope), not))
 
-  const selectAll = () => setChecked(Object.fromEntries(scopes.map((s) => [s.scope, true])))
+  const selectAll = () => setChecked(fromPairs(map((s) => [s.scope, true], scopes)))
 
   // Required scopes stay checked since they are always granted.
-  const unselectAll = () => setChecked(Object.fromEntries(scopes.map((s) => [s.scope, Boolean(s.required)])))
+  const unselectAll = () => setChecked(fromPairs(map((s) => [s.scope, Boolean(s.required)], scopes)))
 
   // A successful save redirects (back to settings, or on to EVE SSO), so we only
   // surface a message when saving fails.

--- a/src/app/settings/grants/grants.tsx
+++ b/src/app/settings/grants/grants.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { lensProp, not, over } from 'ramda'
 
 import type { EsiScope } from '@/app/character/scopes'
 import Dot from '@/app/account/settings/dot'
@@ -20,7 +21,7 @@ const Grants = ({ scopes, enabled, from }: GrantsProps) => {
   )
   const [response, setResponse] = useState('')
 
-  const toggle = (scope: string) => setChecked((prev) => ({ ...prev, [scope]: !prev[scope] }))
+  const toggle = (scope: string) => setChecked(over(lensProp(scope), not))
 
   const selectAll = () => setChecked(Object.fromEntries(scopes.map((s) => [s.scope, true])))
 
@@ -40,8 +41,8 @@ const Grants = ({ scopes, enabled, from }: GrantsProps) => {
     <>
       <p className={styles.intro}>
         When you add a character we ask EVE Online for permission to read the data below. Check anything you would like
-        to share &mdash; we can only provide the related features for the data you grant. Changes apply to characters you
-        add from now on.
+        to share &mdash; we can only provide the related features for the data you grant. Changes apply to characters
+        you add from now on.
       </p>
       <form>
         <input type="hidden" name="from" value={from} />

--- a/src/app/stationNames.ts
+++ b/src/app/stationNames.ts
@@ -4,16 +4,17 @@
 // systemNames.ts. Unresolved ids are simply omitted so callers can fall back to
 // showing the raw id (never read the evesde SDE). Player Upwell structures are
 // resolved separately from corp_structure/structure.
+import { filter, fromPairs, map, uniq } from 'ramda'
 import { createClient } from '@/utils/supabase/server'
 
+const idNamePairs = map((r: { id: number | string; name: string }): [number, string] => [Number(r.id), r.name])
+
 export const fetchStationNames = async (stationIDs: Iterable<number>): Promise<Record<number, string>> => {
-  const ids = Array.from(new Set([...stationIDs].filter((n) => Number.isFinite(n))))
+  const ids = uniq(filter(Number.isFinite, [...stationIDs]))
   if (ids.length === 0) return {}
   const supabase = await createClient()
   const { data } = await supabase.from('eve_name').select('id, name').eq('category', 'station').in('id', ids)
-  return Object.fromEntries(
-    ((data ?? []) as Array<{ id: number | string; name: string }>).map((r) => [Number(r.id), r.name])
-  )
+  return fromPairs(idNamePairs((data ?? []) as Array<{ id: number | string; name: string }>))
 }
 
 // universe/names doesn't return a station's solar system, so we don't cache it.

--- a/src/app/stationNames.ts
+++ b/src/app/stationNames.ts
@@ -11,11 +11,9 @@ export const fetchStationNames = async (stationIDs: Iterable<number>): Promise<R
   if (ids.length === 0) return {}
   const supabase = await createClient()
   const { data } = await supabase.from('eve_name').select('id, name').eq('category', 'station').in('id', ids)
-  const result: Record<number, string> = {}
-  for (const r of (data ?? []) as Array<{ id: number | string; name: string }>) {
-    result[Number(r.id)] = r.name
-  }
-  return result
+  return Object.fromEntries(
+    ((data ?? []) as Array<{ id: number | string; name: string }>).map((r) => [Number(r.id), r.name])
+  )
 }
 
 // universe/names doesn't return a station's solar system, so we don't cache it.

--- a/src/app/systemNames.ts
+++ b/src/app/systemNames.ts
@@ -8,14 +8,8 @@ export const fetchSystemNames = async (systemIDs: Iterable<number>): Promise<Rec
   const ids = Array.from(new Set([...systemIDs].filter((n) => Number.isFinite(n))))
   if (ids.length === 0) return {}
   const supabase = await createClient()
-  const { data } = await supabase
-    .from('eve_name')
-    .select('id, name')
-    .eq('category', 'solar_system')
-    .in('id', ids)
-  const result: Record<number, string> = {}
-  for (const r of (data ?? []) as Array<{ id: number | string; name: string }>) {
-    result[Number(r.id)] = r.name
-  }
-  return result
+  const { data } = await supabase.from('eve_name').select('id, name').eq('category', 'solar_system').in('id', ids)
+  return Object.fromEntries(
+    ((data ?? []) as Array<{ id: number | string; name: string }>).map((r) => [Number(r.id), r.name])
+  )
 }

--- a/src/app/systemNames.ts
+++ b/src/app/systemNames.ts
@@ -2,14 +2,15 @@
 // job keeps populated for every system we hold a structure in (and for systems
 // referenced by other resolved-name pulls). Unresolved ids are simply omitted
 // so callers can fall back to showing the raw id (never read the evesde SDE).
+import { filter, fromPairs, map, uniq } from 'ramda'
 import { createClient } from '@/utils/supabase/server'
 
+const idNamePairs = map((r: { id: number | string; name: string }): [number, string] => [Number(r.id), r.name])
+
 export const fetchSystemNames = async (systemIDs: Iterable<number>): Promise<Record<number, string>> => {
-  const ids = Array.from(new Set([...systemIDs].filter((n) => Number.isFinite(n))))
+  const ids = uniq(filter(Number.isFinite, [...systemIDs]))
   if (ids.length === 0) return {}
   const supabase = await createClient()
   const { data } = await supabase.from('eve_name').select('id, name').eq('category', 'solar_system').in('id', ids)
-  return Object.fromEntries(
-    ((data ?? []) as Array<{ id: number | string; name: string }>).map((r) => [Number(r.id), r.name])
-  )
+  return fromPairs(idNamePairs((data ?? []) as Array<{ id: number | string; name: string }>))
 }

--- a/src/industryIndexes.js
+++ b/src/industryIndexes.js
@@ -1,4 +1,4 @@
-import { chain } from 'ramda'
+import { chain, filter, map, prop } from 'ramda'
 
 import { industrySystems } from './esi.js'
 import { sudoSupabase } from './supabase.js'
@@ -38,9 +38,10 @@ export const pullIndustryIndexes = async () => {
   const rows = chain((s) => {
     const system_id = Number(s?.solar_system_id)
     if (!systemIds.has(system_id)) return []
-    return (s?.cost_indices ?? [])
-      .filter((ci) => ci?.activity)
-      .map((ci) => ({ system_id, activity: ci.activity, cost_index: ci.cost_index ?? null, recorded_at }))
+    return map(
+      (ci) => ({ system_id, activity: ci.activity, cost_index: ci.cost_index ?? null, recorded_at }),
+      filter(prop('activity'), s?.cost_indices ?? [])
+    )
   }, systems ?? [])
 
   if (rows.length === 0) {

--- a/src/industryIndexes.js
+++ b/src/industryIndexes.js
@@ -1,3 +1,5 @@
+import { chain } from 'ramda'
+
 import { industrySystems } from './esi.js'
 import { sudoSupabase } from './supabase.js'
 
@@ -33,20 +35,13 @@ export const pullIndustryIndexes = async () => {
 
   const systems = await industrySystems()
   const recorded_at = new Date().toISOString()
-  const rows = []
-  for (const s of systems ?? []) {
+  const rows = chain((s) => {
     const system_id = Number(s?.solar_system_id)
-    if (!systemIds.has(system_id)) continue
-    for (const ci of s?.cost_indices ?? []) {
-      if (!ci?.activity) continue
-      rows.push({
-        system_id,
-        activity: ci.activity,
-        cost_index: ci.cost_index ?? null,
-        recorded_at,
-      })
-    }
-  }
+    if (!systemIds.has(system_id)) return []
+    return (s?.cost_indices ?? [])
+      .filter((ci) => ci?.activity)
+      .map((ci) => ({ system_id, activity: ci.activity, cost_index: ci.cost_index ?? null, recorded_at }))
+  }, systems ?? [])
 
   if (rows.length === 0) {
     console.log('[industry_index] no matching systems returned by ESI, nothing to record')

--- a/src/jobs/assets.js
+++ b/src/jobs/assets.js
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'node:url'
 
-import { splitEvery } from 'ramda'
+import { filter, identity, juxt, map, pipe, prop, props, splitEvery } from 'ramda'
 
 import { assets, assetNames, userAgent } from '../esi.js'
 import SingleSignOn from '@philihp/eve-sso'
@@ -35,7 +35,7 @@ const signature = (a) =>
 // ESI returns the literal string "None" for singletons with no player-assigned
 // name (e.g. blueprints), so treat that sentinel as "no name" rather than text.
 const fetchNames = async (access_token, characterID, fetched) => {
-  const ids = fetched.filter((a) => a.is_singleton).map((a) => Number(a.item_id))
+  const ids = map(pipe(prop('item_id'), Number), filter(prop('is_singleton'), fetched))
   const names = new Map()
   for (const part of splitEvery(1000, ids)) {
     try {
@@ -105,11 +105,12 @@ const reconcile = async (character_id, fetched, hasName) => {
     if (data.length < PAGE) break
   }
 
-  const currentByItem = new Map(current.map((r) => [Number(r.item_id), r]))
+  const byItemId = map(juxt([pipe(prop('item_id'), Number), identity]))
+  const currentByItem = new Map(byItemId(current))
 
   // ESI can return the same item twice across pages if assets shift mid-fetch;
   // collapse to one entry per item so we never queue two inserts for it.
-  const fetchedByItem = new Map(fetched.map((a) => [Number(a.item_id), a]))
+  const fetchedByItem = new Map(byItemId(fetched))
   fetched = [...fetchedByItem.values()]
 
   const now = new Date().toISOString()
@@ -171,7 +172,7 @@ export const runAssets = async ({ characterIds } = {}) => {
     console.error('[assets] character lookup failed:', charactersError)
     throw charactersError
   }
-  const characterName = new Map((characters ?? []).map((c) => [c.id, c.name]))
+  const characterName = new Map(map(props(['id', 'name']), characters ?? []))
 
   let tokenQuery = sudoSupabase
     .from('token')
@@ -204,11 +205,9 @@ export const runAssets = async ({ characterIds } = {}) => {
         continue
       }
 
-      const { all, totalPages } = await fetchAssets(access_token, characterID)
-      if (hasName) {
-        const names = await fetchNames(access_token, characterID, all)
-        for (const a of all) a.name = names.get(Number(a.item_id)) ?? null
-      }
+      const { all: fetched, totalPages } = await fetchAssets(access_token, characterID)
+      const names = hasName ? await fetchNames(access_token, characterID, fetched) : null
+      const all = hasName ? map((a) => ({ ...a, name: names.get(Number(a.item_id)) ?? null }), fetched) : fetched
       const { touched, opened, closed } = await reconcile(tokenRow.character_id, all, hasName)
 
       const dt = Date.now() - t0

--- a/src/jobs/assets.js
+++ b/src/jobs/assets.js
@@ -1,5 +1,7 @@
 import { fileURLToPath } from 'node:url'
 
+import { splitEvery } from 'ramda'
+
 import { assets, assetNames, userAgent } from '../esi.js'
 import SingleSignOn from '@philihp/eve-sso'
 import { sudoSupabase } from '../supabase.js'
@@ -11,13 +13,6 @@ const EVE_CALLBACK_URL = process.env.EVE_CALLBACK_URL
 const ASSETS_SCOPE = 'esi-assets.read_assets.v1'
 
 const sso = new SingleSignOn(EVE_CLIENT_ID, EVE_SECRET_KEY, EVE_CALLBACK_URL, userAgent)
-
-// Keep id lists under PostgREST's URL length limit when filtering with .in().
-const chunk = (arr, n) => {
-  const out = []
-  for (let i = 0; i < arr.length; i += n) out.push(arr.slice(i, i + n))
-  return out
-}
 
 // The tracked attributes that define a version of an item. Two sightings with
 // the same signature are the "same" row; any difference opens a new SCD row.
@@ -42,8 +37,7 @@ const signature = (a) =>
 const fetchNames = async (access_token, characterID, fetched) => {
   const ids = fetched.filter((a) => a.is_singleton).map((a) => Number(a.item_id))
   const names = new Map()
-  for (const part of chunk(ids, 1000)) {
-    if (part.length === 0) continue
+  for (const part of splitEvery(1000, ids)) {
     try {
       const rows = await assetNames(access_token, characterID, part)
       for (const r of rows ?? []) names.set(Number(r.item_id), r.name && r.name !== 'None' ? r.name : null)
@@ -149,16 +143,16 @@ const reconcile = async (character_id, fetched, hasName) => {
   // Anything still open but not seen this run has left the character's assets.
   for (const cur of currentByItem.values()) closeIds.push(cur.id)
 
-  for (const ids of chunk(touchIds, 200)) {
+  for (const ids of splitEvery(200, touchIds)) {
     const { error: touchErr } = await sudoSupabase.from('asset_over_time').update({ last_seen_at: now }).in('id', ids)
     if (touchErr) throw touchErr
   }
   // Close before inserting so the unique-current-per-item index never collides.
-  for (const ids of chunk(closeIds, 200)) {
+  for (const ids of splitEvery(200, closeIds)) {
     const { error: closeErr } = await sudoSupabase.from('asset_over_time').update({ is_current: false }).in('id', ids)
     if (closeErr) throw closeErr
   }
-  for (const rows of chunk(inserts, 1000)) {
+  for (const rows of splitEvery(1000, inserts)) {
     const { error: insertErr } = await sudoSupabase.from('asset_over_time').insert(rows)
     if (insertErr) throw insertErr
   }
@@ -179,7 +173,10 @@ export const runAssets = async ({ characterIds } = {}) => {
   }
   const characterName = new Map((characters ?? []).map((c) => [c.id, c.name]))
 
-  let tokenQuery = sudoSupabase.from('token').select('id, character_id, refresh_token').contains('scope', [ASSETS_SCOPE])
+  let tokenQuery = sudoSupabase
+    .from('token')
+    .select('id, character_id, refresh_token')
+    .contains('scope', [ASSETS_SCOPE])
   if (characterIds) tokenQuery = tokenQuery.in('character_id', characterIds)
   const { data: tokens, error } = await tokenQuery
 

--- a/src/jobs/daily.js
+++ b/src/jobs/daily.js
@@ -1,7 +1,9 @@
 import { fileURLToPath } from 'node:url'
 
+import { splitEvery } from 'ramda'
+
 import { characterAffiliations } from '../esi.js'
-import { resolveBatch, resolveCorpJournalNames } from '../resolveNames.js'
+import { resolveAllIds, resolveCorpJournalNames } from '../resolveNames.js'
 import { sudoSupabase } from '../supabase.js'
 
 const BATCH_SIZE = 1000
@@ -18,8 +20,7 @@ const resolveCharacterCorps = async () => {
   if (ids.length === 0) return
 
   const affiliations = []
-  for (let i = 0; i < ids.length; i += BATCH_SIZE) {
-    const batch = ids.slice(i, i + BATCH_SIZE)
+  for (const batch of splitEvery(BATCH_SIZE, ids)) {
     try {
       affiliations.push(...(await characterAffiliations(batch)))
     } catch (e) {
@@ -43,15 +44,12 @@ const resolveCharacterCorps = async () => {
   const corpIds = new Set(rows.map((r) => Number(r.corporation_id)).filter((n) => Number.isFinite(n) && n > 0))
   const { data: known, error: knownErr } = await sudoSupabase.from('eve_name').select('id')
   if (knownErr) throw knownErr
-  for (const k of known ?? []) corpIds.delete(Number(k.id))
+  const knownIds = new Set((known ?? []).map((k) => Number(k.id)))
 
-  const toResolve = [...corpIds]
+  const toResolve = [...corpIds].filter((id) => !knownIds.has(id))
   if (toResolve.length === 0) return
 
-  const resolved = []
-  for (let i = 0; i < toResolve.length; i += BATCH_SIZE) {
-    resolved.push(...(await resolveBatch(toResolve.slice(i, i + BATCH_SIZE))))
-  }
+  const resolved = await resolveAllIds(toResolve)
   if (resolved.length === 0) return
 
   const nameRows = resolved.map((n) => ({ id: n.id, name: n.name, category: n.category }))

--- a/src/jobs/daily.js
+++ b/src/jobs/daily.js
@@ -1,12 +1,15 @@
 import { fileURLToPath } from 'node:url'
 
-import { splitEvery } from 'ramda'
+import { filter, map, pick, pipe, prop, reduce, reject, splitEvery } from 'ramda'
 
 import { characterAffiliations } from '../esi.js'
 import { resolveAllIds, resolveCorpJournalNames } from '../resolveNames.js'
 import { sudoSupabase } from '../supabase.js'
 
 const BATCH_SIZE = 1000
+
+const isPositiveId = (n) => Number.isFinite(n) && n > 0
+const idToNumber = pipe(prop('id'), Number)
 
 // Map each known character to the corporation they currently belong to, so the UI can show who paid
 // industry tax and which corp they fly for. Affiliations are public (no token) and resolved in
@@ -15,44 +18,50 @@ const resolveCharacterCorps = async () => {
   const { data: chars, error: charsErr } = await sudoSupabase.from('eve_name').select('id').eq('category', 'character')
   if (charsErr) throw charsErr
 
-  const ids = (chars ?? []).map((c) => Number(c.id)).filter((n) => Number.isFinite(n) && n > 0)
+  const ids = filter(isPositiveId, map(idToNumber, chars ?? []))
   console.log(`[daily] character corps: resolving affiliations for ${ids.length} character(s)`)
   if (ids.length === 0) return
 
-  const affiliations = []
-  for (const batch of splitEvery(BATCH_SIZE, ids)) {
-    try {
-      affiliations.push(...(await characterAffiliations(batch)))
-    } catch (e) {
-      console.warn(`[daily] characters/affiliation batch failed: ${e?.message}`)
-    }
-  }
+  const affiliations = await reduce(
+    (affiliationsSoFar, batch) =>
+      affiliationsSoFar.then(async (affiliations) => {
+        try {
+          return [...affiliations, ...(await characterAffiliations(batch))]
+        } catch (e) {
+          console.warn(`[daily] characters/affiliation batch failed: ${e?.message}`)
+          return affiliations
+        }
+      }),
+    Promise.resolve([]),
+    splitEvery(BATCH_SIZE, ids)
+  )
   if (affiliations.length === 0) return
 
-  const rows = affiliations
-    .filter((a) => a.character_id != null && a.corporation_id != null)
-    .map((a) => ({
+  const rows = pipe(
+    filter((a) => a.character_id != null && a.corporation_id != null),
+    map((a) => ({
       character_id: a.character_id,
       corporation_id: a.corporation_id,
       resolved_at: new Date().toISOString(),
     }))
+  )(affiliations)
   const { error: upErr } = await sudoSupabase.from('character_corp').upsert(rows, { onConflict: 'character_id' })
   if (upErr) throw upErr
   console.log(`[daily] upserted ${rows.length} character corp affiliation(s)`)
 
   // Resolve names for any corporations we don't already have a name for.
-  const corpIds = new Set(rows.map((r) => Number(r.corporation_id)).filter((n) => Number.isFinite(n) && n > 0))
+  const corpIds = new Set(filter(isPositiveId, map(pipe(prop('corporation_id'), Number), rows)))
   const { data: known, error: knownErr } = await sudoSupabase.from('eve_name').select('id')
   if (knownErr) throw knownErr
-  const knownIds = new Set((known ?? []).map((k) => Number(k.id)))
+  const knownIds = new Set(map(idToNumber, known ?? []))
 
-  const toResolve = [...corpIds].filter((id) => !knownIds.has(id))
+  const toResolve = reject((id) => knownIds.has(id), [...corpIds])
   if (toResolve.length === 0) return
 
   const resolved = await resolveAllIds(toResolve)
   if (resolved.length === 0) return
 
-  const nameRows = resolved.map((n) => ({ id: n.id, name: n.name, category: n.category }))
+  const nameRows = map(pick(['id', 'name', 'category']), resolved)
   const { error: nameErr } = await sudoSupabase.from('eve_name').upsert(nameRows, { onConflict: 'id' })
   if (nameErr) throw nameErr
   console.log(`[daily] upserted ${nameRows.length} corporation name(s)`)

--- a/src/resolveNames.js
+++ b/src/resolveNames.js
@@ -1,10 +1,19 @@
-import { splitEvery } from 'ramda'
+import { filter, isNil, map, pick, pipe, prop, propEq, props, reduce, reject, splitEvery, unnest } from 'ramda'
 
 import { universeNames } from './esi.js'
 import { sudoSupabase } from './supabase.js'
 
 const LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000
 const BATCH_SIZE = 1000
+
+// id → Number(id), point-free.
+const idToNumber = pipe(prop('id'), Number)
+
+// Ids known to eve_name already, as a Set for O(1) membership checks.
+const knownIdSet = pipe(map(idToNumber), (ids) => new Set(ids))
+
+// A resolved id/name/category row, trimmed down to the eve_name upsert shape.
+const toNameRow = pick(['id', 'name', 'category'])
 
 // ESI /universe/names/ rejects the whole batch if any id is invalid, so bisect on failure
 // until either the batch resolves or we narrow down to single bad ids we can drop.
@@ -24,15 +33,15 @@ export const resolveBatch = async (ids) => {
 }
 
 // Resolve every id in BATCH_SIZE chunks (the names endpoint caps at 1000 ids per
-// call) and flatten the results. Shared by every resolve* function below and by
-// the daily job's corp-name resolution.
-export const resolveAllIds = async (ids) => {
-  const resolved = []
-  for (const batch of splitEvery(BATCH_SIZE, ids)) {
-    resolved.push(...(await resolveBatch(batch)))
-  }
-  return resolved
-}
+// call) and flatten the results, one chunk at a time so we never hold more than
+// one batch of in-flight requests. Shared by every resolve* function below and
+// by the daily job's corp-name resolution.
+export const resolveAllIds = (ids) =>
+  reduce(
+    (resolvedSoFar, batch) => resolvedSoFar.then(async (resolved) => [...resolved, ...(await resolveBatch(batch))]),
+    Promise.resolve([]),
+    splitEvery(BATCH_SIZE, ids)
+  )
 
 // Resolve and cache (in eve_name) the name of every party seen in the corp wallet journal over the
 // last 30 days that we don't already have a name for. The UI reads eve_name to show who paid each
@@ -47,15 +56,14 @@ export const resolveCorpJournalNames = async () => {
     .gte('date', cutoff)
   if (journalErr) throw journalErr
 
-  const ids = new Set(
-    (journal ?? []).flatMap((r) => [r.first_party_id, r.second_party_id].filter((v) => v != null).map(Number))
-  )
+  const journalPartyIds = pipe(map(props(['first_party_id', 'second_party_id'])), unnest, reject(isNil), map(Number))
+  const ids = new Set(journalPartyIds(journal ?? []))
 
   const { data: known, error: knownErr } = await sudoSupabase.from('eve_name').select('id')
   if (knownErr) throw knownErr
-  const knownIds = new Set((known ?? []).map((k) => Number(k.id)))
+  const knownIds = knownIdSet(known ?? [])
 
-  const toResolve = [...ids].filter((n) => Number.isFinite(n) && n > 0 && !knownIds.has(n))
+  const toResolve = filter((n) => Number.isFinite(n) && n > 0 && !knownIds.has(n), [...ids])
   console.log(`[names] corp journal: ${ids.size} unknown id(s) seen in last 30d, ${toResolve.length} to resolve`)
   if (toResolve.length === 0) return
 
@@ -66,11 +74,11 @@ export const resolveCorpJournalNames = async () => {
     return
   }
 
-  const rows = resolved.map((n) => ({ id: n.id, name: n.name, category: n.category }))
+  const rows = map(toNameRow, resolved)
   const { error: upErr } = await sudoSupabase.from('eve_name').upsert(rows, { onConflict: 'id' })
   if (upErr) throw upErr
 
-  const characterCount = rows.filter((r) => r.category === 'character').length
+  const characterCount = filter(propEq('character', 'category'), rows).length
   console.log(`[names] upserted ${rows.length} name(s) (${characterCount} character)`)
 }
 
@@ -79,19 +87,19 @@ export const resolveCorpJournalNames = async () => {
 // by corporation name instead of a raw id. Only resolves missing ids, so
 // steady-state runs do nothing.
 export const resolveCorpNames = async (corporationIds) => {
-  const ids = [...new Set((corporationIds ?? []).map(Number).filter((n) => Number.isFinite(n) && n > 0))]
+  const ids = [...new Set(filter((n) => Number.isFinite(n) && n > 0, map(Number, corporationIds ?? [])))]
   if (ids.length === 0) return
 
   const { data: known, error: knownErr } = await sudoSupabase.from('eve_name').select('id').in('id', ids)
   if (knownErr) throw knownErr
-  const knownIds = new Set((known ?? []).map((k) => Number(k.id)))
-  const toResolve = ids.filter((id) => !knownIds.has(id))
+  const knownIds = knownIdSet(known ?? [])
+  const toResolve = reject((id) => knownIds.has(id), ids)
   if (toResolve.length === 0) return
 
   const resolved = await resolveAllIds(toResolve)
   if (resolved.length === 0) return
 
-  const rows = resolved.map((n) => ({ id: n.id, name: n.name, category: n.category }))
+  const rows = map(toNameRow, resolved)
   const { error: upErr } = await sudoSupabase.from('eve_name').upsert(rows, { onConflict: 'id' })
   if (upErr) throw upErr
   console.log(`[names] upserted ${rows.length} corp name(s)`)
@@ -124,9 +132,9 @@ export const resolveAssetStationNames = async () => {
 
   const { data: known, error: knownErr } = await sudoSupabase.from('eve_name').select('id').eq('category', 'station')
   if (knownErr) throw knownErr
-  const knownIds = new Set((known ?? []).map((k) => Number(k.id)))
+  const knownIds = knownIdSet(known ?? [])
 
-  const toResolve = [...ids].filter((n) => Number.isFinite(n) && n > 0 && !knownIds.has(n))
+  const toResolve = filter((n) => Number.isFinite(n) && n > 0 && !knownIds.has(n), [...ids])
   console.log(`[names] asset stations: ${toResolve.length} to resolve`)
   if (toResolve.length === 0) return
 
@@ -137,7 +145,7 @@ export const resolveAssetStationNames = async () => {
     return
   }
 
-  const rows = resolved.map((n) => ({ id: n.id, name: n.name, category: n.category }))
+  const rows = map(toNameRow, resolved)
   const { error: upErr } = await sudoSupabase.from('eve_name').upsert(rows, { onConflict: 'id' })
   if (upErr) throw upErr
   console.log(`[names] upserted ${rows.length} station name(s)`)
@@ -151,16 +159,17 @@ export const resolveCorpStructureSystemNames = async () => {
   const { data: structures, error: structuresErr } = await sudoSupabase.from('corp_structure').select('system_id')
   if (structuresErr) throw structuresErr
 
-  const ids = new Set((structures ?? []).filter((r) => r.system_id != null).map((r) => Number(r.system_id)))
+  const systemId = pipe(prop('system_id'), Number)
+  const ids = new Set(map(systemId, reject(pipe(prop('system_id'), isNil), structures ?? [])))
 
   const { data: known, error: knownErr } = await sudoSupabase
     .from('eve_name')
     .select('id')
     .eq('category', 'solar_system')
   if (knownErr) throw knownErr
-  const knownIds = new Set((known ?? []).map((k) => Number(k.id)))
+  const knownIds = knownIdSet(known ?? [])
 
-  const toResolve = [...ids].filter((n) => Number.isFinite(n) && n > 0 && !knownIds.has(n))
+  const toResolve = filter((n) => Number.isFinite(n) && n > 0 && !knownIds.has(n), [...ids])
   console.log(`[names] corp structure systems: ${toResolve.length} to resolve`)
   if (toResolve.length === 0) return
 
@@ -171,7 +180,7 @@ export const resolveCorpStructureSystemNames = async () => {
     return
   }
 
-  const rows = resolved.map((n) => ({ id: n.id, name: n.name, category: n.category }))
+  const rows = map(toNameRow, resolved)
   const { error: upErr } = await sudoSupabase.from('eve_name').upsert(rows, { onConflict: 'id' })
   if (upErr) throw upErr
   console.log(`[names] upserted ${rows.length} system name(s)`)

--- a/src/resolveNames.js
+++ b/src/resolveNames.js
@@ -1,3 +1,5 @@
+import { splitEvery } from 'ramda'
+
 import { universeNames } from './esi.js'
 import { sudoSupabase } from './supabase.js'
 
@@ -21,6 +23,17 @@ export const resolveBatch = async (ids) => {
   }
 }
 
+// Resolve every id in BATCH_SIZE chunks (the names endpoint caps at 1000 ids per
+// call) and flatten the results. Shared by every resolve* function below and by
+// the daily job's corp-name resolution.
+export const resolveAllIds = async (ids) => {
+  const resolved = []
+  for (const batch of splitEvery(BATCH_SIZE, ids)) {
+    resolved.push(...(await resolveBatch(batch)))
+  }
+  return resolved
+}
+
 // Resolve and cache (in eve_name) the name of every party seen in the corp wallet journal over the
 // last 30 days that we don't already have a name for. The UI reads eve_name to show who paid each
 // unaccounted industry tax instead of a raw id. Cheap to run often: it only resolves ids missing
@@ -34,26 +47,19 @@ export const resolveCorpJournalNames = async () => {
     .gte('date', cutoff)
   if (journalErr) throw journalErr
 
-  const ids = new Set()
-  for (const r of journal ?? []) {
-    if (r.first_party_id != null) ids.add(Number(r.first_party_id))
-    if (r.second_party_id != null) ids.add(Number(r.second_party_id))
-  }
+  const ids = new Set(
+    (journal ?? []).flatMap((r) => [r.first_party_id, r.second_party_id].filter((v) => v != null).map(Number))
+  )
 
   const { data: known, error: knownErr } = await sudoSupabase.from('eve_name').select('id')
   if (knownErr) throw knownErr
-  for (const k of known ?? []) ids.delete(Number(k.id))
+  const knownIds = new Set((known ?? []).map((k) => Number(k.id)))
 
-  const toResolve = [...ids].filter((n) => Number.isFinite(n) && n > 0)
+  const toResolve = [...ids].filter((n) => Number.isFinite(n) && n > 0 && !knownIds.has(n))
   console.log(`[names] corp journal: ${ids.size} unknown id(s) seen in last 30d, ${toResolve.length} to resolve`)
   if (toResolve.length === 0) return
 
-  const resolved = []
-  for (let i = 0; i < toResolve.length; i += BATCH_SIZE) {
-    const batch = toResolve.slice(i, i + BATCH_SIZE)
-    const names = await resolveBatch(batch)
-    resolved.push(...names)
-  }
+  const resolved = await resolveAllIds(toResolve)
 
   if (resolved.length === 0) {
     console.log('[names] no names resolved')
@@ -82,11 +88,7 @@ export const resolveCorpNames = async (corporationIds) => {
   const toResolve = ids.filter((id) => !knownIds.has(id))
   if (toResolve.length === 0) return
 
-  const resolved = []
-  for (let i = 0; i < toResolve.length; i += BATCH_SIZE) {
-    const names = await resolveBatch(toResolve.slice(i, i + BATCH_SIZE))
-    resolved.push(...names)
-  }
+  const resolved = await resolveAllIds(toResolve)
   if (resolved.length === 0) return
 
   const rows = resolved.map((n) => ({ id: n.id, name: n.name, category: n.category }))
@@ -122,17 +124,13 @@ export const resolveAssetStationNames = async () => {
 
   const { data: known, error: knownErr } = await sudoSupabase.from('eve_name').select('id').eq('category', 'station')
   if (knownErr) throw knownErr
-  for (const k of known ?? []) ids.delete(Number(k.id))
+  const knownIds = new Set((known ?? []).map((k) => Number(k.id)))
 
-  const toResolve = [...ids].filter((n) => Number.isFinite(n) && n > 0)
+  const toResolve = [...ids].filter((n) => Number.isFinite(n) && n > 0 && !knownIds.has(n))
   console.log(`[names] asset stations: ${toResolve.length} to resolve`)
   if (toResolve.length === 0) return
 
-  const resolved = []
-  for (let i = 0; i < toResolve.length; i += BATCH_SIZE) {
-    const names = await resolveBatch(toResolve.slice(i, i + BATCH_SIZE))
-    resolved.push(...names)
-  }
+  const resolved = await resolveAllIds(toResolve)
 
   if (resolved.length === 0) {
     console.log('[names] no station names resolved')
@@ -153,28 +151,20 @@ export const resolveCorpStructureSystemNames = async () => {
   const { data: structures, error: structuresErr } = await sudoSupabase.from('corp_structure').select('system_id')
   if (structuresErr) throw structuresErr
 
-  const ids = new Set()
-  for (const r of structures ?? []) {
-    if (r.system_id != null) ids.add(Number(r.system_id))
-  }
+  const ids = new Set((structures ?? []).filter((r) => r.system_id != null).map((r) => Number(r.system_id)))
 
   const { data: known, error: knownErr } = await sudoSupabase
     .from('eve_name')
     .select('id')
     .eq('category', 'solar_system')
   if (knownErr) throw knownErr
-  for (const k of known ?? []) ids.delete(Number(k.id))
+  const knownIds = new Set((known ?? []).map((k) => Number(k.id)))
 
-  const toResolve = [...ids].filter((n) => Number.isFinite(n) && n > 0)
+  const toResolve = [...ids].filter((n) => Number.isFinite(n) && n > 0 && !knownIds.has(n))
   console.log(`[names] corp structure systems: ${toResolve.length} to resolve`)
   if (toResolve.length === 0) return
 
-  const resolved = []
-  for (let i = 0; i < toResolve.length; i += BATCH_SIZE) {
-    const batch = toResolve.slice(i, i + BATCH_SIZE)
-    const names = await resolveBatch(batch)
-    resolved.push(...names)
-  }
+  const resolved = await resolveAllIds(toResolve)
 
   if (resolved.length === 0) {
     console.log('[names] no system names resolved')

--- a/src/structureNames.js
+++ b/src/structureNames.js
@@ -1,3 +1,5 @@
+import { map, pipe, prop, reject } from 'ramda'
+
 import { universeStructure } from './esi.js'
 import { sudoSupabase } from './supabase.js'
 import { refreshAccessToken } from './tokenRefresh.js'
@@ -33,7 +35,7 @@ export const resolveStructureNames = async () => {
   // Ids we don't need to resolve: our own corp structures and anything already cached.
   const { data: corpStructs } = await sudoSupabase.from('corp_structure').select('structure_id')
   const { data: knownStructs } = await sudoSupabase.from('structure').select('structure_id')
-  const resolved = new Set([...(corpStructs ?? []), ...(knownStructs ?? [])].map((s) => Number(s.structure_id)))
+  const resolved = new Set(map(pipe(prop('structure_id'), Number), [...(corpStructs ?? []), ...(knownStructs ?? [])]))
 
   // Pool candidate structure ids from every character's live assets. itemIds is
   // the union of all owned item ids across characters: a location in the
@@ -62,7 +64,7 @@ export const resolveStructureNames = async () => {
     }
     if (rows.length < ASSET_PAGE) break
   }
-  const candidates = [...locationIds].filter((id) => !itemIds.has(id) && !resolved.has(id))
+  const candidates = reject((id) => itemIds.has(id) || resolved.has(id), [...locationIds])
   console.log(`[structures] ${candidates.length} candidate player structure(s) to resolve`)
   if (candidates.length === 0) return
 

--- a/src/structureNames.js
+++ b/src/structureNames.js
@@ -33,9 +33,7 @@ export const resolveStructureNames = async () => {
   // Ids we don't need to resolve: our own corp structures and anything already cached.
   const { data: corpStructs } = await sudoSupabase.from('corp_structure').select('structure_id')
   const { data: knownStructs } = await sudoSupabase.from('structure').select('structure_id')
-  const resolved = new Set()
-  for (const s of corpStructs ?? []) resolved.add(Number(s.structure_id))
-  for (const s of knownStructs ?? []) resolved.add(Number(s.structure_id))
+  const resolved = new Set([...(corpStructs ?? []), ...(knownStructs ?? [])].map((s) => Number(s.structure_id)))
 
   // Pool candidate structure ids from every character's live assets. itemIds is
   // the union of all owned item ids across characters: a location in the

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -112,13 +112,14 @@ export const selectCharacters = async (columns, owner) => {
 // The Vercel cron producers use this to enumerate the characters to fan out one
 // queue message per character. Throws on a lookup failure.
 export const selectCharacterIdsWithScopes = async (scopes) => {
-  const ids = new Set()
-  for (const scope of scopes) {
-    const { data, error } = await sudoSupabase.from('token').select('character_id').contains('scope', [scope])
-    if (error) throw error
-    for (const r of data ?? []) ids.add(r.character_id)
-  }
-  return [...ids]
+  const perScope = await Promise.all(
+    scopes.map(async (scope) => {
+      const { data, error } = await sudoSupabase.from('token').select('character_id').contains('scope', [scope])
+      if (error) throw error
+      return (data ?? []).map((r) => r.character_id)
+    })
+  )
+  return [...new Set(perScope.flat())]
 }
 
 export const selectToken = async (character_id, scope = []) => {

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js'
+import { map, pluck, unnest } from 'ramda'
 
 // The cron/GitHub Actions environment sets SUPABASE_URL / SUPABASE_KEY, but the
 // Vercel runtime only exposes the NEXT_PUBLIC_* vars (same project). This module
@@ -113,13 +114,13 @@ export const selectCharacters = async (columns, owner) => {
 // queue message per character. Throws on a lookup failure.
 export const selectCharacterIdsWithScopes = async (scopes) => {
   const perScope = await Promise.all(
-    scopes.map(async (scope) => {
+    map(async (scope) => {
       const { data, error } = await sudoSupabase.from('token').select('character_id').contains('scope', [scope])
       if (error) throw error
-      return (data ?? []).map((r) => r.character_id)
-    })
+      return pluck('character_id', data ?? [])
+    }, scopes)
   )
-  return [...new Set(perScope.flat())]
+  return [...new Set(unnest(perScope))]
 }
 
 export const selectToken = async (character_id, scope = []) => {


### PR DESCRIPTION
## Summary

Surveyed the codebase for `for`/`while` loops that could be expressed more directly with `map`/`reduce`, and for places where a ramda lens would fit. Applied the changes that genuinely simplify without forcing functional style onto inherently imperative code — and, per review feedback, leaned on **ramda's `map`/`reduce`** (data-last, point-free where it reads at least as clearly as a named-parameter lambda) rather than the native `Array.prototype` methods.

- **`src/resolveNames.js`**: the four name-resolution functions each had a near-identical "chunk ids into batches, call `resolveBatch`, flatten" loop, plus a "subtract known ids from a Set via `for...of` + `.delete()`" loop. Both patterns are now: a shared `resolveAllIds` helper that chunks via ramda's `splitEvery` and flattens via a sequential `reduce`-over-promises, and point-free helpers (`idToNumber`, `knownIdSet`, `toNameRow`) built from `prop`/`pick`/`pipe`.
- **`src/jobs/daily.js`**: same batching pattern, now a ramda `reduce` with the same per-batch try/catch; id/name extraction uses `prop`/`pick`.
- **`src/jobs/assets.js`**: dropped the hand-rolled `chunk()` helper in favor of ramda's `splitEvery`; id-keyed `Map` construction uses `juxt`/`props` instead of inline arrow-tuple lambdas; the per-item name-mutation loop became a non-mutating `map`.
- **`src/supabase.js`**: `selectCharacterIdsWithScopes` fires its per-scope queries with `Promise.all` + ramda's `map`/`pluck`/`unnest` instead of sequential `await`s inside a `for...of`.
- **`src/app/market/aggregate.ts`**: `topTypesByValue` and `bucketSales` now `filter`+`reduce` (ramda) instead of a `for...of` with manual Map/array mutation.
- **`src/app/character/page.tsx`**, **`src/app/account/chancellor/page.tsx`**, **`src/app/characters/refresh/page.tsx`**, **`src/app/assets/page.tsx`**: replaced `for...of` loops that built up Maps/Sets with ramda's `reduce`, `filter`/`map`/`pluck`/`uniq`, or `chain` (matching the existing pattern in `src/app/structures/industryIndex.ts`).
- **`src/app/stationNames.ts`** / **`src/app/systemNames.ts`**: `fromPairs(map(...))` instead of `Object.fromEntries(...map(...))`, for consistency with ramda used elsewhere in the same files.
- **`src/structureNames.js`**, **`src/industryIndexes.js`**: small loop-to-expression cleanups (`Set` construction via `map`, `reject`, ramda `chain`/`filter`/`map`).
- **`src/app/settings/grants/grants.tsx`**: the boolean-toggle `setChecked((prev) => ({ ...prev, [scope]: !prev[scope] }))` is the one genuine immutable-nested-update spot in the UI layer, so it's now `setChecked(over(lensProp(scope), not))` — a direct ramda lens application. The adjacent select-all/unselect-all builders now use ramda's `fromPairs`/`map` too.

Left untouched: ESI pagination loops (`for (;;)` / `while`), the asset-reconciliation diff loop in `jobs/assets.js` (mutates three accumulators plus deletes from a `Map` mid-iteration — too stateful to express cleanly as `reduce`), and the sequential per-character cron loops with `try`/`catch` per iteration (`hourly.js`, `structures.js`, `corpWalletJournal.js`, etc.).

## Test plan

- [x] `npm run lint` — clean (pre-existing unrelated warnings only)
- [x] `npm run build` — compiles and typechecks
- [x] Smoke-tested the refactored pure functions (`topTypesByValue`, `bucketSales`, the `resolveAllIds` chunking/flattening order, the point-free `knownIdSet`/`toNameRow`/`journalPartyIds` helpers, the lens toggle) against their original behavior with synthetic inputs
- [ ] No automated test suite exists for this repo; cron-job changes (`resolveNames.js`, `jobs/daily.js`, `jobs/assets.js`) are best verified by a scheduled run since they depend on Supabase/ESI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
