### PR TITLE
Add missing corp industry jobs ESI scope

### DIFF
--- a/src/app/character/scopes.ts
+++ b/src/app/character/scopes.ts
@@ -80,6 +80,12 @@ export const esiScopes: EsiScope[] = [
     without: 'corporation blueprints will not be tracked from this character.',
   },
   {
+    scope: 'esi-industry.read_corporation_jobs.v1',
+    name: 'Corporation industry jobs',
+    why: 'Tracks your corporation’s manufacturing, research, invention and reaction jobs, and when they finish. Requires the Factory Manager role in game.',
+    without: 'industry jobs run against corporation blueprints or facilities will not be tracked.',
+  },
+  {
     scope: 'esi-universe.read_structures.v1',
     name: 'Structure names',
     why: 'Resolves the names of player-owned Upwell structures where this character keeps assets, so they show a name instead of a raw ID.',


### PR DESCRIPTION
## Summary
- The `/industry` page already unions `character_industry_job` and `corp_industry_job` (#485), and `src/jobs/corpIndustryJobs.js` already filters tokens by the `esi-industry.read_corporation_jobs.v1` scope — but that scope string never appeared in `src/app/character/scopes.ts`, the list `sso.ts`/`userScopes.ts` draw from when building the EVE SSO authorize request.
- Net effect: EVE SSO was never asked to grant this scope, so no character token in the `token` table ever carried it, so the `corp-industry-jobs` extract job's token query always matched zero rows, and `corp_industry_job` was never populated for **any** user — not just one. Players whose industry jobs run against corp blueprints/facilities (rather than their own) saw an empty Active Jobs table.
- Added the scope entry (mirroring the other corp-scoped entries, noting the in-game Factory Manager role requirement). `src/app/settings/grants/page.tsx` and the register flow read `esiScopes` generically, so the new scope now shows up as a toggle with no further wiring needed.

## Follow-up for existing users
Characters that already authorized before this change won't have the new scope on their stored token until they re-grant it — e.g. via `/settings/grants` (toggle "Corporation industry jobs" on and re-authorize) or by re-adding the character.

## Test plan
- [ ] `pnpm run lint` passes (verified locally, pre-existing unrelated warning only)
- [ ] After deploy, re-authorize a character with the Factory Manager role and confirm `corp_industry_job` rows populate on the next `corp-industry-jobs` run
- [ ] Confirm corp-run jobs appear on `/industry` for a corp-jobs-only user


---
_Generated by [Claude Code](https://claude.ai/code/session_01TPVacCFdSE9caR7zAUM5g6)_