### PR TITLE
Run corp-wallet-journal extract hourly

### DIFF
--- a/.github/workflows/corp-wallet-journal.yml
+++ b/.github/workflows/corp-wallet-journal.yml
@@ -3,7 +3,7 @@ name: Corp Wallet Journal
 on:
   workflow_dispatch:
   schedule:
-    - cron: '37 9 * * *'
+    - cron: '37 * * * *'
 
 jobs:
   refresh:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ One job per ESI endpoint. The npm script, queue job name, and heartbeat job labe
 | `corp-structures` | `/corporations/{id}/structures/` | `corp_structure` | 09:17 daily |
 | `corp-assets` | `/corporations/{id}/assets/` | `corp_asset_over_time`, `corp_structure_rig` | 09:27 daily |
 | `corp-blueprints` | `/corporations/{id}/blueprints/` | `corp_blueprint_over_time` | 09:07 daily |
-| `corp-wallet-journal` | `/corporations/{id}/wallets/{division}/journal/` | `corp_wallet_journal` | 09:37 daily |
+| `corp-wallet-journal` | `/corporations/{id}/wallets/{division}/journal/` | `corp_wallet_journal` | hourly `:37` |
 | `corp-wallet-transactions` | `/corporations/{id}/wallets/{division}/transactions/` | `corp_wallet_transaction` | hourly `:50` |
 | `corp-industry-jobs` | `/corporations/{id}/industry/jobs/` | `corp_industry_job` | 09:47 daily |
 | `industry-systems` | `/industry/systems/` | `industry_system_index` (systems with structures ∪ user-watched systems) | hourly `:10` |


### PR DESCRIPTION
## Summary
- Changed the `corp-wallet-journal` GitHub Actions schedule from once daily (`09:37`) to hourly (`:37` past every hour), matching the cadence of the other per-hour extract jobs.
- Updated the job schedule table in `CLAUDE.md` to reflect the new hourly cadence.

## Test plan
- N/A — schedule-only change to `.github/workflows/corp-wallet-journal.yml`; no code paths affected. Next scheduled run will confirm the new cadence in Actions.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NvcDAFJNF5RZbBVeFGd9bx)_