### PR TITLE
Add /api/corp/assets and /api/corp/jobs IMPORTDATA endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,8 @@ Each job exports its `run*()` function and self-invokes as CLI when run directly
 | `corp_structure_rig` | Rigs on structures | `structure_id`, `location_flag`, `type_id`, `corporation_id` |
 | `corp_wallet_journal` | Corp transaction log | `corporation_id`, `division`, `entry_id`, `ref_type`, `amount`, `date` |
 | `corp_market_transaction` | Corp market buys/sells (unioned into market page) | `transaction_id`, `corporation_id`, `division`, `type_id`, `unit_price`, `quantity`, `is_buy`, `date` |
-| `corp_asset` | Corp asset snapshot (replaced wholesale per run, not SCD-2) | `item_id`, `corporation_id`, `type_id`, `location_id`, `location_flag`, `quantity` |
+| `corp_asset_over_time` | SCD Type 2 corp asset history | `item_id`, `corporation_id`, `type_id`, `location_id`, `location_flag`, `quantity`, `is_current`, `first_seen_at`, `last_seen_at` |
+| `corp_asset` | View: `is_current` corp assets | same columns as above |
 | `corp_industry_job` | Corp manufacturing/research jobs | `job_id`, `corporation_id`, `installer_id`, `blueprint_id`, `product_type_id`, `activity_id`, `status`, `end_date` |
 | `industry_system_index` | Cost index history (append-only) | `system_id`, `activity`, `cost_index`, `recorded_at` |
 | `eve_name` | Cached id→name | `id` (bigint PK), `name`, `category` |
@@ -203,7 +204,7 @@ Key Postgres functions (callable via RPC or SQL):
 
 ## Design patterns
 
-- **SCD Type 2 assets:** `asset_over_time` tracks the full history of each item. `is_current=true` rows form the current snapshot. `last_seen_at` is bumped each run for unchanged items; a new row is inserted when anything changes, and the old row's `is_current` is set to `false`.
+- **SCD Type 2 assets:** `asset_over_time` tracks the full history of each item. `is_current=true` rows form the current snapshot. `last_seen_at` is bumped each run for unchanged items; a new row is inserted when anything changes, and the old row's `is_current` is set to `false`. `corp_asset_over_time` (+ `corp_asset` view) mirrors this exact pattern for corp assets, reconciled in `src/jobs/structures.js`.
 - **Supabase RLS:** All tables use RLS scoped to `auth.uid()`. Cron scripts use the service-role key (`sudoSupabase` / `src/utils/supabase/service.ts`) which bypasses RLS.
 - **Google Sheets IMPORTDATA:** `/api/assets`, `/api/orders`, `/api/industry`, `/api/corp/assets`, `/api/corp/jobs` authenticate via `user_settings.api_token`, call a Postgres function, and return CSV.
 - **Vercel queue:** The queue consumer at `/api/queue/jobs` dispatches to the same `run*()` functions the CLI jobs use. The UI enqueues work via `@vercel/queue`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ All functions take `(characterId, accessToken)` unless noted. Returns raw ESI re
 - `character(characterId, token)` — character sheet
 - `corpStructures(corpId, token)` — corporation Upwell structures
 - `corpAssets(corpId, token)` — corporation assets
+- `corpIndustryJobs(corpId, token)` — corporation industry jobs
 - `corpWalletJournal(corpId, division, token)` — corp wallet journal by division
 - `corpTransactions(token, corpId, division)` — corp wallet market transactions for one division
 - `assetNames(characterId, token, itemIds[])` — player-assigned names for specific item IDs
@@ -144,6 +145,8 @@ All functions take `(characterId, accessToken)` unless noted. Returns raw ESI re
 | `/api/assets` | `src/app/api/assets/route.ts` |
 | `/api/orders` | `src/app/api/orders/route.ts` |
 | `/api/industry` | `src/app/api/industry/route.ts` |
+| `/api/corp/assets` | `src/app/api/corp/assets/route.ts` |
+| `/api/corp/jobs` | `src/app/api/corp/jobs/route.ts` |
 | `/api/queue/jobs` | `src/app/api/queue/jobs/route.ts` |
 | `/api/type/search` | `src/app/api/type/search/route.ts` |
 
@@ -178,6 +181,8 @@ Each job exports its `run*()` function and self-invokes as CLI when run directly
 | `corp_structure_rig` | Rigs on structures | `structure_id`, `location_flag`, `type_id`, `corporation_id` |
 | `corp_wallet_journal` | Corp transaction log | `corporation_id`, `division`, `entry_id`, `ref_type`, `amount`, `date` |
 | `corp_market_transaction` | Corp market buys/sells (unioned into market page) | `transaction_id`, `corporation_id`, `division`, `type_id`, `unit_price`, `quantity`, `is_buy`, `date` |
+| `corp_asset` | Corp asset snapshot (replaced wholesale per run, not SCD-2) | `item_id`, `corporation_id`, `type_id`, `location_id`, `location_flag`, `quantity` |
+| `corp_industry_job` | Corp manufacturing/research jobs | `job_id`, `corporation_id`, `installer_id`, `blueprint_id`, `product_type_id`, `activity_id`, `status`, `end_date` |
 | `industry_system_index` | Cost index history (append-only) | `system_id`, `activity`, `cost_index`, `recorded_at` |
 | `eve_name` | Cached id→name | `id` (bigint PK), `name`, `category` |
 | `character_corp` | Character→Corp mapping | `character_id`, `corporation_id` |
@@ -193,12 +198,14 @@ Key Postgres functions (callable via RPC or SQL):
 - `asset_snapshot_at(character_ids[], as_of)` — time-travel asset snapshot as JSON (used by `/api/assets`)
 - `industry_jobs(character_ids[])` — export for Sheets IMPORTDATA
 - `market_orders(character_ids[])` — export for Sheets IMPORTDATA
+- `corp_assets(character_ids[])` — corp asset snapshot for the caller's corp(s), export for Sheets IMPORTDATA (used by `/api/corp/assets`)
+- `corp_industry_jobs(character_ids[], include_delivered)` — corp industry jobs for the caller's corp(s), export for Sheets IMPORTDATA (used by `/api/corp/jobs`)
 
 ## Design patterns
 
 - **SCD Type 2 assets:** `asset_over_time` tracks the full history of each item. `is_current=true` rows form the current snapshot. `last_seen_at` is bumped each run for unchanged items; a new row is inserted when anything changes, and the old row's `is_current` is set to `false`.
 - **Supabase RLS:** All tables use RLS scoped to `auth.uid()`. Cron scripts use the service-role key (`sudoSupabase` / `src/utils/supabase/service.ts`) which bypasses RLS.
-- **Google Sheets IMPORTDATA:** `/api/assets`, `/api/orders`, `/api/industry` authenticate via `user_settings.api_token`, call a Postgres function, and return CSV.
+- **Google Sheets IMPORTDATA:** `/api/assets`, `/api/orders`, `/api/industry`, `/api/corp/assets`, `/api/corp/jobs` authenticate via `user_settings.api_token`, call a Postgres function, and return CSV.
 - **Vercel queue:** The queue consumer at `/api/queue/jobs` dispatches to the same `run*()` functions the CLI jobs use. The UI enqueues work via `@vercel/queue`.
 - **Token lifecycle:** ESI OAuth tokens are stored in `token`. Before any ESI call, `refreshAccessToken()` checks expiry and refreshes via EVE SSO if needed.
 - **Name resolution:** `eve_name` table caches ESI `universeNames` lookups. `resolveBatch()` handles bisect-on-error for large batches. Type names (items/ships) come from the locally generated SDE data (`src/sdeTypes.ts`), not the DB.

--- a/schema.sql
+++ b/schema.sql
@@ -720,6 +720,175 @@ create policy "Users read own corp transactions"
 grant select on public.corp_market_transaction to authenticated;
 grant all    on public.corp_market_transaction to service_role;
 
+-- ── corp_asset ────────────────────────────────────────────────────────────
+-- Live snapshot of a corporation's assets (esi-assets.read_corporation_assets.v1).
+-- Replaced wholesale per corp on each structures run rather than kept as SCD-2
+-- history like asset_over_time — corp inventories are large and the IMPORTDATA
+-- use case only needs current state. Sourced from the same ESI pull that feeds
+-- corp_structure_rig.
+create table public.corp_asset (
+  item_id bigint primary key,
+  corporation_id bigint not null,
+  type_id bigint not null,
+  location_id bigint,
+  location_flag text,
+  location_type text,
+  quantity bigint,
+  is_singleton boolean,
+  is_blueprint_copy boolean,
+  updated_at timestamptz not null default now()
+);
+create index corp_asset_corporation_id_idx on public.corp_asset (corporation_id);
+
+alter table public.corp_asset enable row level security;
+create policy "Users read assets for own corps"
+  on public.corp_asset
+  for select
+  to authenticated
+  using (
+    corporation_id in (
+      select corporation_id from public.registration
+      where user_id = (select auth.uid()) and corporation_id is not null
+    )
+  );
+
+grant select on public.corp_asset to authenticated;
+grant all    on public.corp_asset to service_role;
+
+-- /api/corp/assets IMPORTDATA endpoint: the caller's corporation(s) raw asset
+-- rows (one per item stack), mirroring asset_snapshot_at()'s shape for the
+-- per-character assets endpoint. Returns json (not jsonb) so json_build_object's
+-- key order is preserved for the sheet's columns, and a single scalar sidesteps
+-- PostgREST's max-rows cap.
+create or replace function public.corp_assets(character_ids uuid[])
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'item_id',           a.item_id,
+        'corporation_id',    a.corporation_id,
+        'type_id',           a.type_id,
+        'location_id',       a.location_id,
+        'location_flag',     a.location_flag,
+        'location_type',     a.location_type,
+        'quantity',          a.quantity,
+        'is_singleton',      a.is_singleton,
+        'is_blueprint_copy', a.is_blueprint_copy
+      )
+      order by a.item_id
+    ),
+    '[]'::json
+  )
+  from public.corp_asset a
+  where a.corporation_id in (
+    select corporation_id from public.registration
+    where id = any(character_ids) and corporation_id is not null
+  );
+$$;
+
+grant execute on function public.corp_assets(uuid[]) to service_role;
+
+-- ── corp_industry_job ─────────────────────────────────────────────────────
+-- Corporation industry jobs (esi-industry.read_corporation_jobs.v1), pulled
+-- once per corp per structures run (like corp_structure/corp_wallet_journal).
+-- Same shape as the per-character industry_job table plus corporation_id;
+-- installer_id is the character who started the job.
+create table public.corp_industry_job (
+  job_id bigint primary key,
+  corporation_id bigint not null,
+  installer_id bigint not null,
+  facility_id bigint not null,
+  station_id bigint,
+  activity_id smallint not null,
+  blueprint_id bigint not null,
+  blueprint_type_id bigint not null,
+  blueprint_location_id bigint not null,
+  output_location_id bigint not null,
+  product_type_id bigint,
+  runs integer not null,
+  cost numeric(20, 2),
+  licensed_runs integer,
+  probability real,
+  status text not null,
+  duration integer not null,
+  start_date timestamptz not null,
+  end_date timestamptz not null,
+  pause_date timestamptz,
+  completed_date timestamptz,
+  completed_character_id bigint,
+  successful_runs integer,
+  seen_at timestamptz not null default now()
+);
+create index corp_industry_job_corporation_id_end_date_idx on public.corp_industry_job (corporation_id, end_date desc);
+
+alter table public.corp_industry_job enable row level security;
+create policy "Users read industry jobs for own corps"
+  on public.corp_industry_job
+  for select
+  to authenticated
+  using (
+    corporation_id in (
+      select corporation_id from public.registration
+      where user_id = (select auth.uid()) and corporation_id is not null
+    )
+  );
+
+grant select on public.corp_industry_job to authenticated;
+grant all    on public.corp_industry_job to service_role;
+
+-- /api/corp/jobs IMPORTDATA endpoint: the caller's corporation(s) industry jobs,
+-- mirroring industry_jobs()'s shape for the per-character endpoint. Returns json
+-- (not jsonb) so json_build_object's key order is preserved for the sheet's
+-- columns, and a single scalar sidesteps PostgREST's max-rows cap.
+create or replace function public.corp_industry_jobs(character_ids uuid[], include_delivered boolean default false)
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'activity_id',            j.activity_id,
+        'blueprint_id',           j.blueprint_id,
+        'blueprint_location_id',  j.blueprint_location_id,
+        'blueprint_type_id',      j.blueprint_type_id,
+        'completed_character_id', j.completed_character_id,
+        'completed_date',         j.completed_date,
+        'corporation_id',         j.corporation_id,
+        'cost',                   j.cost,
+        'duration',               j.duration,
+        'end_date',               j.end_date,
+        'facility_id',            j.facility_id,
+        'installer_id',           j.installer_id,
+        'job_id',                 j.job_id,
+        'licensed_runs',          j.licensed_runs,
+        'output_location_id',     j.output_location_id,
+        'pause_date',             j.pause_date,
+        'probability',            j.probability,
+        'product_type_id',        j.product_type_id,
+        'runs',                   j.runs,
+        'start_date',             j.start_date,
+        'station_id',             j.station_id,
+        'status',                 j.status,
+        'successful_runs',        j.successful_runs
+      )
+      order by j.start_date desc
+    ),
+    '[]'::json
+  )
+  from public.corp_industry_job j
+  where j.corporation_id in (
+    select corporation_id from public.registration
+    where id = any(character_ids) and corporation_id is not null
+  )
+  and (include_delivered or j.status not in ('delivered', 'cancelled', 'archived'));
+$$;
+
+grant execute on function public.corp_industry_jobs(uuid[], boolean) to service_role;
+
 -- ── eve_name ──────────────────────────────────────────────────────────────
 -- Cache of resolved EVE id -> name/category lookups.
 create table public.eve_name (

--- a/schema.sql
+++ b/schema.sql
@@ -720,14 +720,15 @@ create policy "Users read own corp transactions"
 grant select on public.corp_market_transaction to authenticated;
 grant all    on public.corp_market_transaction to service_role;
 
--- ── corp_asset ────────────────────────────────────────────────────────────
--- Live snapshot of a corporation's assets (esi-assets.read_corporation_assets.v1).
--- Replaced wholesale per corp on each structures run rather than kept as SCD-2
--- history like asset_over_time — corp inventories are large and the IMPORTDATA
--- use case only needs current state. Sourced from the same ESI pull that feeds
--- corp_structure_rig.
-create table public.corp_asset (
-  item_id bigint primary key,
+-- ── corp_asset_over_time ──────────────────────────────────────────────────
+-- SCD Type 2 history of a corporation's assets (esi-assets.read_corporation_assets.v1),
+-- mirroring asset_over_time for per-character assets: is_current=true rows form
+-- the current snapshot, last_seen_at is bumped each run for unchanged items, and
+-- a new row is inserted when anything changes (old row's is_current set false).
+-- Sourced from the same ESI pull that feeds corp_structure_rig.
+create table public.corp_asset_over_time (
+  id bigint generated always as identity primary key,
+  item_id bigint not null,
   corporation_id bigint not null,
   type_id bigint not null,
   location_id bigint,
@@ -736,13 +737,19 @@ create table public.corp_asset (
   quantity bigint,
   is_singleton boolean,
   is_blueprint_copy boolean,
-  updated_at timestamptz not null default now()
+  is_current boolean not null default true,
+  first_seen_at timestamptz not null default now(),
+  last_seen_at timestamptz not null default now()
 );
-create index corp_asset_corporation_id_idx on public.corp_asset (corporation_id);
+create index corp_asset_over_time_corporation_id_idx on public.corp_asset_over_time (corporation_id);
+-- At most one live row per item; also the conflict target the reconcile relies on.
+create unique index corp_asset_over_time_current_item_idx on public.corp_asset_over_time (item_id) where is_current;
+-- Time-travel lookups walking an item's version history.
+create index corp_asset_over_time_item_id_idx on public.corp_asset_over_time (item_id, last_seen_at desc);
 
-alter table public.corp_asset enable row level security;
+alter table public.corp_asset_over_time enable row level security;
 create policy "Users read assets for own corps"
-  on public.corp_asset
+  on public.corp_asset_over_time
   for select
   to authenticated
   using (
@@ -752,14 +759,20 @@ create policy "Users read assets for own corps"
     )
   );
 
-grant select on public.corp_asset to authenticated;
-grant all    on public.corp_asset to service_role;
+-- Live snapshot of corp assets. security_invoker keeps the underlying RLS in
+-- force for the querying (authenticated) role rather than running as the view owner.
+create view public.corp_asset with (security_invoker = on) as
+  select * from public.corp_asset_over_time where is_current;
 
--- /api/corp/assets IMPORTDATA endpoint: the caller's corporation(s) raw asset
--- rows (one per item stack), mirroring asset_snapshot_at()'s shape for the
--- per-character assets endpoint. Returns json (not jsonb) so json_build_object's
--- key order is preserved for the sheet's columns, and a single scalar sidesteps
--- PostgREST's max-rows cap.
+grant select on public.corp_asset_over_time to authenticated;
+grant select on public.corp_asset           to authenticated;
+grant all    on public.corp_asset_over_time to service_role;
+
+-- /api/corp/assets IMPORTDATA endpoint: the caller's corporation(s) current
+-- asset rows (one per item stack), mirroring asset_snapshot_at()'s shape for
+-- the per-character assets endpoint. Returns json (not jsonb) so
+-- json_build_object's key order is preserved for the sheet's columns, and a
+-- single scalar sidesteps PostgREST's max-rows cap.
 create or replace function public.corp_assets(character_ids uuid[])
 returns json
 language sql

--- a/src/app/account/settings/apiToken.tsx
+++ b/src/app/account/settings/apiToken.tsx
@@ -29,6 +29,8 @@ const ApiToken = ({ initialToken }: { initialToken: string | null }) => {
   const assetsUrl = token ? `${origin}/api/assets?token=${token}` : null
   const industryUrl = token ? `${origin}/api/industry?token=${token}` : null
   const ordersUrl = token ? `${origin}/api/orders?token=${token}` : null
+  const corpAssetsUrl = token ? `${origin}/api/corp/assets?token=${token}` : null
+  const corpJobsUrl = token ? `${origin}/api/corp/jobs?token=${token}` : null
 
   return (
     <>
@@ -37,7 +39,7 @@ const ApiToken = ({ initialToken }: { initialToken: string | null }) => {
         Pull your data into a spreadsheet with <code>=IMPORTDATA(url)</code> (the first row is the column
         headers):
       </p>
-      {assetsUrl && industryUrl && ordersUrl && (
+      {assetsUrl && industryUrl && ordersUrl && corpAssetsUrl && corpJobsUrl && (
         <ul>
           <li>
             Assets (one row per item stack): <code>=IMPORTDATA(&quot;{assetsUrl}&quot;)</code>
@@ -47,6 +49,12 @@ const ApiToken = ({ initialToken }: { initialToken: string | null }) => {
           </li>
           <li>
             Market orders (open): <code>=IMPORTDATA(&quot;{ordersUrl}&quot;)</code>
+          </li>
+          <li>
+            Corp assets (one row per item stack): <code>=IMPORTDATA(&quot;{corpAssetsUrl}&quot;)</code>
+          </li>
+          <li>
+            Corp industry jobs: <code>=IMPORTDATA(&quot;{corpJobsUrl}&quot;)</code>
           </li>
         </ul>
       )}

--- a/src/app/api/corp/assets/route.ts
+++ b/src/app/api/corp/assets/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { resolvePlayer } from '@/utils/apiToken'
+import { toCsv } from '@/utils/csv'
+
+// Public CSV endpoint for Google Sheets =IMPORTDATA(): the current live asset
+// rows (one per item stack) for the corporation(s) the caller's characters
+// belong to. The first row is the column headers. Authenticated by the
+// per-user api_token in the query string (Sheets carries no session cookie),
+// so it always recomputes — no caching.
+export const dynamic = 'force-dynamic'
+// Headroom over Vercel's default function timeout for a large inventory.
+export const maxDuration = 60
+
+export const GET = async (request: NextRequest): Promise<NextResponse> => {
+  const { searchParams } = new URL(request.url)
+
+  const player = await resolvePlayer(searchParams.get('token')?.trim())
+  if (!player.ok) {
+    return NextResponse.json({ error: player.error }, { status: player.status })
+  }
+
+  // Built and returned as one json array by Postgres (corp_assets), which keeps
+  // the field order for the sheet's columns and sidesteps PostgREST's max-rows cap.
+  const { data: rows, error: rowsError } = await player.supabase.rpc('corp_assets', {
+    character_ids: player.characterIds,
+  })
+  if (rowsError) {
+    return NextResponse.json({ error: 'Query failed' }, { status: 500 })
+  }
+
+  return new NextResponse(toCsv(rows ?? []), {
+    headers: { 'Content-Type': 'text/csv; charset=utf-8' },
+  })
+}

--- a/src/app/api/corp/jobs/route.ts
+++ b/src/app/api/corp/jobs/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { resolvePlayer } from '@/utils/apiToken'
+import { toCsv } from '@/utils/csv'
+
+// Public CSV endpoint for Google Sheets =IMPORTDATA(): industry jobs for the
+// corporation(s) the caller's characters belong to. The first row is the
+// column headers. Authenticated by the per-user api_token in the query string
+// (Sheets carries no session cookie), so it always recomputes — no caching.
+export const dynamic = 'force-dynamic'
+// Headroom over Vercel's default function timeout.
+export const maxDuration = 60
+
+export const GET = async (request: NextRequest): Promise<NextResponse> => {
+  const { searchParams } = new URL(request.url)
+
+  const player = await resolvePlayer(searchParams.get('token')?.trim())
+  if (!player.ok) {
+    return NextResponse.json({ error: player.error }, { status: player.status })
+  }
+
+  // Hide terminal-status rows (delivered/cancelled/archived) by default; the
+  // sheet typically only cares about in-flight work. Callers that want the full
+  // history can opt in with ?include_delivered=true.
+  const includeDelivered = /^(1|true|yes)$/i.test(searchParams.get('include_delivered')?.trim() ?? '')
+
+  // Built and returned as one json array by Postgres (corp_industry_jobs), which
+  // keeps the field order for the sheet's columns and sidesteps PostgREST's
+  // max-rows cap.
+  const { data: rows, error: rowsError } = await player.supabase.rpc('corp_industry_jobs', {
+    character_ids: player.characterIds,
+    include_delivered: includeDelivered,
+  })
+  if (rowsError) {
+    return NextResponse.json({ error: 'Query failed' }, { status: 500 })
+  }
+
+  return new NextResponse(toCsv(rows ?? []), {
+    headers: { 'Content-Type': 'text/csv; charset=utf-8' },
+  })
+}

--- a/src/esi.js
+++ b/src/esi.js
@@ -82,6 +82,13 @@ export const corpAssets = (access_token, corporationID, page = 1) =>
     label: `corpAssets ${corporationID} page=${page}`,
   })
 
+export const corpIndustryJobs = (access_token, corporationID, page = 1) =>
+  esiPaged(`/corporations/${corporationID}/industry/jobs/`, {
+    access_token,
+    params: { page, include_completed: 'true' },
+    label: `corpIndustryJobs ${corporationID} page=${page}`,
+  })
+
 export const corpWalletJournal = (access_token, corporationID, division, page = 1) =>
   esiPaged(`/corporations/${corporationID}/wallets/${division}/journal/`, {
     access_token,

--- a/src/jobs/structures.js
+++ b/src/jobs/structures.js
@@ -1,7 +1,7 @@
 import { fileURLToPath } from 'node:url'
 
 import { pullCorpWalletJournals } from '../corpWalletJournal.js'
-import { character as fetchCharacter, corpAssets, corpStructures, universeNames } from '../esi.js'
+import { character as fetchCharacter, corpAssets, corpIndustryJobs, corpStructures, universeNames } from '../esi.js'
 import { resolveAssetStationNames, resolveCorpJournalNames, resolveCorpStructureSystemNames } from '../resolveNames.js'
 import { resolveStructureNames } from '../structureNames.js'
 import { sudoSupabase } from '../supabase.js'
@@ -10,6 +10,7 @@ import { refreshAccessToken } from '../tokenRefresh.js'
 const STRUCTURES_SCOPE = 'esi-corporations.read_structures.v1'
 const WALLET_SCOPE = 'esi-wallet.read_corporation_wallets.v1'
 const ASSETS_SCOPE = 'esi-assets.read_corporation_assets.v1'
+const JOBS_SCOPE = 'esi-industry.read_corporation_jobs.v1'
 
 // Items fitted to an Upwell structure show up in corp assets with location_id
 // equal to the structure_id and a RigSlotN location_flag.
@@ -72,6 +73,7 @@ export const runStructures = async ({ characterIds } = {}) => {
   const seenStructureCorps = new Set()
   const seenWalletCorps = new Set()
   const seenAssetCorps = new Set()
+  const seenJobsCorps = new Set()
   for (const tokenRow of tokens ?? []) {
     const t0 = Date.now()
     const name = characterName.get(tokenRow.character_id) ?? '?'
@@ -204,6 +206,32 @@ export const runStructures = async ({ characterIds } = {}) => {
           )
 
           const now = new Date().toISOString()
+
+          // Replace this corp's asset snapshot wholesale (not SCD-2 like character
+          // assets — corp inventories are large and IMPORTDATA only needs current state).
+          const assetRows = assets.map((a) => ({
+            item_id: a.item_id,
+            corporation_id,
+            type_id: a.type_id,
+            location_id: a.location_id ?? null,
+            location_flag: a.location_flag ?? null,
+            location_type: a.location_type ?? null,
+            quantity: a.quantity ?? null,
+            is_singleton: a.is_singleton ?? null,
+            is_blueprint_copy: a.is_blueprint_copy ?? null,
+            updated_at: now,
+          }))
+          const { error: assetDelErr } = await sudoSupabase
+            .from('corp_asset')
+            .delete()
+            .eq('corporation_id', corporation_id)
+          if (assetDelErr) throw assetDelErr
+          if (assetRows.length > 0) {
+            const { error: assetErr } = await sudoSupabase.from('corp_asset').insert(assetRows)
+            if (assetErr) throw assetErr
+          }
+          console.log(`[structures] ${ctx}: corp ${corpLabel} stored ${assetRows.length} corp_asset row(s)`)
+
           const rigRows = assets
             .filter((a) => isRigSlot(a.location_flag) && structureIds.has(Number(a.location_id)))
             .map((a) => ({
@@ -243,6 +271,70 @@ export const runStructures = async ({ characterIds } = {}) => {
       } else {
         seenWalletCorps.add(corporation_id)
         await pullCorpWalletJournals({ access_token, corporation_id, ctx, corpLabel })
+      }
+
+      if (!scope.includes(JOBS_SCOPE)) {
+        console.log(`[structures] ${ctx}: corp ${corpLabel} token lacks ${JOBS_SCOPE}, skipping industry jobs`)
+      } else if (seenJobsCorps.has(corporation_id)) {
+        console.log(`[structures] ${ctx}: corp ${corpLabel} industry jobs already pulled this run, skipping`)
+      } else {
+        seenJobsCorps.add(corporation_id)
+        try {
+          const tj = Date.now()
+          const jobs = []
+          console.log(`[structures] ${ctx}: fetching corp ${corpLabel} industry jobs page 1`)
+          const [firstJobPage, jobPagesHeader] = await corpIndustryJobs(access_token, corporation_id, 1)
+          jobs.push(...firstJobPage)
+          const jobPages = Math.max(1, Number.parseInt(jobPagesHeader, 10) || 1)
+          for (let page = 2; page <= jobPages; page++) {
+            const [more] = await corpIndustryJobs(access_token, corporation_id, page)
+            jobs.push(...more)
+          }
+          console.log(
+            `[structures] ${ctx}: corp ${corpLabel} returned ${jobs.length} industry job(s) across ${jobPages} page(s)`
+          )
+
+          const now = new Date().toISOString()
+          const jobRows = jobs.map((j) => ({
+            job_id: j.job_id,
+            corporation_id,
+            installer_id: j.installer_id,
+            facility_id: j.facility_id,
+            station_id: j.station_id ?? null,
+            activity_id: j.activity_id,
+            blueprint_id: j.blueprint_id,
+            blueprint_type_id: j.blueprint_type_id,
+            blueprint_location_id: j.blueprint_location_id,
+            output_location_id: j.output_location_id,
+            product_type_id: j.product_type_id ?? null,
+            runs: j.runs,
+            cost: j.cost ?? null,
+            licensed_runs: j.licensed_runs ?? null,
+            probability: j.probability ?? null,
+            status: j.status,
+            duration: j.duration,
+            start_date: j.start_date,
+            end_date: j.end_date,
+            pause_date: j.pause_date ?? null,
+            completed_date: j.completed_date ?? null,
+            completed_character_id: j.completed_character_id ?? null,
+            successful_runs: j.successful_runs ?? null,
+            seen_at: now,
+          }))
+          if (jobRows.length > 0) {
+            const { error: jobErr } = await sudoSupabase
+              .from('corp_industry_job')
+              .upsert(jobRows, { onConflict: 'job_id' })
+            if (jobErr) throw jobErr
+          }
+          console.log(
+            `[structures] ${ctx}: corp ${corpLabel} stored ${jobRows.length} industry job(s) in ${Date.now() - tj}ms`
+          )
+        } catch (e) {
+          console.error(
+            `[structures] ${ctx}: corp ${corpLabel} industry jobs pull FAILED name=${e?.name} message=${e?.message}`
+          )
+        }
       }
     } catch (e) {
       const dt = Date.now() - t0

--- a/src/jobs/structures.js
+++ b/src/jobs/structures.js
@@ -1,5 +1,7 @@
 import { fileURLToPath } from 'node:url'
 
+import { splitEvery } from 'ramda'
+
 import { pullCorpWalletJournals } from '../corpWalletJournal.js'
 import { character as fetchCharacter, corpAssets, corpIndustryJobs, corpStructures, universeNames } from '../esi.js'
 import { resolveAssetStationNames, resolveCorpJournalNames, resolveCorpStructureSystemNames } from '../resolveNames.js'
@@ -34,6 +36,97 @@ const resolveCorpName = async (corporation_id) => {
   return name
 }
 const corpLabelFor = (name, corporation_id) => (name ? `${name} (${corporation_id})` : `${corporation_id}`)
+
+// The tracked attributes that define a version of a corp asset row. Two
+// sightings with the same signature are the "same" row; any difference opens
+// a new SCD row. Mirrors assets.js's per-character signature (minus `name`,
+// which ESI doesn't expose for corp assets).
+const corpAssetSignature = (a) =>
+  JSON.stringify([
+    Number(a.type_id),
+    a.location_id == null ? null : Number(a.location_id),
+    a.location_flag ?? null,
+    a.location_type ?? null,
+    a.quantity == null ? null : Number(a.quantity),
+    a.is_singleton ?? null,
+    !!a.is_blueprint_copy,
+  ])
+
+// Reconcile freshly fetched corp assets against the corp's current (open) rows
+// in corp_asset_over_time, the same SCD-2 approach assets.js uses for
+// per-character assets: unchanged items get last_seen_at extended, changed
+// items close their old row and open a new one, and vanished items are closed.
+const reconcileCorpAssets = async (corporation_id, fetched) => {
+  const baseCols =
+    'id, item_id, type_id, location_id, location_flag, location_type, quantity, is_singleton, is_blueprint_copy'
+  // Page through every open row: PostgREST caps a select at the API "Max rows"
+  // limit (1000), but a corp can hold tens of thousands of items.
+  const PAGE = 1000
+  const current = []
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await sudoSupabase
+      .from('corp_asset_over_time')
+      .select(baseCols)
+      .eq('corporation_id', corporation_id)
+      .eq('is_current', true)
+      .order('id', { ascending: true })
+      .range(from, from + PAGE - 1)
+    if (error) throw error
+    if (!data || data.length === 0) break
+    current.push(...data)
+    if (data.length < PAGE) break
+  }
+
+  const currentByItem = new Map(current.map((c) => [Number(c.item_id), c]))
+  // ESI can return the same item twice across pages if assets shift mid-fetch;
+  // collapse to one entry per item so we never queue two inserts for it.
+  const fetchedByItem = new Map(fetched.map((a) => [Number(a.item_id), a]))
+
+  const now = new Date().toISOString()
+  const touchIds = [] // unchanged: bump last_seen_at on the open row
+  const closeIds = [] // changed or gone: close the open row
+  const inserts = [] // changed or new: open a fresh version
+
+  for (const a of fetchedByItem.values()) {
+    const cur = currentByItem.get(Number(a.item_id))
+    if (cur && corpAssetSignature(cur) === corpAssetSignature(a)) {
+      touchIds.push(cur.id)
+    } else {
+      if (cur) closeIds.push(cur.id)
+      inserts.push({
+        item_id: a.item_id,
+        corporation_id,
+        type_id: a.type_id,
+        location_id: a.location_id ?? null,
+        location_flag: a.location_flag ?? null,
+        location_type: a.location_type ?? null,
+        quantity: a.quantity ?? null,
+        is_singleton: a.is_singleton ?? null,
+        is_blueprint_copy: !!a.is_blueprint_copy,
+        last_seen_at: now,
+      })
+    }
+    currentByItem.delete(Number(a.item_id))
+  }
+  // Anything still open but not seen this run has left the corp's assets.
+  for (const cur of currentByItem.values()) closeIds.push(cur.id)
+
+  for (const ids of splitEvery(200, touchIds)) {
+    const { error } = await sudoSupabase.from('corp_asset_over_time').update({ last_seen_at: now }).in('id', ids)
+    if (error) throw error
+  }
+  // Close before inserting so the unique-current-per-item index never collides.
+  for (const ids of splitEvery(200, closeIds)) {
+    const { error } = await sudoSupabase.from('corp_asset_over_time').update({ is_current: false }).in('id', ids)
+    if (error) throw error
+  }
+  for (const rows of splitEvery(1000, inserts)) {
+    const { error } = await sudoSupabase.from('corp_asset_over_time').insert(rows)
+    if (error) throw error
+  }
+
+  return { touched: touchIds.length, opened: inserts.length, closed: closeIds.length }
+}
 
 // Pull corp structures (plus structure rigs and corp wallet journals where the
 // linked tokens allow) for tokens carrying the structures scope. Pass `characterIds`
@@ -205,33 +298,12 @@ export const runStructures = async ({ characterIds } = {}) => {
             `[structures] ${ctx}: corp ${corpLabel} returned ${assets.length} asset(s) across ${assetPages} page(s)`
           )
 
+          const { touched, opened, closed } = await reconcileCorpAssets(corporation_id, assets)
+          console.log(
+            `[structures] ${ctx}: corp ${corpLabel} assets ${touched} unchanged, ${opened} opened, ${closed} closed`
+          )
+
           const now = new Date().toISOString()
-
-          // Replace this corp's asset snapshot wholesale (not SCD-2 like character
-          // assets — corp inventories are large and IMPORTDATA only needs current state).
-          const assetRows = assets.map((a) => ({
-            item_id: a.item_id,
-            corporation_id,
-            type_id: a.type_id,
-            location_id: a.location_id ?? null,
-            location_flag: a.location_flag ?? null,
-            location_type: a.location_type ?? null,
-            quantity: a.quantity ?? null,
-            is_singleton: a.is_singleton ?? null,
-            is_blueprint_copy: a.is_blueprint_copy ?? null,
-            updated_at: now,
-          }))
-          const { error: assetDelErr } = await sudoSupabase
-            .from('corp_asset')
-            .delete()
-            .eq('corporation_id', corporation_id)
-          if (assetDelErr) throw assetDelErr
-          if (assetRows.length > 0) {
-            const { error: assetErr } = await sudoSupabase.from('corp_asset').insert(assetRows)
-            if (assetErr) throw assetErr
-          }
-          console.log(`[structures] ${ctx}: corp ${corpLabel} stored ${assetRows.length} corp_asset row(s)`)
-
           const rigRows = assets
             .filter((a) => isRigSlot(a.location_flag) && structureIds.has(Number(a.location_id)))
             .map((a) => ({

--- a/supabase/migrations/20260702120000_add_corp_asset_and_industry_job.sql
+++ b/supabase/migrations/20260702120000_add_corp_asset_and_industry_job.sql
@@ -3,9 +3,11 @@
 -- them via IMPORTDATA-style RPCs (/api/corp/assets, /api/corp/jobs), like
 -- asset_snapshot_at()/industry_jobs() do for the per-character endpoints.
 
--- ── corp_asset ────────────────────────────────────────────────────────────
-create table if not exists public.corp_asset (
-  item_id bigint primary key,
+-- ── corp_asset_over_time ──────────────────────────────────────────────────
+-- SCD Type 2 history, mirroring asset_over_time for per-character assets.
+create table if not exists public.corp_asset_over_time (
+  id bigint generated always as identity primary key,
+  item_id bigint not null,
   corporation_id bigint not null,
   type_id bigint not null,
   location_id bigint,
@@ -14,15 +16,21 @@ create table if not exists public.corp_asset (
   quantity bigint,
   is_singleton boolean,
   is_blueprint_copy boolean,
-  updated_at timestamptz not null default now()
+  is_current boolean not null default true,
+  first_seen_at timestamptz not null default now(),
+  last_seen_at timestamptz not null default now()
 );
-create index if not exists corp_asset_corporation_id_idx on public.corp_asset (corporation_id);
+create index if not exists corp_asset_over_time_corporation_id_idx on public.corp_asset_over_time (corporation_id);
+create unique index if not exists corp_asset_over_time_current_item_idx
+  on public.corp_asset_over_time (item_id) where is_current;
+create index if not exists corp_asset_over_time_item_id_idx
+  on public.corp_asset_over_time (item_id, last_seen_at desc);
 
-alter table public.corp_asset enable row level security;
+alter table public.corp_asset_over_time enable row level security;
 
-drop policy if exists "Users read assets for own corps" on public.corp_asset;
+drop policy if exists "Users read assets for own corps" on public.corp_asset_over_time;
 create policy "Users read assets for own corps"
-  on public.corp_asset
+  on public.corp_asset_over_time
   for select
   to authenticated
   using (
@@ -32,8 +40,13 @@ create policy "Users read assets for own corps"
     )
   );
 
-grant select on public.corp_asset to authenticated;
-grant all    on public.corp_asset to service_role;
+drop view if exists public.corp_asset;
+create view public.corp_asset with (security_invoker = on) as
+  select * from public.corp_asset_over_time where is_current;
+
+grant select on public.corp_asset_over_time to authenticated;
+grant select on public.corp_asset           to authenticated;
+grant all    on public.corp_asset_over_time to service_role;
 
 create or replace function public.corp_assets(character_ids uuid[])
 returns json

--- a/supabase/migrations/20260702120000_add_corp_asset_and_industry_job.sql
+++ b/supabase/migrations/20260702120000_add_corp_asset_and_industry_job.sql
@@ -1,0 +1,160 @@
+-- Corp assets and corp industry jobs, mirroring the existing per-corp tables
+-- (corp_structure, corp_wallet_journal, corp_market_transaction) and exposing
+-- them via IMPORTDATA-style RPCs (/api/corp/assets, /api/corp/jobs), like
+-- asset_snapshot_at()/industry_jobs() do for the per-character endpoints.
+
+-- ── corp_asset ────────────────────────────────────────────────────────────
+create table if not exists public.corp_asset (
+  item_id bigint primary key,
+  corporation_id bigint not null,
+  type_id bigint not null,
+  location_id bigint,
+  location_flag text,
+  location_type text,
+  quantity bigint,
+  is_singleton boolean,
+  is_blueprint_copy boolean,
+  updated_at timestamptz not null default now()
+);
+create index if not exists corp_asset_corporation_id_idx on public.corp_asset (corporation_id);
+
+alter table public.corp_asset enable row level security;
+
+drop policy if exists "Users read assets for own corps" on public.corp_asset;
+create policy "Users read assets for own corps"
+  on public.corp_asset
+  for select
+  to authenticated
+  using (
+    corporation_id in (
+      select corporation_id from public.registration
+      where user_id = (select auth.uid()) and corporation_id is not null
+    )
+  );
+
+grant select on public.corp_asset to authenticated;
+grant all    on public.corp_asset to service_role;
+
+create or replace function public.corp_assets(character_ids uuid[])
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'item_id',           a.item_id,
+        'corporation_id',    a.corporation_id,
+        'type_id',           a.type_id,
+        'location_id',       a.location_id,
+        'location_flag',     a.location_flag,
+        'location_type',     a.location_type,
+        'quantity',          a.quantity,
+        'is_singleton',      a.is_singleton,
+        'is_blueprint_copy', a.is_blueprint_copy
+      )
+      order by a.item_id
+    ),
+    '[]'::json
+  )
+  from public.corp_asset a
+  where a.corporation_id in (
+    select corporation_id from public.registration
+    where id = any(character_ids) and corporation_id is not null
+  );
+$$;
+
+grant execute on function public.corp_assets(uuid[]) to service_role;
+
+-- ── corp_industry_job ─────────────────────────────────────────────────────
+create table if not exists public.corp_industry_job (
+  job_id bigint primary key,
+  corporation_id bigint not null,
+  installer_id bigint not null,
+  facility_id bigint not null,
+  station_id bigint,
+  activity_id smallint not null,
+  blueprint_id bigint not null,
+  blueprint_type_id bigint not null,
+  blueprint_location_id bigint not null,
+  output_location_id bigint not null,
+  product_type_id bigint,
+  runs integer not null,
+  cost numeric(20, 2),
+  licensed_runs integer,
+  probability real,
+  status text not null,
+  duration integer not null,
+  start_date timestamptz not null,
+  end_date timestamptz not null,
+  pause_date timestamptz,
+  completed_date timestamptz,
+  completed_character_id bigint,
+  successful_runs integer,
+  seen_at timestamptz not null default now()
+);
+create index if not exists corp_industry_job_corporation_id_end_date_idx
+  on public.corp_industry_job (corporation_id, end_date desc);
+
+alter table public.corp_industry_job enable row level security;
+
+drop policy if exists "Users read industry jobs for own corps" on public.corp_industry_job;
+create policy "Users read industry jobs for own corps"
+  on public.corp_industry_job
+  for select
+  to authenticated
+  using (
+    corporation_id in (
+      select corporation_id from public.registration
+      where user_id = (select auth.uid()) and corporation_id is not null
+    )
+  );
+
+grant select on public.corp_industry_job to authenticated;
+grant all    on public.corp_industry_job to service_role;
+
+create or replace function public.corp_industry_jobs(character_ids uuid[], include_delivered boolean default false)
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'activity_id',            j.activity_id,
+        'blueprint_id',           j.blueprint_id,
+        'blueprint_location_id',  j.blueprint_location_id,
+        'blueprint_type_id',      j.blueprint_type_id,
+        'completed_character_id', j.completed_character_id,
+        'completed_date',         j.completed_date,
+        'corporation_id',         j.corporation_id,
+        'cost',                   j.cost,
+        'duration',               j.duration,
+        'end_date',               j.end_date,
+        'facility_id',            j.facility_id,
+        'installer_id',           j.installer_id,
+        'job_id',                 j.job_id,
+        'licensed_runs',          j.licensed_runs,
+        'output_location_id',     j.output_location_id,
+        'pause_date',             j.pause_date,
+        'probability',            j.probability,
+        'product_type_id',        j.product_type_id,
+        'runs',                   j.runs,
+        'start_date',             j.start_date,
+        'station_id',             j.station_id,
+        'status',                 j.status,
+        'successful_runs',        j.successful_runs
+      )
+      order by j.start_date desc
+    ),
+    '[]'::json
+  )
+  from public.corp_industry_job j
+  where j.corporation_id in (
+    select corporation_id from public.registration
+    where id = any(character_ids) and corporation_id is not null
+  )
+  and (include_delivered or j.status not in ('delivered', 'cancelled', 'archived'));
+$$;
+
+grant execute on function public.corp_industry_jobs(uuid[], boolean) to service_role;


### PR DESCRIPTION
## Summary
- Add `corp_asset` and `corp_industry_job` tables to store the corp-wide asset snapshot and industry jobs pulled from ESI (`esi-assets.read_corporation_assets.v1`, `esi-industry.read_corporation_jobs.v1`), populated by the existing `structures` cron job alongside its existing corp-structure/rig/wallet pulls.
- Add `corp_assets(character_ids[])` and `corp_industry_jobs(character_ids[], include_delivered)` Postgres RPCs, mirroring `asset_snapshot_at()`/`industry_jobs()`, that resolve the caller's corporation(s) from their registered characters.
- Add `GET /api/corp/assets` and `GET /api/corp/jobs` — CSV IMPORTDATA endpoints for Google Sheets, authenticated the same way as the existing `/api/assets`, `/api/orders`, `/api/industry` endpoints (per-user `api_token` query param).
- Add `corpIndustryJobs()` to the ESI wrapper (`src/esi.js`).
- Add a matching non-destructive migration under `supabase/migrations/`, and update `schema.sql` and `CLAUDE.md`'s codebase map.

## Test plan
- [x] `npm run lint`
- [x] `npm run build` (typechecks the new routes, both appear in the route list)
- [ ] `supabase db push` against a real project to apply the new migration
- [ ] Manually verify `/api/corp/assets?token=...` and `/api/corp/jobs?token=...` against a corp with a real ESI token


---
_Generated by [Claude Code](https://claude.ai/code/session_01MGxvrWP5tM9HjqHLJtw9VR)_