### PR TITLE
Widen sparkline min-display range to 1%

### DIFF
--- a/src/app/structure/sparkline.tsx
+++ b/src/app/structure/sparkline.tsx
@@ -46,12 +46,12 @@ export const Sparkline = ({ values, liveCount = values.length, label, updatedAt 
   const w = 100
   const h = 20
   const pad = 1
-  // Cost indices are fractions (0.001 = 0.1%). When the real spread is tighter
+  // Cost indices are fractions (0.01 = 1%). When the real spread is tighter
   // than that, the line would look perfectly flat and hide the (tiny) trend —
-  // so we widen the displayed range to a fixed 0.1% centered on the actual
+  // so we widen the displayed range to a fixed 1% centered on the actual
   // midpoint, rather than the actual min/max, and use that widened range for
   // both the plotted line and the min/max labels beside it.
-  const MIN_DISPLAY_RANGE = 0.001
+  const MIN_DISPLAY_RANGE = 0.01
   const actualMin = Math.min(...values)
   const actualMax = Math.max(...values)
   const actualRange = actualMax - actualMin


### PR DESCRIPTION
## Summary
- Bump the shared `Sparkline` component's `MIN_DISPLAY_RANGE` from 0.001 (0.1%) to 0.01 (1%), so cost-index sparklines whose actual spread is tighter than 1% now display a fixed ±0.5% window centered on the midpoint instead of ±0.05%.
- This is the single shared component used by both the structure page and the indexes/watched-systems page, so both pick up the recalibrated range.

## Test plan
- [ ] Visually confirm sparklines on `/structure` and `/indexes` render with the new 1% floor for flat/near-flat cost index series


---
_Generated by [Claude Code](https://claude.ai/code/session_01PmVgHhU3QMsvLDe2sRkK8Z)_