### PR TITLE
Run corp industry jobs hourly; attribute heartbeat to character/corp/user

### DIFF
--- a/.github/workflows/corp-industry-jobs.yml
+++ b/.github/workflows/corp-industry-jobs.yml
@@ -3,7 +3,7 @@ name: Corp Industry Jobs
 on:
   workflow_dispatch:
   schedule:
-    - cron: '47 9 * * *'
+    - cron: '47 * * * *'
 
 jobs:
   refresh:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,14 +181,14 @@ One job per ESI endpoint. The npm script, queue job name, and heartbeat job labe
 | `corp-blueprints` | `/corporations/{id}/blueprints/` | `corp_blueprint_over_time` | 09:07 daily |
 | `corp-wallet-journal` | `/corporations/{id}/wallets/{division}/journal/` | `corp_wallet_journal` | hourly `:37` |
 | `corp-wallet-transactions` | `/corporations/{id}/wallets/{division}/transactions/` | `corp_wallet_transaction` | hourly `:50` |
-| `corp-industry-jobs` | `/corporations/{id}/industry/jobs/` | `corp_industry_job` | 09:47 daily |
+| `corp-industry-jobs` | `/corporations/{id}/industry/jobs/` | `corp_industry_job` | hourly `:47` |
 | `industry-systems` | `/industry/systems/` | `industry_system_index` (systems with structures ∪ user-watched systems) | hourly `:10` |
 | `universe-names` | `/universe/names/` | `universe_name` | hourly `:58` |
 | `universe-structures` | `/universe/structures/{id}` | `universe_structure` | 09:57 daily |
 
 `src/heartbeat.js` (`heartbeat.yml`, 10:55 daily) is a canary that just proves heartbeat recording works.
 
-The per-character jobs (`character-*` except `character-affiliations`, plus `corp-wallet-transactions`) are also dispatched on demand via the Vercel queue at `/api/queue/jobs` (the "Refresh ESI" flow), fanned out one message per character; `character-affiliations` and `universe-names` are dispatched once account-wide. The daily corp jobs (including `corp-blueprints`) and `industry-systems` are cron-only — they do whole-corp/whole-universe work that isn't character-scoped.
+The per-character jobs (`character-*` except `character-affiliations`, plus `corp-wallet-transactions`, `corp-assets`, `corp-industry-jobs`) are also dispatched on demand via the Vercel queue at `/api/queue/jobs` (the "Refresh ESI" flow), fanned out one message per character; `character-affiliations` and `universe-names` are dispatched once account-wide. The remaining daily corp jobs (`corp-structures`, `corp-blueprints`, `corp-wallet-journal`) and `industry-systems` are cron-only — they do whole-corp/whole-universe work that isn't character-scoped.
 
 `industry-systems` runs on Vercel Cron rather than GitHub Actions: `vercel.json`'s `crons` entry hits `src/app/api/cron/industry-systems/route.ts` hourly at `:10`, which checks the `Authorization: Bearer $CRON_SECRET` header Vercel signs cron requests with, then calls `runIndustrySystems()` and records its own start/end heartbeat (`source: 'vercel-cron'`) — mirroring how the queue consumer heartbeats account-wide jobs. Requires a `CRON_SECRET` env var set in Vercel (see `.env.example`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,8 +88,8 @@ All functions take `(accessToken, id, ...)` unless noted. Returns raw ESI respon
 - `characterAffiliations(characterIds[])` — bulk character→corp mapping (no auth)
 
 ### `src/jobs/lib.js` — shared extract-job plumbing
-- `forEachCharacter(tag, { scope, characterIds }, handler)` — iterate tokens carrying an ESI scope, refresh each, call handler with `{ access_token, characterID, character_id, name, ctx }`
-- `forEachCorporation(tag, { scope, characterIds }, handler)` — same, deduped to one handler call per corporation; also keeps `registration.corporation_id` fresh (corp-table RLS keys off it)
+- `forEachCharacter(tag, { scope, characterIds, heartbeat = true }, handler)` — iterate tokens carrying an ESI scope, refresh each, call handler with `{ access_token, characterID, character_id, userId, name, ctx }`. Wraps each call in a start/end `heartbeat` row attributed to that character (`character_id`/`user_id`) unless `heartbeat: false` (forEachCorporation passes this to avoid a redundant row)
+- `forEachCorporation(tag, { scope, characterIds }, handler)` — same, deduped to one handler call per corporation; also keeps `registration.corporation_id` fresh (corp-table RLS keys off it). Wraps each call in its own start/end `heartbeat` row attributed to the corp and the character whose token authorized the pull (`corporation_id`/`character_id`/`user_id`)
 - `fetchAllPages(fetchPage)` — drain an x-pages-paginated ESI endpoint
 - `forEachSequential(items, fn)` — the jobs' ramda-based stand-in for `for (const x of items) { await fn(x) }`; runs `fn` once per item in order, awaiting each before the next
 - `cli(import.meta.url, tag, run)` — self-run a job module when invoked directly as a CLI
@@ -97,7 +97,7 @@ All functions take `(accessToken, id, ...)` unless noted. Returns raw ESI respon
 ### `src/supabase.js` — Supabase clients and DB helpers
 - `supabase` — anon client (respects RLS)
 - `sudoSupabase` — service-role client (bypasses RLS; use in cron only)
-- `recordHeartbeat(job, phase, opts)` — write heartbeat row
+- `recordHeartbeat(job, phase, opts)` — write a heartbeat row; `opts.characterId`/`corporationId`/`userId` attribute it to the entity a per-character/per-corp job ran for (omit for whole-job/account-wide runs). The start/end pair upserts onto one row keyed on `job, run_id, run_attempt, owner_key` — `owner_key` is a generated column folding `character_id`/`corporation_id` into a single non-null discriminator so per-entity rows within the same run pair correctly instead of collapsing onto each other
 - `authenticate(token)` — verify user session token
 - `upsertCharacter(characterId, name, ownerId, corporationId)` — insert/update registration row
 - `upsertToken(characterId, accessToken, refreshToken, issuedAt, expiresAt, scope[])` — store OAuth tokens
@@ -223,7 +223,7 @@ The per-character jobs (`character-*` except `character-affiliations`, plus `cor
 | `user_settings` | User preferences | `user_id`, `enabled_scopes[]`, `api_token` (unique), `flags[]` |
 | `invite_code` | Invite-only registration | `code` (unique), `created_by`, `redeemed_by`, `redeemed_at` |
 | `refresh_task` | On-demand job tracking | `batch_id`, `user_id`, `job`, `character_id`, `status` (pending/running/done/error) |
-| `heartbeat` | Cron job monitoring | `job`, `run_id`, `started_at`, `ended_at` |
+| `heartbeat` | Cron job monitoring | `job`, `run_id`, `started_at`, `ended_at`, `duration` (generated), `character_id`, `corporation_id`, `user_id`, `owner_key` (generated) |
 
 Key Postgres functions (callable via RPC or SQL):
 - `character_asset_location_summary()` — aggregate character assets per location

--- a/schema.sql
+++ b/schema.sql
@@ -499,29 +499,53 @@ grant execute on function public.character_blueprints(uuid[]) to service_role;
 -- One row per scheduled-job run. Workflows write a 'start' step (stamps
 -- started_at) and an 'end' step (stamps ended_at), both keyed on the GitHub
 -- Actions run so they land on the same row. run_url links back to that run.
+-- character_id/corporation_id/user_id attribute a run to the entity a
+-- per-character or per-corp job processed it for (null for whole-job/
+-- account-wide runs, e.g. universe-names); owner_key folds those two
+-- nullable columns into a single non-null discriminator so the start/end
+-- upsert still pairs correctly per entity (see recordHeartbeat).
 create table public.heartbeat (
   id uuid primary key default gen_random_uuid(),
   job text not null,
   run_id bigint,
   run_attempt integer,
   run_url text,
+  character_id uuid references public.registration(id) on delete cascade,
+  corporation_id bigint,
+  user_id uuid references auth.users(id) on delete cascade,
+  owner_key text generated always as (coalesce(character_id::text, '') || '|' || coalesce(corporation_id::text, '')) stored,
   started_at timestamptz,
   ended_at timestamptz,
+  -- How long the run took for that job/entity; null until ended_at lands.
+  duration interval generated always as (ended_at - started_at) stored,
   ran_at timestamptz not null default now()
 );
 -- Pairs the start/end steps of a single run onto one row. Local runs (no run
 -- id) fall back to plain inserts, and Postgres keeps null keys distinct.
-create unique index heartbeat_run_idx on public.heartbeat (job, run_id, run_attempt);
+create unique index heartbeat_run_idx on public.heartbeat (job, run_id, run_attempt, owner_key);
 create index heartbeat_ran_at_idx on public.heartbeat (ran_at desc);
 -- Lets the UI find a job's most recent completion with an index scan.
 create index heartbeat_job_ended_at_idx on public.heartbeat (job, ended_at desc);
+create index heartbeat_character_id_idx on public.heartbeat (character_id);
+create index heartbeat_corporation_id_idx on public.heartbeat (corporation_id);
 
 alter table public.heartbeat enable row level security;
+-- Whole-job/account-wide rows (user_id null) are visible to everyone signed
+-- in, same as before this table carried any owner info. A per-character row
+-- is visible to the owning user; a per-corp row to anyone with a character
+-- in that corp — mirroring the corp_structure/corp_asset RLS convention.
 create policy "Authenticated read heartbeat"
   on public.heartbeat
   for select
   to authenticated
-  using (true);
+  using (
+    user_id is null
+    or user_id = (select auth.uid())
+    or corporation_id in (
+      select corporation_id from public.registration
+      where user_id = (select auth.uid()) and corporation_id is not null
+    )
+  );
 
 grant select on public.heartbeat to authenticated;
 grant all    on public.heartbeat to service_role;

--- a/src/app/api/queue/jobs/route.ts
+++ b/src/app/api/queue/jobs/route.ts
@@ -111,7 +111,10 @@ export const POST = handleCallback(async (message: Msg) => {
       return
     }
     // Account-wide jobs consume a single whole-job message, so the consumer records
-    // their heartbeat (the per-character producers record their own at enqueue time).
+    // their heartbeat here. Per-character/per-corp jobs record their own instead,
+    // one row per character/corp attributed via character_id/corporation_id/user_id
+    // (see withHeartbeat in src/jobs/lib.js), regardless of whether this queue or a
+    // GitHub Actions cron invoked them.
     const { recordHeartbeat } = await import('@/supabase.js')
     const runId = randomInt(1, 2 ** 48)
     await recordHeartbeat(job, 'start', { runId, source: 'vercel' })

--- a/src/app/character/dispatchRefresh.ts
+++ b/src/app/character/dispatchRefresh.ts
@@ -3,11 +3,13 @@ import { randomUUID } from 'node:crypto'
 // The per-character ESI extracts a refresh fans out, one queue message per
 // character each. Each job is named after the ESI endpoint it extracts.
 //
-// The daily corp jobs (corp-structures, corp-assets, corp-blueprints,
-// corp-wallet-journal, corp-industry-jobs) are deliberately NOT here: they do
-// whole-corp work that a per-character fan-out would just redo once per
-// character, and the heavier ones blow past the 60s queue function limit.
-// They run on their own GitHub Actions crons instead.
+// corp-assets and corp-industry-jobs are included so a newly added character's
+// corp data shows up immediately rather than waiting for the next cron. The
+// remaining daily corp jobs (corp-structures, corp-blueprints,
+// corp-wallet-journal) are deliberately NOT here: they do whole-corp work that
+// a per-character fan-out would just redo once per character, and running
+// them on every character add isn't worth the extra load. They run on their
+// own GitHub Actions crons instead.
 const PER_CHARACTER_JOBS = [
   'character-assets',
   'character-blueprints',
@@ -16,6 +18,8 @@ const PER_CHARACTER_JOBS = [
   'character-wallet-transactions',
   'character-industry-jobs',
   'corp-wallet-transactions',
+  'corp-assets',
+  'corp-industry-jobs',
 ] as const
 
 // Account-wide batch jobs (they process every registration at once), dispatched

--- a/src/jobs/lib.js
+++ b/src/jobs/lib.js
@@ -1,9 +1,28 @@
+import { randomInt } from 'node:crypto'
 import { fileURLToPath } from 'node:url'
 import { range, reduce } from 'ramda'
 
 import { character as fetchCharacter } from '../esi.js'
-import { sudoSupabase } from '../supabase.js'
+import { recordHeartbeat, sudoSupabase } from '../supabase.js'
 import { refreshAccessToken } from '../tokenRefresh.js'
+
+// Wraps one character/corp's worth of work with a start/end heartbeat pair so
+// its duration can be attributed to that entity (see recordHeartbeat's
+// characterId/corporationId/userId). A fresh runId per call keeps this pairing
+// independent of any GITHUB_RUN_ID — every character/corp handled in a single
+// job invocation gets its own row, whether that invocation loops over many
+// (a GitHub Actions cron) or just one (a Vercel queue message dispatched for a
+// single character). Runs fn even if the heartbeat write fails; always records
+// the end heartbeat, success or failure, so a thrown error still has a duration.
+const withHeartbeat = async (tag, owner, fn) => {
+  const runId = randomInt(1, 2 ** 48)
+  await recordHeartbeat(tag, 'start', { runId, ...owner })
+  try {
+    return await fn()
+  } finally {
+    await recordHeartbeat(tag, 'end', { runId, ...owner })
+  }
+}
 
 // Shared plumbing for the per-endpoint extract jobs. Every job follows the same
 // shape: enumerate the tokens carrying the endpoint's ESI scope (optionally
@@ -27,15 +46,23 @@ export const forEachSequential = (items, fn) =>
   reduce((settled, item) => settled.then(() => fn(item)), Promise.resolve(), items)
 
 // Iterate the tokens that carry `scope`, calling handler once per token with
-// { access_token, characterID, character_id, name, ctx }. `characterID` is the
-// EVE character id from the token; `character_id` is the registration uuid.
-export const forEachCharacter = async (tag, { scope, characterIds }, handler) => {
-  const { data: characters, error: charactersError } = await sudoSupabase.from('registration').select('id, name')
+// { access_token, characterID, character_id, userId, name, ctx }. `characterID`
+// is the EVE character id from the token; `character_id` is the registration
+// uuid. Each call is wrapped in a start/end heartbeat attributed to that
+// character (job/character_id/user_id), unless `heartbeat: false` — set by
+// forEachCorporation, which records its own corp-attributed heartbeat instead
+// so a corp job doesn't get two rows (one bare-character, one per-corp) for
+// the same unit of work.
+export const forEachCharacter = async (tag, { scope, characterIds, heartbeat = true }, handler) => {
+  const { data: characters, error: charactersError } = await sudoSupabase
+    .from('registration')
+    .select('id, name, user_id')
   if (charactersError) {
     console.error(`[${tag}] character lookup failed:`, charactersError)
     throw charactersError
   }
   const characterName = new Map((characters ?? []).map((c) => [c.id, c.name]))
+  const characterUserId = new Map((characters ?? []).map((c) => [c.id, c.user_id]))
 
   let tokenQuery = sudoSupabase.from('token').select('id, character_id, refresh_token').contains('scope', [scope])
   if (characterIds) tokenQuery = tokenQuery.in('character_id', characterIds)
@@ -49,6 +76,7 @@ export const forEachCharacter = async (tag, { scope, characterIds }, handler) =>
 
   await forEachSequential(tokens ?? [], async (tokenRow) => {
     const name = characterName.get(tokenRow.character_id) ?? '?'
+    const userId = characterUserId.get(tokenRow.character_id) ?? null
     const ctx = `character=${name} (${tokenRow.character_id}) token=${tokenRow.id}`
     const t0 = Date.now()
     try {
@@ -57,7 +85,13 @@ export const forEachCharacter = async (tag, { scope, characterIds }, handler) =>
         console.error(`[${tag}] ${ctx}: refreshed token no longer has ${scope}, skipping`)
         return
       }
-      await handler({ access_token, characterID, character_id: tokenRow.character_id, name, ctx })
+      const run = () =>
+        handler({ access_token, characterID, character_id: tokenRow.character_id, userId, name, ctx })
+      if (heartbeat) {
+        await withHeartbeat(tag, { characterId: tokenRow.character_id, userId }, run)
+      } else {
+        await run()
+      }
     } catch (e) {
       const dt = Date.now() - t0
       console.error(`[${tag}] ${ctx}: FAILED after ${dt}ms name=${e?.name} message=${e?.message}\n${e?.stack ?? e}`)
@@ -69,30 +103,40 @@ export const forEachCharacter = async (tag, { scope, characterIds }, handler) =>
 // handler once per corporation with { access_token, corporation_id, character_id,
 // ctx }. Two characters in the same corp resolve to one handler call per run.
 // Also keeps registration.corporation_id fresh — the corp tables' RLS policies
-// key off it. Returns the set of corporation ids handled.
+// key off it. Returns the set of corporation ids handled. The handler call is
+// wrapped in a start/end heartbeat attributed to the corp (and the character
+// whose token authorized the pull, so "which user" is derivable too); the
+// inner forEachCharacter's own per-character heartbeat is disabled to avoid a
+// redundant second row for the same unit of work.
 export const forEachCorporation = async (tag, { scope, characterIds }, handler) => {
   const seenCorps = new Set()
-  await forEachCharacter(tag, { scope, characterIds }, async ({ access_token, characterID, character_id, ctx }) => {
-    const info = await fetchCharacter(access_token, characterID)
-    const corporation_id = info?.corporation_id
-    if (!corporation_id) {
-      console.error(`[${tag}] ${ctx}: character payload missing corporation_id`)
-      return
+  await forEachCharacter(
+    tag,
+    { scope, characterIds, heartbeat: false },
+    async ({ access_token, characterID, character_id, userId, ctx }) => {
+      const info = await fetchCharacter(access_token, characterID)
+      const corporation_id = info?.corporation_id
+      if (!corporation_id) {
+        console.error(`[${tag}] ${ctx}: character payload missing corporation_id`)
+        return
+      }
+      const { error: charUpdateErr } = await sudoSupabase
+        .from('registration')
+        .update({ corporation_id })
+        .eq('id', character_id)
+      if (charUpdateErr) {
+        console.error(`[${tag}] ${ctx}: registration.corporation_id update failed: ${charUpdateErr.message}`)
+      }
+      if (seenCorps.has(corporation_id)) {
+        console.log(`[${tag}] ${ctx}: corp ${corporation_id} already pulled this run, skipping`)
+        return
+      }
+      seenCorps.add(corporation_id)
+      await withHeartbeat(tag, { characterId: character_id, corporationId: corporation_id, userId }, () =>
+        handler({ access_token, corporation_id, character_id, ctx })
+      )
     }
-    const { error: charUpdateErr } = await sudoSupabase
-      .from('registration')
-      .update({ corporation_id })
-      .eq('id', character_id)
-    if (charUpdateErr) {
-      console.error(`[${tag}] ${ctx}: registration.corporation_id update failed: ${charUpdateErr.message}`)
-    }
-    if (seenCorps.has(corporation_id)) {
-      console.log(`[${tag}] ${ctx}: corp ${corporation_id} already pulled this run, skipping`)
-      return
-    }
-    seenCorps.add(corporation_id)
-    await handler({ access_token, corporation_id, character_id, ctx })
-  })
+  )
   return seenCorps
 }
 

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -40,15 +40,23 @@ const githubRun = () => {
 // two separate steps — once with phase "start" before the job and once with
 // "end" after — so each run is a single row stamped with started_at, ended_at,
 // and a link to the workflow run. The two steps of one GitHub run upsert onto
-// the same row (keyed on job + run id); run locally with no run id, each call is
-// a standalone insert. Returns true on success, false (after logging) on failure
-// so callers can decide whether a failed heartbeat should fail the whole step.
+// the same row (keyed on job + run id + owner_key); run locally with no run id,
+// each call is a standalone insert. Returns true on success, false (after
+// logging) on failure so callers can decide whether a failed heartbeat should
+// fail the whole step.
+//
+// opts.characterId/corporationId/userId attribute the row to the entity a
+// per-character or per-corp job ran for (see forEachCharacter/forEachCorporation
+// in src/jobs/lib.js, which pass these so a run's duration can later be broken
+// down per job/character-or-corp/user rather than just per whole job invocation).
+// Leave them unset for whole-job/account-wide jobs.
 export const recordHeartbeat = async (job, phase = 'end', opts = {}) => {
   // GitHub Actions path: derive run identity from the environment so the two steps
-  // of one workflow run land on a single row. Vercel queue path: the caller passes
-  // an explicit { runId } (and source: 'vercel'), so its start/end pair up the same
-  // way without a GITHUB_RUN_ID. run_id is bigint, so callers pass a bigint-safe id
-  // (not a UUID); a non-null sentinel run_attempt keeps the upsert key fully non-null.
+  // of one workflow run land on a single row. Vercel queue path (and the
+  // per-character/per-corp loops): the caller passes an explicit { runId } (and
+  // source: 'vercel'), so its start/end pair up the same way without a
+  // GITHUB_RUN_ID. run_id is bigint, so callers pass a bigint-safe id (not a
+  // UUID); a non-null sentinel run_attempt keeps the upsert key fully non-null.
   const gh = githubRun()
   const run_id = opts.runId != null ? Number(opts.runId) : gh.run_id
   const run_attempt = opts.runId != null ? 1 : gh.run_attempt
@@ -59,11 +67,16 @@ export const recordHeartbeat = async (job, phase = 'end', opts = {}) => {
     run_id,
     run_attempt,
     run_url,
+    character_id: opts.characterId ?? null,
+    corporation_id: opts.corporationId ?? null,
+    user_id: opts.userId ?? null,
     ...(phase === 'start' ? { started_at: now } : { ended_at: now }),
   }
   const table = sudoSupabase.from('heartbeat')
   const { error } =
-    run_id != null ? await table.upsert(row, { onConflict: 'job,run_id,run_attempt' }) : await table.insert(row)
+    run_id != null
+      ? await table.upsert(row, { onConflict: 'job,run_id,run_attempt,owner_key' })
+      : await table.insert(row)
   if (error) {
     console.error(`[heartbeat] failed to record "${job}" ${phase}:`, error)
     return false

--- a/supabase/migrations/20260705110000_heartbeat_owner_attribution.sql
+++ b/supabase/migrations/20260705110000_heartbeat_owner_attribution.sql
@@ -1,0 +1,42 @@
+-- Attribute a heartbeat row to the character/corp/user a per-character or
+-- per-corp job ran it for (null for whole-job/account-wide runs). owner_key
+-- folds the two nullable id columns into a single non-null discriminator so
+-- the start/end upsert (keyed on job, run_id, run_attempt, owner_key) still
+-- pairs correctly per entity instead of collapsing every character/corp in
+-- a run onto one row. duration is a convenience for "how long did this run
+-- take" once ended_at lands. Mirrors the columns added to schema.sql.
+alter table public.heartbeat
+  add column if not exists character_id uuid references public.registration(id) on delete cascade,
+  add column if not exists corporation_id bigint,
+  add column if not exists user_id uuid references auth.users(id) on delete cascade;
+
+alter table public.heartbeat
+  add column if not exists owner_key text
+    generated always as (coalesce(character_id::text, '') || '|' || coalesce(corporation_id::text, '')) stored;
+
+alter table public.heartbeat
+  add column if not exists duration interval generated always as (ended_at - started_at) stored;
+
+drop index if exists heartbeat_run_idx;
+create unique index if not exists heartbeat_run_idx on public.heartbeat (job, run_id, run_attempt, owner_key);
+create index if not exists heartbeat_character_id_idx on public.heartbeat (character_id);
+create index if not exists heartbeat_corporation_id_idx on public.heartbeat (corporation_id);
+
+-- Tighten the previously "any authenticated user can read every heartbeat
+-- row" policy now that rows can carry per-user/per-corp identity: whole-job
+-- rows (user_id null) stay visible to everyone, a per-character row is
+-- visible only to its owner, and a per-corp row to anyone with a character
+-- in that corp (mirrors the corp_structure/corp_asset RLS convention).
+drop policy if exists "Authenticated read heartbeat" on public.heartbeat;
+create policy "Authenticated read heartbeat"
+  on public.heartbeat
+  for select
+  to authenticated
+  using (
+    user_id is null
+    or user_id = (select auth.uid())
+    or corporation_id in (
+      select corporation_id from public.registration
+      where user_id = (select auth.uid()) and corporation_id is not null
+    )
+  );


### PR DESCRIPTION
## Summary

**Corp industry jobs cadence + on-demand dispatch**
- `corp-industry-jobs` moves from a daily `09:47` GitHub Actions cron to hourly `:47`, matching the cadence of its character-scoped counterpart (`character-industry-jobs`, hourly `:48`).
- `dispatchRefresh` (fired when a character is added, via `/character/callback`) now also fans out `corp-assets` and `corp-industry-jobs` per character, alongside the existing per-character jobs, so a newly linked character's corp assets and corp industry jobs populate immediately instead of waiting for their (now-hourly, but still not instant) crons.
- `corp-structures`, `corp-blueprints`, `corp-wallet-journal` stay cron-only as before — no change there.

**Heartbeat: attribute a run to character/corp/user, add duration**
- `heartbeat` previously recorded one start/end pair per whole job invocation, with no way to tell how long a per-character or per-corp job took for a specific entity. Added nullable `character_id`, `corporation_id`, `user_id` columns (unset for whole-job/account-wide runs like `universe-names`), plus a generated `owner_key` column that folds the two nullable id columns into a single non-null discriminator so the start/end upsert still pairs correctly per entity instead of every character/corp in a run collapsing onto one row. A generated `duration` column gives "how long did this run take" directly once `ended_at` lands.
- `forEachCharacter`/`forEachCorporation` (`src/jobs/lib.js`) now wrap each character/corp's unit of work in its own start/end heartbeat via a fresh per-call run id, independent of `GITHUB_RUN_ID` — covers both the GitHub Actions cron path and the Vercel queue's per-character/per-corp dispatch (previously unheartbeated there). Corp jobs record one row (character + corp + user) rather than a redundant inner character-only row plus an outer corp row.
- Tightened `heartbeat`'s RLS policy to match: whole-job rows (`user_id` null) stay visible to everyone signed in, a per-character row only to its owner, and a per-corp row to anyone with a character in that corp — mirroring the existing `corp_structure`/`corp_asset` convention.
- This lands the raw per-entity timing; computing job cadence per job/character-or-corp/user from it is follow-up work.
- Updated `CLAUDE.md`'s job schedule table, on-demand-dispatch description, and codebase map to match.

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] Verified the migration (column adds, generated `owner_key`/`duration`, index, RLS policy) against a local throwaway Postgres instance: confirmed the start/end upsert pairs correctly per character even when two characters share a `run_id`, and confirmed the RLS policy correctly hides another user's character-only heartbeat rows while surfacing account-wide and shared-corp rows
- [ ] Confirm the `corp-industry-jobs` workflow fires hourly after merge
- [ ] Add a character and confirm `refresh_task` rows (and `/character/refresh` status) include `corp-assets` and `corp-industry-jobs` for that character
- [ ] After the migration ships, confirm new `heartbeat` rows carry `character_id`/`corporation_id`/`user_id` and `duration` for a live cron/queue run
