### PR TITLE
Ignore local pnpm build-script approval file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@
 .pnp.js
 .yarn/install-state.gz
 
+# pnpm-generated build-script approvals (`pnpm approve-builds`) — committing
+# this breaks Vercel's build (missing "packages" field, pnpm/pnpm#9361); the
+# approval only needs to exist locally, not in the repo
+/pnpm-workspace.yaml
+
 # testing
 /coverage
 


### PR DESCRIPTION
## What

Small repo-hygiene follow-up to #528. `pnpm approve-builds` writes its approvals to a project-root `pnpm-workspace.yaml`. That file was briefly committed and reverted in #528 because it breaks Vercel's build — the version pnpm generates omits a `packages` field, which trips a known pnpm bug ([pnpm/pnpm#9361](https://github.com/pnpm/pnpm/issues/9361)) during Vercel's install even though it works fine locally.

Since the approval only needs to exist on a local machine (or whichever environment is running `pnpm install` interactively), this adds it to `.gitignore` so it stops showing up as an untracked file to commit, without touching `package.json`'s existing (harmless but no-longer-read) `pnpm.onlyBuiltDependencies` field.

## Verification

- `pnpm run lint` / `pnpm run build` — both pass with the file present locally and ignored by git.
- `git check-ignore -v pnpm-workspace.yaml` confirms the new rule matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVkCmWJ7NRBi9uUziJAVUo

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVkCmWJ7NRBi9uUziJAVUo)_