### PR TITLE
Let the Industry page hide noisy corps from the "all owners" view

### DIFF
--- a/src/app/industry/activeJobs.tsx
+++ b/src/app/industry/activeJobs.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 
 import { DateTime } from '../DateTime'
 import { Name } from '../names'
-import { ALL_OWNERS, OwnerSelect, ownerNames, useOwnerFilter, type Owners } from '../ownerFilter'
+import { ALL_OWNERS, OwnerSelect, ownerNames, useExcludedCorps, useOwnerFilter, type Owners } from '../ownerFilter'
 import retro from '../retro.module.css'
 import { TypeName } from '../typeName'
 import styles from './industry.module.css'
@@ -34,6 +34,7 @@ type ActiveJobsProps = {
 }
 
 const OWNER_STORAGE_KEY = 'industry.activeJobs.ownerId'
+const EXCLUDED_CORPS_STORAGE_KEY = 'industry.activeJobs.excludedCorpIds'
 
 const formatRemaining = (endIso: string, now: number) => {
   const ms = new Date(endIso).getTime() - now
@@ -51,8 +52,16 @@ export const ActiveJobs = ({ jobs, owners, initialNow, typeNamesPromise, station
   const ownerName = ownerNames(owners)
 
   const [ownerId, setOwnerId] = useOwnerFilter(OWNER_STORAGE_KEY, owners)
+  const [excludedCorpIds, setExcludedCorpIds] = useExcludedCorps(EXCLUDED_CORPS_STORAGE_KEY, owners)
+  const toggleCorp = (id: string) =>
+    setExcludedCorpIds(
+      excludedCorpIds.includes(id) ? excludedCorpIds.filter((x) => x !== id) : [...excludedCorpIds, id]
+    )
 
-  const filtered = jobs.filter((j) => ownerId === ALL_OWNERS || j.owner_id === ownerId)
+  const filtered = jobs.filter((j) => {
+    if (ownerId !== ALL_OWNERS) return j.owner_id === ownerId
+    return !excludedCorpIds.includes(j.owner_id)
+  })
 
   const [now, setNow] = useState<number>(initialNow)
   useEffect(() => {
@@ -65,16 +74,28 @@ export const ActiveJobs = ({ jobs, owners, initialNow, typeNamesPromise, station
       <div className={styles.jobsHeader}>
         <h2>Active Jobs</h2>
       </div>
+      <div className={styles.jobsFilters}>
+        <label className={styles.jobsFilter}>
+          Owner:&nbsp;
+          <OwnerSelect owners={owners} value={ownerId} onChange={setOwnerId} />
+        </label>
+        {ownerId === ALL_OWNERS && owners.corporations.length > 0 && (
+          <span className={styles.corpToggles}>
+            Corporations:&nbsp;
+            {owners.corporations.map((c) => (
+              <label key={c.id} className={styles.corpToggle}>
+                <input type="checkbox" checked={!excludedCorpIds.includes(c.id)} onChange={() => toggleCorp(c.id)} />
+                {c.name}
+              </label>
+            ))}
+          </span>
+        )}
+      </div>
       {jobs.length > 0 ? (
         <table className={retro.retro}>
           <thead>
             <tr>
-              <th>
-                <label className={styles.jobsFilter}>
-                  Owner:&nbsp;
-                  <OwnerSelect owners={owners} value={ownerId} onChange={setOwnerId} />
-                </label>
-              </th>
+              <th>Owner</th>
               <th>Activity</th>
               <th>Product</th>
               <th className={retro.num}>Runs</th>
@@ -117,10 +138,11 @@ export const ActiveJobs = ({ jobs, owners, initialNow, typeNamesPromise, station
               </tr>
             ))}
             {filtered.length === 0 && (
-              // Keep the table (and the owner dropdown in its header) rendered
-              // so the filter can be changed back when an owner has no jobs.
+              // Keep the table (and the filter toolbar above it) rendered so
+              // the owner/corp filters can be changed back when they leave
+              // nothing to show.
               <tr>
-                <td colSpan={8}>No active jobs for this owner.</td>
+                <td colSpan={8}>No active jobs match the current filters.</td>
               </tr>
             )}
           </tbody>

--- a/src/app/industry/industry.module.css
+++ b/src/app/industry/industry.module.css
@@ -13,12 +13,31 @@
 .jobsFilters {
   display: flex;
   align-items: center;
-  gap: 12pt;
+  flex-wrap: wrap;
+  gap: 6pt 16pt;
+  margin: 8pt 0;
 }
 
 .jobsFilter {
   font-size: 10pt;
   color: var(--ink-soft);
+}
+
+.corpToggles {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 2pt 10pt;
+  font-size: 10pt;
+  color: var(--ink-soft);
+}
+
+.corpToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4pt;
+  font-weight: normal;
+  white-space: nowrap;
 }
 
 .jobs {

--- a/src/app/ownerFilter.tsx
+++ b/src/app/ownerFilter.tsx
@@ -19,6 +19,20 @@ export const useOwnerFilter = (storageKey: string, owners: Owners) =>
     raw === ALL_OWNERS || [...owners.characters, ...owners.corporations].some((o) => o.id === raw) ? raw : undefined
   )
 
+// A set of corporation ids to hide from an "all owners" view — e.g. a huge
+// corp whose jobs aren't personally yours, on top of a smaller alt corp you
+// still want to see. Persisted as a comma-joined list (usePersist stringifies
+// via String(), which comma-joins an array; corp ids are plain numeric
+// strings so they never contain a comma themselves). Orthogonal to
+// useOwnerFilter: excluding a corp here only changes what "all owners" shows,
+// it doesn't stop you from explicitly picking that corp in the owner select.
+export const useExcludedCorps = (storageKey: string, owners: Owners) => {
+  const validIds = new Set(owners.corporations.map((c) => c.id))
+  return usePersist<string[]>(storageKey, [], (raw) =>
+    raw === '' ? [] : raw.split(',').filter((id) => validIds.has(id))
+  )
+}
+
 type OwnerSelectProps = {
   owners: Owners
   value: string


### PR DESCRIPTION
## What

On `/industry`, viewing "All owners" mixes every character's jobs with every corp's jobs. For a player in a very large corp (e.g. a megacorp with thousands of members) alongside a smaller alt corp, the big corp's jobs bury the ones that are actually theirs.

Adds a per-corporation checkbox toggle next to the existing Owner dropdown: unchecking a corp hides its jobs from the "All owners" view. It's persisted in localStorage (same mechanism as the existing owner filter) and is purely additive — explicitly picking a corp in the Owner dropdown still shows its jobs regardless of the checkbox state.

- `src/app/ownerFilter.tsx`: new `useExcludedCorps` hook, persisting a comma-joined list of excluded corp ids (reuses `usePersist`'s existing `String()` serialization — no changes to that shared hook).
- `src/app/industry/activeJobs.tsx`: moves the Owner filter out of the table's first header cell into a toolbar row above the table (reusing the `.jobsFilters` class that was already defined in CSS but unused), and adds the corp checkboxes there, shown only when "All owners" is selected.
- `src/app/industry/industry.module.css`: styles for the new checkbox row.

Scoped to the Industry page only — the asset pages share `ownerFilter.tsx` but only use the existing single-owner select, which is unchanged.

## Verification

- `pnpm run lint` — clean (one pre-existing warning in `character/actions.ts`, unrelated).
- `pnpm run build` — compiles and type-checks.
- No live Supabase credentials in this environment, so the filter wasn't exercised against real job data in a browser — worth a quick look after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVkCmWJ7NRBi9uUziJAVUo

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVkCmWJ7NRBi9uUziJAVUo)_