### PR TITLE
Enforce a minimum sparkline height of 0.1%

### DIFF
--- a/src/app/structure/sparkline.tsx
+++ b/src/app/structure/sparkline.tsx
@@ -46,8 +46,20 @@ export const Sparkline = ({ values, liveCount = values.length, label, updatedAt 
   const w = 100
   const h = 20
   const pad = 1
-  const min = Math.min(...values)
-  const max = Math.max(...values)
+  // Cost indices are fractions (0.001 = 0.1%). When the real spread is tighter
+  // than that, the line would look perfectly flat and hide the (tiny) trend —
+  // so we widen the displayed range to a fixed 0.1% centered on the actual
+  // midpoint, rather than the actual min/max, and use that widened range for
+  // both the plotted line and the min/max labels beside it.
+  const MIN_DISPLAY_RANGE = 0.001
+  const actualMin = Math.min(...values)
+  const actualMax = Math.max(...values)
+  const actualRange = actualMax - actualMin
+  const mid = (actualMin + actualMax) / 2
+  const [min, max] =
+    actualRange < MIN_DISPLAY_RANGE
+      ? [mid - MIN_DISPLAY_RANGE / 2, mid + MIN_DISPLAY_RANGE / 2]
+      : [actualMin, actualMax]
   const range = max - min || 1
   const step = (w - pad * 2) / (values.length - 1)
   const coords = values.map((v, i) => {


### PR DESCRIPTION
## Summary
- When a cost index's real min/max spread is tighter than 0.1%, the sparkline in `src/app/structure/sparkline.tsx` now widens the plotted (and labeled) range to a fixed 0.1%, centered on the actual midpoint, instead of drawing a barely-visible flat line.
- Since both the structure list and the Indexes page (`watchedSystemsTable.tsx`) render sparklines through this same shared `Sparkline` component, both pick up the fix automatically.

## Test plan
- [ ] Verify a near-flat index history (e.g. 5.09%/5.07%) now renders with visible height, with the min/max labels showing the widened bounds (5.03%/5.13%)
- [ ] Verify a normal, already-wide-spread index history still renders unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_01C9a5PqKSGBMFxV2j3DBrXp)_