### PR TITLE
Filter structure page industry jobs to active status only

### DIFF
--- a/src/app/structure/[structureId]/page.tsx
+++ b/src/app/structure/[structureId]/page.tsx
@@ -104,6 +104,7 @@ const StructurePage = async ({ params }: StructureParams) => {
       'job_id, character_id, activity_id, blueprint_type_id, product_type_id, runs, status, start_date, end_date, station_id, facility_id'
     )
     .or(`station_id.eq.${structureId},facility_id.eq.${structureId}`)
+    .eq('status', 'active')
     .order('end_date', { ascending: true })
 
   const jobs = (jobsData ?? []) as Job[]


### PR DESCRIPTION
## Summary
- The Industry Jobs table on a structure detail page (`/structure/[structureId]`) previously showed all jobs at that structure regardless of status.
- ESI industry jobs have a `status` field with values `active`, `paused`, `ready`, `delivered`, `cancelled`, `reverted`. The `/industry` page already filters to `status = 'active'` only; the structure page did not.
- Added the same `.eq('status', 'active')` filter to the structure page's query so delivered, cancelled, and reverted (aborted) jobs no longer show.

## Test plan
- [ ] Visually confirm `/structure/[structureId]` only lists jobs with `status = 'active'` once deployed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XYYuMudDzgKZ7Mduyg48Jw)_