### PR TITLE
Let users drag-reorder the Indexes watch list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,7 +203,7 @@ The per-character jobs (`character-*` except `character-affiliations`, plus `cor
 | `industry_system_index` | Cost index history (append-only) | `system_id`, `activity`, `cost_index`, `recorded_at` |
 | `universe_name` | Cached id→name | `id` (bigint PK), `name`, `category` |
 | `universe_structure` | Player structure cache | `structure_id`, `name`, `system_id`, `type_id` |
-| `watched_system` | Per-user systems to track indexes for (drives `industry-systems` + `/indexes`) | `user_id`, `system_id` |
+| `watched_system` | Per-user systems to track indexes for (drives `industry-systems` + `/indexes`) | `user_id`, `system_id`, `position` (drag order) |
 | `user_settings` | User preferences | `user_id`, `enabled_scopes[]`, `api_token` (unique), `flags[]` |
 | `invite_code` | Invite-only registration | `code` (unique), `created_by`, `redeemed_by`, `redeemed_at` |
 | `refresh_task` | On-demand job tracking | `batch_id`, `user_id`, `job`, `character_id`, `status` (pending/running/done/error) |

--- a/schema.sql
+++ b/schema.sql
@@ -1126,7 +1126,12 @@ create table public.watched_system (
   user_id uuid not null references auth.users(id) on delete cascade,
   system_id bigint not null,
   created_at timestamptz not null default now(),
-  primary key (user_id, system_id)
+  primary key (user_id, system_id),
+  -- Drag order on the /indexes page (lower sorts first). watchSystem() assigns
+  -- new rows the next position; reorderWatchedSystems() rewrites the whole
+  -- list in one request when the user drags a row. Kept last to match the
+  -- add-column migration's column order.
+  position integer not null default 0
 );
 create index watched_system_user_id_idx on public.watched_system (user_id);
 

--- a/src/app/indexes/actions.ts
+++ b/src/app/indexes/actions.ts
@@ -22,16 +22,38 @@ const requireUser = async () => {
 
 // Add a system to the caller's watch list. Invoked from the search results, so
 // it takes the id directly; the SDE lookup rejects ids that aren't real
-// known-space systems. The upsert tolerates re-adding a watched system.
+// known-space systems. New rows are appended to the end of the drag order;
+// the upsert (with ignoreDuplicates) tolerates re-adding an already-watched
+// system without disturbing its existing position.
 export const watchSystem = async (systemId: number) => {
   if (!getSdeSystem(Number(systemId))) return
   const { supabase, userId } = await requireUser()
+  const { data: last } = await supabase
+    .from('watched_system')
+    .select('position')
+    .eq('user_id', userId)
+    .order('position', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  const position = (last?.position ?? -1) + 1
   await supabase
     .from('watched_system')
     .upsert(
-      { user_id: userId, system_id: Number(systemId) },
+      { user_id: userId, system_id: Number(systemId), position },
       { onConflict: 'user_id,system_id', ignoreDuplicates: true }
     )
+  revalidatePath('/indexes')
+}
+
+// Persist a drag-reordered watch list: rewrites every row's position to match
+// the given order in one upsert. Called with the caller's full watch list, so
+// this always leaves position a dense 0..n-1 sequence with no gaps.
+export const reorderWatchedSystems = async (systemIds: number[]) => {
+  const { supabase, userId } = await requireUser()
+  await supabase.from('watched_system').upsert(
+    systemIds.map((systemId, position) => ({ user_id: userId, system_id: systemId, position })),
+    { onConflict: 'user_id,system_id' }
+  )
   revalidatePath('/indexes')
 }
 

--- a/src/app/indexes/indexes.module.css
+++ b/src/app/indexes/indexes.module.css
@@ -54,6 +54,11 @@
   background: color-mix(in srgb, currentColor 6%, transparent);
 }
 
+/* Highlights the row a dragged system would land on if dropped now. */
+.dragOver {
+  background: color-mix(in srgb, currentColor 10%, transparent);
+}
+
 .system {
   font-weight: 600;
 }
@@ -84,6 +89,13 @@
   color: var(--ink-faint);
 }
 
+/* Delete (✕) and drag-grip controls, right-aligned in the row's last cell. */
+.actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4pt;
+}
+
 /* The ✕ that drops a system from the watch list — quiet until hovered. */
 .unwatch {
   border: none;
@@ -95,6 +107,23 @@
 
 .unwatch:hover {
   color: var(--ink);
+}
+
+/* Drag handle for reordering a row — the only part of the row that starts a
+ * drag, so the rest stays ordinary click/hover surface. */
+.grip {
+  cursor: grab;
+  padding: 0 4pt;
+  color: var(--ink-faint);
+  user-select: none;
+}
+
+.grip:hover {
+  color: var(--ink);
+}
+
+.grip:active {
+  cursor: grabbing;
 }
 
 .search {

--- a/src/app/indexes/page.tsx
+++ b/src/app/indexes/page.tsx
@@ -4,16 +4,9 @@ import { indexesFlag } from '@/flags'
 import { formatSecurity, getSdeSystem } from '@/sdeSystems'
 import { createClient } from '@/utils/supabase/server'
 
-import {
-  fetchLatestSystemIndexes,
-  fetchSystemIndexHistory,
-  formatIndex,
-  INDEX_ACTIVITY_LABELS,
-  type Activity,
-} from '../structure/industryIndex'
-import { Sparkline } from '../structure/sparkline'
-import { unwatchSystem } from './actions'
+import { fetchLatestSystemIndexes, fetchSystemIndexHistory, type Activity } from '../structure/industryIndex'
 import { SystemSearch } from './systemSearch'
+import { WatchedSystemsTable, type WatchedRow } from './watchedSystemsTable'
 import { WindowSelect } from './windowSelect'
 import { indexWindowOption } from './windows'
 import styles from './indexes.module.css'
@@ -47,21 +40,38 @@ const IndexesPage = async ({ searchParams }: { searchParams: Promise<{ days?: st
     redirect('/')
   }
 
-  // The caller's watched systems (RLS scopes the read), labelled from the
-  // locally generated SDE data and sorted by name.
-  const { data: watchedRows } = await supabase.from('watched_system').select('system_id')
-  const systems = (watchedRows ?? [])
-    .map((r) => {
-      const id = Number(r.system_id)
-      return { id, sde: getSdeSystem(id) }
-    })
-    .sort((a, b) => (a.sde?.name ?? String(a.id)).localeCompare(b.sde?.name ?? String(b.id)))
+  // The caller's watched systems (RLS scopes the read), in the user's own
+  // drag order, labelled from the locally generated SDE data.
+  const { data: watchedRows } = await supabase
+    .from('watched_system')
+    .select('system_id')
+    .order('position', { ascending: true })
+    .order('created_at', { ascending: true })
+  const systems = (watchedRows ?? []).map((r) => {
+    const id = Number(r.system_id)
+    return { id, sde: getSdeSystem(id) }
+  })
   const systemIds = systems.map((s) => s.id)
 
   const [latestBySystem, historyBySystem] = await Promise.all([
     fetchLatestSystemIndexes(supabase, systemIds),
     fetchSystemIndexHistory(supabase, systemIds, { days: window.days, bucketHours: window.bucketHours }),
   ])
+
+  const rows: WatchedRow[] = systems.map(({ id, sde }) => {
+    const latest = latestBySystem.get(id)
+    const history = historyBySystem.get(id)
+    return {
+      id,
+      name: sde?.name ?? `#${id}`,
+      security: sde ? formatSecurity(sde.security) : null,
+      cells: COLUMNS.map((activity) => ({
+        activity,
+        cost: latest?.get(activity) ?? null,
+        series: history?.get(activity) ?? null,
+      })),
+    }
+  })
 
   return (
     <>
@@ -70,66 +80,16 @@ const IndexesPage = async ({ searchParams }: { searchParams: Promise<{ days?: st
         <WindowSelect days={window.days} />
       </div>
 
-      {systems.length > 0 ? (
-        <table className={styles.table}>
-          <thead>
-            <tr>
-              <th>System</th>
-              {COLUMNS.map((activity) => (
-                <th key={activity}>{INDEX_ACTIVITY_LABELS[activity]}</th>
-              ))}
-              <th />
-            </tr>
-          </thead>
-          <tbody>
-            {systems.map(({ id, sde }) => {
-              const latest = latestBySystem.get(id)
-              const history = historyBySystem.get(id)
-              return (
-                <tr key={id}>
-                  <td>
-                    <span className={styles.system}>{sde?.name ?? `#${id}`}</span>{' '}
-                    {sde && <span className={styles.security}>{formatSecurity(sde.security)}</span>}
-                  </td>
-                  {COLUMNS.map((activity) => {
-                    const cost = latest?.get(activity)
-                    const series = history?.get(activity)
-                    return (
-                      <td key={activity}>
-                        {series || cost != null ? (
-                          <span className={styles.cell}>
-                            <Sparkline
-                              values={series?.values ?? []}
-                              liveCount={series?.liveCount}
-                              updatedAt={series?.updatedAt}
-                              label={`${sde?.name ?? id} ${INDEX_ACTIVITY_LABELS[activity]}`}
-                            />
-                            <span className={styles.current}>{cost != null ? formatIndex(cost) : '—'}</span>
-                          </span>
-                        ) : (
-                          <span className={styles.empty}>—</span>
-                        )}
-                      </td>
-                    )
-                  })}
-                  <td>
-                    <form action={unwatchSystem}>
-                      <input type="hidden" name="system_id" value={id} />
-                      <button
-                        type="submit"
-                        className={styles.unwatch}
-                        title={`Stop watching ${sde?.name ?? id}`}
-                        aria-label={`Stop watching ${sde?.name ?? id}`}
-                      >
-                        ✕
-                      </button>
-                    </form>
-                  </td>
-                </tr>
-              )
-            })}
-          </tbody>
-        </table>
+      {rows.length > 0 ? (
+        // Keyed on the id set + window (not the drag order) so a reorder
+        // doesn't remount — only adding/removing a watched system, or
+        // switching the time window, does. That re-syncs the table's local
+        // drag state and sparkline data to the server's canonical values.
+        <WatchedSystemsTable
+          key={`${[...systemIds].sort((a, b) => a - b).join(',')}-${window.days}`}
+          columns={COLUMNS}
+          rows={rows}
+        />
       ) : (
         <p>
           No watched systems yet. Search below to add one — its cost indices are picked up by the next hourly extract.

--- a/src/app/indexes/watchedSystemsTable.tsx
+++ b/src/app/indexes/watchedSystemsTable.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+import { useRef, useState, useTransition } from 'react'
+
+import { formatIndex, INDEX_ACTIVITY_LABELS, type Activity, type IndexSeries } from '../structure/industryIndex'
+import { Sparkline } from '../structure/sparkline'
+import { reorderWatchedSystems, unwatchSystem } from './actions'
+import styles from './indexes.module.css'
+
+export type WatchedRow = {
+  id: number
+  name: string
+  security: string | null
+  cells: Array<{ activity: Activity; cost: number | null; series: IndexSeries | null }>
+}
+
+type WatchedSystemsTableProps = {
+  columns: Activity[]
+  rows: WatchedRow[]
+}
+
+// Renders the watch list and lets the user drag rows (via the grip handle) to
+// reorder them. Dragging is initiated only from the grip — it's the drag
+// source — so the delete button and the rest of the row stay ordinary click
+// targets. `order` is optimistic local state so the row moves immediately;
+// the actual reorder persists via reorderWatchedSystems() once the row is
+// dropped, and the parent remounts this component (see the `key` in
+// page.tsx) once the server confirms the new order.
+export const WatchedSystemsTable = ({ columns, rows }: WatchedSystemsTableProps) => {
+  const [order, setOrder] = useState(rows)
+  const [, startTransition] = useTransition()
+  const dragIndex = useRef<number | null>(null)
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null)
+
+  const handleDrop = (index: number) => {
+    const from = dragIndex.current
+    dragIndex.current = null
+    setDragOverIndex(null)
+    if (from === null || from === index) return
+    setOrder((prev) => {
+      const next = [...prev]
+      const [moved] = next.splice(from, 1)
+      next.splice(index, 0, moved)
+      startTransition(() => {
+        reorderWatchedSystems(next.map((r) => r.id))
+      })
+      return next
+    })
+  }
+
+  return (
+    <table className={styles.table}>
+      <thead>
+        <tr>
+          <th>System</th>
+          {columns.map((activity) => (
+            <th key={activity}>{INDEX_ACTIVITY_LABELS[activity]}</th>
+          ))}
+          <th />
+        </tr>
+      </thead>
+      <tbody>
+        {order.map((row, index) => (
+          <tr
+            key={row.id}
+            onDragOver={(e) => {
+              if (dragIndex.current === null) return
+              e.preventDefault()
+              if (dragOverIndex !== index) setDragOverIndex(index)
+            }}
+            onDragLeave={() => setDragOverIndex((current) => (current === index ? null : current))}
+            onDrop={(e) => {
+              e.preventDefault()
+              handleDrop(index)
+            }}
+            className={dragOverIndex === index ? styles.dragOver : undefined}
+          >
+            <td>
+              <span className={styles.system}>{row.name}</span>{' '}
+              {row.security && <span className={styles.security}>{row.security}</span>}
+            </td>
+            {row.cells.map(({ activity, cost, series }) => (
+              <td key={activity}>
+                {series || cost != null ? (
+                  <span className={styles.cell}>
+                    <Sparkline
+                      values={series?.values ?? []}
+                      liveCount={series?.liveCount}
+                      updatedAt={series?.updatedAt}
+                      label={`${row.name} ${INDEX_ACTIVITY_LABELS[activity]}`}
+                    />
+                    <span className={styles.current}>{cost != null ? formatIndex(cost) : '—'}</span>
+                  </span>
+                ) : (
+                  <span className={styles.empty}>—</span>
+                )}
+              </td>
+            ))}
+            <td>
+              <span className={styles.actions}>
+                <form action={unwatchSystem}>
+                  <input type="hidden" name="system_id" value={row.id} />
+                  <button
+                    type="submit"
+                    className={styles.unwatch}
+                    title={`Stop watching ${row.name}`}
+                    aria-label={`Stop watching ${row.name}`}
+                  >
+                    ✕
+                  </button>
+                </form>
+                <span
+                  className={styles.grip}
+                  draggable
+                  onDragStart={(e) => {
+                    dragIndex.current = index
+                    e.dataTransfer.effectAllowed = 'move'
+                    e.dataTransfer.setData('text/plain', String(index))
+                  }}
+                  onDragEnd={() => {
+                    dragIndex.current = null
+                    setDragOverIndex(null)
+                  }}
+                  title="Drag to reorder"
+                  aria-label={`Drag to reorder ${row.name}`}
+                >
+                  ⠿
+                </span>
+              </span>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/supabase/migrations/20260703120000_watched_system_position.sql
+++ b/supabase/migrations/20260703120000_watched_system_position.sql
@@ -1,0 +1,14 @@
+-- Lets a user drag rows on /indexes to reorder their watch list, instead of it
+-- always sorting alphabetically. Existing rows are backfilled in their
+-- created_at order (oldest first) per user; watchSystem() assigns new rows
+-- the next position, and the drag UI persists a full reorder in one request
+-- via reorderWatchedSystems().
+alter table public.watched_system add column if not exists position integer not null default 0;
+
+update public.watched_system w
+set position = ranked.rn
+from (
+  select user_id, system_id, row_number() over (partition by user_id order by created_at) - 1 as rn
+  from public.watched_system
+) ranked
+where w.user_id = ranked.user_id and w.system_id = ranked.system_id;


### PR DESCRIPTION
## Summary

On `/indexes`, each watched-system row now has a drag handle (⠿) to the right of the ✕ delete button, letting users reorder their watch list by dragging instead of always seeing it sorted alphabetically.

- `watched_system` gains a `position` column (migration `20260703120000_watched_system_position.sql` + `schema.sql`), backfilled from each row's `created_at` order. `watchSystem()` appends new watches at the end of the list; a new `reorderWatchedSystems(systemIds)` action rewrites the whole list's positions in one upsert when a row is dropped.
- The watch table moved into a client component (`src/app/indexes/watchedSystemsTable.tsx`) that owns optimistic drag state so a row moves immediately on drop, before the server confirms. The server page keys the component on the watched-id set plus the selected time window, so adding/removing a system or switching the days dropdown remounts and resyncs it (fresh sparkline data), while a pure reorder doesn't force a remount.
- Dragging only starts from the grip handle (`draggable` lives on that element, not the row), so the rest of the row — including the delete button — stays ordinary click/hover surface.

## Test plan
- `pnpm run lint` passes (one pre-existing, unrelated warning in `src/app/character/actions.ts`).
- `tsc --noEmit` and `pnpm run build` pass.
- Verified `next dev` compiles the new page/component with no module errors (this sandbox has no live Supabase credentials, so I couldn't exercise the actual drag interaction against a real account — worth a manual check on `/indexes` before/after merge).
- No automated tests in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01932QfXPXbLiruN1VHx6icP

---
_Generated by [Claude Code](https://claude.ai/code/session_01932QfXPXbLiruN1VHx6icP)_