### PR TITLE
Remove all Google Analytics references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,4 +13,3 @@ CRON_SECRET=random-secret-shared-with-vercel-cron
 # this is so NextJS will make these things available in client components
 NEXT_PUBLIC_SUPABASE_URL=https://ifqywgxsdjxbonsytqya.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJh...JIM
-NEXT_PUBLIC_GOOGLE_ANALYTICS_ID=G-MAYBENOT

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ cp .env.example .env
 - `FLAGS_SECRET` — any base64-encoded 32-byte secret, e.g. `openssl rand -base64 32`.
 - `CRON_SECRET` — only used by deployed Vercel Cron; any placeholder value works
   locally since nothing checks it outside of `/api/cron/*` routes.
-- `NEXT_PUBLIC_GOOGLE_ANALYTICS_ID` — optional; leave as-is or blank for local dev.
 
 ## 5. Run the app
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "@eveshipfit/data": "^10.4.20260609",
     "@eveshipfit/dogma-engine": "^7.1.0",
     "@eveshipfit/react": "^4.7.2",
-    "@next/third-parties": "16.2.10",
     "@philihp/eve-sso": "2.1.0",
     "@supabase/ssr": "0.12.0",
     "@supabase/supabase-js": "2.110.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@eveshipfit/react':
         specifier: ^4.7.2
         version: 4.7.2(@eveshipfit/data@10.4.20260609)(@eveshipfit/dogma-engine@7.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@next/third-parties':
-        specifier: 16.2.10
-        version: 16.2.10(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       '@philihp/eve-sso':
         specifier: 2.1.0
         version: 2.1.0
@@ -408,12 +405,6 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
-
-  '@next/third-parties@16.2.10':
-    resolution: {integrity: sha512-H3yxCMLziM1JKXnjQv83WBH2cp1fB1vMxpC1/bBTpvvaesBEuRuprpzq5RI32atis0VhUZflgdpJdGNZIGpQaQ==}
-    peerDependencies:
-      next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0
-      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
 
   '@noble/ciphers@1.3.0':
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
@@ -1312,9 +1303,6 @@ packages:
     resolution: {integrity: sha512-ECT61HUnVMXCAX/1O4Dmj0ifUPCM4AonSYcd/degMGbJdAmgwdquht43cKDp9k1cE15uJKfILjZEQTOSw7Np/w==}
     hasBin: true
 
-  third-party-capital@1.0.20:
-    resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
-
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
@@ -1612,12 +1600,6 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.2.10':
     optional: true
-
-  '@next/third-parties@16.2.10(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      next: 16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      third-party-capital: 1.0.20
 
   '@noble/ciphers@1.3.0': {}
 
@@ -2464,8 +2446,6 @@ snapshots:
       '@supabase/cli-linux-x64-musl': 2.109.0
       '@supabase/cli-windows-arm64': 2.109.0
       '@supabase/cli-windows-x64': 2.109.0
-
-  third-party-capital@1.0.20: {}
 
   tinyexec@1.2.4: {}
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import { Analytics } from '@vercel/analytics/react'
 import { SpeedInsights } from '@vercel/speed-insights/next'
-// import { GoogleAnalytics } from '@next/third-parties/google'
 import type { Metadata } from 'next'
 import './globals.css'
 import Header from './layout/header'
@@ -43,7 +42,6 @@ const RootLayout = ({
         <Analytics />
         <SpeedInsights />
       </body>
-      {/* <GoogleAnalytics gaId="{ process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID }" /> */}
     </html>
   )
 }


### PR DESCRIPTION
## Summary
- Removed the commented-out `GoogleAnalytics` import/usage from `src/app/layout.tsx`
- Dropped the unused `@next/third-parties` dependency (only consumer was the commented-out code) from `package.json`/`pnpm-lock.yaml`
- Removed `NEXT_PUBLIC_GOOGLE_ANALYTICS_ID` from `.env.example` and its README mention

## Test plan
- [x] `grep -ri google_analytics src/ .env.example README.md` returns no matches
- [ ] `pnpm install`/`pnpm run build` not run in this session — package registry auth for `@eveshipfit/data` was unavailable in the sandbox


---
_Generated by [Claude Code](https://claude.ai/code/session_01V4tCskYS7aoS76vPCCWZa9)_