### PR TITLE
Signal decommissioned PDS to AT Protocol crawlers via /xrpc catch-all

### DIFF
--- a/src/app/xrpc/[method]/route.ts
+++ b/src/app/xrpc/[method]/route.ts
@@ -11,7 +11,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 const MESSAGE =
-  'This host is not an AT Protocol PDS. edencom.link (including pds.edencom.link) previously ran a PDS, which has been permanently decommissioned; please remove it from your crawl/relay list.'
+  'This host, edencom.link (including pds.edencom.link) previously ran an ATProto PDS. It might again in the future, but is currently decommissioned; please remove it from your crawl/relay list.'
 
 const swallow = async (request: NextRequest, params: Promise<{ method: string }>) => {
   const { method } = await params

--- a/src/app/xrpc/[method]/route.ts
+++ b/src/app/xrpc/[method]/route.ts
@@ -1,0 +1,25 @@
+// edencom.link (and pds.edencom.link) used to run an AT Protocol PDS. That PDS
+// was decommissioned, but relays/crawlers that discovered it keep polling
+// well-known XRPC methods (com.atproto.sync.subscribeRepos,
+// com.atproto.server.describeServer, ...) indefinitely. Without this route
+// those requests fall through to the app's default 404, which renders the
+// full root layout (theme resolution, header, footer) for every bot request.
+//
+// This route answers every /xrpc/<method> request directly, with the
+// AT Protocol XRPC error shape a well-behaved client/relay recognizes for an
+// unimplemented method, so crawlers can tell this host is no longer a PDS.
+import { NextRequest, NextResponse } from 'next/server'
+
+const MESSAGE =
+  'This host is not an AT Protocol PDS. edencom.link (including pds.edencom.link) previously ran a PDS, which has been permanently decommissioned; please remove it from your crawl/relay list.'
+
+const swallow = async (request: NextRequest, params: Promise<{ method: string }>) => {
+  const { method } = await params
+  console.log(`xrpc: rejecting decommissioned-pds request host=${request.headers.get('host')} method=${method}`)
+  return NextResponse.json({ error: 'MethodNotImplemented', message: MESSAGE }, { status: 501 })
+}
+
+type Context = { params: Promise<{ method: string }> }
+
+export const GET = (request: NextRequest, { params }: Context) => swallow(request, params)
+export const POST = (request: NextRequest, { params }: Context) => swallow(request, params)


### PR DESCRIPTION
## Summary
- This domain (and `pds.edencom.link`) used to run an AT Protocol PDS. Relays/crawlers still poll `com.atproto.sync.subscribeRepos` and `com.atproto.server.describeServer` on it, presumably from that history.
- Those requests currently fall through to the app's default 404, which renders the full root layout (theme resolution, header, footer) for every bot hit — wasted compute for pure bot noise.
- Adds `src/app/xrpc/[method]/route.ts`, a single dynamic-segment route handler that answers **any** `/xrpc/<method>` request (XRPC methods are always one path segment) with the AT Protocol XRPC `MethodNotImplemented` error shape (`501`), including a message stating the PDS has been permanently decommissioned. This is the standard AT Protocol convention for "this server doesn't implement that method," which well-behaved relays use as the signal to stop treating the host as a PDS.
- Logs `host` + `method` for each swallowed request, so it's easy to confirm from Vercel logs whether these hits are indeed landing on `pds.edencom.link`.

## Test plan
- [x] `pnpm run lint` (pre-existing unrelated warning only)
- [x] `pnpm run build`
- [x] `pnpm start` + `curl -H "Host: pds.edencom.link" /xrpc/com.atproto.server.describeServer` and `/xrpc/com.atproto.sync.subscribeRepos` → both return `501` with the expected JSON body


---
_Generated by [Claude Code](https://claude.ai/code/session_01U2MjWdYB6VUPibPsTp6B7o)_