### PR TITLE
Move /asset search bar to top, resolve floating-in-space system names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ All functions take `(accessToken, id, ...)` unless noted. Returns raw ESI respon
 - `resolveKnownCorpNames()` — resolve+cache corp names seen in `corp_wallet_transaction`/`character_affiliation`/`corp_structure`
 - `resolveCorpStructureSystemNames()` — resolve system IDs for corp structures
 - `resolveAssetStationNames()` — resolve+cache NPC station names (location_type 'station' in assets) into `universe_name`
+- `resolveAssetSystemNames()` — resolve+cache solar system names for assets floating directly in space (location_type 'solar_system') into `universe_name`
 
 ### `src/utils/apiToken.ts`
 - `resolvePlayer(token: string)` — look up `user_settings.api_token`, return `{ supabase, characterIds }` for Sheets API endpoints

--- a/src/app/asset/assets.module.css
+++ b/src/app/asset/assets.module.css
@@ -55,7 +55,7 @@
   display: flex;
   align-items: center;
   gap: 8pt;
-  margin: 24px 0 0;
+  margin: 24px 0;
 }
 
 .searchForm input {

--- a/src/app/asset/page.tsx
+++ b/src/app/asset/page.tsx
@@ -125,6 +125,7 @@ const Locations = async () => {
 
   return (
     <>
+      <AssetSearchForm />
       <AssetsTable locations={locations} owners={owners} />
       <p className={styles.lastRun}>
         Assets last refreshed:{' '}
@@ -136,7 +137,6 @@ const Locations = async () => {
           <DateTime value={lastRun?.ended_at} fallback="never" />
         )}
       </p>
-      <AssetSearchForm />
     </>
   )
 }

--- a/src/jobs/universeNames.js
+++ b/src/jobs/universeNames.js
@@ -1,5 +1,6 @@
 import {
   resolveAssetStationNames,
+  resolveAssetSystemNames,
   resolveCorpJournalNames,
   resolveCorpStructureSystemNames,
   resolveKnownCorpNames,
@@ -11,15 +12,17 @@ const TAG = 'universe-names'
 // POST /universe/names/ → universe_name. Resolves and caches a name for every
 // id the other extracts have surfaced but that universe_name doesn't know yet:
 // corp wallet journal parties, corporations seen in transactions/affiliations,
-// NPC stations holding assets, and the solar systems our structures sit in.
-// Cheap in steady state — each resolver only asks ESI for missing ids — so it
-// can run often. Account-wide batch work, so it takes no character scope.
+// NPC stations holding assets, the solar systems our structures sit in, and the
+// solar systems any asset is floating in directly. Cheap in steady state — each
+// resolver only asks ESI for missing ids — so it can run often. Account-wide
+// batch work, so it takes no character scope.
 export const runUniverseNames = async () => {
   const resolvers = [
     ['corp journal parties', resolveCorpJournalNames],
     ['corporations', resolveKnownCorpNames],
     ['asset stations', resolveAssetStationNames],
     ['corp structure systems', resolveCorpStructureSystemNames],
+    ['asset systems', resolveAssetSystemNames],
   ]
   let failed = 0
   await forEachSequential(resolvers, async ([what, resolve]) => {

--- a/src/resolveNames.js
+++ b/src/resolveNames.js
@@ -171,6 +171,64 @@ export const resolveAssetStationNames = async () => {
   console.log(`[names] upserted ${rows.length} station name(s)`)
 }
 
+// Page through live asset rows in `table` located directly in a solar system
+// (location_type 'solar_system' — the item is floating in space, not docked
+// anywhere), collecting distinct location_id values. Shared by
+// resolveAssetSystemNames for the character/corp asset tables, which are
+// otherwise identical here. Order by the primary key so range paging is
+// stable (an unordered .range() can skip rows).
+const collectFloatingSystemIds = async (table, ids) => {
+  const PAGE = 1000
+  for (let from = 0; ; from += PAGE) {
+    const { data: rows, error } = await sudoSupabase
+      .from(table)
+      .select('location_id')
+      .eq('is_current', true)
+      .eq('location_type', 'solar_system')
+      .order('id', { ascending: true })
+      .range(from, from + PAGE - 1)
+    if (error) throw error
+    if (!rows || rows.length === 0) break
+    for (const r of rows) if (r.location_id != null) ids.add(Number(r.location_id))
+    if (rows.length < PAGE) break
+  }
+}
+
+// Cache (in universe_name) the name of every solar system a character or corp
+// asset is currently floating in directly (location_type 'solar_system' — no
+// station/structure to resolve a name from otherwise). Only resolves ids
+// missing from universe_name, so steady-state runs do nothing. The assets
+// pages read universe_name to label these roots instead of falling back to a
+// raw system_id.
+export const resolveAssetSystemNames = async () => {
+  const ids = new Set()
+  await collectFloatingSystemIds('character_asset_over_time', ids)
+  await collectFloatingSystemIds('corp_asset_over_time', ids)
+
+  const { data: known, error: knownErr } = await sudoSupabase
+    .from('universe_name')
+    .select('id')
+    .eq('category', 'solar_system')
+  if (knownErr) throw knownErr
+  const knownIds = knownIdSet(known ?? [])
+
+  const toResolve = filter((n) => Number.isFinite(n) && n > 0 && !knownIds.has(n), [...ids])
+  console.log(`[names] asset systems: ${toResolve.length} to resolve`)
+  if (toResolve.length === 0) return
+
+  const resolved = await resolveAllIds(toResolve)
+
+  if (resolved.length === 0) {
+    console.log('[names] no asset system names resolved')
+    return
+  }
+
+  const rows = map(toNameRow, resolved)
+  const { error: upErr } = await sudoSupabase.from('universe_name').upsert(rows, { onConflict: 'id' })
+  if (upErr) throw upErr
+  console.log(`[names] upserted ${rows.length} asset system name(s)`)
+}
+
 // Cache (in universe_name) the name of every solar system we currently have a
 // corp structure in. Only resolves ids missing from universe_name, so
 // steady-state runs do nothing. The structures page reads universe_name to label


### PR DESCRIPTION
## Summary
- Moves the search bar on `/asset` from the bottom of the page to the top, above the location table, so it's usable immediately
- Fixes `/asset/search` (and `/asset`) showing a raw `System #<id>` fallback instead of a resolved name for assets sitting directly in a solar system (`location_type = 'solar_system'`, e.g. floating in space rather than docked/anchored anywhere) — reported live at `/asset/search?q=Purifier+Blueprint` (system `30000832` wasn't resolving)
- Root cause: no extract job ever cached names for these bare-system asset roots — `resolveAssetStationNames()` covered NPC stations, `resolveCorpStructureSystemNames()` covered corp structure systems, but nothing covered a system that only shows up as an asset's root location
- Adds `resolveAssetSystemNames()` (`src/resolveNames.js`), mirroring the existing NPC-station resolver: pages `character_asset_over_time`/`corp_asset_over_time` for current rows with `location_type = 'solar_system'`, resolves any unknown ids via ESI, and caches them into `universe_name`. Wired into the `universe-names` job (hourly `:58`)
- Documents the new resolver in `CLAUDE.md`

## Test plan
- [x] `pnpm run lint` — clean (only the pre-existing unrelated `formData` warning)
- [x] `pnpm exec tsc --noEmit` — passes
- [x] `pnpm run build` — succeeds
- [ ] The system-name fix depends on the hourly `universe-names` job running once against production data to backfill the missing name (or a manual dispatch) — cannot be verified end-to-end in this sandbox since it requires live ESI credentials and the production DB


---
_Generated by [Claude Code](https://claude.ai/code/session_01932QfXPXbLiruN1VHx6icP)_