### PR TITLE
Standardize ISK prices on kISK, keep structure tax events in ISK

### DIFF
--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation'
 import { reduce } from 'ramda'
 
 import { createClient } from '@/utils/supabase/server'
+import { formatKisk } from '../isk'
 import { register, refreshEsi, setMainCharacter } from './actions'
 import MainCharacterForm from './mainCharacterForm'
 import { requiredScopes } from './scopes'
@@ -29,9 +30,6 @@ const CharacterPage = async () => {
     new Map<string, string>(),
     wallets ?? []
   )
-  const formatIsk = (raw: string | number) =>
-    new Intl.NumberFormat('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(Number(raw))
-
   // If the player has turned off every optional ESI scope, characters they add
   // grant nothing beyond identification, so almost no features will work.
   const enabledScopes = await getEnabledScopes(supabase, data.user.id)
@@ -69,7 +67,7 @@ const CharacterPage = async () => {
                 <div className={styles.name}>{c.name}</div>
                 <div className={styles.meta}>
                   <span className={styles.metaLabel}>ISK:</span>
-                  {latestBalance.has(c.id) ? `${formatIsk(latestBalance.get(c.id)!)} ISK` : '—'}
+                  {latestBalance.has(c.id) ? formatKisk(latestBalance.get(c.id)!) : '—'}
                 </div>
                 <div className={styles.meta}>
                   <span className={styles.metaLabel}>Location:</span>

--- a/src/app/isk.ts
+++ b/src/app/isk.ts
@@ -1,14 +1,25 @@
-// Money in millions of ISK as a bare number, e.g. "1,234". Non-zero amounts that
-// would round down to zero millions are shown as "<1". Use when the "mISK" unit
-// lives elsewhere (e.g. a column header).
-export const formatMiskValue = (raw: string | number | null) => {
-  if (raw === null) return ''
-  const isk = Number(raw)
-  return isk.toLocaleString('en-US', { maximumFractionDigits: 0 })
+// Money in thousands of ISK as a bare number, e.g. "1,234". Use when the "kISK"
+// unit lives elsewhere (e.g. a column header).
+export const formatKiskValue = (raw: string | number | null) => {
+  if (raw === null) return '—'
+  return (Number(raw) / 1_000).toLocaleString('en-US', { maximumFractionDigits: 0 })
 }
 
-// Money shown in millions of ISK with the unit, e.g. "1,234 mISK".
-export const formatMisk = (raw: string | number | null) => {
-  const value = formatMiskValue(raw)
-  return value === '—' ? value : `${value} mISK`
+// Money shown in thousands of ISK with the unit, e.g. "1,234 kISK".
+export const formatKisk = (raw: string | number | null) => {
+  const value = formatKiskValue(raw)
+  return value === '—' ? value : `${value} kISK`
+}
+
+// Money in raw ISK as a bare number, e.g. "1,234". Reserved for structure
+// taxable events (industry job tax), which are kept in ISK rather than kISK.
+export const formatIskValue = (raw: string | number | null) => {
+  if (raw === null) return '—'
+  return Number(raw).toLocaleString('en-US', { maximumFractionDigits: 0 })
+}
+
+// Money shown in raw ISK with the unit, e.g. "1,234 ISK".
+export const formatIsk = (raw: string | number | null) => {
+  const value = formatIskValue(raw)
+  return value === '—' ? value : `${value} ISK`
 }

--- a/src/app/market/marketOverview.tsx
+++ b/src/app/market/marketOverview.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react'
 
-import { formatMisk, formatMiskValue } from '../isk'
+import { formatKisk, formatKiskValue } from '../isk'
 import { TypeName } from '../typeName'
 import { bucketSales, topTypesByValue, type Bucket, type TypeTotal } from './aggregate'
 import type { Sale } from './recentSales'
@@ -52,8 +52,8 @@ const TopItems = ({
             <span className={styles.topQty} title={`${it.quantity.toLocaleString('en-US')} sold`}>
               ×{it.quantity.toLocaleString('en-US')}
             </span>
-            <span className={styles.topValue} title={formatMisk(it.total)}>
-              {formatMiskValue(it.total)}
+            <span className={styles.topValue} title={formatKisk(it.total)}>
+              {formatKiskValue(it.total)}
             </span>
           </li>
         ))}
@@ -71,7 +71,7 @@ const bucketTip = (b: Bucket, bucketHours: number) => {
   const start = new Date(b.start)
   // Sub-day buckets need the hour to disambiguate; daily buckets just the date.
   const when = bucketHours < 24 ? start.toISOString().slice(0, 16).replace('T', ' ') : start.toISOString().slice(0, 10)
-  return `${when} — ${formatMisk(b.total)}`
+  return `${when} — ${formatKisk(b.total)}`
 }
 
 const SalesBars = ({ buckets, bucketHours }: { buckets: Bucket[]; bucketHours: number }) => {
@@ -111,7 +111,7 @@ export const MarketOverview = ({ now, sales, windowDays, typeNamesPromise }: Mar
       <TopItems
         wide
         title="Top sellers"
-        subtitle={`per total sales volume (in mISK) over the last ${opt.label}`}
+        subtitle={`per total sales volume (in kISK) over the last ${opt.label}`}
         items={current}
         typeNamesPromise={typeNamesPromise}
       />

--- a/src/app/market/recentSales.tsx
+++ b/src/app/market/recentSales.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { DateTime } from '../DateTime'
-import { formatMiskValue } from '../isk'
+import { formatKiskValue } from '../isk'
 import { Name } from '../names'
 import { TypeName } from '../typeName'
 import styles from './market.module.css'
@@ -138,8 +138,8 @@ export const RecentSales = ({ now, sales, characters, corpNames, typeNamesPromis
               <th>Seller</th>
               <th>Type</th>
               <th>Qty</th>
-              <th>Unit (mISK)</th>
-              <th>Total (mISK)</th>
+              <th>Unit (kISK)</th>
+              <th>Total (kISK)</th>
               <th>Sold</th>
               <th>Seen</th>
             </tr>
@@ -154,8 +154,8 @@ export const RecentSales = ({ now, sales, characters, corpNames, typeNamesPromis
                   <TypeName id={Number(s.type_id)} promise={typeNamesPromise} />
                 </td>
                 <td>{s.quantity}</td>
-                <td>{formatMiskValue(s.unit_price)}</td>
-                <td>{formatMiskValue(Number(s.unit_price) * Number(s.quantity))}</td>
+                <td>{formatKiskValue(s.unit_price)}</td>
+                <td>{formatKiskValue(Number(s.unit_price) * Number(s.quantity))}</td>
                 <td>
                   <DateTime value={s.date} />
                 </td>

--- a/src/app/structure/page.tsx
+++ b/src/app/structure/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
 import { DateTime } from '../DateTime'
-import { formatMisk } from '../isk'
+import { formatIsk, formatKisk } from '../isk'
 import { Name, SystemName } from '../names'
 import { fetchSystemNames } from '../systemNames'
 import { fetchTypeNames } from '../typeNames'
@@ -245,7 +245,7 @@ const StructuresPage = async () => {
                   <div className={styles.fields}>
                     <span className={styles.label}>Revenue</span>
                     <span className={`${styles.value} ${styles.num}`}>
-                      {formatMisk(totalByStructure.get(String(s.structure_id)) ?? 0)}
+                      {formatIsk(totalByStructure.get(String(s.structure_id)) ?? 0)}
                     </span>
                     <span className={styles.label}>Type</span>
                     <span className={styles.value}>
@@ -324,9 +324,9 @@ const StructuresPage = async () => {
 
           <div className={styles.footer}>
             <span>Unaccounted tax revenue:</span>
-            <span className={styles.footerValue}>{formatMisk(unaccounted)}</span>
+            <span className={styles.footerValue}>{formatIsk(unaccounted)}</span>
             <span>Clone revenue:</span>
-            <span className={styles.footerValue}>{formatMisk(cloneRevenue)}</span>
+            <span className={styles.footerValue}>{formatKisk(cloneRevenue)}</span>
           </div>
           <p className={styles.unaccountedNote}>
             <em>
@@ -347,7 +347,7 @@ const StructuresPage = async () => {
                         <span>{name}</span>
                         {corp && <span className={styles.payerCorp}>{corp}</span>}
                       </span>
-                      <span className={styles.footerValue}>{formatMisk(amount)}</span>
+                      <span className={styles.footerValue}>{formatIsk(amount)}</span>
                     </span>
                   )
                 })}

--- a/src/app/structure/revenue/page.tsx
+++ b/src/app/structure/revenue/page.tsx
@@ -3,7 +3,7 @@ import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
 import { DateTime } from '../../DateTime'
-import { formatMiskValue } from '../../isk'
+import { formatIskValue } from '../../isk'
 import { Name } from '../../names'
 import { fetchTypeNames } from '../../typeNames'
 import retro from '../../retro.module.css'
@@ -216,7 +216,7 @@ const RevenuePage = async ({ searchParams }: RevenueParams) => {
                 <tr>
                   <th>Timestamp</th>
                   <th>Payer</th>
-                  <th className={retro.num}>Amount (mISK)</th>
+                  <th className={retro.num}>Amount (ISK)</th>
                   <th>Structure</th>
                   <th>Output</th>
                 </tr>
@@ -239,7 +239,7 @@ const RevenuePage = async ({ searchParams }: RevenueParams) => {
                           {payerCorp && <span className={structureStyles.payerCorp}>{payerCorp}</span>}
                         </span>
                       </td>
-                      <td className={retro.num}>{formatMiskValue(entry.amount)}</td>
+                      <td className={retro.num}>{formatIskValue(entry.amount)}</td>
                       <td>
                         {structureId != null ? (
                           <Link href={`/structure/${structureId}`}>
@@ -267,7 +267,7 @@ const RevenuePage = async ({ searchParams }: RevenueParams) => {
                 <tr>
                   <th>Total</th>
                   <th />
-                  <th className={retro.num}>{formatMiskValue(dayTotal)}</th>
+                  <th className={retro.num}>{formatIskValue(dayTotal)}</th>
                   <th />
                   <th />
                 </tr>


### PR DESCRIPTION
## Summary
- Every monetary display was previously labeled "mISK" but the shared formatter (`src/app/isk.ts`) never actually divided by a million — it just showed raw ISK mislabeled as millions. Fixed it to genuinely scale by 1,000 (kISK) and added a parallel raw-ISK formatter.
- Applied the corrected kISK formatting consistently: market recent sales (unit/total price), market overview (top sellers, sales-over-time tooltips), the character wallet balance (previously its own 2-decimal ISK-only formatter), and structure clone-bay revenue.
- Kept structure taxable events (industry job tax, on `/structure`'s per-structure Revenue / Unaccounted tax revenue / payer breakdown, and the whole `/structure/revenue` tax ledger) in raw ISK, since that's the exact tax amount operators care about.

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [ ] Manually verify `/market`, `/character`, `/structure`, and `/structure/revenue` render the expected units (no local Supabase data available in this environment)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TS54Wvzw3StUnBe8yVKKZC)_