### PR TITLE
Show ship cargo/fitting as an EVE-style bay grid on the asset page

### DIFF
--- a/src/app/asset/[locationId]/page.tsx
+++ b/src/app/asset/[locationId]/page.tsx
@@ -1,12 +1,17 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
+import { getSdeType } from '@/sdeTypes'
 import { createClient } from '@/utils/supabase/server'
 import { fetchOwners } from '../../owners'
 import { fetchStationNames, fetchStationSystems } from '../../stationNames'
 import { fetchSystemNames } from '../../systemNames'
 import { fetchTypeNames } from '../../typeNames'
 import { LocationAssets, type ItemRow } from './locationAssets'
+import { ShipCargo } from './shipCargo'
+
+// invGroups.categoryID for the Ship category in CCP's SDE.
+const SHIP_CATEGORY_ID = 6
 
 // Bigint ids arrive from PostgREST as strings; keep them as strings and only
 // convert at the API/system-lookup boundary (mirrors the assets index page).
@@ -185,7 +190,11 @@ const AssetLocationPage = async ({ params }: { params: Promise<{ locationId: str
         <Link href={backHref}>&laquo; {backLabel}</Link>
       </p>
 
-      <LocationAssets rows={rows} owners={owners} typeNamesPromise={typeNamesPromise} />
+      {self && getSdeType(Number(self.type_id))?.categoryID === SHIP_CATEGORY_ID ? (
+        <ShipCargo rows={rows} owners={owners} typeNamesPromise={typeNamesPromise} />
+      ) : (
+        <LocationAssets rows={rows} owners={owners} typeNamesPromise={typeNamesPromise} />
+      )}
     </>
   )
 }

--- a/src/app/asset/[locationId]/shipCargo.module.css
+++ b/src/app/asset/[locationId]/shipCargo.module.css
@@ -1,0 +1,87 @@
+/*
+ * Ship cargo/fitting view: bay sections of item-icon tiles, echoing the EVE
+ * client's fitting-and-cargo layout while staying in this app's flat/paper
+ * visual language (see structures.module.css for the sibling tile-grid).
+ */
+
+.bay {
+  margin: 20px 0;
+}
+
+.bayLabel {
+  margin: 0 0 8px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--ink-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(84px, 1fr));
+  gap: 8px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.tile {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 6px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--paper-raised);
+  text-align: center;
+  min-width: 0;
+}
+
+.tileLink {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  color: inherit !important;
+  text-decoration: none !important;
+}
+
+.tile:has(.tileLink):hover {
+  border-color: var(--accent);
+}
+
+.icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 4px;
+}
+
+.qty {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  padding: 1px 4px;
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 10px;
+  line-height: 1.4;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+}
+
+.name {
+  font-size: 11px;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.owner {
+  font-size: 10px;
+  color: var(--ink-faint);
+}

--- a/src/app/asset/[locationId]/shipCargo.tsx
+++ b/src/app/asset/[locationId]/shipCargo.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+import Link from 'next/link'
+
+import { ALL_OWNERS, OwnerSelect, ownerNames, useOwnerFilter, type Owners } from '../../ownerFilter'
+import { TypeName } from '../../typeName'
+import styles from '../assets.module.css'
+import { OWNER_STORAGE_KEY } from '../filterKey'
+import { type ItemRow } from './locationAssets'
+import bayStyles from './shipCargo.module.css'
+
+// Fitted-slot flags (HiSlot0, MedSlot3, RigSlot1, …) share a bay per slot
+// kind, ordered by slot index within it. Every other flag ("Cargo",
+// "DroneBay", "OreHold", a Rorqual's "SpecializedGasHold", …) is its own bay,
+// keyed by the raw flag so unrecognized ones still get a sensible section
+// instead of being dropped or lumped together.
+const SLOT_KINDS = ['Hi', 'Med', 'Lo', 'Rig', 'SubSystem', 'Service']
+const SLOT_LABELS: Record<string, string> = {
+  Hi: 'High Power',
+  Med: 'Mid Power',
+  Lo: 'Low Power',
+  Rig: 'Rig Slots',
+  SubSystem: 'Subsystems',
+  Service: 'Service Slots',
+}
+// Display order for the bay sections; anything not listed here (an
+// unrecognized flag, or no flag at all) sorts after all of these, by label.
+const BAY_ORDER = [...SLOT_KINDS, 'DroneBay', 'FighterBay', 'Cargo', 'FleetHangar', 'ShipHangar']
+
+// "OreHold" → "Ore Hold", "SpecializedGasHold" → "Specialized Gas Hold". Falls
+// back to this for any flag with no hardcoded label above.
+const humanizeFlag = (flag: string) => flag.replace(/([a-z0-9])([A-Z])/g, '$1 $2').trim()
+
+type Bay = { key: string; label: string; order: number; slotIndex: number; items: ItemRow[] }
+
+const bayFor = (flag: string | null): Omit<Bay, 'items'> => {
+  const slotMatch = flag?.match(/^(Hi|Med|Lo|Rig|SubSystem|Service)Slot(\d+)$/)
+  if (slotMatch) {
+    const [, kind, index] = slotMatch
+    return { key: kind, label: SLOT_LABELS[kind], order: BAY_ORDER.indexOf(kind), slotIndex: Number(index) }
+  }
+  const key = flag ?? 'Other'
+  return {
+    key,
+    label: key === 'Cargo' ? 'Cargo Hold' : key === 'Other' ? 'Other' : humanizeFlag(key),
+    order: BAY_ORDER.includes(key) ? BAY_ORDER.indexOf(key) : BAY_ORDER.length,
+    slotIndex: 0,
+  }
+}
+
+const groupIntoBays = (rows: ItemRow[]): Bay[] => {
+  const bays = new Map<string, Bay>()
+  for (const row of rows) {
+    const meta = bayFor(row.flag)
+    const bay = bays.get(meta.key) ?? { ...meta, items: [] }
+    bay.items.push(row)
+    bays.set(meta.key, bay)
+  }
+  return [...bays.values()]
+    .map((bay) => ({ ...bay, items: bay.items.sort((a, b) => a.typeId - b.typeId) }))
+    .sort((a, b) => a.order - b.order || a.slotIndex - b.slotIndex || a.label.localeCompare(b.label))
+}
+
+type ShipCargoProps = {
+  rows: ItemRow[]
+  owners: Owners
+  typeNamesPromise: Promise<Record<number, string>>
+}
+
+// Item icons/quantity tiles grouped by hold/slot, echoing the EVE client's
+// fitting-and-cargo layout — the bays a ship actually has (only sections with
+// at least one item render) rather than a blank slot-by-slot mockup.
+export const ShipCargo = ({ rows, owners, typeNamesPromise }: ShipCargoProps) => {
+  const [ownerId, setOwnerId] = useOwnerFilter(OWNER_STORAGE_KEY, owners)
+
+  const filtered = rows.filter((r) => ownerId === ALL_OWNERS || r.ownerId === ownerId)
+  const ownerMap = ownerNames(owners)
+  const bays = groupIntoBays(filtered)
+
+  return (
+    <section>
+      <label className={styles.filter}>
+        Owner:&nbsp;
+        <OwnerSelect owners={owners} value={ownerId} onChange={setOwnerId} />
+      </label>
+
+      {bays.length > 0 ? (
+        bays.map((bay) => (
+          <div key={bay.key} className={bayStyles.bay}>
+            <h3 className={bayStyles.bayLabel}>{bay.label}</h3>
+            <ul className={bayStyles.grid}>
+              {bay.items.map((item) => {
+                const tile = (
+                  <>
+                    <img
+                      className={bayStyles.icon}
+                      src={`https://images.evetech.net/types/${item.typeId}/icon?size=64`}
+                      alt=""
+                      width={48}
+                      height={48}
+                    />
+                    {!item.isSingleton && item.quantity != null && Number(item.quantity) > 1 && (
+                      <span className={bayStyles.qty}>{Number(item.quantity).toLocaleString('en-US')}</span>
+                    )}
+                    <span className={bayStyles.name}>
+                      <TypeName id={item.typeId} name={item.name} promise={typeNamesPromise} />
+                    </span>
+                    {ownerId === ALL_OWNERS && (
+                      <span className={bayStyles.owner}>{ownerMap.get(item.ownerId) ?? item.ownerId}</span>
+                    )}
+                  </>
+                )
+                return (
+                  <li key={`item-${item.itemId}`} className={bayStyles.tile}>
+                    {item.contents > 0 ? (
+                      <Link href={`/asset/${item.itemId}`} className={bayStyles.tileLink}>
+                        {tile}
+                      </Link>
+                    ) : (
+                      tile
+                    )}
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
+        ))
+      ) : (
+        <p>Nothing in this ship for this owner.</p>
+      )}
+    </section>
+  )
+}

--- a/src/app/asset/[locationId]/shipCargo.tsx
+++ b/src/app/asset/[locationId]/shipCargo.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from 'next/link'
+import { ascend, groupBy, sortBy, sortWith } from 'ramda'
 
 import { ALL_OWNERS, OwnerSelect, ownerNames, useOwnerFilter, type Owners } from '../../ownerFilter'
 import { TypeName } from '../../typeName'
@@ -49,16 +50,13 @@ const bayFor = (flag: string | null): Omit<Bay, 'items'> => {
 }
 
 const groupIntoBays = (rows: ItemRow[]): Bay[] => {
-  const bays = new Map<string, Bay>()
-  for (const row of rows) {
-    const meta = bayFor(row.flag)
-    const bay = bays.get(meta.key) ?? { ...meta, items: [] }
-    bay.items.push(row)
-    bays.set(meta.key, bay)
-  }
-  return [...bays.values()]
-    .map((bay) => ({ ...bay, items: bay.items.sort((a, b) => a.typeId - b.typeId) }))
-    .sort((a, b) => a.order - b.order || a.slotIndex - b.slotIndex || a.label.localeCompare(b.label))
+  const byBayKey = groupBy((row: ItemRow) => bayFor(row.flag).key, rows)
+  const bays = Object.entries(byBayKey).map(([key, items = []]) => ({
+    ...bayFor(items[0].flag),
+    key,
+    items: sortBy((item: ItemRow) => item.typeId, items),
+  }))
+  return sortWith([ascend((bay) => bay.order), ascend((bay) => bay.slotIndex), ascend((bay) => bay.label)], bays)
 }
 
 type ShipCargoProps = {

--- a/src/app/asset/[locationId]/shipCargo.tsx
+++ b/src/app/asset/[locationId]/shipCargo.tsx
@@ -1,7 +1,28 @@
 'use client'
 
 import Link from 'next/link'
-import { ascend, groupBy, sortBy, sortWith } from 'ramda'
+import {
+  __,
+  allPass,
+  always,
+  ascend,
+  complement,
+  cond,
+  equals,
+  filter,
+  groupBy,
+  gt,
+  isNil,
+  lensProp,
+  map,
+  pipe,
+  prop,
+  sortBy,
+  sortWith,
+  T,
+  toPairs,
+  view,
+} from 'ramda'
 
 import { ALL_OWNERS, OwnerSelect, ownerNames, useOwnerFilter, type Owners } from '../../ownerFilter'
 import { TypeName } from '../../typeName'
@@ -32,7 +53,20 @@ const BAY_ORDER = [...SLOT_KINDS, 'DroneBay', 'FighterBay', 'Cargo', 'FleetHanga
 // back to this for any flag with no hardcoded label above.
 const humanizeFlag = (flag: string) => flag.replace(/([a-z0-9])([A-Z])/g, '$1 $2').trim()
 
+// The two hardcoded labels, then everything else humanized — a `cond` reads
+// as the "match this key against a few cases" it is, point-free on the key.
+const labelForKey: (key: string) => string = cond([
+  [equals('Cargo'), always('Cargo Hold')],
+  [equals('Other'), always('Other')],
+  [T, humanizeFlag],
+])
+
 type Bay = { key: string; label: string; order: number; slotIndex: number; items: ItemRow[] }
+
+// Lenses onto the two ItemRow fields bays care about: the flag that decides
+// which bay an item belongs in, and the type id items within a bay sort by.
+const flagLens = lensProp<ItemRow, 'flag'>('flag')
+const typeIdLens = lensProp<ItemRow, 'typeId'>('typeId')
 
 const bayFor = (flag: string | null): Omit<Bay, 'items'> => {
   const slotMatch = flag?.match(/^(Hi|Med|Lo|Rig|SubSystem|Service)Slot(\d+)$/)
@@ -43,21 +77,34 @@ const bayFor = (flag: string | null): Omit<Bay, 'items'> => {
   const key = flag ?? 'Other'
   return {
     key,
-    label: key === 'Cargo' ? 'Cargo Hold' : key === 'Other' ? 'Other' : humanizeFlag(key),
+    label: labelForKey(key),
     order: BAY_ORDER.includes(key) ? BAY_ORDER.indexOf(key) : BAY_ORDER.length,
     slotIndex: 0,
   }
 }
 
-const groupIntoBays = (rows: ItemRow[]): Bay[] => {
-  const byBayKey = groupBy((row: ItemRow) => bayFor(row.flag).key, rows)
-  const bays = Object.entries(byBayKey).map(([key, items = []]) => ({
-    ...bayFor(items[0].flag),
+// Group rows by bay key (read off each row through the flag lens), fold each
+// group into a Bay — reusing bayFor on the group's first row for the shared
+// label/order/slot metadata, sorting its items by type id through the type id
+// lens — then order the bays themselves for display.
+const groupIntoBays: (rows: ItemRow[]) => Bay[] = pipe(
+  groupBy<ItemRow>(pipe(view(flagLens), bayFor, prop('key'))),
+  toPairs,
+  map(([key, items = []]: [string, ItemRow[] | undefined]) => ({
+    ...bayFor(items.length > 0 ? view(flagLens, items[0]) : null),
     key,
-    items: sortBy((item: ItemRow) => item.typeId, items),
-  }))
-  return sortWith([ascend((bay) => bay.order), ascend((bay) => bay.slotIndex), ascend((bay) => bay.label)], bays)
-}
+    items: sortBy(view(typeIdLens), items),
+  })),
+  sortWith([ascend(prop('order')), ascend(prop('slotIndex')), ascend(prop('label'))])
+)
+
+// An item earns a quantity badge when it isn't a unique/fitted singleton, its
+// quantity is known, and its stack is more than one.
+const hasVisibleQuantity: (item: ItemRow) => boolean = allPass([
+  complement(prop('isSingleton')),
+  pipe(prop('quantity'), complement(isNil)),
+  pipe(prop('quantity'), Number, gt(__, 1)),
+])
 
 type ShipCargoProps = {
   rows: ItemRow[]
@@ -71,7 +118,7 @@ type ShipCargoProps = {
 export const ShipCargo = ({ rows, owners, typeNamesPromise }: ShipCargoProps) => {
   const [ownerId, setOwnerId] = useOwnerFilter(OWNER_STORAGE_KEY, owners)
 
-  const filtered = rows.filter((r) => ownerId === ALL_OWNERS || r.ownerId === ownerId)
+  const filtered = filter((r: ItemRow) => equals(ownerId, ALL_OWNERS) || equals(r.ownerId, ownerId), rows)
   const ownerMap = ownerNames(owners)
   const bays = groupIntoBays(filtered)
 
@@ -83,46 +130,49 @@ export const ShipCargo = ({ rows, owners, typeNamesPromise }: ShipCargoProps) =>
       </label>
 
       {bays.length > 0 ? (
-        bays.map((bay) => (
-          <div key={bay.key} className={bayStyles.bay}>
-            <h3 className={bayStyles.bayLabel}>{bay.label}</h3>
-            <ul className={bayStyles.grid}>
-              {bay.items.map((item) => {
-                const tile = (
-                  <>
-                    <img
-                      className={bayStyles.icon}
-                      src={`https://images.evetech.net/types/${item.typeId}/icon?size=64`}
-                      alt=""
-                      width={48}
-                      height={48}
-                    />
-                    {!item.isSingleton && item.quantity != null && Number(item.quantity) > 1 && (
-                      <span className={bayStyles.qty}>{Number(item.quantity).toLocaleString('en-US')}</span>
-                    )}
-                    <span className={bayStyles.name}>
-                      <TypeName id={item.typeId} name={item.name} promise={typeNamesPromise} />
-                    </span>
-                    {ownerId === ALL_OWNERS && (
-                      <span className={bayStyles.owner}>{ownerMap.get(item.ownerId) ?? item.ownerId}</span>
-                    )}
-                  </>
-                )
-                return (
-                  <li key={`item-${item.itemId}`} className={bayStyles.tile}>
-                    {item.contents > 0 ? (
-                      <Link href={`/asset/${item.itemId}`} className={bayStyles.tileLink}>
-                        {tile}
-                      </Link>
-                    ) : (
-                      tile
-                    )}
-                  </li>
-                )
-              })}
-            </ul>
-          </div>
-        ))
+        map(
+          (bay: Bay) => (
+            <div key={bay.key} className={bayStyles.bay}>
+              <h3 className={bayStyles.bayLabel}>{bay.label}</h3>
+              <ul className={bayStyles.grid}>
+                {map((item: ItemRow) => {
+                  const tile = (
+                    <>
+                      <img
+                        className={bayStyles.icon}
+                        src={`https://images.evetech.net/types/${item.typeId}/icon?size=64`}
+                        alt=""
+                        width={48}
+                        height={48}
+                      />
+                      {hasVisibleQuantity(item) && (
+                        <span className={bayStyles.qty}>{Number(item.quantity).toLocaleString('en-US')}</span>
+                      )}
+                      <span className={bayStyles.name}>
+                        <TypeName id={item.typeId} name={item.name} promise={typeNamesPromise} />
+                      </span>
+                      {equals(ownerId, ALL_OWNERS) && (
+                        <span className={bayStyles.owner}>{ownerMap.get(item.ownerId) ?? item.ownerId}</span>
+                      )}
+                    </>
+                  )
+                  return (
+                    <li key={`item-${item.itemId}`} className={bayStyles.tile}>
+                      {item.contents > 0 ? (
+                        <Link href={`/asset/${item.itemId}`} className={bayStyles.tileLink}>
+                          {tile}
+                        </Link>
+                      ) : (
+                        tile
+                      )}
+                    </li>
+                  )
+                }, bay.items)}
+              </ul>
+            </div>
+          ),
+          bays
+        )
       ) : (
         <p>Nothing in this ship for this owner.</p>
       )}


### PR DESCRIPTION
## Summary

Drilling into a ship on `/asset/[locationId]` previously rendered its contents in the same plain table used for stations/containers. This adds a dedicated view for ships: items are grouped into bays (Cargo Hold, Drone Bay, High/Mid/Low Power, Rig Slots, Ore Hold, Fleet Hangar, etc. — derived from each item's `location_flag`) and rendered as an icon-tile grid using the item's real EVE type icon (`images.evetech.net`) and quantity badge, echoing the game client's fitting/cargo layout while staying in this app's existing flat/paper visual language.

We looked at pulling in EVEShipFit's `@eveshipfit/react` `CargoBay` component first, but it's gated behind GitHub Packages auth, depends on self-hosting their CORS-locked dogma/type dataset, and is built around an editable "fit" model rather than read-only real asset data — so a small in-repo component ended up being the better fit.

## Changes

- `src/app/asset/[locationId]/shipCargo.tsx` (new) — `ShipCargo` component: groups the location's rows into bays by `location_flag` (fitted slots get one bay per slot kind, ordered by slot index; every other flag gets its own bay, with a sensible label derived from the raw flag as a fallback so nothing unrecognized is dropped), renders each as a tile grid, reuses the existing owner filter.
- `src/app/asset/[locationId]/shipCargo.module.css` (new) — bay/tile grid styling consistent with the existing tile-grid pattern (`structures.module.css`).
- `src/app/asset/[locationId]/page.tsx` — when the drilled-into item's SDE `categoryID` is `6` (Ship), render `ShipCargo` instead of the existing `LocationAssets` table. Containers and stations are unaffected.

## Test plan

- [x] `eslint .` passes
- [x] `prettier --check` passes on the new/changed files
- [x] `tsc --noEmit` passes
- [ ] Manually open a ship's asset page in a browser to confirm the bay grid renders correctly across owners/hulls (no local Supabase data available in this environment to drive a full manual check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jJRqT6fqEwhk8jTLkKCv2

---
_Generated by [Claude Code](https://claude.ai/code/session_011jJRqT6fqEwhk8jTLkKCv2)_