### PR TITLE
Fix flatlined structure sparklines by paging industry_system_index reads

### DIFF
--- a/src/app/structures/industryIndex.ts
+++ b/src/app/structures/industryIndex.ts
@@ -192,6 +192,10 @@ const seriesFrom = (nowHour: number, readings: Reading[]): IndexSeries => {
   return { values, liveCount, updatedAt: last(readings)!.recordedAt }
 }
 
+// PostgREST caps a single select; page through industry_system_index so a busy
+// week of readings doesn't get silently truncated.
+const HISTORY_PAGE = 1000
+
 // 30-day cost-index history per system per activity, in chronological order.
 // Used to draw sparklines next to each index. The pull job runs on GitHub
 // Actions and fires irregularly — sometimes several times an hour, sometimes
@@ -209,18 +213,25 @@ export const fetchSystemIndexHistory = async (
   if (ids.length === 0) return new Map<number, Map<Activity, IndexSeries>>()
 
   const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
-  const { data: rows } = await supabase
-    .from('industry_system_index')
-    .select('system_id, activity, cost_index, recorded_at')
-    .gte('recorded_at', since)
-    .in('system_id', ids)
-    .order('recorded_at', { ascending: true })
+  const rows: HistoryRow[] = []
+  for (let from = 0; ; from += HISTORY_PAGE) {
+    const { data: page } = await supabase
+      .from('industry_system_index')
+      .select('system_id, activity, cost_index, recorded_at')
+      .gte('recorded_at', since)
+      .in('system_id', ids)
+      .order('recorded_at', { ascending: true })
+      .range(from, from + HISTORY_PAGE - 1)
+    if (!page || page.length === 0) break
+    rows.push(...(page as HistoryRow[]))
+    if (page.length < HISTORY_PAGE) break
+  }
 
   // Group the readings system → activity, then collapse each activity's readings
   // into its hourly series. `collectBy` keeps the rows' ascending order within
   // each group, so a group's first row identifies it and its last row is latest.
   const nowHour = Math.floor(Date.now() / 3_600_000)
-  const readings = chain(toReadings, (rows ?? []) as HistoryRow[])
+  const readings = chain(toReadings, rows)
 
   return new Map(
     pipe(


### PR DESCRIPTION
## Summary
- The structures page's 30-day cost-index sparklines were flatlining because `fetchSystemIndexHistory` (`src/app/structures/industryIndex.ts`) selected the 7-day reading window in a single Supabase query with no pagination.
- PostgREST caps a single `select` at 1000 rows. With ~24 rows recorded per hourly `industry_index` cron run, a 7-day window easily produces several thousand rows, so the ascending-ordered query was silently truncated to roughly the oldest ~1.7 days. Everything after that got forward-filled flat by the sparkline's gap-fill logic, which reads as the chart having stopped updating.
- The actual cron jobs (`industry_index`, `structures`) were running and inserting fine — confirmed via the GitHub Actions run logs, which is why this looked like "automatic jobs are broken" even though only the read path was affected.
- Fixed by paging through `.range()` in `HISTORY_PAGE` (1000-row) chunks, the same pattern `pullIndustryIndexes()` already uses for `corp_structure`, so the full 7-day window comes back.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [ ] Confirm in the deployed app that structure sparklines now show the full week of history instead of a flat tail


---
_Generated by [Claude Code](https://claude.ai/code/session_01AVvu6Yhd7qnVndY9uD3axA)_