### PR TITLE
Collect clone jump timers and per-clone solar system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ All functions take `(accessToken, id, ...)` unless noted. Returns raw ESI respon
 - `industryJobs(token, characterId)` — industry job list
 - `character(token, characterId)` — character sheet
 - `characterLocation(token, characterId)` — current solar system (and station/structure, if docked)
-- `characterClones(token, characterId)` — home clone + jump clones, each with location and (for jump clones) implants
+- `characterClones(token, characterId)` — home clone + jump clones, each with location and (for jump clones) implants, plus `last_clone_jump_date`/`last_station_change_date`
 - `characterImplants(token, characterId)` — implants currently plugged into whichever clone body the character occupies
 - `corpStructures(token, corpId, page)` — corporation Upwell structures (paged)
 - `corpAssets(token, corpId, page)` — corporation assets (paged)
@@ -88,6 +88,7 @@ All functions take `(accessToken, id, ...)` unless noted. Returns raw ESI respon
 - `industrySystems()` — public industry system cost indices (no auth)
 - `universeNames(ids[])` — bulk id→name resolution (no auth)
 - `universeStructure(token, structureId)` — structure info by ID
+- `universeStation(stationId)` — NPC station info by ID (no auth; used to place clones in a solar system)
 - `characterAffiliations(characterIds[])` — bulk character→corp mapping (no auth)
 
 ### `src/jobs/lib.js` — shared extract-job plumbing
@@ -180,7 +181,7 @@ One job per ESI endpoint. The npm script, queue job name, and heartbeat job labe
 | `character-industry-jobs` | `/characters/{id}/industry/jobs/` | `character_industry_job` | hourly `:48` |
 | `character-location` | `/characters/{id}/location/` | `character_location` | hourly `:14` |
 | `character-implants` | `/characters/{id}/implants/` | `character_implant` | hourly `:16` |
-| `character-clones` | `/characters/{id}/clones/` | `character_clone_over_time` | hourly `:18` |
+| `character-clones` | `/characters/{id}/clones/` | `character_clone_over_time`, `character_clone_state` | hourly `:18` |
 | `character-affiliations` | `/characters/affiliation/` | `character_affiliation` | 11:41 daily |
 | `corp-structures` | `/corporations/{id}/structures/` | `corp_structure` | 09:17 daily |
 | `corp-assets` | `/corporations/{id}/assets/` | `corp_asset_over_time`, `corp_structure_rig` | 09:27 daily |
@@ -218,8 +219,9 @@ Requires a `CRON_SECRET` env var set in Vercel (see `.env.example`).
 | `character_order` | Live open orders | `order_id`, `character_id`, `type_id`, `price`, `volume_remain`, `is_buy`, `seen_at` |
 | `character_industry_job` | Manufacturing/research | `job_id`, `character_id`, `blueprint_id`, `product_type_id`, `activity_id`, `status`, `end_date` |
 | `character_location` | Live current solar system/station/structure | `character_id` (PK), `solar_system_id`, `station_id`, `structure_id`, `recorded_at` |
-| `character_clone_over_time` | SCD Type 2 clone history (home + jump clones, with implants) | `character_id`, `jump_clone_id`, `is_home`, `location_id`, `location_type`, `name`, `implants` (jsonb type-id array), `is_current`, `first_seen_at`, `last_seen_at` |
+| `character_clone_over_time` | SCD Type 2 clone history (home + jump clones, with implants) | `character_id`, `jump_clone_id`, `is_home`, `location_id`, `location_type`, `name`, `implants` (jsonb type-id array), `is_current`, `first_seen_at`, `last_seen_at`, `system_id` (resolved solar system, null until resolvable) |
 | `character_clone` | View: `is_current` clones | same columns as above |
+| `character_clone_state` | Live per-character clone-jump timers (next jump ≈ `last_clone_jump_date` + 24h) | `character_id` (PK), `last_clone_jump_date`, `last_station_change_date`, `recorded_at` |
 | `character_implant` | Live current implants plugged into the character's active clone | `character_id` (PK), `type_ids` (bigint array), `recorded_at` |
 | `character_affiliation` | Character→Corp mapping | `character_id`, `corporation_id` |
 | `corp_structure` | Corp Upwell structures | `structure_id`, `corporation_id`, `type_id`, `system_id`, `name`, `state`, `fuel_expires`, `services` (jsonb) |

--- a/schema.sql
+++ b/schema.sql
@@ -66,6 +66,11 @@ drop table if exists public.corp_asset_over_time      cascade;
 drop table if exists public.corp_industry_job         cascade;
 drop view  if exists public.corp_blueprint            cascade;
 drop table if exists public.corp_blueprint_over_time  cascade;
+drop table if exists public.character_location        cascade;
+drop view  if exists public.character_clone            cascade;
+drop table if exists public.character_clone_over_time  cascade;
+drop table if exists public.character_clone_state      cascade;
+drop table if exists public.character_implant          cascade;
 drop table if exists public.universe_name        cascade;
 drop table if exists public.universe_structure   cascade;
 drop table if exists public.invite_code          cascade;
@@ -855,7 +860,11 @@ create table public.character_clone_over_time (
   implants jsonb not null default '[]'::jsonb,
   is_current boolean not null default true,
   first_seen_at timestamptz not null default now(),
-  last_seen_at timestamptz not null default now()
+  last_seen_at timestamptz not null default now(),
+  -- Solar system the clone's station/structure sits in, resolved at extract
+  -- time (null until resolvable). Kept last so a fresh reset matches the
+  -- column order of migrated databases (the character_clone view is select *).
+  system_id bigint
 );
 create index character_clone_over_time_character_id_idx on public.character_clone_over_time (character_id);
 create unique index character_clone_over_time_current_jump_idx
@@ -905,6 +914,34 @@ create policy "Users read own implants"
 
 grant select on public.character_implant to authenticated;
 grant all    on public.character_implant to service_role;
+
+-- ── character_clone_state ──────────────────────────────────────────────────
+-- Character-level fields from ESI /characters/{id}/clones/, written by the
+-- character-clones job alongside the per-clone SCD rows: when the last clone
+-- jump happened and when the home station was last changed. Live current-state
+-- data, like character_location. "Next jump available" is derived as
+-- last_clone_jump_date + 24h (conservative; Infomorph Synchronizing shortens
+-- it, but reading the skill would need the esi-skills.read_skills.v1 scope).
+create table public.character_clone_state (
+  character_id uuid primary key references public.registration(id) on delete cascade,
+  last_clone_jump_date timestamptz,
+  last_station_change_date timestamptz,
+  recorded_at timestamptz not null default now()
+);
+
+alter table public.character_clone_state enable row level security;
+create policy "Users read own clone state"
+  on public.character_clone_state
+  for select
+  to authenticated
+  using (
+    character_id in (
+      select id from public.registration where user_id = (select auth.uid())
+    )
+  );
+
+grant select on public.character_clone_state to authenticated;
+grant all    on public.character_clone_state to service_role;
 
 -- ── corp_structure ────────────────────────────────────────────────────────
 -- ESI /corporations/{id}/structures/, written by the corp-structures job.

--- a/src/esi.js
+++ b/src/esi.js
@@ -150,6 +150,13 @@ export const universeStructure = (access_token, structureID) =>
     label: `universeStructure ${structureID}`,
   })
 
+// Public (no token): resolve a single NPC station. Returns { system_id, name,
+// type_id, ... }; used to place clones parked in NPC stations in a solar system.
+export const universeStation = (stationID) =>
+  esiJson(`/universe/stations/${stationID}/`, {
+    label: `universeStation ${stationID}`,
+  })
+
 // A character's current solar system (and station/structure, if docked).
 export const characterLocation = (access_token, characterID) =>
   esiJson(`/characters/${characterID}/location/`, {

--- a/src/jobs/characterClones.js
+++ b/src/jobs/characterClones.js
@@ -1,8 +1,8 @@
 import { filter, map, prop, reduce } from 'ramda'
 
-import { characterClones } from '../esi.js'
+import { characterClones, universeStation, universeStructure } from '../esi.js'
 import { sudoSupabase } from '../supabase.js'
-import { cli, forEachCharacter } from './lib.js'
+import { cli, forEachCharacter, forEachSequential } from './lib.js'
 
 const TAG = 'character-clones'
 const SCOPE = 'esi-clones.read_clones.v1'
@@ -11,9 +11,15 @@ const SCOPE = 'esi-clones.read_clones.v1'
 // row per clone (the home clone plus every jump clone). Most jump clones sit
 // unchanged for a long time, so this tracks history the same way
 // character_asset_over_time does, keyed per clone rather than per item.
+// The payload's character-level timestamps (last_clone_jump_date,
+// last_station_change_date) go to character_clone_state, a live one-row-per-
+// character table like character_location.
 
 const cloneKey = (c) => (c.is_home ? 'home' : `jump:${c.jump_clone_id}`)
 
+// system_id is derived from location_id, so it's deliberately not part of the
+// signature: a late-resolving system backfills the open row (see reconcile)
+// instead of closing it and opening a new one.
 const signature = (c) =>
   JSON.stringify([
     c.location_id,
@@ -22,10 +28,59 @@ const signature = (c) =>
     [...(c.implants ?? [])].sort((a, b) => a - b),
   ])
 
+// Resolve each clone's station/structure to its solar system, memoized across
+// every character in the run (clones cluster in the same few locations).
+// NPC stations resolve via the public /universe/stations/ endpoint; player
+// structures via the universe_structure cache, falling back to an ESI call
+// with the character's own token (403 if it can't dock — the daily
+// universe-structures job pools clone locations too, so another character's
+// token may backfill it later). Unresolvable locations stay null.
+const makeSystemResolver = () => {
+  const memo = new Map()
+  return async (location_id, location_type, access_token) => {
+    if (memo.has(location_id)) return memo.get(location_id)
+    let system_id = null
+    try {
+      if (location_type === 'station') {
+        const station = await universeStation(location_id)
+        system_id = station?.system_id ?? null
+      } else if (location_type === 'structure') {
+        const { data } = await sudoSupabase
+          .from('universe_structure')
+          .select('system_id')
+          .eq('structure_id', location_id)
+          .maybeSingle()
+        if (data?.system_id != null) {
+          system_id = Number(data.system_id)
+        } else {
+          const info = await universeStructure(access_token, location_id)
+          system_id = info?.solar_system_id ?? null
+          if (system_id != null) {
+            await sudoSupabase.from('universe_structure').upsert(
+              {
+                structure_id: location_id,
+                name: info?.name ?? null,
+                system_id,
+                type_id: info?.type_id ?? null,
+                resolved_at: new Date().toISOString(),
+              },
+              { onConflict: 'structure_id' }
+            )
+          }
+        }
+      }
+    } catch (e) {
+      console.warn(`[${TAG}] system for ${location_type} ${location_id} unresolved: ${e?.message}`)
+    }
+    memo.set(location_id, system_id)
+    return system_id
+  }
+}
+
 const fetchCurrentRows = async (character_id) => {
   const { data, error } = await sudoSupabase
     .from('character_clone_over_time')
-    .select('id, jump_clone_id, is_home, location_id, location_type, name, implants')
+    .select('id, jump_clone_id, is_home, location_id, location_type, name, implants, system_id')
     .eq('character_id', character_id)
     .eq('is_current', true)
   if (error) throw error
@@ -33,9 +88,10 @@ const fetchCurrentRows = async (character_id) => {
 }
 
 // Reconcile the freshly fetched clones against the character's current (open)
-// rows: an unchanged clone gets its last_seen_at extended, a changed clone has
-// its old row closed and a new one inserted, and a clone that's gone (jump
-// clone destroyed/consumed) is closed.
+// rows: an unchanged clone gets its last_seen_at extended (and its system_id
+// backfilled if resolution newly succeeded), a changed clone has its old row
+// closed and a new one inserted, and a clone that's gone (jump clone
+// destroyed/consumed) is closed.
 const reconcile = async (character_id, fetchedClones) => {
   const current = await fetchCurrentRows(character_id)
   const currentByKey = new Map(map((c) => [cloneKey(c), c], current))
@@ -43,11 +99,15 @@ const reconcile = async (character_id, fetchedClones) => {
 
   const now = new Date().toISOString()
 
-  const { touchIds, closeIds, inserts } = reduce(
+  const { touchIds, retags, closeIds, inserts } = reduce(
     (acc, c) => {
       const cur = currentByKey.get(cloneKey(c))
       if (cur && signature(cur) === signature(c)) {
-        acc.touchIds.push(cur.id)
+        if (c.system_id != null && Number(cur.system_id ?? NaN) !== c.system_id) {
+          acc.retags.push({ id: cur.id, system_id: c.system_id })
+        } else {
+          acc.touchIds.push(cur.id)
+        }
       } else {
         if (cur) acc.closeIds.push(cur.id)
         acc.inserts.push({
@@ -58,12 +118,13 @@ const reconcile = async (character_id, fetchedClones) => {
           location_type: c.location_type ?? null,
           name: c.name ?? null,
           implants: c.implants ?? [],
+          system_id: c.system_id ?? null,
           last_seen_at: now,
         })
       }
       return acc
     },
-    { touchIds: [], closeIds: [], inserts: [] },
+    { touchIds: [], retags: [], closeIds: [], inserts: [] },
     [...fetchedByKey.values()]
   )
 
@@ -81,6 +142,15 @@ const reconcile = async (character_id, fetchedClones) => {
       .in('id', touchIds)
     if (error) throw error
   }
+  // Unchanged rows whose location just became resolvable: backfill system_id
+  // per row (each may resolve to a different system) while extending last_seen_at.
+  await forEachSequential(retags, async ({ id, system_id }) => {
+    const { error } = await sudoSupabase
+      .from('character_clone_over_time')
+      .update({ last_seen_at: now, system_id })
+      .eq('id', id)
+    if (error) throw error
+  })
   // Close before inserting so the unique-current-per-clone indexes never collide.
   if (allCloseIds.length) {
     const { error } = await sudoSupabase
@@ -94,11 +164,12 @@ const reconcile = async (character_id, fetchedClones) => {
     if (error) throw error
   }
 
-  return { touched: touchIds.length, opened: inserts.length, closed: allCloseIds.length }
+  return { touched: touchIds.length + retags.length, opened: inserts.length, closed: allCloseIds.length }
 }
 
-export const runCharacterClones = ({ characterIds } = {}) =>
-  forEachCharacter(TAG, { scope: SCOPE, characterIds }, async ({ access_token, characterID, character_id, ctx }) => {
+export const runCharacterClones = ({ characterIds } = {}) => {
+  const resolveSystem = makeSystemResolver()
+  return forEachCharacter(TAG, { scope: SCOPE, characterIds }, async ({ access_token, characterID, character_id, ctx }) => {
     const payload = await characterClones(access_token, characterID)
     const home = payload.home_location
       ? [
@@ -121,8 +192,25 @@ export const runCharacterClones = ({ characterIds } = {}) =>
       }),
       payload.jump_clones ?? []
     )
-    const { touched, opened, closed } = await reconcile(character_id, [...home, ...jumpClones])
+    const clones = [...home, ...jumpClones]
+    await forEachSequential(clones, async (c) => {
+      c.system_id = await resolveSystem(c.location_id, c.location_type, access_token)
+    })
+
+    const { error: stateErr } = await sudoSupabase.from('character_clone_state').upsert(
+      {
+        character_id,
+        last_clone_jump_date: payload.last_clone_jump_date ?? null,
+        last_station_change_date: payload.last_station_change_date ?? null,
+        recorded_at: new Date().toISOString(),
+      },
+      { onConflict: 'character_id' }
+    )
+    if (stateErr) throw stateErr
+
+    const { touched, opened, closed } = await reconcile(character_id, clones)
     console.log(`[${TAG}] ${ctx}: ${touched} unchanged, ${opened} opened, ${closed} closed`)
   })
+}
 
 cli(import.meta.url, TAG, runCharacterClones)

--- a/src/jobs/universeStructures.js
+++ b/src/jobs/universeStructures.js
@@ -35,8 +35,8 @@ const fetchAssetLocationRows = async (from = 0) => {
 }
 
 // GET /universe/structures/{id} → universe_structure. Resolves and caches the
-// names/systems of the player structures characters hold assets in. Candidates
-// are pooled across *all* linked characters and each is attempted against
+// names/systems of the player structures characters hold assets or clones in.
+// Candidates are pooled across *all* linked characters and each is attempted against
 // *every* scoped token until one can dock and resolve it — a structure only
 // needs a single character with docking access, and that character is often not
 // the one whose assets sit there. Cheap in steady state: candidates exclude
@@ -72,6 +72,24 @@ export const runUniverseStructures = async () => {
       if (Number.isFinite(id) && id >= STRUCTURE_ID_FLOOR) locationIds.add(id)
     },
     await fetchAssetLocationRows()
+  )
+
+  // Clones parked in player structures are candidates too — the character-clones
+  // job resolves what it can with each clone's own token, but only a character
+  // with docking access can resolve a given structure, and that's often a
+  // different character than the clone's owner.
+  const { data: cloneRows, error: clonesErr } = await sudoSupabase
+    .from('character_clone_over_time')
+    .select('location_id')
+    .eq('is_current', true)
+    .eq('location_type', 'structure')
+  if (clonesErr) throw clonesErr
+  forEach(
+    (r) => {
+      const id = Number(r.location_id)
+      if (Number.isFinite(id) && id >= STRUCTURE_ID_FLOOR) locationIds.add(id)
+    },
+    cloneRows ?? []
   )
 
   const candidates = reject((id) => itemIds.has(id) || resolved.has(id), [...locationIds])

--- a/supabase/migrations/20260710120000_add_clone_system_and_jump_state.sql
+++ b/supabase/migrations/20260710120000_add_clone_system_and_jump_state.sql
@@ -1,0 +1,43 @@
+-- Clone jump cooldown timestamps and per-clone solar system.
+--
+-- The /characters/{id}/clones/ payload also carries two character-level
+-- timestamps (last_clone_jump_date, last_station_change_date) that the
+-- character-clones job previously discarded; store them as a live
+-- current-state row per character (like character_location /
+-- character_implant). "Next jump available" is derived in the UI as
+-- last_clone_jump_date + 24h (conservative: Infomorph Synchronizing shortens
+-- it, but reading the skill would need another ESI scope).
+--
+-- Each clone row also gains system_id: the solar system its station/structure
+-- sits in, resolved at extract time, so "which character has a clone
+-- closest to system X" can be answered from the database alone.
+
+-- ── character_clone_over_time.system_id ───────────────────────────────────
+alter table public.character_clone_over_time
+  add column system_id bigint;
+
+-- select * re-expands on replace, picking up the appended column.
+create or replace view public.character_clone with (security_invoker = on) as
+  select * from public.character_clone_over_time where is_current;
+
+-- ── character_clone_state ──────────────────────────────────────────────────
+create table public.character_clone_state (
+  character_id uuid primary key references public.registration(id) on delete cascade,
+  last_clone_jump_date timestamptz,
+  last_station_change_date timestamptz,
+  recorded_at timestamptz not null default now()
+);
+
+alter table public.character_clone_state enable row level security;
+create policy "Users read own clone state"
+  on public.character_clone_state
+  for select
+  to authenticated
+  using (
+    character_id in (
+      select id from public.registration where user_id = (select auth.uid())
+    )
+  );
+
+grant select on public.character_clone_state to authenticated;
+grant all    on public.character_clone_state to service_role;


### PR DESCRIPTION
## What

Extends the existing `character-clones` extract (data collection only — no UI in this pass):

- **`character_clone_state`** (new table, live one-row-per-character like `character_location`): stores `last_clone_jump_date` and `last_station_change_date` from the same `/characters/{id}/clones/` payload the job already fetches — no new ESI scope needed. "Next jump available" is derived as `last_clone_jump_date + 24h` (conservative; the exact cooldown would need the Infomorph Synchronizing skill level via `esi-skills.read_skills.v1`, deliberately skipped to avoid re-authorizing every character).
- **`character_clone_over_time.system_id`** (new column, also on the `character_clone` view): the solar system each clone's station/structure sits in, resolved at extract time so "which character has a clone closest to system X" can later be answered from the database alone.
  - NPC stations resolve via the public `/universe/stations/{id}/` endpoint (new `universeStation` wrapper in `src/esi.js`), memoized per run.
  - Player structures resolve via the `universe_structure` cache, falling back to an ESI call with the clone owner's token (cached back into `universe_structure` on success).
  - `system_id` is not part of the SCD signature: an unchanged clone whose location becomes resolvable gets its open row backfilled instead of a new row.
- The daily `universe-structures` job now pools current clone structure locations as resolution candidates, so a structure the clone's owner can't dock at can still be resolved by another linked character's token.
- Schema: incremental migration `20260710120000_add_clone_system_and_jump_state.sql` + matching `schema.sql` updates (including adding the previously missing drop statements for the clone/implant/location tables so a fresh reset re-runs cleanly). CLAUDE.md map updated.

## Notes

- `pnpm install` fails in this environment (the `@eveshipfit` GitHub Packages registry requires auth), so lint/build could not be run here; the modified JS files pass `node --check`. CI should cover the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtDuKN2n43avft1AcAWcPd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtDuKN2n43avft1AcAWcPd)_