### PR TITLE
Show character wallet balances in billions of ISK

### DIFF
--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -3,7 +3,7 @@ import { redirect } from 'next/navigation'
 import { reduce } from 'ramda'
 
 import { createClient } from '@/utils/supabase/server'
-import { formatKisk } from '../isk'
+import { formatBisk } from '../isk'
 import { register, refreshEsi, setMainCharacter } from './actions'
 import MainCharacterForm from './mainCharacterForm'
 import { requiredScopes } from './scopes'
@@ -67,7 +67,7 @@ const CharacterPage = async () => {
                 <div className={styles.name}>{c.name}</div>
                 <div className={styles.meta}>
                   <span className={styles.metaLabel}>ISK:</span>
-                  {latestBalance.has(c.id) ? formatKisk(latestBalance.get(c.id)!) : '—'}
+                  {latestBalance.has(c.id) ? formatBisk(latestBalance.get(c.id)!) : '—'}
                 </div>
                 <div className={styles.meta}>
                   <span className={styles.metaLabel}>Location:</span>

--- a/src/app/isk.ts
+++ b/src/app/isk.ts
@@ -23,3 +23,11 @@ export const formatIsk = (raw: string | number | null) => {
   const value = formatIskValue(raw)
   return value === '—' ? value : `${value} ISK`
 }
+
+// Money shown in billions of ISK with the unit, e.g. "123.456 bISK" or
+// "0.004 bISK". Capped at 3 decimal places, never more.
+export const formatBisk = (raw: string | number | null) => {
+  if (raw === null) return '—'
+  const value = (Number(raw) / 1_000_000_000).toLocaleString('en-US', { maximumFractionDigits: 3 })
+  return `${value} bISK`
+}


### PR DESCRIPTION
## Summary
- Add `formatBisk` to `src/app/isk.ts`: formats a raw ISK balance as billions of ISK, capped at 3 decimal places (e.g. `123.456 bISK`, `0.004 bISK`).
- Use it on the characters list (`src/app/character/page.tsx`) in place of `formatKisk`, so wallet balances read in billions instead of thousands.

## Test plan
- [ ] Visually confirm the characters list shows wallet balances as `X.XXX bISK`, correctly capped at 3 decimals for both large and small balances


---
_Generated by [Claude Code](https://claude.ai/code/session_01PmVgHhU3QMsvLDe2sRkK8Z)_