### PR TITLE
Add bare ShipFit-only view at /asset/[locationId]/fit

### DIFF
--- a/src/app/asset/[locationId]/esfFit.ts
+++ b/src/app/asset/[locationId]/esfFit.ts
@@ -2,13 +2,18 @@ import type { EsiFit } from '@eveshipfit/react'
 
 import type { ItemRow } from './locationAssets'
 
+// Only these 4 fields of ItemRow are actually needed, so callers that don't
+// already have a full ItemRow (e.g. a lean fetch that skips owners/contents)
+// don't need to fabricate the rest.
+type EsiFitRow = Pick<ItemRow, 'itemId' | 'typeId' | 'flag' | 'quantity'>
+
 // Shapes a ship's fitted-module/cargo/drone rows (the same ItemRow[] fed to
 // ShipCargo) into the ESI-fitting-JSON shape @eveshipfit/react's
 // useImportEsiFitting() hook expects. Slot vs. charge disambiguation and
 // cargo/drone-bay routing happen inside that hook (it already has the full
 // type/dogma dataset loaded), so this is a plain reshape — no location-flag
 // parsing needed here.
-export const toEsiFit = (shipTypeId: number, shipName: string | null, rows: ItemRow[]): EsiFit => ({
+export const toEsiFit = (shipTypeId: number, shipName: string | null, rows: EsiFitRow[]): EsiFit => ({
   name: shipName ?? '',
   description: '',
   ship_type_id: shipTypeId,

--- a/src/app/asset/[locationId]/fit/page.tsx
+++ b/src/app/asset/[locationId]/fit/page.tsx
@@ -1,0 +1,54 @@
+import { redirect } from 'next/navigation'
+
+import { createClient } from '@/utils/supabase/server'
+import { toEsiFit } from '../esfFit'
+import { ShipFitViewDynamic } from '../shipFitViewDynamic'
+
+// Bare view of a single ship's fit — no heading, back link, or cargo grid,
+// just the ShipFit component, for the same locationId /asset/[locationId]
+// uses. Only the fields toEsiFit needs are fetched.
+type ChildRow = {
+  item_id: number | string
+  type_id: number | string
+  location_flag: string | null
+  quantity: number | string | null
+}
+
+const FitLocationPage = async ({ params }: { params: Promise<{ locationId: string }> }) => {
+  const { locationId } = await params
+  const supabase = await createClient()
+
+  const { data: auth, error: authError } = await supabase.auth.getUser()
+  if (authError || !auth?.user) {
+    redirect('/')
+  }
+
+  const { data: characterSelf } = await supabase
+    .from('character_asset')
+    .select('type_id, name')
+    .eq('item_id', locationId)
+    .maybeSingle<{ type_id: number | string; name: string | null }>()
+  const { data: corpSelf } = characterSelf
+    ? { data: null }
+    : await supabase
+        .from('corp_asset')
+        .select('type_id')
+        .eq('item_id', locationId)
+        .maybeSingle<{ type_id: number | string }>()
+  const self = characterSelf ?? (corpSelf ? { ...corpSelf, name: null } : null)
+  if (!self) return null
+
+  const [{ data: characterChildren }, { data: corpChildren }] = await Promise.all([
+    supabase.from('character_asset').select('item_id, type_id, location_flag, quantity').eq('location_id', locationId),
+    supabase.from('corp_asset').select('item_id, type_id, location_flag, quantity').eq('location_id', locationId),
+  ])
+  const rows = [...((characterChildren ?? []) as ChildRow[]), ...((corpChildren ?? []) as ChildRow[])].map((r) => ({
+    itemId: String(r.item_id),
+    typeId: Number(r.type_id),
+    flag: r.location_flag,
+    quantity: r.quantity,
+  }))
+
+  return <ShipFitViewDynamic esiFit={toEsiFit(Number(self.type_id), self.name, rows)} />
+}
+export default FitLocationPage


### PR DESCRIPTION
## What

`/asset/[locationId]/fit` renders just the `ShipFit` component for the same `locationId` `/asset/[locationId]` uses — no heading, back link, or cargo grid, just the fit wheel + stats.

Site header/footer still wrap it. Getting a page with truly zero chrome (no header/footer either) would require Next.js's "multiple root layouts" pattern, which means removing the single root layout and moving every existing top-level route into a route group — out of scope for a bare debug/embed view; confirmed with the user this is the right tradeoff.

## Changes

- **`esfFit.ts`** — `toEsiFit` now takes `Pick<ItemRow, 'itemId' | 'typeId' | 'flag' | 'quantity'>` instead of a full `ItemRow[]`, since that's all it actually reads. Lets this new page's lean query (skips owners/contents/names it doesn't need) avoid fabricating irrelevant fields just to satisfy the type.
- **`fit/page.tsx`** — minimal server component: auth check (mirrors the main asset page), a lean self-lookup (just `type_id`/`name`) and children query (just `item_id`/`type_id`/`location_flag`/`quantity`), then renders `<ShipFitViewDynamic esiFit={toEsiFit(...)} />` and nothing else. Returns `null` if the locationId doesn't resolve to one of the user's own items.

## Verification

- `pnpm run build` — clean; `/asset/[locationId]/fit` shows up as a real route.
- `pnpm run lint` / prettier — clean (one pre-existing, unrelated warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011fB8z9h2T28o7xRTxRntpK

---
_Generated by [Claude Code](https://claude.ai/code/session_011fB8z9h2T28o7xRTxRntpK)_