### PR TITLE
Show a deterministic sample of matched types on /asset/search overflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@vercel/queue": "^0.3.0",
     "@vercel/speed-insights": "2.0.0",
     "eve-industry": "0.1.0",
+    "fast-shuffle": "^6.2.0",
     "flags": "^4.2.0",
     "next": "16.2.9",
     "ramda": "^0.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       eve-industry:
         specifier: 0.1.0
         version: 0.1.0
+      fast-shuffle:
+        specifier: ^6.2.0
+        version: 6.2.0
       flags:
         specifier: ^4.2.0
         version: 4.2.0(next@16.2.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -815,6 +818,10 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-shuffle@6.2.0:
+    resolution: {integrity: sha512-Y7MexltTgkdI2UzeRx7zVIWiHSuQ41dD+2PPwukkIZW2b1wCSaciISyKNSKFVW6ImkH+QQivlDsmY552EO22Ig==}
+    engines: {node: '>=14'}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1117,6 +1124,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  pcg@3.0.0:
+    resolution: {integrity: sha512-lHETDr3c//q4xs0iZk9+LRFgmvjLtaUDIE3ztE2KN4IhwyHLcJ3H5VBv93SGop1XHZalC1UFSwoJepoZSMSVLQ==}
+    engines: {node: '>=18'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1957,6 +1968,10 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-shuffle@6.2.0:
+    dependencies:
+      pcg: 3.0.0
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -2230,6 +2245,8 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  pcg@3.0.0: {}
 
   picocolors@1.1.1: {}
 

--- a/src/app/asset/search/page.tsx
+++ b/src/app/asset/search/page.tsx
@@ -1,3 +1,4 @@
+import { createShuffle } from 'fast-shuffle'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { prop, uniqBy } from 'ramda'
@@ -15,6 +16,12 @@ import { Quantity } from '../[locationId]/quantity'
 // Above this, the substring is too broad to be a useful item filter (and the
 // search functions below would end up walking a large chunk of the hangar).
 const MAX_TYPES = 100
+
+// Fixed seed so the "too many types" preview shuffle is reproducible across
+// requests rather than changing every page load. createShuffle's returned
+// shuffler carries internal state across calls, so a fresh one is created per
+// request rather than reused from module scope.
+const SHUFFLE_SEED = 20260704
 
 type CharacterSearchRow = {
   item_id: number | string
@@ -69,6 +76,9 @@ const AssetSearchPage = async ({ searchParams }: { searchParams: Promise<{ q?: s
   const matches = searchSdeTypesAll(query)
 
   if (matches.length > MAX_TYPES) {
+    const sample = createShuffle(SHUFFLE_SEED)(matches)
+      .slice(0, 10)
+      .sort((a, b) => a.name.localeCompare(b.name))
     return (
       <>
         <h1>Search Assets</h1>
@@ -76,6 +86,12 @@ const AssetSearchPage = async ({ searchParams }: { searchParams: Promise<{ q?: s
           &quot;{query}&quot; matched {matches.length} item types — that&apos;s too many to search at once. Try a more
           specific term.
         </p>
+        <p>A sample of what matched:</p>
+        <ul>
+          {sample.map((m) => (
+            <li key={m.typeID}>{m.name}</li>
+          ))}
+        </ul>
         <AssetSearchForm initialQuery={query} />
       </>
     )


### PR DESCRIPTION
## Summary
- When an `/asset/search` query matches more item types than `MAX_TYPES` (100), the page previously just reported the count and asked for a narrower term.
- Now it also shows a preview of 10 matched type names: the full match list is shuffled deterministically (via `fast-shuffle`'s `createShuffle` with a fixed seed), the first 10 are taken, and that sample is sorted alphabetically for display.

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [ ] Manually search `/asset/search?q=<broad term>` for a term matching >100 types and confirm the sample list renders


---
_Generated by [Claude Code](https://claude.ai/code/session_019LmWpwRXq2WvysKVqbLsum)_