### PR TITLE
Change hourly extract jobs to run every 6 hours

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,24 +173,24 @@ One job per ESI endpoint. The npm script, queue job name, and heartbeat job labe
 
 | Job | ESI endpoint | Writes to | Schedule (UTC) |
 |---|---|---|---|
-| `character-assets` | `/characters/{id}/assets/` (+`/assets/names/`) | `character_asset_over_time` | hourly `:26` |
-| `character-blueprints` | `/characters/{id}/blueprints/` | `character_blueprint_over_time` | hourly `:28` |
-| `character-orders` | `/characters/{id}/orders/` | `character_order` | hourly `:24` |
-| `character-wallet` | `/characters/{id}/wallet/` | `character_wallet` | hourly `:44` |
-| `character-wallet-transactions` | `/characters/{id}/wallet/transactions/` | `character_wallet_transaction` | hourly `:46` |
-| `character-industry-jobs` | `/characters/{id}/industry/jobs/` | `character_industry_job` | hourly `:48` |
-| `character-location` | `/characters/{id}/location/` | `character_location` | hourly `:14` |
-| `character-implants` | `/characters/{id}/implants/` | `character_implant` | hourly `:16` |
-| `character-clones` | `/characters/{id}/clones/` | `character_clone_over_time`, `character_clone_state` | hourly `:18` |
+| `character-assets` | `/characters/{id}/assets/` (+`/assets/names/`) | `character_asset_over_time` | every 6h `:26` |
+| `character-blueprints` | `/characters/{id}/blueprints/` | `character_blueprint_over_time` | every 6h `:28` |
+| `character-orders` | `/characters/{id}/orders/` | `character_order` | every 6h `:24` |
+| `character-wallet` | `/characters/{id}/wallet/` | `character_wallet` | every 6h `:44` |
+| `character-wallet-transactions` | `/characters/{id}/wallet/transactions/` | `character_wallet_transaction` | every 6h `:46` |
+| `character-industry-jobs` | `/characters/{id}/industry/jobs/` | `character_industry_job` | every 6h `:48` |
+| `character-location` | `/characters/{id}/location/` | `character_location` | every 6h `:14` |
+| `character-implants` | `/characters/{id}/implants/` | `character_implant` | every 6h `:16` |
+| `character-clones` | `/characters/{id}/clones/` | `character_clone_over_time`, `character_clone_state` | every 6h `:18` |
 | `character-affiliations` | `/characters/affiliation/` | `character_affiliation` | 11:41 daily |
 | `corp-structures` | `/corporations/{id}/structures/` | `corp_structure` | 09:17 daily |
 | `corp-assets` | `/corporations/{id}/assets/` | `corp_asset_over_time`, `corp_structure_rig` | 09:27 daily |
 | `corp-blueprints` | `/corporations/{id}/blueprints/` | `corp_blueprint_over_time` | 09:07 daily |
-| `corp-wallet-journal` | `/corporations/{id}/wallets/{division}/journal/` | `corp_wallet_journal` | hourly `:37` |
-| `corp-wallet-transactions` | `/corporations/{id}/wallets/{division}/transactions/` | `corp_wallet_transaction` | hourly `:50` |
-| `corp-industry-jobs` | `/corporations/{id}/industry/jobs/` | `corp_industry_job` | hourly `:47` |
-| `industry-systems` | `/industry/systems/` | `industry_system_index` (systems with structures ∪ user-watched systems) | hourly `:10` |
-| `universe-names` | `/universe/names/` | `universe_name` | hourly `:58` |
+| `corp-wallet-journal` | `/corporations/{id}/wallets/{division}/journal/` | `corp_wallet_journal` | every 6h `:37` |
+| `corp-wallet-transactions` | `/corporations/{id}/wallets/{division}/transactions/` | `corp_wallet_transaction` | every 6h `:50` |
+| `corp-industry-jobs` | `/corporations/{id}/industry/jobs/` | `corp_industry_job` | every 6h `:47` |
+| `industry-systems` | `/industry/systems/` | `industry_system_index` (systems with structures ∪ user-watched systems) | every 6h `:10` |
+| `universe-names` | `/universe/names/` | `universe_name` | every 6h `:58` |
 | `universe-structures` | `/universe/structures/{id}` | `universe_structure` | 09:57 daily |
 
 `src/heartbeat.js` (`heartbeat.yml`, 10:55 daily) is a canary that just proves heartbeat recording works; it remains on GitHub Actions since it isn't an ESI extract job.

--- a/src/app/character/refresh/page.tsx
+++ b/src/app/character/refresh/page.tsx
@@ -211,9 +211,9 @@ const RefreshPage = async () => {
     <>
       <h1>Refresh ESI</h1>
       <p>
-        Extracts run on their own schedule (hourly for most, daily for corp assets and affiliations); nothing starts
-        just by opening this page. A cell shows when its job last ran — green within 15 minutes, yellow within 75, red
-        beyond that — and stale cells can be refreshed one at a time.
+        Extracts run on their own schedule (every 6 hours for most, daily for corp assets and affiliations); nothing
+        starts just by opening this page. A cell shows when its job last ran — green within 15 minutes, yellow within
+        6 hours, red beyond that — and stale cells can be refreshed one at a time.
       </p>
 
       {registrations.length === 0 ? (

--- a/src/app/freshness.ts
+++ b/src/app/freshness.ts
@@ -1,10 +1,10 @@
 // Freshness thresholds shared by the header indicator and the /character/refresh
-// matrix: green under 15 minutes, yellow up to 75 minutes, red beyond that — a
-// hair over the hourly extract cadence, so red means a scheduled pull was missed
-// (or the job only runs daily). Kept separate from the Freshness component so
-// server components can grade a timestamp without importing client code.
+// matrix: green under 15 minutes, yellow up to 6 hours, red beyond that — matching
+// the extract cadence, so red means a scheduled pull was missed (or the job only
+// runs daily). Kept separate from the Freshness component so server components
+// can grade a timestamp without importing client code.
 export const FRESH_MINUTES = 15
-export const STALE_MINUTES = 75
+export const STALE_MINUTES = 360
 
 export type FreshnessLevel = 'fresh' | 'aging' | 'stale' | 'none'
 

--- a/vercel.json
+++ b/vercel.json
@@ -3,59 +3,59 @@
   "crons": [
     {
       "path": "/api/cron/character-orders",
-      "schedule": "24 * * * *"
+      "schedule": "24 */6 * * *"
     },
     {
       "path": "/api/cron/character-assets",
-      "schedule": "26 * * * *"
+      "schedule": "26 */6 * * *"
     },
     {
       "path": "/api/cron/character-blueprints",
-      "schedule": "28 * * * *"
+      "schedule": "28 */6 * * *"
     },
     {
       "path": "/api/cron/corp-wallet-journal",
-      "schedule": "37 * * * *"
+      "schedule": "37 */6 * * *"
     },
     {
       "path": "/api/cron/character-wallet",
-      "schedule": "44 * * * *"
+      "schedule": "44 */6 * * *"
     },
     {
       "path": "/api/cron/character-wallet-transactions",
-      "schedule": "46 * * * *"
+      "schedule": "46 */6 * * *"
     },
     {
       "path": "/api/cron/corp-industry-jobs",
-      "schedule": "47 * * * *"
+      "schedule": "47 */6 * * *"
     },
     {
       "path": "/api/cron/character-industry-jobs",
-      "schedule": "48 * * * *"
+      "schedule": "48 */6 * * *"
     },
     {
       "path": "/api/cron/character-location",
-      "schedule": "14 * * * *"
+      "schedule": "14 */6 * * *"
     },
     {
       "path": "/api/cron/character-implants",
-      "schedule": "16 * * * *"
+      "schedule": "16 */6 * * *"
     },
     {
       "path": "/api/cron/character-clones",
-      "schedule": "18 * * * *"
+      "schedule": "18 */6 * * *"
     },
     {
       "path": "/api/cron/corp-wallet-transactions",
-      "schedule": "50 * * * *"
+      "schedule": "50 */6 * * *"
     },
     {
       "path": "/api/cron/universe-names",
-      "schedule": "58 * * * *"
+      "schedule": "58 */6 * * *"
     },
     {
       "path": "/api/cron/industry-systems",
-      "schedule": "10 * * * *"
+      "schedule": "10 */6 * * *"
     },
     {
       "path": "/api/cron/corp-blueprints",


### PR DESCRIPTION
## Summary
- Switched all 14 previously-hourly Vercel Cron entries (`character-*`, `corp-wallet-journal`, `corp-wallet-transactions`, `corp-industry-jobs`, `universe-names`, `industry-systems`) in `vercel.json` from `M * * * *` to `M */6 * * *`, keeping their existing offset minute.
- Widened the `/character/refresh` freshness-dot yellow threshold (`STALE_MINUTES` in `src/app/freshness.ts`) from 75 minutes to 360 minutes (6 hours) to match the new cadence — green stays under 15 minutes, yellow up to 6 hours, red beyond that.
- Updated the copy on `/character/refresh` and the job schedule table in `CLAUDE.md` to reflect "every 6 hours" instead of "hourly".

## Test plan
- [ ] Verify Vercel picks up the new cron schedules after deploy
- [ ] Confirm `/character/refresh` freshness dots grade green/yellow/red at the new thresholds


---
_Generated by [Claude Code](https://claude.ai/code/session_01XkQPXYPCm6XuHdPPw14qfh)_