### PR TITLE
Show character-blueprints in the Refresh ESI job matrix

### DIFF
--- a/src/app/character/refresh/page.tsx
+++ b/src/app/character/refresh/page.tsx
@@ -15,6 +15,7 @@ import styles from './refresh.module.css'
 // columns here.
 const JOBS = [
   ['character-assets', 'assets'],
+  ['character-blueprints', 'blueprints'],
   ['character-orders', 'orders'],
   ['character-wallet', 'wallet'],
   ['character-wallet-transactions', 'transactions'],


### PR DESCRIPTION
## Summary

`/character/refresh` shows a matrix of per-character job status for the "Refresh ESI" flow, driven by a local `JOBS` column list in `src/app/character/refresh/page.tsx`. When `character-blueprints` was added as a per-character job (`dispatchRefresh.ts`'s `PER_CHARACTER_JOBS`), this page's separate display list wasn't updated to match — so blueprint refresh tasks were dispatched and tracked in `refresh_task` correctly, but had no column to show their status in.

- Adds `['character-blueprints', 'blueprints']` to `JOBS`, right after assets.
- Checked for other places a job list might need the same fix (`/api/queue/jobs/route.ts`, `dispatchRefresh.ts`) — both already correctly include `character-blueprints`; this page's list was the only one missed.

## Test plan
- `pnpm run lint` passes (one pre-existing, unrelated warning in `src/app/character/actions.ts`).
- `tsc --noEmit` and `pnpm run build` pass.
- No automated tests in this repo; couldn't exercise a live refresh against real Supabase credentials in this sandbox — the change is a one-line addition to a static column list, low risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01932QfXPXbLiruN1VHx6icP

---
_Generated by [Claude Code](https://claude.ai/code/session_01932QfXPXbLiruN1VHx6icP)_