### PR TITLE
Show main character name in header instead of email

### DIFF
--- a/src/app/layout/header.tsx
+++ b/src/app/layout/header.tsx
@@ -9,7 +9,22 @@ const Header = async () => {
   const {
     data: { user },
   } = await supabase.auth.getUser()
-  const userId = user?.email ?? undefined
+
+  // Label the signed-in user by their main character, falling back to their
+  // earliest one, and to their email if they haven't registered a character yet.
+  // Mirrors the inviter lookup on /account/invite.
+  let displayName: string | undefined
+  if (user) {
+    const { data: mainCharacter } = await supabase
+      .from('registration')
+      .select('name')
+      .order('is_main', { ascending: false })
+      .order('created_at', { ascending: true })
+      .limit(1)
+      .maybeSingle()
+    displayName = mainCharacter?.name ?? user.email ?? undefined
+  }
+
   const showIndexes = await indexesFlag()
   return (
     <header>
@@ -18,11 +33,11 @@ const Header = async () => {
           <Link href="/" className={styles.brand}>
             Edencom Link
           </Link>
-          {userId && <span className={styles.user}>{userId}</span>}
+          {displayName && <span className={styles.user}>{displayName}</span>}
         </div>
         <nav className={styles.nav}>
           <span className={styles.bracket}>[</span>
-          {!userId ? (
+          {!user ? (
             <>
               <Link href="/account/login">login</Link>
               <span className={styles.sep}>|</span>


### PR DESCRIPTION
## Summary
- `src/app/layout/header.tsx` labeled the signed-in user with their Supabase auth email. Replaced that with their main character's name.
- Resolution order mirrors the existing inviter lookup on `/account/invite`: the registration flagged `is_main`, falling back to the earliest-created registration, falling back to email if the user hasn't registered any character yet.
- No new query pattern — reuses the anon client (RLS already scopes `registration` reads to the caller) and the same `is_main` / `created_at` ordering already used elsewhere.

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [ ] Manually verify in a browser: header shows main character name when one is set, earliest character when none is flagged main, and email when the account has no registered characters


---
_Generated by [Claude Code](https://claude.ai/code/session_01TPVacCFdSE9caR7zAUM5g6)_