### PR TITLE
Add blueprint IMPORTDATA URLs to the settings page

### DIFF
--- a/src/app/account/settings/apiToken.tsx
+++ b/src/app/account/settings/apiToken.tsx
@@ -27,9 +27,11 @@ const ApiToken = ({ initialToken }: { initialToken: string | null }) => {
   }
 
   const assetsUrl = token ? `${origin}/api/character/assets?token=${token}` : null
+  const blueprintsUrl = token ? `${origin}/api/character/blueprints?token=${token}` : null
   const industryUrl = token ? `${origin}/api/character/jobs?token=${token}` : null
   const ordersUrl = token ? `${origin}/api/character/orders?token=${token}` : null
   const corpAssetsUrl = token ? `${origin}/api/corp/assets?token=${token}` : null
+  const corpBlueprintsUrl = token ? `${origin}/api/corp/blueprints?token=${token}` : null
   const corpJobsUrl = token ? `${origin}/api/corp/jobs?token=${token}` : null
 
   return (
@@ -38,10 +40,13 @@ const ApiToken = ({ initialToken }: { initialToken: string | null }) => {
       <p>
         Pull your data into a spreadsheet with <code>=IMPORTDATA(url)</code> (the first row is the column headers):
       </p>
-      {assetsUrl && industryUrl && ordersUrl && corpAssetsUrl && corpJobsUrl && (
+      {assetsUrl && blueprintsUrl && industryUrl && ordersUrl && corpAssetsUrl && corpBlueprintsUrl && corpJobsUrl && (
         <ul>
           <li>
             Assets (one row per item stack): <code>=IMPORTDATA(&quot;{assetsUrl}&quot;)</code>
+          </li>
+          <li>
+            Blueprints (one row per blueprint stack): <code>=IMPORTDATA(&quot;{blueprintsUrl}&quot;)</code>
           </li>
           <li>
             Industry jobs: <code>=IMPORTDATA(&quot;{industryUrl}&quot;)</code>
@@ -51,6 +56,9 @@ const ApiToken = ({ initialToken }: { initialToken: string | null }) => {
           </li>
           <li>
             Corp assets (one row per item stack): <code>=IMPORTDATA(&quot;{corpAssetsUrl}&quot;)</code>
+          </li>
+          <li>
+            Corp blueprints (one row per blueprint stack): <code>=IMPORTDATA(&quot;{corpBlueprintsUrl}&quot;)</code>
           </li>
           <li>
             Corp industry jobs: <code>=IMPORTDATA(&quot;{corpJobsUrl}&quot;)</code>


### PR DESCRIPTION
## Summary

The whole point of the `/api/character/blueprints` and `/api/corp/blueprints` IMPORTDATA endpoints (added alongside the blueprints extract) is to replace GESI's blueprint sheet functions in Google Sheets — but `/account/settings`'s API Access section, where users discover and copy their `=IMPORTDATA(...)` URLs, was never updated to list them. The endpoints existed but were undiscoverable.

- `src/app/account/settings/apiToken.tsx`: adds `blueprintsUrl` (character) and `corpBlueprintsUrl` (corp) alongside the existing assets/jobs/orders URLs, following the exact same pattern — same token-gated construction, same list-item format, inserted right after their assets counterparts.

## Test plan
- `pnpm run lint` passes (one pre-existing, unrelated warning in `src/app/character/actions.ts`).
- `tsc --noEmit` and `pnpm run build` pass.
- Verified `next dev` compiles `/account/settings` with no module errors (this sandbox has no live Supabase credentials, so I couldn't log in and see the rendered list — worth a manual check on `/account/settings` after merge to confirm both new list items render and the URLs actually return CSV).
- No automated tests in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01932QfXPXbLiruN1VHx6icP

---
_Generated by [Claude Code](https://claude.ai/code/session_01932QfXPXbLiruN1VHx6icP)_