### PR TITLE
Add item name search across assets on /asset/search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,8 @@ Quick-reference for navigation. Covers key exports, route→file paths, DB table
 ### `src/sdeTypes.ts`
 - `getSdeType(typeID)` — `{ typeID, name, groupID, categoryID }` from the generated SDE data, or `null`
 - `getSdeTypeNames(typeIDs[])` — bulk id→name lookup
-- `searchSdeTypes(query, limit?)` — case-insensitive substring search over type names, ranked by match coverage
+- `searchSdeTypesAll(query)` — case-insensitive substring search over every published type name, ranked by match coverage, unbounded (used where the true match count matters, e.g. `/asset/search`'s "too many types" check)
+- `searchSdeTypes(query, limit?)` — same search capped to `limit` results, for autocomplete UIs
 
 ### `src/sdeSystems.ts`
 - `getSdeSystem(systemID)` — `{ systemID, name, security }` from the generated SDE data, or `null`
@@ -135,6 +136,7 @@ All functions take `(accessToken, id, ...)` unless noted. Returns raw ESI respon
 | `/account/invite` | `src/app/account/invite/page.tsx` |
 | `/asset` | `src/app/asset/page.tsx` |
 | `/asset/[locationId]` | `src/app/asset/[locationId]/page.tsx` |
+| `/asset/search` | `src/app/asset/search/page.tsx` |
 | `/character` | `src/app/character/page.tsx` |
 | `/character/callback` | `src/app/character/callback/route.ts` |
 | `/character/refresh` | `src/app/character/refresh/page.tsx` |
@@ -158,7 +160,7 @@ All functions take `(accessToken, id, ...)` unless noted. Returns raw ESI respon
 
 The old CSV endpoint paths (`/api/assets`, `/api/orders`, `/api/industry`) and `/characters/refresh` permanently redirect to their new homes (see `next.config.mjs`) so existing Google Sheets keep working.
 
-Shared UI helpers: `src/app/isk.ts` (ISK formatting), `src/app/DateTime.tsx`, `src/app/typeName.tsx` (renders a type name from ID), `src/app/typeNames.ts` (resolves type names from the locally generated SDE data), `src/app/systemNames.ts`, `src/app/stationNames.ts`.
+Shared UI helpers: `src/app/isk.ts` (ISK formatting), `src/app/DateTime.tsx`, `src/app/typeName.tsx` (renders a type name from ID), `src/app/typeNames.ts` (resolves type names from the locally generated SDE data), `src/app/systemNames.ts`, `src/app/stationNames.ts`, `src/app/owners.ts` / `src/app/ownerFilter.tsx` (the character/corp "owner" picker shared by the assets and industry pages), `src/app/resolveLocations.ts` (resolves a set of root locations — station, player structure, or bare solar system — to display names + systems; shared by `/asset` and `/asset/search`).
 
 ## Extract jobs
 
@@ -223,8 +225,10 @@ The per-character jobs (`character-*` except `character-affiliations`, plus `cor
 Key Postgres functions (callable via RPC or SQL):
 - `character_asset_location_summary()` — aggregate character assets per location
 - `character_asset_location_contents(parent_id)` — count nested character items in a location
+- `character_asset_search(type_ids[])` — every current character item matching one of the given type ids, with its root location and nested-item count (used by `/asset/search`)
 - `corp_asset_location_summary()` — aggregate corp assets per location (mirrors the character version; RLS scopes to corps the caller has a registered character in)
 - `corp_asset_location_contents(parent_id)` — count nested corp items in a location
+- `corp_asset_search(type_ids[])` — mirrors `character_asset_search()` over corp assets (used by `/asset/search`)
 - `character_asset_snapshot_at(character_ids[], as_of)` — time-travel asset snapshot as JSON (used by `/api/character/assets`)
 - `character_industry_jobs(character_ids[], include_delivered)` — export for Sheets IMPORTDATA (used by `/api/character/jobs`)
 - `character_orders(character_ids[])` — export for Sheets IMPORTDATA (used by `/api/character/orders`)
@@ -238,6 +242,7 @@ Key Postgres functions (callable via RPC or SQL):
 - **One extract job per ESI endpoint:** each job in `src/jobs/` pulls exactly one endpoint into its like-named table, sharing the token loops in `src/jobs/lib.js`. Job names double as npm script, queue message `job`, heartbeat label, and workflow file name.
 - **Prefer ramda over `for`/`while` loops:** synchronous iteration uses ramda (`map`/`filter`/`reduce`/`pipe`/`chain`/`reject`/`forEach`, …) instead of imperative loops — `src/jobs/*.js` is the canonical example. Sequential *async* iteration (`for (const x of xs) { await ... }`) uses `forEachSequential(items, fn)` from `src/jobs/lib.js`, which chains promises through ramda's `reduce` so each item awaits before the next starts and a rejection propagates like a thrown error would out of a loop; an unbounded pagination loop (`for (let page = 1; ; page++)`) becomes a small function that recurses on the next page instead. One accepted exception: when a `reduce` builds up a large array (an extract job can reconcile tens of thousands of rows), the accumulator is a plain object/array mutated via `.push()` rather than rebuilt with `[...acc, x]` on every item — spreading a new array per iteration turns an O(n) pass into O(n²). The loop itself still isn't a `for`/`while`; only the accumulator's internals are pragmatically mutable.
 - **SCD Type 2 assets:** `character_asset_over_time` tracks the full history of each item. `is_current=true` rows form the current snapshot. `last_seen_at` is bumped each run for unchanged items; a new row is inserted when anything changes, and the old row's `is_current` is set to `false`. `corp_asset_over_time` (+ `corp_asset` view) mirrors this exact pattern for corp assets, reconciled in `src/jobs/corpAssets.js`. `character_blueprint_over_time` / `corp_blueprint_over_time` (+ their `_blueprint` views) apply the identical SCD-2 pattern to blueprints (location, quantity, ME/TE, runs), reconciled in `src/jobs/characterBlueprints.js` / `src/jobs/corpBlueprints.js`.
+- **Asset location-walk functions come in two shapes:** the `*_location_summary()`/`*_location_contents()` functions seed their recursive climb/descend from *every* asset (they're computing an aggregate over the whole hangar). `character_asset_search()`/`corp_asset_search()` instead seed from just the rows matching a filter (a set of type ids), so a search stays cheap regardless of hangar size — reuse this seeded-recursion shape for any future "look up a few items, walk their location tree" function rather than the walk-everything shape.
 - **Supabase RLS:** All tables use RLS scoped to `auth.uid()`. Cron scripts use the service-role key (`sudoSupabase` / `src/utils/supabase/service.ts`) which bypasses RLS.
 - **Google Sheets IMPORTDATA:** `/api/character/assets`, `/api/character/blueprints`, `/api/character/orders`, `/api/character/jobs`, `/api/corp/assets`, `/api/corp/blueprints`, `/api/corp/jobs` authenticate via `user_settings.api_token`, call a Postgres function, and return CSV. The pre-rename paths permanently redirect to the new ones.
 - **Vercel queue:** The queue consumer at `/api/queue/jobs` dispatches to the same `run*()` functions the CLI jobs use. The UI enqueues work via `@vercel/queue`.

--- a/schema.sql
+++ b/schema.sql
@@ -283,8 +283,85 @@ as $$
   group by root_child;
 $$;
 
+-- item search (/asset/search): every current item whose type_id is in
+-- `type_ids`, with its root location and nested-item count. Seeded from just
+-- the matched items (rather than every asset, like the two functions above),
+-- so this stays cheap even though the caller can pass up to 100 type ids.
+create or replace function public.character_asset_search(type_ids bigint[])
+returns table (
+  item_id bigint,
+  character_id uuid,
+  type_id bigint,
+  quantity bigint,
+  is_singleton boolean,
+  name text,
+  location_flag text,
+  root_location_id bigint,
+  root_location_type text,
+  contents bigint
+)
+language sql
+stable
+as $$
+  with recursive parent_of as (
+    select distinct on (item_id) item_id, location_id, location_type
+    from public.character_asset_over_time
+    order by item_id, is_current desc, last_seen_at desc
+  ),
+  matched as (
+    select a.item_id, a.character_id, a.type_id, a.quantity, a.is_singleton, a.name,
+           a.location_flag, a.location_id, a.location_type
+    from public.character_asset a
+    where a.type_id = any(type_ids)
+  ),
+  climb as (
+    select m.item_id as start_item, m.location_id, m.location_type, 1 as depth
+    from matched m
+    union all
+    select c.start_item, p.location_id, p.location_type, c.depth + 1
+    from climb c
+    join parent_of p on p.item_id = c.location_id
+    where c.depth < 64
+  ),
+  roots as (
+    select w.start_item, w.location_id as root_location_id, w.location_type as root_location_type
+    from climb w
+    where w.location_id is not null
+      and not exists (select 1 from parent_of o where o.item_id = w.location_id)
+  ),
+  descend as (
+    select m.item_id as ancestor, m.item_id as node, 1 as depth
+    from matched m
+    union all
+    select d.ancestor, c.item_id, d.depth + 1
+    from descend d
+    join public.character_asset c on c.location_id = d.node
+    where d.depth < 64
+  ),
+  contents as (
+    select ancestor, count(*) - 1 as contents
+    from descend
+    group by ancestor
+  )
+  select
+    m.item_id,
+    m.character_id,
+    m.type_id,
+    m.quantity,
+    m.is_singleton,
+    m.name,
+    m.location_flag,
+    r.root_location_id,
+    r.root_location_type,
+    coalesce(ct.contents, 0) as contents
+  from matched m
+  join roots r on r.start_item = m.item_id
+  left join contents ct on ct.ancestor = m.item_id;
+$$;
+
 grant execute on function public.character_asset_location_summary()        to authenticated;
 grant execute on function public.character_asset_location_contents(bigint) to authenticated;
+grant execute on function public.character_asset_search(bigint[])          to authenticated;
 
 -- /api/character/assets IMPORTDATA endpoint: the player's raw asset rows (one
 -- per item stack), with the owning character's name, as of `as_of`,
@@ -982,8 +1059,81 @@ as $$
   group by root_child;
 $$;
 
+-- item search (/asset/search): mirrors character_asset_search() over corp
+-- assets, seeded from just the matched items.
+create or replace function public.corp_asset_search(type_ids bigint[])
+returns table (
+  item_id bigint,
+  corporation_id bigint,
+  type_id bigint,
+  quantity bigint,
+  is_singleton boolean,
+  location_flag text,
+  root_location_id bigint,
+  root_location_type text,
+  contents bigint
+)
+language sql
+stable
+as $$
+  with recursive parent_of as (
+    select distinct on (item_id) item_id, location_id, location_type
+    from public.corp_asset_over_time
+    order by item_id, is_current desc, last_seen_at desc
+  ),
+  matched as (
+    select a.item_id, a.corporation_id, a.type_id, a.quantity, a.is_singleton,
+           a.location_flag, a.location_id, a.location_type
+    from public.corp_asset a
+    where a.type_id = any(type_ids)
+  ),
+  climb as (
+    select m.item_id as start_item, m.location_id, m.location_type, 1 as depth
+    from matched m
+    union all
+    select c.start_item, p.location_id, p.location_type, c.depth + 1
+    from climb c
+    join parent_of p on p.item_id = c.location_id
+    where c.depth < 64
+  ),
+  roots as (
+    select w.start_item, w.location_id as root_location_id, w.location_type as root_location_type
+    from climb w
+    where w.location_id is not null
+      and not exists (select 1 from parent_of o where o.item_id = w.location_id)
+  ),
+  descend as (
+    select m.item_id as ancestor, m.item_id as node, 1 as depth
+    from matched m
+    union all
+    select d.ancestor, c.item_id, d.depth + 1
+    from descend d
+    join public.corp_asset c on c.location_id = d.node
+    where d.depth < 64
+  ),
+  contents as (
+    select ancestor, count(*) - 1 as contents
+    from descend
+    group by ancestor
+  )
+  select
+    m.item_id,
+    m.corporation_id,
+    m.type_id,
+    m.quantity,
+    m.is_singleton,
+    m.location_flag,
+    r.root_location_id,
+    r.root_location_type,
+    coalesce(ct.contents, 0) as contents
+  from matched m
+  join roots r on r.start_item = m.item_id
+  left join contents ct on ct.ancestor = m.item_id;
+$$;
+
 grant execute on function public.corp_asset_location_summary()        to authenticated;
 grant execute on function public.corp_asset_location_contents(bigint) to authenticated;
+grant execute on function public.corp_asset_search(bigint[])          to authenticated;
 
 -- /api/corp/assets IMPORTDATA endpoint: the caller's corporation(s) current
 -- asset rows (one per item stack), mirroring character_asset_snapshot_at()'s

--- a/src/app/asset/assetSearchForm.tsx
+++ b/src/app/asset/assetSearchForm.tsx
@@ -1,0 +1,16 @@
+// A plain GET form — the browser handles the navigation to /asset/search, so
+// this needs no client-side JS.
+import styles from './assets.module.css'
+
+export const AssetSearchForm = ({ initialQuery = '' }: { initialQuery?: string }) => (
+  <form action="/asset/search" method="get" className={styles.searchForm}>
+    <input
+      type="text"
+      name="q"
+      defaultValue={initialQuery}
+      placeholder='Item name, e.g. "ftl interlink"…'
+      aria-label="Search item name"
+    />
+    <button type="submit">Search</button>
+  </form>
+)

--- a/src/app/asset/assets.module.css
+++ b/src/app/asset/assets.module.css
@@ -50,3 +50,23 @@
   font-size: 10pt;
   color: var(--ink-soft);
 }
+
+.searchForm {
+  display: flex;
+  align-items: center;
+  gap: 8pt;
+  margin: 24px 0 0;
+}
+
+.searchForm input {
+  flex: 1;
+  max-width: 320px;
+  font: inherit;
+  padding: 6pt 8pt;
+}
+
+.searchForm button {
+  font: inherit;
+  cursor: pointer;
+  padding: 6pt 12pt;
+}

--- a/src/app/asset/page.tsx
+++ b/src/app/asset/page.tsx
@@ -1,12 +1,12 @@
 import { redirect } from 'next/navigation'
 import { Suspense } from 'react'
-import { chain, filter, map, pipe, reduce } from 'ramda'
+import { map, reduce } from 'ramda'
 
 import { createClient } from '@/utils/supabase/server'
 import { DateTime } from '../DateTime'
 import { fetchOwners } from '../owners'
-import { fetchStationNames, fetchStationSystems } from '../stationNames'
-import { fetchSystemNames } from '../systemNames'
+import { resolveLocations, type LocationRef } from '../resolveLocations'
+import { AssetSearchForm } from './assetSearchForm'
 import styles from './assets.module.css'
 import { AssetsTable, type Location } from './assetsTable'
 
@@ -34,18 +34,6 @@ type SummaryRow = {
   owner_id: string
   stacks: number | string
 }
-
-type Structure = {
-  structure_id: number | string
-  name: string | null
-  system_id: number | string | null
-}
-
-// The place an item ultimately sits. Items can be nested (a module in a ship in
-// a station), so the root is found by walking location_id up through any parent
-// items we also own until it points at something that isn't one of our items —
-// a station, structure, or solar system.
-type Root = { id: string; type: string | null }
 
 const AssetsPage = async () => {
   const supabase = await createClient()
@@ -119,82 +107,16 @@ const Locations = async () => {
       entry.counts.set(row.owner_id, (entry.counts.get(row.owner_id) ?? 0) + Number(row.stacks))
       return acc.set(id, entry)
     },
-    new Map<string, { root: Root; counts: Map<string, number> }>(),
+    new Map<string, { root: LocationRef; counts: Map<string, number> }>(),
     summary
   )
 
-  // Structure names + systems come from two caches: our own corp's structures
-  // (corp_structure) and foreign player structures characters hold assets in,
-  // resolved from ESI by the universe-structures job (universe_structure).
-  // Own-corp entries win on overlap. In-space `solar_system` locations are the
-  // system itself.
-  const locationIds = filter(Number.isFinite, map(Number, [...byLocation.keys()]))
-
-  const [{ data: corpStructures }, { data: playerStructures }] = await Promise.all([
-    supabase.from('corp_structure').select('structure_id, name, system_id'),
-    locationIds.length
-      ? supabase.from('universe_structure').select('structure_id, name, system_id').in('structure_id', locationIds)
-      : Promise.resolve({ data: [] }),
-  ])
-
-  // Own-corp structures override the ESI-resolved cache (later entries win).
-  const byStructureId = (list: Structure[]): [string, Structure][] => map((s) => [String(s.structure_id), s], list)
-  const structureById = new Map<string, Structure>([
-    ...byStructureId((playerStructures ?? []) as Structure[]),
-    ...byStructureId((corpStructures ?? []) as Structure[]),
-  ])
-
-  // NPC station names come from the universe_name DB cache; player structures
-  // aren't there, so those still resolve via corp_structure above.
-  const stationIds = pipe(
-    filter(({ root }: { root: Root }) => root.type === 'station'),
-    map(({ root }: { root: Root }) => Number(root.id))
-  )([...byLocation.values()])
-  const [stationNames, stationSystems] = await Promise.all([
-    fetchStationNames(stationIds),
-    fetchStationSystems(stationIds),
-  ])
-
-  const systemIds = new Set<number>(
-    chain(
-      ({ root }) => {
-        const structure = structureById.get(root.id)
-        return [
-          root.type === 'solar_system' ? Number(root.id) : null,
-          structure?.system_id != null ? Number(structure.system_id) : null,
-          // NPC stations aren't in corp_structure/universe_structure; their system
-          // comes from the calculator's station lookup above.
-          root.type === 'station' ? (stationSystems[Number(root.id)] ?? null) : null,
-        ].filter((id): id is number => id != null)
-      },
-      [...byLocation.values()]
-    )
-  )
-  const systemNames = await fetchSystemNames(systemIds)
-
-  const labelFor = (loc: Root): string => {
-    const structure = structureById.get(loc.id)
-    if (structure) return structure.name ?? `Structure #${loc.id}`
-    if (loc.type === 'station') return stationNames[Number(loc.id)] ?? `Station #${loc.id}`
-    if (loc.type === 'solar_system') return systemNames[Number(loc.id)] ?? `System #${loc.id}`
-    return `Location #${loc.id}`
-  }
-
-  const systemFor = (loc: Root): string | undefined => {
-    const structure = structureById.get(loc.id)
-    if (structure?.system_id != null) return systemNames[Number(structure.system_id)] ?? `#${structure.system_id}`
-    if (loc.type === 'solar_system') return systemNames[Number(loc.id)]
-    if (loc.type === 'station') {
-      const systemId = stationSystems[Number(loc.id)]
-      if (systemId != null) return systemNames[systemId] ?? `#${systemId}`
-    }
-    return undefined
-  }
+  const { nameFor, systemFor } = await resolveLocations(map(({ root }) => root, [...byLocation.values()]))
 
   const locations: Location[] = map(
     ({ root, counts }) => ({
       id: root.id,
-      name: labelFor(root),
+      name: nameFor(root),
       system: systemFor(root) ?? null,
       counts: Object.fromEntries(counts),
     }),
@@ -214,6 +136,7 @@ const Locations = async () => {
           <DateTime value={lastRun?.ended_at} fallback="never" />
         )}
       </p>
+      <AssetSearchForm />
     </>
   )
 }

--- a/src/app/asset/search/page.tsx
+++ b/src/app/asset/search/page.tsx
@@ -1,0 +1,215 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { prop, uniqBy } from 'ramda'
+
+import { searchSdeTypesAll } from '@/sdeTypes'
+import { createClient } from '@/utils/supabase/server'
+
+import { fetchOwners } from '../../owners'
+import { resolveLocations, type LocationRef } from '../../resolveLocations'
+import retro from '../../retro.module.css'
+import { TypeName } from '../../typeName'
+import { AssetSearchForm } from '../assetSearchForm'
+import { Quantity } from '../[locationId]/quantity'
+
+// Above this, the substring is too broad to be a useful item filter (and the
+// search functions below would end up walking a large chunk of the hangar).
+const MAX_TYPES = 100
+
+type CharacterSearchRow = {
+  item_id: number | string
+  character_id: string
+  type_id: number | string
+  quantity: number | string | null
+  is_singleton: boolean | null
+  name: string | null
+  location_flag: string | null
+  root_location_id: number | string | null
+  root_location_type: string | null
+  contents: number | string
+}
+
+// Corp assets carry no player-assigned name column; owner is the corporation.
+type CorpSearchRow = Omit<CharacterSearchRow, 'character_id' | 'name'> & { corporation_id: number | string }
+
+type SearchRow = {
+  itemId: string
+  ownerId: string
+  typeId: number
+  name: string | null
+  quantity: number | string | null
+  isSingleton: boolean | null
+  flag: string | null
+  root: LocationRef | null
+  contents: number
+}
+
+const AssetSearchPage = async ({ searchParams }: { searchParams: Promise<{ q?: string }> }) => {
+  const { q } = await searchParams
+  const query = (q ?? '').trim()
+
+  const supabase = await createClient()
+  const { data: auth, error: authError } = await supabase.auth.getUser()
+  if (authError || !auth?.user) {
+    redirect('/')
+  }
+
+  if (!query) {
+    return (
+      <>
+        <h1>Search Assets</h1>
+        <p>Enter part of an item name to find every stack of it across your hangars.</p>
+        <AssetSearchForm />
+      </>
+    )
+  }
+
+  // Case-insensitive substring match against every published type name, resolved
+  // from the locally generated SDE data (never the stale evesde DB schema).
+  const matches = searchSdeTypesAll(query)
+
+  if (matches.length > MAX_TYPES) {
+    return (
+      <>
+        <h1>Search Assets</h1>
+        <p>
+          &quot;{query}&quot; matched {matches.length} item types — that&apos;s too many to search at once. Try a more
+          specific term.
+        </p>
+        <AssetSearchForm initialQuery={query} />
+      </>
+    )
+  }
+
+  if (matches.length === 0) {
+    return (
+      <>
+        <h1>Search Assets</h1>
+        <p>No item types matched &quot;{query}&quot;.</p>
+        <AssetSearchForm initialQuery={query} />
+      </>
+    )
+  }
+
+  const typeIds = matches.map((m) => m.typeID)
+  const typeNameById = new Map(matches.map((m) => [m.typeID, m.name]))
+  // Pre-resolved (not streamed) since the search results above already carry
+  // every matched type's name — no extra SDE lookup needed. TypeName still
+  // expects a promise (it also renders each row's player-assigned name, if any).
+  const typeNamesPromise = Promise.resolve(Object.fromEntries(typeNameById))
+
+  const [{ data: characterRows }, { data: corpRows }, owners] = await Promise.all([
+    supabase.rpc('character_asset_search', { type_ids: typeIds }),
+    supabase.rpc('corp_asset_search', { type_ids: typeIds }),
+    fetchOwners(),
+  ])
+
+  const rows: SearchRow[] = [
+    ...((characterRows ?? []) as CharacterSearchRow[]).map((r): SearchRow => ({
+      itemId: String(r.item_id),
+      ownerId: r.character_id,
+      typeId: Number(r.type_id),
+      name: r.name,
+      quantity: r.quantity,
+      isSingleton: r.is_singleton,
+      flag: r.location_flag,
+      root: r.root_location_id != null ? { id: String(r.root_location_id), type: r.root_location_type } : null,
+      contents: Number(r.contents),
+    })),
+    ...((corpRows ?? []) as CorpSearchRow[]).map((r): SearchRow => ({
+      itemId: String(r.item_id),
+      ownerId: String(r.corporation_id),
+      typeId: Number(r.type_id),
+      name: null,
+      quantity: r.quantity,
+      isSingleton: r.is_singleton,
+      flag: r.location_flag,
+      root: r.root_location_id != null ? { id: String(r.root_location_id), type: r.root_location_type } : null,
+      contents: Number(r.contents),
+    })),
+  ]
+
+  const rootRefs = uniqBy(
+    prop('id'),
+    rows.map((r) => r.root).filter((r): r is LocationRef => r != null)
+  )
+  const { nameFor, systemFor } = await resolveLocations(rootRefs)
+  const ownerMap = new Map([...owners.characters, ...owners.corporations].map((o) => [o.id, o.name]))
+
+  const displayRows = rows
+    .map((row) => {
+      // A root is either a station/structure (has its own name, distinct from
+      // the system it's in) or a bare solar system (the item is floating —
+      // there's no separate "station" to show).
+      const floating = row.root?.type === 'solar_system'
+      const stationName = row.root && !floating ? nameFor(row.root) : null
+      const systemName = row.root ? (systemFor(row.root) ?? (floating ? nameFor(row.root) : null)) : null
+      return { row, stationName, systemName, floating }
+    })
+    // Group by system, then station, then item name for a stable, browsable order.
+    .sort(
+      (a, b) =>
+        (a.systemName ?? '').localeCompare(b.systemName ?? '') ||
+        (a.stationName ?? '').localeCompare(b.stationName ?? '') ||
+        (typeNameById.get(a.row.typeId) ?? '').localeCompare(typeNameById.get(b.row.typeId) ?? '')
+    )
+
+  return (
+    <>
+      <h1>Search Assets</h1>
+      <p>
+        {displayRows.length} item{displayRows.length === 1 ? '' : 's'} matching &quot;{query}&quot; across{' '}
+        {typeIds.length} item type{typeIds.length === 1 ? '' : 's'}.
+      </p>
+      {displayRows.length > 0 ? (
+        <table className={retro.retro}>
+          <thead>
+            <tr>
+              <th>Owner</th>
+              <th>System</th>
+              <th>Station</th>
+              <th>Item</th>
+              <th className={retro.num}>Quantity</th>
+              <th>Hangar</th>
+              <th className={retro.num}>Contents</th>
+            </tr>
+          </thead>
+          <tbody>
+            {displayRows.map(({ row, stationName, systemName, floating }) => (
+              <tr key={`${row.ownerId}-${row.itemId}`}>
+                <td>{ownerMap.get(row.ownerId) ?? row.ownerId}</td>
+                <td className="serif">
+                  {row.root && floating ? (
+                    <Link href={`/asset/${row.root.id}`}>{systemName}</Link>
+                  ) : (
+                    (systemName ?? '—')
+                  )}
+                </td>
+                <td className="serif">
+                  {row.root && !floating ? <Link href={`/asset/${row.root.id}`}>{stationName}</Link> : '—'}
+                </td>
+                <td>
+                  {row.contents > 0 ? (
+                    <Link href={`/asset/${row.itemId}`}>
+                      <TypeName id={row.typeId} name={row.name} promise={typeNamesPromise} />
+                    </Link>
+                  ) : (
+                    <TypeName id={row.typeId} name={row.name} promise={typeNamesPromise} />
+                  )}
+                </td>
+                <td className={retro.num}>{row.isSingleton ? '—' : <Quantity value={row.quantity} />}</td>
+                <td>{row.flag ?? '—'}</td>
+                <td className={retro.num}>{row.contents > 0 ? row.contents : '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p>No assets found for those item types.</p>
+      )}
+      <AssetSearchForm initialQuery={query} />
+    </>
+  )
+}
+
+export default AssetSearchPage

--- a/src/app/resolveLocations.ts
+++ b/src/app/resolveLocations.ts
@@ -1,0 +1,86 @@
+// Resolve display names + solar systems for a set of root locations (a
+// station, a player structure, or a bare solar system) — the logic the assets
+// pages share: our own corp's structures (corp_structure) win over the
+// ESI-resolved cache (universe_structure) for player structures; NPC station
+// names and solar system names come from the universe_name cache.
+import { chain, filter, map, pipe } from 'ramda'
+import { createClient } from '@/utils/supabase/server'
+import { fetchStationNames, fetchStationSystems } from './stationNames'
+import { fetchSystemNames } from './systemNames'
+
+export type LocationRef = { id: string; type: string | null }
+
+type Structure = { structure_id: number | string; name: string | null; system_id: number | string | null }
+
+export type ResolvedLocations = {
+  nameFor: (loc: LocationRef) => string
+  systemFor: (loc: LocationRef) => string | undefined
+}
+
+export const resolveLocations = async (locations: LocationRef[]): Promise<ResolvedLocations> => {
+  const supabase = await createClient()
+  const locationIds = filter(
+    Number.isFinite,
+    map((l: LocationRef) => Number(l.id), locations)
+  )
+
+  const [{ data: corpStructures }, { data: playerStructures }] = await Promise.all([
+    supabase.from('corp_structure').select('structure_id, name, system_id'),
+    locationIds.length
+      ? supabase.from('universe_structure').select('structure_id, name, system_id').in('structure_id', locationIds)
+      : Promise.resolve({ data: [] }),
+  ])
+
+  // Own-corp structures override the ESI-resolved cache (later entries win).
+  const byStructureId = (list: Structure[]): [string, Structure][] => map((s) => [String(s.structure_id), s], list)
+  const structureById = new Map<string, Structure>([
+    ...byStructureId((playerStructures ?? []) as Structure[]),
+    ...byStructureId((corpStructures ?? []) as Structure[]),
+  ])
+
+  // NPC station names come from the universe_name DB cache; player structures
+  // aren't there, so those still resolve via corp_structure above.
+  const stationIds = pipe(
+    filter((l: LocationRef) => l.type === 'station'),
+    map((l: LocationRef) => Number(l.id))
+  )(locations)
+  const [stationNames, stationSystems] = await Promise.all([
+    fetchStationNames(stationIds),
+    fetchStationSystems(stationIds),
+  ])
+
+  const systemIds = new Set<number>(
+    chain((l: LocationRef) => {
+      const structure = structureById.get(l.id)
+      return [
+        l.type === 'solar_system' ? Number(l.id) : null,
+        structure?.system_id != null ? Number(structure.system_id) : null,
+        // NPC stations aren't in corp_structure/universe_structure; their system
+        // comes from the station lookup above.
+        l.type === 'station' ? (stationSystems[Number(l.id)] ?? null) : null,
+      ].filter((id): id is number => id != null)
+    }, locations)
+  )
+  const systemNames = await fetchSystemNames(systemIds)
+
+  const nameFor = (loc: LocationRef): string => {
+    const structure = structureById.get(loc.id)
+    if (structure) return structure.name ?? `Structure #${loc.id}`
+    if (loc.type === 'station') return stationNames[Number(loc.id)] ?? `Station #${loc.id}`
+    if (loc.type === 'solar_system') return systemNames[Number(loc.id)] ?? `System #${loc.id}`
+    return `Location #${loc.id}`
+  }
+
+  const systemFor = (loc: LocationRef): string | undefined => {
+    const structure = structureById.get(loc.id)
+    if (structure?.system_id != null) return systemNames[Number(structure.system_id)] ?? `#${structure.system_id}`
+    if (loc.type === 'solar_system') return systemNames[Number(loc.id)]
+    if (loc.type === 'station') {
+      const systemId = stationSystems[Number(loc.id)]
+      if (systemId != null) return systemNames[systemId] ?? `#${systemId}`
+    }
+    return undefined
+  }
+
+  return { nameFor, systemFor }
+}

--- a/src/sdeTypes.ts
+++ b/src/sdeTypes.ts
@@ -36,9 +36,13 @@ export const getSdeTypeNames = (typeIDs: Iterable<number>): Record<number, strin
 
 export type SdeSearchResult = { typeID: number; name: string; coverage: number }
 
-// Case-insensitive substring search, ranked by how much of the name the query
-// covers (a tighter match ranks above a longer name containing the same term).
-export const searchSdeTypes = (query: string, limit = 25): SdeSearchResult[] => {
+// Case-insensitive substring search over every published type, ranked by how
+// much of the name the query covers (a tighter match ranks above a longer
+// name containing the same term). Unbounded — callers that only want a
+// preview list should slice the result themselves (see searchSdeTypes below);
+// callers that need the true match count (e.g. "too many results") can use
+// `.length` on the full array instead of guessing from a capped page.
+export const searchSdeTypesAll = (query: string): SdeSearchResult[] => {
   const needle = query.trim().toLowerCase()
   if (needle === '') return []
   const results: SdeSearchResult[] = []
@@ -48,5 +52,8 @@ export const searchSdeTypes = (query: string, limit = 25): SdeSearchResult[] => 
     results.push({ typeID: t.typeID, name: t.name, coverage: needle.length / t.name.length })
   }
   results.sort((a, b) => b.coverage - a.coverage || a.name.length - b.name.length)
-  return results.slice(0, limit)
+  return results
 }
+
+// Same search, capped to `limit` results — what the autocomplete UIs want.
+export const searchSdeTypes = (query: string, limit = 25): SdeSearchResult[] => searchSdeTypesAll(query).slice(0, limit)

--- a/supabase/migrations/20260705100000_add_asset_search.sql
+++ b/supabase/migrations/20260705100000_add_asset_search.sql
@@ -1,0 +1,154 @@
+-- item search (/asset/search): given a set of type ids (resolved client-side
+-- from a substring match against the SDE), find every current character/corp
+-- asset whose type_id is in that set, its root location (station/structure/
+-- solar system) and nested-item count. Seeded from just the matched items —
+-- not every asset, like character_asset_location_summary()/corp_asset_
+-- location_summary() — so this stays cheap even though the caller can pass up
+-- to 100 type ids. Both SECURITY INVOKER (the default), so character_asset/
+-- corp_asset RLS keeps reads scoped to the caller.
+
+create or replace function public.character_asset_search(type_ids bigint[])
+returns table (
+  item_id bigint,
+  character_id uuid,
+  type_id bigint,
+  quantity bigint,
+  is_singleton boolean,
+  name text,
+  location_flag text,
+  root_location_id bigint,
+  root_location_type text,
+  contents bigint
+)
+language sql
+stable
+as $$
+  with recursive parent_of as (
+    select distinct on (item_id) item_id, location_id, location_type
+    from public.character_asset_over_time
+    order by item_id, is_current desc, last_seen_at desc
+  ),
+  matched as (
+    select a.item_id, a.character_id, a.type_id, a.quantity, a.is_singleton, a.name,
+           a.location_flag, a.location_id, a.location_type
+    from public.character_asset a
+    where a.type_id = any(type_ids)
+  ),
+  climb as (
+    select m.item_id as start_item, m.location_id, m.location_type, 1 as depth
+    from matched m
+    union all
+    select c.start_item, p.location_id, p.location_type, c.depth + 1
+    from climb c
+    join parent_of p on p.item_id = c.location_id
+    where c.depth < 64
+  ),
+  roots as (
+    select w.start_item, w.location_id as root_location_id, w.location_type as root_location_type
+    from climb w
+    where w.location_id is not null
+      and not exists (select 1 from parent_of o where o.item_id = w.location_id)
+  ),
+  descend as (
+    select m.item_id as ancestor, m.item_id as node, 1 as depth
+    from matched m
+    union all
+    select d.ancestor, c.item_id, d.depth + 1
+    from descend d
+    join public.character_asset c on c.location_id = d.node
+    where d.depth < 64
+  ),
+  contents as (
+    select ancestor, count(*) - 1 as contents
+    from descend
+    group by ancestor
+  )
+  select
+    m.item_id,
+    m.character_id,
+    m.type_id,
+    m.quantity,
+    m.is_singleton,
+    m.name,
+    m.location_flag,
+    r.root_location_id,
+    r.root_location_type,
+    coalesce(ct.contents, 0) as contents
+  from matched m
+  join roots r on r.start_item = m.item_id
+  left join contents ct on ct.ancestor = m.item_id;
+$$;
+
+grant execute on function public.character_asset_search(bigint[]) to authenticated;
+
+create or replace function public.corp_asset_search(type_ids bigint[])
+returns table (
+  item_id bigint,
+  corporation_id bigint,
+  type_id bigint,
+  quantity bigint,
+  is_singleton boolean,
+  location_flag text,
+  root_location_id bigint,
+  root_location_type text,
+  contents bigint
+)
+language sql
+stable
+as $$
+  with recursive parent_of as (
+    select distinct on (item_id) item_id, location_id, location_type
+    from public.corp_asset_over_time
+    order by item_id, is_current desc, last_seen_at desc
+  ),
+  matched as (
+    select a.item_id, a.corporation_id, a.type_id, a.quantity, a.is_singleton,
+           a.location_flag, a.location_id, a.location_type
+    from public.corp_asset a
+    where a.type_id = any(type_ids)
+  ),
+  climb as (
+    select m.item_id as start_item, m.location_id, m.location_type, 1 as depth
+    from matched m
+    union all
+    select c.start_item, p.location_id, p.location_type, c.depth + 1
+    from climb c
+    join parent_of p on p.item_id = c.location_id
+    where c.depth < 64
+  ),
+  roots as (
+    select w.start_item, w.location_id as root_location_id, w.location_type as root_location_type
+    from climb w
+    where w.location_id is not null
+      and not exists (select 1 from parent_of o where o.item_id = w.location_id)
+  ),
+  descend as (
+    select m.item_id as ancestor, m.item_id as node, 1 as depth
+    from matched m
+    union all
+    select d.ancestor, c.item_id, d.depth + 1
+    from descend d
+    join public.corp_asset c on c.location_id = d.node
+    where d.depth < 64
+  ),
+  contents as (
+    select ancestor, count(*) - 1 as contents
+    from descend
+    group by ancestor
+  )
+  select
+    m.item_id,
+    m.corporation_id,
+    m.type_id,
+    m.quantity,
+    m.is_singleton,
+    m.location_flag,
+    r.root_location_id,
+    r.root_location_type,
+    coalesce(ct.contents, 0) as contents
+  from matched m
+  join roots r on r.start_item = m.item_id
+  left join contents ct on ct.ancestor = m.item_id;
+$$;
+
+grant execute on function public.corp_asset_search(bigint[]) to authenticated;


### PR DESCRIPTION
## Summary
- Adds a search bar to the bottom of `/asset` that submits to `/asset/search?q=<substring>`
- `/asset/search` does a case-insensitive substring match over every published SDE type name (`searchSdeTypesAll`, new unbounded variant of the existing SDE search); if more than 100 types match, shows a "too many types" message instead of running the query
- Otherwise lists every matching asset stack across characters and corps in a table: Owner, System, Station, Item, Quantity, Hangar, Contents
- New `character_asset_search(type_ids)` / `corp_asset_search(type_ids)` Postgres functions seed a recursive CTE from only the type_id-matched rows (rather than walking the whole hangar) to resolve each stack's root location and nested-item count — cheap regardless of hangar size. Added to both `schema.sql` and a new incremental migration (`supabase/migrations/20260705100000_add_asset_search.sql`)
- Extracted `resolveLocations()` (station/structure/system name resolution) out of `/asset`'s page into a shared helper now used by both `/asset` and `/asset/search`, removing duplicated logic
- Documented the new route, functions, and search helpers in `CLAUDE.md`

## Test plan
- [x] Validated `character_asset_search()` / `corp_asset_search()` against a local Postgres 16 instance: nested containers, ships with fitted modules, items floating in a solar system (no station), corp office-folder nesting, non-matching type ids, multi-type-id searches
- [x] `pnpm run lint` — clean (only the pre-existing unrelated `formData` warning in `src/app/character/actions.ts`)
- [x] `pnpm exec tsc --noEmit` — passes
- [x] `pnpm run build` — succeeds, `/asset/search` present in the route list


---
_Generated by [Claude Code](https://claude.ai/code/session_01932QfXPXbLiruN1VHx6icP)_