### PR TITLE
Draw a midpoint reference line behind each sparkline

### DIFF
--- a/src/app/structure/sparkline.tsx
+++ b/src/app/structure/sparkline.tsx
@@ -87,6 +87,18 @@ export const Sparkline = ({ values, liveCount = values.length, label, updatedAt 
         role="img"
         aria-label={label ? `${label}, ${trend}` : trend}
       >
+        {/* Midpoint reference line, drawn behind the data so a perfectly flat
+            line (e.g. an index that never moves) sits right on top of it and
+            hides it rather than overlapping in a visible way. */}
+        <line
+          x1={pad}
+          y1={h / 2}
+          x2={w - pad}
+          y2={h / 2}
+          stroke="var(--line)"
+          strokeWidth={1}
+          vectorEffect="non-scaling-stroke"
+        />
         {live.length >= 2 && (
           <polyline
             points={live.join(' ')}


### PR DESCRIPTION
## Summary

- `Sparkline` (`src/app/structure/sparkline.tsx`, shared by `/structure` and `/indexes`) now draws a thin `var(--line)` horizontal reference line at the vertical midpoint of the chart, behind the data polylines.
- A perfectly flat line (an index that never moves, e.g. 0.14 → 0.14) sits exactly on that midpoint by construction (the displayed range is always centered on the actual value), so its data line draws on top of and fully hides the reference line — that's expected, not a bug.

## Test plan

- [x] `pnpm run lint` — clean (one pre-existing unrelated warning)
- [x] `pnpm run build` — succeeds
- [ ] Visual check on `/structure` and `/indexes` in a live deploy: reference line visible for indices with any real variance, hidden behind perfectly flat ones, and legible in both light and dark theme (`var(--line)` is already theme-aware)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017jJCZ2LguZeuiptQZUAGVq

---
_Generated by [Claude Code](https://claude.ai/code/session_017jJCZ2LguZeuiptQZUAGVq)_