### PR TITLE
Retry corp wallet pulls on total division failure; show corp-wide jobs on the revenue page

### DIFF
--- a/src/app/structure/revenue/page.tsx
+++ b/src/app/structure/revenue/page.tsx
@@ -102,21 +102,33 @@ const RevenuePage = async ({ searchParams }: RevenueParams) => {
   // Each tax entry references its industry job via context_id
   // (context_id_type = industry_job_id); older entries may only carry the job
   // id inside the description text, so collect those numeric tokens too and
-  // let the lookup decide which token is really a job id (cf. /structure).
+  // let the lookup decide which token is really a job id (cf. /structure). The
+  // job's installer pays the tax, and they aren't necessarily one of this app's
+  // linked characters (character_industry_job only covers those) — anyone in the
+  // corp can run a job here, so corp_industry_job (pulled by a director,
+  // covering every corp member) is checked too.
   const jobIds = new Set<string>()
   for (const entry of entries) {
     if (entry.context_id != null) jobIds.add(String(entry.context_id))
     for (const token of entry.description?.match(/\d+/g) ?? []) jobIds.add(token)
   }
-  const { data: jobRows } = jobIds.size
-    ? await supabase
-        .from('character_industry_job')
-        .select('job_id, station_id, facility_id, runs, product_type_id')
-        .in('job_id', [...jobIds])
-    : { data: [] }
+  const [{ data: characterJobRows }, { data: corpJobRows }] = jobIds.size
+    ? await Promise.all([
+        supabase
+          .from('character_industry_job')
+          .select('job_id, station_id, facility_id, runs, product_type_id')
+          .in('job_id', [...jobIds]),
+        supabase
+          .from('corp_industry_job')
+          .select('job_id, station_id, facility_id, runs, product_type_id')
+          .in('job_id', [...jobIds]),
+      ])
+    : [{ data: [] }, { data: [] }]
 
   const jobById = new Map<string, JobRow>()
-  for (const j of (jobRows ?? []) as JobRow[]) jobById.set(String(j.job_id), j)
+  for (const j of [...((characterJobRows ?? []) as JobRow[]), ...((corpJobRows ?? []) as JobRow[])]) {
+    jobById.set(String(j.job_id), j)
+  }
 
   const jobForEntry = (entry: JournalRow): JobRow | undefined => {
     if (entry.context_id != null) {

--- a/src/jobs/corpWalletJournal.js
+++ b/src/jobs/corpWalletJournal.js
@@ -58,6 +58,7 @@ const fetchDivision = (access_token, corporation_id, division, cutoff) =>
 export const runCorpWalletJournal = ({ characterIds } = {}) =>
   forEachCorporation(TAG, { scope: SCOPE, characterIds }, async ({ access_token, corporation_id, ctx }) => {
     const cutoff = Date.now() - JOURNAL_LOOKBACK_MS
+    let failures = 0
     await forEachSequential(WALLET_DIVISIONS, async (division) => {
       try {
         const rows = await fetchDivision(access_token, corporation_id, division, cutoff)
@@ -69,9 +70,19 @@ export const runCorpWalletJournal = ({ characterIds } = {}) =>
         }
         console.log(`[${TAG}] ${ctx}: corp ${corporation_id} div ${division} ${rows.length} entries`)
       } catch (e) {
+        failures += 1
         console.error(`[${TAG}] ${ctx}: corp ${corporation_id} div ${division} FAILED message=${e?.message}`)
       }
     })
+    // Every division failing means this character can't read the corp's wallet at
+    // all — usually it carries the OAuth scope without the in-game role (director,
+    // accountant, etc) the endpoint separately requires — rather than one
+    // division's isolated problem. Throw so forEachCorporation (src/jobs/lib.js)
+    // leaves the corp open for a later, better-privileged character to try instead
+    // of marking it "handled" having pulled nothing.
+    if (failures === WALLET_DIVISIONS.length) {
+      throw new Error(`corp ${corporation_id}: all ${WALLET_DIVISIONS.length} wallet divisions failed`)
+    }
   })
 
 cli(import.meta.url, TAG, runCorpWalletJournal)

--- a/src/jobs/corpWalletTransactions.js
+++ b/src/jobs/corpWalletTransactions.js
@@ -20,6 +20,7 @@ export const runCorpWalletTransactions = ({ characterIds } = {}) =>
     TAG,
     { scope: SCOPE, characterIds },
     async ({ access_token, corporation_id, character_id, ctx }) => {
+      let failures = 0
       await forEachSequential(WALLET_DIVISIONS, async (division) => {
         try {
           const txns = await corpTransactions(access_token, corporation_id, division)
@@ -47,9 +48,19 @@ export const runCorpWalletTransactions = ({ characterIds } = {}) =>
           if (error) throw error
           console.log(`[${TAG}] ${ctx}: corp ${corporation_id} div ${division} ${rows.length} transactions`)
         } catch (e) {
+          failures += 1
           console.error(`[${TAG}] ${ctx}: corp ${corporation_id} div ${division} FAILED message=${e?.message}`)
         }
       })
+      // Every division failing means this character can't read the corp's wallet at
+      // all — usually it carries the OAuth scope without the in-game role (director,
+      // accountant, etc) the endpoint separately requires — rather than one
+      // division's isolated problem. Throw so forEachCorporation (src/jobs/lib.js)
+      // leaves the corp open for a later, better-privileged character to try instead
+      // of marking it "handled" having pulled nothing.
+      if (failures === WALLET_DIVISIONS.length) {
+        throw new Error(`corp ${corporation_id}: all ${WALLET_DIVISIONS.length} wallet divisions failed`)
+      }
     }
   )
 


### PR DESCRIPTION
## Summary

Investigating why `/structure/revenue?day=2026-07-05` wasn't showing a payer name or job details for one entry turned up two separate, confirmed bugs.

**1. corp-wallet-journal / corp-wallet-transactions never trigger the #518 role-fallback**

Both jobs isolate each of a corp's 7 wallet divisions in its own try/catch — by design, so one division's permissions edge doesn't abort the others. But that also means a character with **no** wallet role at all still "succeeds" from `forEachCorporation`'s point of view (every division fails, but nothing throws), permanently marking the corp handled for that run and blocking the retry-through-other-characters fallback #518 just added.

Confirmed in Vercel's runtime logs: corp `667531913`'s wallet journal has been stuck retrying the same role-less character (`Sinsayer Brutus`, 403 on all 7 divisions) every run since, while several other linked characters in the same corp (`Quuixote`, `Bato Cryno`, `Sir Cuddles`, ...) sit unused right behind it, logged as `already pulled this run, skipping`.

Fix: both jobs now throw when *every* division fails, so `forEachCorporation` falls through to the next character instead of stopping there.

**2. `/structure/revenue` only checked `character_industry_job`**

That table only covers characters who've individually linked to this app. A job run by any other corp member — the common case for industry tax entries, since tax is paid by whoever installed the job — only ever lands in `corp_industry_job` (pulled by a director, covering the whole corp). So the Structure/Output columns always showed `—` for those entries. Confirmed the specific job id from the report would only be findable there. The job lookup now checks both tables (verified `corp_industry_job`'s RLS policy already scopes read access to the caller's own corp, same as everywhere else).

Note: I also confirmed via a direct, unauthenticated call to ESI's public `/universe/names/` that the specific character id reported (`2121151117`) resolves fine to "Del Rissa" — that part isn't an ESI or resolver bug, and per Vercel logs `universe-names` has consistently reported "0 to resolve" for that corp's known journal parties in every recent run, meaning the name should already be cached. `/structure/[structureId]`'s own industry-jobs table has the same `character_industry_job`-only gap as `/structure/revenue` did — not fixed here since nobody reported it there, but worth knowing about if it comes up.

## Test plan

- [x] `pnpm run lint` — clean (one pre-existing unrelated warning)
- [x] `pnpm run build` — succeeds
- [ ] Confirm corp `667531913`'s wallet journal/transactions start advancing past the previously-stuck character on the next scheduled run
- [ ] Confirm `/structure/revenue?day=2026-07-05` now shows structure/output for the previously-blank entry

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017jJCZ2LguZeuiptQZUAGVq

---
_Generated by [Claude Code](https://claude.ai/code/session_017jJCZ2LguZeuiptQZUAGVq)_