### PR TITLE
Fix corp-scoped extract race that drops assets when a corp has multiple scoped characters

### DIFF
--- a/src/app/api/cron/corp-assets/route.ts
+++ b/src/app/api/cron/corp-assets/route.ts
@@ -1,12 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-import { fanOutPerCharacterCronJob, requireCronSecret } from '@/utils/cron'
+import { fanOutPerCorporationCronJob, requireCronSecret } from '@/utils/cron'
 
 const SCOPE = 'esi-assets.read_corporation_assets.v1'
 
 // Vercel Cron replacement for the old `corp-assets.yml` GitHub Action. Fans out one
-// Vercel queue message per scoped character, mirroring the on-demand "Refresh ESI"
-// flow, so this stays within the function duration limit regardless of account size.
+// Vercel queue message per corporation (deduped across its scoped characters — see
+// fanOutPerCorporationCronJob), so this stays within the function duration limit
+// regardless of account size without risking two concurrent reconciles racing for
+// the same corp.
 export const runtime = 'nodejs'
 export const maxDuration = 60
 
@@ -14,7 +16,7 @@ export async function GET(request: NextRequest) {
   const denied = requireCronSecret(request)
   if (denied) return denied
 
-  const dispatched = await fanOutPerCharacterCronJob('corp-assets', SCOPE)
+  const dispatched = await fanOutPerCorporationCronJob('corp-assets', SCOPE)
 
   return NextResponse.json({ ok: true, dispatched })
 }

--- a/src/app/api/cron/corp-industry-jobs/route.ts
+++ b/src/app/api/cron/corp-industry-jobs/route.ts
@@ -1,12 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-import { fanOutPerCharacterCronJob, requireCronSecret } from '@/utils/cron'
+import { fanOutPerCorporationCronJob, requireCronSecret } from '@/utils/cron'
 
 const SCOPE = 'esi-industry.read_corporation_jobs.v1'
 
 // Vercel Cron replacement for the old `corp-industry-jobs.yml` GitHub Action. Fans out
-// one Vercel queue message per scoped character, mirroring the on-demand "Refresh ESI"
-// flow, so this stays within the function duration limit regardless of account size.
+// one Vercel queue message per corporation (deduped across its scoped characters — see
+// fanOutPerCorporationCronJob) rather than one per character, so a corp with several
+// scoped characters doesn't get pulled redundantly every run.
 export const runtime = 'nodejs'
 export const maxDuration = 60
 
@@ -14,7 +15,7 @@ export async function GET(request: NextRequest) {
   const denied = requireCronSecret(request)
   if (denied) return denied
 
-  const dispatched = await fanOutPerCharacterCronJob('corp-industry-jobs', SCOPE)
+  const dispatched = await fanOutPerCorporationCronJob('corp-industry-jobs', SCOPE)
 
   return NextResponse.json({ ok: true, dispatched })
 }

--- a/src/app/api/cron/corp-wallet-transactions/route.ts
+++ b/src/app/api/cron/corp-wallet-transactions/route.ts
@@ -1,12 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-import { fanOutPerCharacterCronJob, requireCronSecret } from '@/utils/cron'
+import { fanOutPerCorporationCronJob, requireCronSecret } from '@/utils/cron'
 
 const SCOPE = 'esi-wallet.read_corporation_wallets.v1'
 
 // Vercel Cron replacement for the old `corp-wallet-transactions.yml` GitHub Action. Fans
-// out one Vercel queue message per scoped character, mirroring the on-demand "Refresh
-// ESI" flow, so this stays within the function duration limit regardless of account size.
+// out one Vercel queue message per corporation (deduped across its scoped characters —
+// see fanOutPerCorporationCronJob) rather than one per character, so a corp with several
+// scoped characters doesn't get pulled redundantly every run.
 export const runtime = 'nodejs'
 export const maxDuration = 60
 
@@ -14,7 +15,7 @@ export async function GET(request: NextRequest) {
   const denied = requireCronSecret(request)
   if (denied) return denied
 
-  const dispatched = await fanOutPerCharacterCronJob('corp-wallet-transactions', SCOPE)
+  const dispatched = await fanOutPerCorporationCronJob('corp-wallet-transactions', SCOPE)
 
   return NextResponse.json({ ok: true, dispatched })
 }

--- a/src/app/api/queue/jobs/route.ts
+++ b/src/app/api/queue/jobs/route.ts
@@ -88,20 +88,25 @@ const JOBS = {
 type JobName = keyof typeof JOBS
 
 // characterId is a registration uuid (per-character fan-out); absent runs the job
-// for everyone. taskId, when present, is a refresh_task row the "Refresh ESI" flow
-// tracks — the consumer flips it running -> done/error so /character/refresh can
-// show live status.
+// for everyone. characterIds carries more than one — used for the corp-scoped jobs,
+// where a single queue message covers every character known to carry the corp's
+// scope, so forEachCorporation (src/jobs/lib.js) can fall back to the next one if an
+// earlier character turns out to lack the in-game role the corp endpoint requires.
+// taskId, when present, is a refresh_task row the "Refresh ESI" flow tracks — the
+// consumer flips it running -> done/error so /character/refresh can show live status.
 type Msg = {
   job: JobName
   characterId?: string
+  characterIds?: string[]
   taskId?: string
 }
 
 // A thrown error fails the callback, so the Vercel queue retries the message
 // (per retryAfterSeconds in vercel.json).
 export const POST = handleCallback(async (message: Msg) => {
-  const { job, characterId, taskId } = message
-  console.log(`[queue/jobs] consume job=${job} characterId=${characterId ?? '-'} taskId=${taskId ?? '-'}`)
+  const { job, characterId, characterIds, taskId } = message
+  const ids = characterIds ?? (characterId != null ? [characterId] : undefined)
+  console.log(`[queue/jobs] consume job=${job} characterIds=${ids?.join(',') ?? '-'} taskId=${taskId ?? '-'}`)
 
   const entry = JOBS[job]
   if (!entry) throw new Error(`unknown job: ${String(job)}`)
@@ -109,7 +114,7 @@ export const POST = handleCallback(async (message: Msg) => {
   const runJob = async () => {
     const run = await entry.load()
     if (entry.characterIds) {
-      await run(characterId != null ? { characterIds: [characterId] } : undefined)
+      await run(ids ? { characterIds: ids } : undefined)
       return
     }
     // Account-wide jobs consume a single whole-job message, so the consumer records

--- a/src/app/character/dispatchRefresh.ts
+++ b/src/app/character/dispatchRefresh.ts
@@ -1,7 +1,28 @@
 import { randomUUID } from 'node:crypto'
 
+import { forEach, reduce } from 'ramda'
+
 // The per-character ESI extracts a refresh fans out, one queue message per
 // character each. Each job is named after the ESI endpoint it extracts.
+const PER_CHARACTER_JOBS = [
+  'character-assets',
+  'character-blueprints',
+  'character-orders',
+  'character-wallet',
+  'character-wallet-transactions',
+  'character-industry-jobs',
+] as const
+
+// Corp-scoped jobs pull one corp's whole asset/job/transaction set. Fanning one
+// message per character (like PER_CHARACTER_JOBS) risks two of the user's
+// characters in the same corp racing a concurrent reconcile for it — the
+// losing invocation's INSERT collides with the winner's already-committed row
+// (`duplicate key value violates unique constraint ..._current_item_idx`),
+// which can abort partway through with rows closed but never reopened, so real
+// items vanish until a later, non-racing run reinserts them (see
+// fanOutPerCorporationCronJob in src/utils/cron.ts, which has the same fix for
+// the cron-triggered path). Dedupe to the user's first scoped character per
+// corporation before dispatching.
 //
 // corp-assets and corp-industry-jobs are included so a newly added character's
 // corp data shows up immediately rather than waiting for the next cron. The
@@ -11,23 +32,34 @@ import { randomUUID } from 'node:crypto'
 // them on every character add isn't worth the extra load. They run on their
 // own Vercel Cron schedule instead (see src/app/api/cron/corp-structures,
 // corp-blueprints, corp-wallet-journal).
-const PER_CHARACTER_JOBS = [
-  'character-assets',
-  'character-blueprints',
-  'character-orders',
-  'character-wallet',
-  'character-wallet-transactions',
-  'character-industry-jobs',
-  'corp-wallet-transactions',
-  'corp-assets',
-  'corp-industry-jobs',
-] as const
+const PER_CORPORATION_JOBS = ['corp-wallet-transactions', 'corp-assets', 'corp-industry-jobs'] as const
 
 // Account-wide batch jobs (they process every registration at once), dispatched
 // once per refresh with no character.
 const ACCOUNT_JOBS = ['character-affiliations', 'universe-names'] as const
 
 type Character = { id: string; name: string | null }
+
+// Drop any character whose corporation is already represented by an earlier
+// character in the list. A character with no known corporation yet (a
+// brand-new registration whose corp hasn't been resolved) is always kept —
+// there's nothing to dedupe it against, and it's exactly the case
+// corp-assets/corp-industry-jobs need to run for right away.
+const oneCharacterPerCorporation = (characters: Character[], corporationById: Map<string, number | null>) => {
+  const seenCorps = new Set<number>()
+  return reduce(
+    (kept: Character[], c) => {
+      const corporationId = corporationById.get(c.id)
+      if (corporationId != null) {
+        if (seenCorps.has(corporationId)) return kept
+        seenCorps.add(corporationId)
+      }
+      return [...kept, c]
+    },
+    [] as Character[],
+    characters
+  )
+}
 
 // Run every on-demand ESI extract for the given characters: insert a
 // refresh_task row per unit of work (a per-character job for one character, or an
@@ -37,9 +69,37 @@ type Character = { id: string; name: string | null }
 // so callers must pass a userId they've already authorized.
 export const dispatchRefresh = async (userId: string, characters: Character[]): Promise<string> => {
   const batchId = randomUUID()
+
+  // Imported lazily so importing this module never pulls the service client / queue
+  // setup into a page bundle or `next build`.
+  const { sudoSupabase } = await import('@/supabase.js')
+
+  const corporationById = new Map<string, number | null>()
+  if (characters.length > 0) {
+    const { data: registrations, error: registrationsError } = await sudoSupabase
+      .from('registration')
+      .select('id, corporation_id')
+      .in(
+        'id',
+        characters.map((c) => c.id)
+      )
+    if (registrationsError) throw registrationsError
+    forEach((r) => corporationById.set(r.id, r.corporation_id), registrations ?? [])
+  }
+  const corpScopedCharacters = oneCharacterPerCorporation(characters, corporationById)
+
   const tasks = [
     ...PER_CHARACTER_JOBS.flatMap((job) =>
       characters.map((c) => ({
+        batch_id: batchId,
+        user_id: userId,
+        job,
+        character_id: c.id,
+        character_name: c.name,
+      }))
+    ),
+    ...PER_CORPORATION_JOBS.flatMap((job) =>
+      corpScopedCharacters.map((c) => ({
         batch_id: batchId,
         user_id: userId,
         job,
@@ -56,9 +116,6 @@ export const dispatchRefresh = async (userId: string, characters: Character[]): 
     })),
   ]
 
-  // Imported lazily so importing this module never pulls the service client / queue
-  // setup into a page bundle or `next build`.
-  const { sudoSupabase } = await import('@/supabase.js')
   const { data: inserted, error } = await sudoSupabase
     .from('refresh_task')
     .insert(tasks)

--- a/src/app/character/dispatchRefresh.ts
+++ b/src/app/character/dispatchRefresh.ts
@@ -19,10 +19,15 @@ const PER_CHARACTER_JOBS = [
 // losing invocation's INSERT collides with the winner's already-committed row
 // (`duplicate key value violates unique constraint ..._current_item_idx`),
 // which can abort partway through with rows closed but never reopened, so real
-// items vanish until a later, non-racing run reinserts them (see
-// fanOutPerCorporationCronJob in src/utils/cron.ts, which has the same fix for
-// the cron-triggered path). Dedupe to the user's first scoped character per
-// corporation before dispatching.
+// items vanish until a later, non-racing run reinserts them. So, like the
+// cron-triggered fan-out (fanOutPerCorporationCronJob in src/utils/cron.ts),
+// each of these queues exactly one message per corporation — see
+// dispatchRefresh below, which looks up every character (account-wide, not
+// just this batch) known to carry the job's scope for that corp and sends the
+// whole group, so forEachCorporation (src/jobs/lib.js) can fall back through
+// them if the one representative character chosen for the refresh_task/UI row
+// turns out to lack the in-game role — director, accountant, etc — the
+// endpoint separately requires.
 //
 // corp-assets and corp-industry-jobs are included so a newly added character's
 // corp data shows up immediately rather than waiting for the next cron. The
@@ -32,7 +37,11 @@ const PER_CHARACTER_JOBS = [
 // them on every character add isn't worth the extra load. They run on their
 // own Vercel Cron schedule instead (see src/app/api/cron/corp-structures,
 // corp-blueprints, corp-wallet-journal).
-const PER_CORPORATION_JOBS = ['corp-wallet-transactions', 'corp-assets', 'corp-industry-jobs'] as const
+const PER_CORPORATION_JOBS = [
+  { job: 'corp-wallet-transactions', loadScope: async () => (await import('@/jobs/corpWalletTransactions.js')).SCOPE },
+  { job: 'corp-assets', loadScope: async () => (await import('@/jobs/corpAssets.js')).SCOPE },
+  { job: 'corp-industry-jobs', loadScope: async () => (await import('@/jobs/corpIndustryJobs.js')).SCOPE },
+] as const
 
 // Account-wide batch jobs (they process every registration at once), dispatched
 // once per refresh with no character.
@@ -44,7 +53,10 @@ type Character = { id: string; name: string | null }
 // character in the list. A character with no known corporation yet (a
 // brand-new registration whose corp hasn't been resolved) is always kept —
 // there's nothing to dedupe it against, and it's exactly the case
-// corp-assets/corp-industry-jobs need to run for right away.
+// corp-assets/corp-industry-jobs need to run for right away. This only picks
+// the representative character for the refresh_task/UI row — the actual queue
+// message sent for that task carries every scoped character for the corp, not
+// just this one (see dispatchRefresh below).
 const oneCharacterPerCorporation = (characters: Character[], corporationById: Map<string, number | null>) => {
   const seenCorps = new Set<number>()
   return reduce(
@@ -88,6 +100,19 @@ export const dispatchRefresh = async (userId: string, characters: Character[]): 
   }
   const corpScopedCharacters = oneCharacterPerCorporation(characters, corporationById)
 
+  // For each corp-scoped job, group every account-wide character carrying its
+  // scope by corporation, so the message sent for a corp's task isn't limited
+  // to just the one representative character chosen above.
+  const { groupCharacterIdsByCorporation } = await import('@/supabase.js')
+  const corpGroupsByJob = new Map<string, Map<number, string[]>>()
+  await Promise.all(
+    PER_CORPORATION_JOBS.map(async ({ job, loadScope }) => {
+      const scope = await loadScope()
+      const { byCorp } = await groupCharacterIdsByCorporation([scope])
+      corpGroupsByJob.set(job, byCorp)
+    })
+  )
+
   const tasks = [
     ...PER_CHARACTER_JOBS.flatMap((job) =>
       characters.map((c) => ({
@@ -98,7 +123,7 @@ export const dispatchRefresh = async (userId: string, characters: Character[]): 
         character_name: c.name,
       }))
     ),
-    ...PER_CORPORATION_JOBS.flatMap((job) =>
+    ...PER_CORPORATION_JOBS.flatMap(({ job }) =>
       corpScopedCharacters.map((c) => ({
         batch_id: batchId,
         user_id: userId,
@@ -124,9 +149,21 @@ export const dispatchRefresh = async (userId: string, characters: Character[]): 
     throw error
   }
 
+  // A corp-scoped task's message carries every scoped character for its
+  // corporation (see corpGroupsByJob above); every other task's message
+  // carries just its own single character (or none, for the account-wide jobs).
+  const characterIdsForTask = (t: { job: string; character_id: string | null }): string[] | undefined => {
+    if (t.character_id == null) return undefined
+    const byCorp = corpGroupsByJob.get(t.job)
+    if (!byCorp) return [t.character_id]
+    const corporationId = corporationById.get(t.character_id)
+    if (corporationId == null) return [t.character_id]
+    return byCorp.get(corporationId) ?? [t.character_id]
+  }
+
   const { send } = await import('@/utils/queue')
   const sent = await Promise.all(
-    (inserted ?? []).map((t) => send('jobs', { job: t.job, characterId: t.character_id ?? undefined, taskId: t.id }))
+    (inserted ?? []).map((t) => send('jobs', { job: t.job, characterIds: characterIdsForTask(t), taskId: t.id }))
   )
   console.log(
     `[dispatchRefresh] enqueued ${sent.length} jobs to topic "jobs" region=${process.env.QUEUE_REGION ?? 'sfo1'}`

--- a/src/jobs/corpAssets.js
+++ b/src/jobs/corpAssets.js
@@ -5,7 +5,7 @@ import { sudoSupabase } from '../supabase.js'
 import { cli, fetchAllPages, forEachCorporation, forEachSequential } from './lib.js'
 
 const TAG = 'corp-assets'
-const SCOPE = 'esi-assets.read_corporation_assets.v1'
+export const SCOPE = 'esi-assets.read_corporation_assets.v1'
 
 // GET /corporations/{id}/assets/ → corp_asset_over_time (SCD type 2) and
 // corp_structure_rig. ESI has no dedicated structure-fitting endpoint; rigs come

--- a/src/jobs/corpIndustryJobs.js
+++ b/src/jobs/corpIndustryJobs.js
@@ -3,7 +3,7 @@ import { sudoSupabase } from '../supabase.js'
 import { cli, fetchAllPages, forEachCorporation } from './lib.js'
 
 const TAG = 'corp-industry-jobs'
-const SCOPE = 'esi-industry.read_corporation_jobs.v1'
+export const SCOPE = 'esi-industry.read_corporation_jobs.v1'
 
 // GET /corporations/{id}/industry/jobs/ → corp_industry_job. Fetched with
 // include_completed, so finished jobs get their terminal status recorded too.

--- a/src/jobs/corpWalletTransactions.js
+++ b/src/jobs/corpWalletTransactions.js
@@ -3,7 +3,7 @@ import { sudoSupabase } from '../supabase.js'
 import { cli, forEachCorporation, forEachSequential } from './lib.js'
 
 const TAG = 'corp-wallet-transactions'
-const SCOPE = 'esi-wallet.read_corporation_wallets.v1'
+export const SCOPE = 'esi-wallet.read_corporation_wallets.v1'
 
 const WALLET_DIVISIONS = [1, 2, 3, 4, 5, 6, 7]
 

--- a/src/jobs/lib.js
+++ b/src/jobs/lib.js
@@ -85,8 +85,7 @@ export const forEachCharacter = async (tag, { scope, characterIds, heartbeat = t
         console.error(`[${tag}] ${ctx}: refreshed token no longer has ${scope}, skipping`)
         return
       }
-      const run = () =>
-        handler({ access_token, characterID, character_id: tokenRow.character_id, userId, name, ctx })
+      const run = () => handler({ access_token, characterID, character_id: tokenRow.character_id, userId, name, ctx })
       if (heartbeat) {
         await withHeartbeat(tag, { characterId: tokenRow.character_id, userId }, run)
       } else {
@@ -101,13 +100,17 @@ export const forEachCharacter = async (tag, { scope, characterIds, heartbeat = t
 
 // Iterate the corporations reachable through tokens carrying `scope`, calling
 // handler once per corporation with { access_token, corporation_id, character_id,
-// ctx }. Two characters in the same corp resolve to one handler call per run.
+// ctx }. Two characters in the same corp resolve to one handler call per run —
+// unless the first one's call fails (most commonly a character that carries the
+// OAuth scope but lacks the in-game role — director, accountant, etc — the corp
+// endpoint itself requires), in which case the corp is left open for a later
+// character to try, rather than being silently skipped for the rest of the run.
 // Also keeps registration.corporation_id fresh — the corp tables' RLS policies
-// key off it. Returns the set of corporation ids handled. The handler call is
-// wrapped in a start/end heartbeat attributed to the corp (and the character
-// whose token authorized the pull, so "which user" is derivable too); the
-// inner forEachCharacter's own per-character heartbeat is disabled to avoid a
-// redundant second row for the same unit of work.
+// key off it. Returns the set of corporation ids successfully handled. The
+// handler call is wrapped in a start/end heartbeat attributed to the corp (and
+// the character whose token authorized the pull, so "which user" is derivable
+// too); the inner forEachCharacter's own per-character heartbeat is disabled to
+// avoid a redundant second row for the same unit of work.
 export const forEachCorporation = async (tag, { scope, characterIds }, handler) => {
   const seenCorps = new Set()
   await forEachCharacter(
@@ -131,10 +134,11 @@ export const forEachCorporation = async (tag, { scope, characterIds }, handler) 
         console.log(`[${tag}] ${ctx}: corp ${corporation_id} already pulled this run, skipping`)
         return
       }
-      seenCorps.add(corporation_id)
       await withHeartbeat(tag, { characterId: character_id, corporationId: corporation_id, userId }, () =>
         handler({ access_token, corporation_id, character_id, ctx })
       )
+      // Only mark the corp as handled once the pull actually succeeds.
+      seenCorps.add(corporation_id)
     }
   )
   return seenCorps

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -1,5 +1,5 @@
 import { createClient } from '@supabase/supabase-js'
-import { map, pluck, unnest } from 'ramda'
+import { forEach, map, pluck, unnest } from 'ramda'
 
 // The cron/GitHub Actions environment sets SUPABASE_URL / SUPABASE_KEY, but the
 // Vercel runtime only exposes the NEXT_PUBLIC_* vars (same project). This module
@@ -134,6 +134,42 @@ export const selectCharacterIdsWithScopes = async (scopes) => {
     }, scopes)
   )
   return [...new Set(unnest(perScope))]
+}
+
+// Every character carrying any of `scopes`, grouped by corporation — `byCorp`
+// maps corporation_id to the character ids known to belong to it; `unresolved`
+// lists characters whose corporation hasn't been resolved yet (brand-new
+// registrations). Used by the corp-scoped extract jobs (corp-assets,
+// corp-industry-jobs, corp-wallet-transactions) to fan out exactly one queue
+// message per corporation covering every character that might be able to
+// authorize the pull — some carry the OAuth scope without the in-game role
+// the ESI endpoint separately requires, and forEachCorporation (src/jobs/lib.js)
+// needs the full group to fall back through if the first one it tries can't.
+// Sending two *separate* messages for the same corp instead would race two
+// concurrent reconciles against each other and corrupt the SCD-2 tables.
+export const groupCharacterIdsByCorporation = async (scopes) => {
+  const characterIds = await selectCharacterIdsWithScopes(scopes)
+  if (characterIds.length === 0) return { byCorp: new Map(), unresolved: [] }
+
+  const { data: registrations, error } = await sudoSupabase
+    .from('registration')
+    .select('id, corporation_id')
+    .in('id', characterIds)
+  if (error) throw error
+
+  const byCorp = new Map()
+  const unresolved = []
+  forEach((r) => {
+    if (r.corporation_id == null) {
+      unresolved.push(r.id)
+      return
+    }
+    const group = byCorp.get(r.corporation_id)
+    if (group) group.push(r.id)
+    else byCorp.set(r.corporation_id, [r.id])
+  }, registrations ?? [])
+
+  return { byCorp, unresolved }
 }
 
 export const selectToken = async (character_id, scope = []) => {

--- a/src/utils/cron.ts
+++ b/src/utils/cron.ts
@@ -1,6 +1,7 @@
 import { randomInt } from 'node:crypto'
 
 import { NextRequest, NextResponse } from 'next/server'
+import { forEach } from 'ramda'
 
 // Shared plumbing for the /api/cron/* routes that replaced the old per-job
 // GitHub Actions schedules. Vercel signs cron requests with a
@@ -43,6 +44,42 @@ export const fanOutPerCharacterCronJob = async (job: string, scope: string) => {
   const characterIds = await selectCharacterIdsWithScopes([scope])
   await Promise.all(characterIds.map((characterId) => send('jobs', { job, characterId })))
   return characterIds.length
+}
+
+// For the corp-scoped extract jobs (corp-assets, corp-industry-jobs,
+// corp-wallet-transactions): fanning out per character, like
+// fanOutPerCharacterCronJob, can enqueue two concurrent messages for the same
+// corp when more than one of its characters carries the scope. Each message
+// independently reconciles that corp's whole asset/job/transaction set, and
+// the two invocations racing corrupts the data — one's INSERT collides with
+// the other's already-committed row (`duplicate key value violates unique
+// constraint ..._current_item_idx`), aborting the losing invocation partway
+// through with some rows already closed (is_current: false) but never
+// reopened, so real items vanish from the *_asset/*_blueprint views until a
+// later, non-racing run reinserts them. Dedupe to one character — and so one
+// queue message — per corporation to make that race impossible.
+export const fanOutPerCorporationCronJob = async (job: string, scope: string) => {
+  const { selectCharacterIdsWithScopes, sudoSupabase } = await import('@/supabase.js')
+  const { send } = await import('@/utils/queue')
+  const characterIds = await selectCharacterIdsWithScopes([scope])
+  if (characterIds.length === 0) return 0
+
+  const { data: registrations, error } = await sudoSupabase
+    .from('registration')
+    .select('id, corporation_id')
+    .in('id', characterIds)
+  if (error) throw error
+
+  const seenCorps = new Set<number>()
+  const picked: string[] = []
+  forEach((r: { id: string; corporation_id: number | null }) => {
+    if (r.corporation_id == null || seenCorps.has(r.corporation_id)) return
+    seenCorps.add(r.corporation_id)
+    picked.push(r.id)
+  }, registrations ?? [])
+
+  await Promise.all(picked.map((characterId) => send('jobs', { job, characterId })))
+  return picked.length
 }
 
 // For the account-wide extract jobs that already process every registration

--- a/src/utils/cron.ts
+++ b/src/utils/cron.ts
@@ -1,7 +1,6 @@
 import { randomInt } from 'node:crypto'
 
 import { NextRequest, NextResponse } from 'next/server'
-import { forEach } from 'ramda'
 
 // Shared plumbing for the /api/cron/* routes that replaced the old per-job
 // GitHub Actions schedules. Vercel signs cron requests with a
@@ -47,39 +46,33 @@ export const fanOutPerCharacterCronJob = async (job: string, scope: string) => {
 }
 
 // For the corp-scoped extract jobs (corp-assets, corp-industry-jobs,
-// corp-wallet-transactions): fanning out per character, like
-// fanOutPerCharacterCronJob, can enqueue two concurrent messages for the same
+// corp-wallet-transactions): fanning out one message per character, like
+// fanOutPerCharacterCronJob, can enqueue two *concurrent* messages for the same
 // corp when more than one of its characters carries the scope. Each message
-// independently reconciles that corp's whole asset/job/transaction set, and
-// the two invocations racing corrupts the data — one's INSERT collides with
-// the other's already-committed row (`duplicate key value violates unique
+// independently reconciles that corp's whole asset/job/transaction set, and the
+// two invocations racing corrupts the data — one's INSERT collides with the
+// other's already-committed row (`duplicate key value violates unique
 // constraint ..._current_item_idx`), aborting the losing invocation partway
 // through with some rows already closed (is_current: false) but never
 // reopened, so real items vanish from the *_asset/*_blueprint views until a
-// later, non-racing run reinserts them. Dedupe to one character — and so one
-// queue message — per corporation to make that race impossible.
+// later, non-racing run reinserts them.
+//
+// Group every scoped character by corporation instead, and send one message
+// per corp carrying *all* of its scoped characters. That's still exactly one
+// invocation per corp (no race), but forEachCorporation (src/jobs/lib.js) can
+// now try them in order and fall back to the next one if an earlier character
+// turns out to carry the OAuth scope without the in-game role — director,
+// accountant, etc — the corp endpoint separately requires; picking just one
+// character up front had no way to know which of them ESI would actually let
+// through.
 export const fanOutPerCorporationCronJob = async (job: string, scope: string) => {
-  const { selectCharacterIdsWithScopes, sudoSupabase } = await import('@/supabase.js')
+  const { groupCharacterIdsByCorporation } = await import('@/supabase.js')
   const { send } = await import('@/utils/queue')
-  const characterIds = await selectCharacterIdsWithScopes([scope])
-  if (characterIds.length === 0) return 0
+  const { byCorp, unresolved } = await groupCharacterIdsByCorporation([scope])
 
-  const { data: registrations, error } = await sudoSupabase
-    .from('registration')
-    .select('id, corporation_id')
-    .in('id', characterIds)
-  if (error) throw error
-
-  const seenCorps = new Set<number>()
-  const picked: string[] = []
-  forEach((r: { id: string; corporation_id: number | null }) => {
-    if (r.corporation_id == null || seenCorps.has(r.corporation_id)) return
-    seenCorps.add(r.corporation_id)
-    picked.push(r.id)
-  }, registrations ?? [])
-
-  await Promise.all(picked.map((characterId) => send('jobs', { job, characterId })))
-  return picked.length
+  const groups = [...byCorp.values(), ...unresolved.map((id: string) => [id])]
+  await Promise.all(groups.map((characterIds) => send('jobs', { job, characterIds })))
+  return groups.length
 }
 
 // For the account-wide extract jobs that already process every registration


### PR DESCRIPTION
## Summary

Root-causes and fixes the reported bug: `/asset/1054577764211` missing items (a freight container and 135 capital siege arrays).

**Race condition (commit 1):** `src/utils/cron.ts` and `dispatchRefresh.ts` (the "Refresh ESI" on-demand flow) both fanned `corp-assets`/`corp-industry-jobs`/`corp-wallet-transactions` out one Vercel queue message **per character**. A corp with more than one character carrying the relevant ESI scope gets **two concurrent queue invocations** independently reconciling the same corp's data. `corpAssets.js`'s SCD-2 `reconcile()` isn't safe against that: it closes superseded/vanished rows (`is_current: false`) in one step, then inserts their replacements in a later step. When two invocations race, the losing one's insert collides with the winner's already-committed row (`duplicate key value violates unique constraint "corp_asset_over_time_current_item_idx"`), throwing and aborting the losing invocation **after** its closes committed but **before** its inserts ran — so real items are left closed with no live replacement until a later, non-racing run reinserts them. Confirmed via Vercel's runtime error logs: this fired the morning after `#515` (ETL jobs → Vercel Cron) merged, for `corp-assets` specifically, at the exact daily cron time, with several concurrent `/api/queue/jobs` invocations for the same corp landing in the same second.

**Wrong-character fix, corrected (commit 2):** the first fix deduped to one queue message per corporation by picking an arbitrary scoped character to represent it. As pointed out in review: holding the OAuth scope isn't the same as holding the in-game ACL role (director, accountant, etc) the ESI corp endpoints separately require — confirmed by many `403 Character does not have required role(s)` errors across several corps in the same logs. Picking the wrong character up front would make that corp's data permanently fail to sync instead of just racing. This also surfaced a latent bug in `forEachCorporation` (`src/jobs/lib.js`): it marked a corp "already pulled" *before* calling the handler, so even a single invocation with several of the corp's characters available never retried after the first one's call failed.

## Fix

- `forEachCorporation` now only marks a corp handled once the pull actually **succeeds**, leaving it open for a later character to try otherwise.
- The per-corporation fan-out — `fanOutPerCorporationCronJob` (cron) and `dispatchRefresh` (on-demand) — now sends **every** scoped character for a corp in one message instead of just one representative, via a new shared `groupCharacterIdsByCorporation` (`src/supabase.js`). Still exactly one message per corp (the original race stays fixed), but `forEachCorporation` can now fall back through the group until one character with the actual in-game role succeeds.
- `corp-industry-jobs` and `corp-wallet-transactions` use `upsert()` and were never at risk of data loss from the race, but get the same grouping for consistency and resilience against the same role-permission gap.

## Recovery

No manual data repair needed — self-healing. The next successful `corp-assets` run for the affected corp will see the missing items in ESI's fetch, find no live `is_current` row for them, and reinsert them as new rows.

## Test plan

- [x] `pnpm run lint` — clean (one pre-existing unrelated warning)
- [x] `pnpm run build` — succeeds
- [ ] Confirm no more `duplicate key value violates unique constraint "corp_asset_over_time_current_item_idx"` errors in Vercel runtime logs after this deploys and the next `corp-assets` cron fires
- [ ] Confirm `/asset/1054577764211` shows the "Priority" freight container and capital siege arrays again after that run
- [ ] Confirm corps that were previously failing with `403 Character does not have required role(s)` on every scoped character now succeed via whichever one actually holds the role

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017jJCZ2LguZeuiptQZUAGVq