### PR TITLE
Paginate the asset list and parallelize its independent queries

### DIFF
--- a/src/app/asset/assets.module.css
+++ b/src/app/asset/assets.module.css
@@ -27,3 +27,26 @@
   font-size: 10pt;
   color: var(--ink-soft);
 }
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12pt;
+  margin: 8pt 0 16pt;
+}
+
+.pagination button {
+  font: inherit;
+  cursor: pointer;
+}
+
+.pagination button:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
+
+.pageStatus {
+  font-size: 10pt;
+  color: var(--ink-soft);
+}

--- a/src/app/asset/assetsTable.tsx
+++ b/src/app/asset/assetsTable.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from 'next/link'
+import { useEffect, useState } from 'react'
 
 import { ALL_OWNERS, OwnerSelect, useOwnerFilter, type Owners } from '../ownerFilter'
 import retro from '../retro.module.css'
@@ -21,8 +22,15 @@ type AssetsTableProps = {
   owners: Owners
 }
 
+// Rendering every location in one table got sluggish for accounts with
+// hundreds of them, so the list is paged client-side — the full owner-scoped
+// row set is already in memory (switching owners is instant, no round trip),
+// so paging is just a slice.
+const PAGE_SIZE = 50
+
 export const AssetsTable = ({ locations, owners }: AssetsTableProps) => {
   const [ownerId, setOwnerId] = useOwnerFilter(OWNER_STORAGE_KEY, owners)
+  const [page, setPage] = useState(0)
 
   const rows = locations
     .map((loc) => ({
@@ -32,6 +40,15 @@ export const AssetsTable = ({ locations, owners }: AssetsTableProps) => {
     .filter((row) => row.count > 0)
     // Busiest locations first, then by name for a stable order.
     .sort((a, b) => b.count - a.count || a.loc.name.localeCompare(b.loc.name))
+
+  const pageCount = Math.max(1, Math.ceil(rows.length / PAGE_SIZE))
+  // Switching owners reorders/shrinks the row set, which can leave `page`
+  // past the end — clamp rather than render a blank page.
+  const currentPage = Math.min(page, pageCount - 1)
+  const pageRows = rows.slice(currentPage * PAGE_SIZE, currentPage * PAGE_SIZE + PAGE_SIZE)
+
+  // A new owner has its own busiest-first order, so always land back on page 1.
+  useEffect(() => setPage(0), [ownerId])
 
   return (
     <section>
@@ -48,28 +65,43 @@ export const AssetsTable = ({ locations, owners }: AssetsTableProps) => {
           <a href="/character">Characters</a> page so the hourly job can fetch them.
         </p>
       ) : rows.length > 0 ? (
-        <table className={retro.retro}>
-          <thead>
-            <tr>
-              <th>Location</th>
-              <th>System</th>
-              <th className={retro.num}>Items</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map(({ loc, count }) => (
-              <tr key={`location-${loc.id}`}>
-                <td>
-                  <Link href={`/asset/${loc.id}`} className="serif">
-                    {loc.name}
-                  </Link>
-                </td>
-                <td className="serif">{loc.system && loc.system !== loc.name ? loc.system : '—'}</td>
-                <td className={retro.num}>{count}</td>
+        <>
+          <table className={retro.retro}>
+            <thead>
+              <tr>
+                <th>Location</th>
+                <th>System</th>
+                <th className={retro.num}>Items</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {pageRows.map(({ loc, count }) => (
+                <tr key={`location-${loc.id}`}>
+                  <td>
+                    <Link href={`/asset/${loc.id}`} className="serif">
+                      {loc.name}
+                    </Link>
+                  </td>
+                  <td className="serif">{loc.system && loc.system !== loc.name ? loc.system : '—'}</td>
+                  <td className={retro.num}>{count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {pageCount > 1 && (
+            <div className={styles.pagination}>
+              <button type="button" onClick={() => setPage(currentPage - 1)} disabled={currentPage === 0}>
+                ‹ Prev
+              </button>
+              <span className={styles.pageStatus}>
+                Page {currentPage + 1} of {pageCount} ({rows.length} locations)
+              </span>
+              <button type="button" onClick={() => setPage(currentPage + 1)} disabled={currentPage >= pageCount - 1}>
+                Next ›
+              </button>
+            </div>
+          )}
+        </>
       ) : (
         <p>No assets for this owner.</p>
       )}

--- a/src/app/asset/page.tsx
+++ b/src/app/asset/page.tsx
@@ -82,11 +82,21 @@ const Locations = async () => {
   // Node and walking the location_id chains here timed the page out. The
   // *_asset_location_summary() functions do the walk in Postgres and return one
   // small row per location/owner pair instead (RLS still scopes character rows
-  // to us and corp rows to corps we have a registered character in).
-  const [{ data: characterSummary }, { data: corpSummary }, owners] = await Promise.all([
+  // to us and corp rows to corps we have a registered character in). The
+  // "last refreshed" heartbeat doesn't depend on any of this, so it's fetched
+  // in the same batch instead of after everything else resolves.
+  const [{ data: characterSummary }, { data: corpSummary }, owners, { data: lastRun }] = await Promise.all([
     supabase.rpc('character_asset_location_summary'),
     supabase.rpc('corp_asset_location_summary'),
     fetchOwners(),
+    supabase
+      .from('heartbeat')
+      .select('ended_at, run_url')
+      .eq('job', 'character-assets')
+      .not('ended_at', 'is', null)
+      .order('ended_at', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
   ])
 
   const summary: SummaryRow[] = [
@@ -120,10 +130,12 @@ const Locations = async () => {
   // system itself.
   const locationIds = filter(Number.isFinite, map(Number, [...byLocation.keys()]))
 
-  const { data: corpStructures } = await supabase.from('corp_structure').select('structure_id, name, system_id')
-  const { data: playerStructures } = locationIds.length
-    ? await supabase.from('universe_structure').select('structure_id, name, system_id').in('structure_id', locationIds)
-    : { data: [] }
+  const [{ data: corpStructures }, { data: playerStructures }] = await Promise.all([
+    supabase.from('corp_structure').select('structure_id, name, system_id'),
+    locationIds.length
+      ? supabase.from('universe_structure').select('structure_id, name, system_id').in('structure_id', locationIds)
+      : Promise.resolve({ data: [] }),
+  ])
 
   // Own-corp structures override the ESI-resolved cache (later entries win).
   const byStructureId = (list: Structure[]): [string, Structure][] => map((s) => [String(s.structure_id), s], list)
@@ -188,18 +200,6 @@ const Locations = async () => {
     }),
     [...byLocation.values()]
   )
-
-  // When the Assets background job last finished. Each scheduled run writes a
-  // public.heartbeat row stamped with ended_at and a link to the workflow run; we
-  // read back the most recent completed one.
-  const { data: lastRun } = await supabase
-    .from('heartbeat')
-    .select('ended_at, run_url')
-    .eq('job', 'character-assets')
-    .not('ended_at', 'is', null)
-    .order('ended_at', { ascending: false })
-    .limit(1)
-    .maybeSingle()
 
   return (
     <>


### PR DESCRIPTION
## Summary

The `/asset` index rendered every location in one table, which got sluggish for accounts with hundreds of locations. This paginates the list and trims some unnecessary sequential latency on the way there.

- **Pagination:** `AssetsTable` now slices its (already owner-filtered, busiest-first-sorted) rows into 50-row pages with Prev/Next controls, purely client-side. The full row set is already loaded to support the existing instant owner-switch (no round trip), so paging is just an array slice — switching the owner filter resets back to page 1, since a new owner has its own busiest-first order.
- **Parallelization** in `src/app/asset/page.tsx` (`Locations()`):
  - The "last refreshed" heartbeat query didn't depend on anything else and was fetched *after* everything else resolved — moved into the same `Promise.all` as the two location-summary RPCs and `fetchOwners()`.
  - The `corp_structure` and `universe_structure` lookups were `await`ed sequentially even though they're independent — now run concurrently via `Promise.all`.

No behavior change to what's queried or how locations are aggregated/sorted — same tables, same RPCs, same owner-filter semantics. Didn't touch the per-location item view (`/asset/[locationId]`); happy to add pagination there too if that's also wanted.

## Test plan
- `pnpm run lint` passes (one pre-existing, unrelated warning in `src/app/character/actions.ts`).
- `tsc --noEmit` and `pnpm run build` pass.
- Verified `next dev` compiles `/asset` with no module errors (this sandbox has no live Supabase credentials, so I couldn't exercise the actual page against real data — worth a manual check on `/asset` before/after merge, especially the owner-switch-resets-to-page-1 behavior).
- No automated tests in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01932QfXPXbLiruN1VHx6icP

---
_Generated by [Claude Code](https://claude.ai/code/session_01932QfXPXbLiruN1VHx6icP)_