### PR TITLE
Add MCP server with OAuth 2.1 auth and six read-only query tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,8 +132,8 @@ All functions take `(accessToken, id, ...)` unless noted. Returns raw ESI respon
 ### `src/utils/csv.ts`
 - `toCsv(rows: object[])` — serialize flat object array to RFC 4180 CSV string
 
-### `src/utils/supabase/client.ts` / `server.ts` / `service.ts`
-- Browser / server-cookie / service-role Supabase client factories
+### `src/utils/supabase/client.ts` / `server.ts` / `service.ts` / `bearer.ts`
+- Browser / server-cookie / service-role / OAuth-bearer-token Supabase client factories (`bearer.ts` builds an RLS-scoped client from an MCP caller's access token)
 
 ## App routes → files
 
@@ -158,6 +158,9 @@ All functions take `(accessToken, id, ...)` unless noted. Returns raw ESI respon
 | `/settings/grants` | `src/app/settings/grants/page.tsx` |
 | `/blueprint` | `src/app/blueprint/page.tsx` |
 | `/blueprint/[typeID]` | `src/app/blueprint/[typeID]/page.tsx` |
+| `/oauth/consent` | `src/app/oauth/consent/page.tsx` |
+| `/api/mcp/[transport]` | `src/app/api/mcp/[transport]/route.ts` |
+| `/.well-known/oauth-protected-resource` | `src/app/.well-known/oauth-protected-resource/[[...resource]]/route.ts` |
 | `/api/character/assets` | `src/app/api/character/assets/route.ts` |
 | `/api/character/blueprints` | `src/app/api/character/blueprints/route.ts` |
 | `/api/character/orders` | `src/app/api/character/orders/route.ts` |
@@ -170,7 +173,7 @@ All functions take `(accessToken, id, ...)` unless noted. Returns raw ESI respon
 
 The old CSV endpoint paths (`/api/assets`, `/api/orders`, `/api/industry`) and `/characters/refresh` permanently redirect to their new homes (see `next.config.mjs`) so existing Google Sheets keep working.
 
-Shared UI helpers: `src/app/isk.ts` (ISK formatting), `src/app/DateTime.tsx`, `src/app/typeName.tsx` (renders a type name from ID), `src/app/typeNames.ts` (resolves type names from the locally generated SDE data), `src/app/systemNames.ts`, `src/app/stationNames.ts`, `src/app/owners.ts` / `src/app/ownerFilter.tsx` (the character/corp "owner" picker shared by the assets and industry pages), `src/app/resolveLocations.ts` (resolves a set of root locations — station, player structure, or bare solar system — to display names + systems; shared by `/asset` and `/asset/search`), `src/app/freshness.ts` / `src/app/Freshness.tsx` (data-freshness grading — green under 15 minutes, yellow under 75, red beyond — and the live dot + "N minutes ago" client component; used by the header's "Refreshed …" indicator and the `/character/refresh` matrix).
+Shared UI helpers: `src/app/isk.ts` (ISK formatting), `src/app/DateTime.tsx`, `src/app/typeName.tsx` (renders a type name from ID), `src/app/typeNames.ts` (resolves type names from the locally generated SDE data), `src/app/systemNames.ts`, `src/app/stationNames.ts`, `src/app/owners.ts` / `src/app/ownerFilter.tsx` (the character/corp "owner" picker shared by the assets and industry pages), `src/app/resolveLocations.ts` (resolves a set of root locations — station, player structure, or bare solar system — to display names + systems; shared by `/asset` and `/asset/search`; it and `owners.ts`/`systemNames.ts`/`stationNames.ts` accept an optional Supabase client so the MCP tools can reuse them with a bearer-token client instead of the cookie session), `src/app/freshness.ts` / `src/app/Freshness.tsx` (data-freshness grading — green under 15 minutes, yellow under 75, red beyond — and the live dot + "N minutes ago" client component; used by the header's "Refreshed …" indicator and the `/character/refresh` matrix).
 
 ## Extract jobs
 
@@ -272,5 +275,6 @@ Key Postgres functions (callable via RPC or SQL):
 - **Supabase RLS:** All tables use RLS scoped to `auth.uid()`. Cron scripts use the service-role key (`sudoSupabase` / `src/utils/supabase/service.ts`) which bypasses RLS.
 - **Google Sheets IMPORTDATA:** `/api/character/assets`, `/api/character/blueprints`, `/api/character/orders`, `/api/character/jobs`, `/api/corp/assets`, `/api/corp/blueprints`, `/api/corp/jobs` authenticate via `user_settings.api_token`, call a Postgres function, and return CSV. The pre-rename paths permanently redirect to the new ones.
 - **Vercel queue:** The queue consumer at `/api/queue/jobs` dispatches to the same `run*()` functions the CLI jobs use. The UI enqueues work via `@vercel/queue`.
+- **MCP server:** `/api/mcp/mcp` (Streamable HTTP, via `mcp-handler`; route at `src/app/api/mcp/[transport]/route.ts`) exposes read-only tools over the extracted data — `search_assets`, `list_clones`, `list_blueprints`, `list_industry_jobs`, `list_market_orders`, `search_transactions` (`src/app/api/mcp/tools.ts`, shared plumbing in `lib.ts`). Tools accept fuzzy names (items/systems/owners resolved via the SDE search helpers) and return resolved names plus a `data_refreshed` freshness stamp from `latest_heartbeats()`. Auth is OAuth 2.1 with Supabase Auth as the authorization server: clients discover it via `/.well-known/oauth-protected-resource` (RFC 9728), the consent page lives at `/oauth/consent` (`supabase.auth.oauth.getAuthorizationDetails`/`approveAuthorization`/`denyAuthorization`), and `withMcpAuth` verifies bearer tokens with `auth.getClaims` (`src/app/api/mcp/auth.ts`). Every query runs on a client carrying the caller's token (`src/utils/supabase/bearer.ts`), so RLS scopes results exactly like the cookie session — tools never widen access and never call ESI. Requires the OAuth 2.1 server enabled in the Supabase dashboard (Authentication → OAuth Server) with the Authorization Path set to `/oauth/consent`, plus dynamic client registration for self-registering MCP clients like Claude.
 - **Token lifecycle:** ESI OAuth tokens are stored in `token`. Before any ESI call, `refreshAccessToken()` checks expiry and refreshes via EVE SSO if needed.
 - **Name resolution:** `universe_name` table caches ESI `universeNames` lookups (kept fresh by the `universe-names` job). `resolveBatch()` handles bisect-on-error for large batches. Type names (items/ships) come from the locally generated SDE data (`src/sdeTypes.ts`), not the DB.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@eveshipfit/data": "^10.4.20260609",
     "@eveshipfit/dogma-engine": "^7.1.0",
     "@eveshipfit/react": "^4.7.2",
+    "@modelcontextprotocol/sdk": "1.26.0",
     "@philihp/eve-sso": "2.1.0",
     "@supabase/ssr": "0.12.0",
     "@supabase/supabase-js": "2.110.0",
@@ -17,11 +18,13 @@
     "eve-industry": "0.1.0",
     "fast-shuffle": "^6.2.0",
     "flags": "^4.2.0",
+    "mcp-handler": "^1.1.0",
     "next": "16.2.10",
     "protobufjs": "^8.7.0",
     "ramda": "^0.32.0",
     "react": "19.2.7",
-    "react-dom": "19.2.7"
+    "react-dom": "19.2.7",
+    "zod": "^3.25.76"
   },
   "scripts": {
     "build": "next build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@eveshipfit/react':
         specifier: ^4.7.2
         version: 4.7.2(@eveshipfit/data@10.4.20260609)(@eveshipfit/dogma-engine@7.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@modelcontextprotocol/sdk':
+        specifier: 1.26.0
+        version: 1.26.0(zod@3.25.76)
       '@philihp/eve-sso':
         specifier: 2.1.0
         version: 2.1.0
@@ -44,6 +47,9 @@ importers:
       flags:
         specifier: ^4.2.0
         version: 4.2.0(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      mcp-handler:
+        specifier: ^1.1.0
+        version: 1.1.0(@modelcontextprotocol/sdk@1.26.0(zod@3.25.76))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       next:
         specifier: 16.2.10
         version: 16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -59,6 +65,9 @@ importers:
       react-dom:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@eslint/eslintrc':
         specifier: 3.3.5
@@ -177,6 +186,12 @@ packages:
       '@eveshipfit/dogma-engine': ^7
       react: ^18
       react-dom: ^18
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -351,6 +366,16 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@modelcontextprotocol/sdk@1.26.0':
+    resolution: {integrity: sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
   '@next/env@16.2.10':
     resolution: {integrity: sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==}
 
@@ -424,6 +449,35 @@ packages:
 
   '@philihp/prettier-config@1.0.0':
     resolution: {integrity: sha512-OZjBpLRyKzSVV++9rQcJeWdleBFn7dVmay44HsZPO6Sc3ecLxXbNn2imxJSiSzHugxc9+d2WIoai3gVeMqFDaA==}
+
+  '@redis/bloom@1.2.0':
+    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/client@1.6.1':
+    resolution: {integrity: sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==}
+    engines: {node: '>=14'}
+
+  '@redis/graph@1.1.1':
+    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/json@1.0.7':
+    resolution: {integrity: sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/search@1.2.0':
+    resolution: {integrity: sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/time-series@1.1.0':
+    resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
 
   '@supabase/auth-js@2.110.0':
     resolution: {integrity: sha512-Mi288WCTp6wxMFCOu/UgzgHEXODjdl2uVTLqK11eanzGZaldU3RyP8Am+ZbNuVzFP+5+iOvppxzv7N5Ym84xTg==}
@@ -662,6 +716,10 @@ packages:
       vue-router:
         optional: true
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -672,8 +730,19 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
@@ -702,6 +771,10 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   brace-expansion@1.1.15:
     resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
@@ -712,12 +785,28 @@ packages:
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
   caniuse-lite@1.0.30001800:
     resolution: {integrity: sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -734,12 +823,44 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
+  commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -760,9 +881,17 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
 
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
@@ -771,12 +900,34 @@ packages:
     resolution: {integrity: sha512-s0J9SEVYAEPg7J63GFMApLYzPH9VNIQIyC6s15JpnqVc0TqcKWdbgFlnAweEBRyMmko2dcs2sfC83Hj4J43tuA==}
     engines: {bun: '>=1', deno: '>=2.7.10', node: '>=16'}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -832,15 +983,37 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   eve-industry@0.1.0:
     resolution: {integrity: sha512-QRE4U44ysq0yYk/XtzLqUW/kSxZrta800mec3Vqhi76BN4IxEljl6Lp2kfWbXQvPSPuVqTWdp32M6Ivr5Ar8Ng==}
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -855,6 +1028,9 @@ packages:
     resolution: {integrity: sha512-Y7MexltTgkdI2UzeRx7zVIWiHSuQ41dD+2PPwukkIZW2b1wCSaciISyKNSKFVW6ImkH+QQivlDsmY552EO22Ig==}
     engines: {node: '>=14'}
 
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -867,6 +1043,10 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -902,9 +1082,32 @@ packages:
   form-urlencoded@6.1.7:
     resolution: {integrity: sha512-ciEL2sRI+hBwEwzIWofE7aHC778Ss1zK2/NK0Y7EYUzkPLU2ZXwddIT9t9Q6w0CM2xEHSJC92kY1SOh1oimlRA==}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  generic-pool@3.9.0:
+    resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
+    engines: {node: '>= 4'}
+
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -922,6 +1125,26 @@ packages:
     resolution: {integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==}
     engines: {node: '>=18'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.28:
+    resolution: {integrity: sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==}
+    engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
@@ -934,6 +1157,10 @@ packages:
   iceberg-js@0.8.1:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
     engines: {node: '>=20.0.0'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -951,6 +1178,17 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -962,6 +1200,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -988,6 +1229,12 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1071,8 +1318,38 @@ packages:
   lru-memoizer@2.3.0:
     resolution: {integrity: sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mcp-handler@1.1.0:
+    resolution: {integrity: sha512-MVCES7g18gcoZy+R/3v5nadkUMzMAWdos8jRl6DyljOKvd2/ZKDmwlCjL6zp4vo+7FeCXOYL1uWinHWlkKAAUg==}
+    hasBin: true
+    peerDependencies:
+      '@modelcontextprotocol/sdk': 1.26.0
+      next: '>=13.0.0'
+    peerDependenciesMeta:
+      next:
+        optional: true
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -1104,6 +1381,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   next@16.2.10:
     resolution: {integrity: sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==}
     engines: {node: '>=20.9.0'}
@@ -1128,6 +1409,21 @@ packages:
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -1157,6 +1453,10 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1164,6 +1464,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pcg@3.0.0:
     resolution: {integrity: sha512-lHETDr3c//q4xs0iZk9+LRFgmvjLtaUDIE3ztE2KN4IhwyHLcJ3H5VBv93SGop1XHZalC1UFSwoJepoZSMSVLQ==}
@@ -1175,6 +1478,10 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -1193,12 +1500,28 @@ packages:
     resolution: {integrity: sha512-uu52JNxLh3vsL7tXU/h0gDaywufvuUCTbGSi0NKQKBZ2ZopkmrWQJSQO/EFqzu/5YhiwgVM8rq/a/iVpx4eZ0g==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
   ramda@0.32.0:
     resolution: {integrity: sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ==}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
@@ -1207,6 +1530,13 @@ packages:
 
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+    engines: {node: '>=0.10.0'}
+
+  redis@4.7.1:
+    resolution: {integrity: sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
@@ -1220,8 +1550,15 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -1230,6 +1567,17 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -1242,6 +1590,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -1261,6 +1625,10 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -1311,6 +1679,10 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -1326,6 +1698,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   types-ramda@0.32.0:
     resolution: {integrity: sha512-iZtriSUdsDqOlip/wUaDNcoiskbVf5RdcqLNpQdUcOM1JKFClochCvPZCDjn/cc9HzoBzi4DEB4iPr1PbrhN1w==}
@@ -1345,8 +1721,16 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -1364,6 +1748,9 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   xdg-app-paths@5.5.1:
     resolution: {integrity: sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==}
@@ -1384,6 +1771,14 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.1.11:
     resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
@@ -1461,6 +1856,10 @@ snapshots:
       jwt-decode: 4.0.0
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+
+  '@hono/node-server@1.19.14(hono@4.12.28)':
+    dependencies:
+      hono: 4.12.28
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -1575,6 +1974,28 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.28)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.28
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
   '@next/env@16.2.10': {}
 
   '@next/swc-darwin-arm64@16.2.10':
@@ -1618,6 +2039,32 @@ snapshots:
       - supports-color
 
   '@philihp/prettier-config@1.0.0': {}
+
+  '@redis/bloom@1.2.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/client@1.6.1':
+    dependencies:
+      cluster-key-slot: 1.1.2
+      generic-pool: 3.9.0
+      yallist: 4.0.0
+
+  '@redis/graph@1.1.1(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/json@1.0.7(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/search@1.2.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/time-series@1.1.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
 
   '@supabase/auth-js@2.110.0':
     dependencies:
@@ -1836,11 +2283,20 @@ snapshots:
       next: 16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
 
   acorn@8.17.0: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
 
   ajv@6.15.0:
     dependencies:
@@ -1848,6 +2304,13 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-escapes@7.3.0:
     dependencies:
@@ -1865,6 +2328,20 @@ snapshots:
 
   baseline-browser-mapping@2.10.42: {}
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@1.1.15:
     dependencies:
       balanced-match: 1.0.2
@@ -1876,9 +2353,23 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001800: {}
+
+  chalk@5.6.2: {}
 
   cli-cursor@5.0.0:
     dependencies:
@@ -1893,9 +2384,28 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
+  commander@11.1.0: {}
+
   concat-map@0.0.1: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
   cookie@1.1.1: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -1911,8 +2421,16 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  depd@2.0.0: {}
+
   detect-libc@2.1.2:
     optional: true
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:
@@ -1925,9 +2443,23 @@ snapshots:
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
 
+  ee-first@1.1.1: {}
+
   emoji-regex@10.6.0: {}
 
+  encodeurl@2.0.0: {}
+
   environment@1.1.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -2003,9 +2535,17 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   eve-industry@0.1.0: {}
 
   eventemitter3@5.0.4: {}
+
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
 
   execa@5.1.1:
     dependencies:
@@ -2019,6 +2559,44 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
@@ -2029,6 +2607,8 @@ snapshots:
     dependencies:
       pcg: 3.0.0
 
+  fast-uri@3.1.3: {}
+
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
@@ -2036,6 +2616,17 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   find-up@5.0.0:
     dependencies:
@@ -2060,7 +2651,33 @@ snapshots:
 
   form-urlencoded@6.1.7: {}
 
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
+  function-bind@1.1.2: {}
+
+  generic-pool@3.9.0: {}
+
   get-east-asian-width@1.6.0: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   get-stream@6.0.1: {}
 
@@ -2072,11 +2689,33 @@ snapshots:
 
   globals@17.7.0: {}
 
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.28: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   human-signals@2.1.0: {}
 
   husky@9.1.7: {}
 
   iceberg-js@0.8.1: {}
+
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -2089,6 +2728,12 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  inherits@2.0.4: {}
+
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@5.1.0:
@@ -2098,6 +2743,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-promise@4.0.0: {}
 
   is-stream@2.0.1: {}
 
@@ -2116,6 +2763,10 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -2222,7 +2873,28 @@ snapshots:
       lodash.clonedeep: 4.5.0
       lru-cache: 6.0.0
 
+  math-intrinsics@1.1.0: {}
+
+  mcp-handler@1.1.0(@modelcontextprotocol/sdk@1.26.0(zod@3.25.76))(next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)):
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.26.0(zod@3.25.76)
+      chalk: 5.6.2
+      commander: 11.1.0
+      redis: 4.7.1
+    optionalDependencies:
+      next: 16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
   merge-stream@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mimic-fn@2.1.0: {}
 
@@ -2243,6 +2915,8 @@ snapshots:
   nanoid@3.3.15: {}
 
   natural-compare@1.4.0: {}
+
+  negotiator@1.0.0: {}
 
   next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
@@ -2271,6 +2945,18 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   onetime@5.1.2:
     dependencies:
@@ -2303,15 +2989,21 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
 
   pcg@3.0.0: {}
 
   picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
+
+  pkce-challenge@5.0.1: {}
 
   postcss@8.4.31:
     dependencies:
@@ -2327,9 +3019,28 @@ snapshots:
     dependencies:
       long: 5.3.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   punycode@2.3.1: {}
 
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
   ramda@0.32.0: {}
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   react-dom@19.2.7(react@19.2.7):
     dependencies:
@@ -2337,6 +3048,17 @@ snapshots:
       scheduler: 0.27.0
 
   react@19.2.7: {}
+
+  redis@4.7.1:
+    dependencies:
+      '@redis/bloom': 1.2.0(@redis/client@1.6.1)
+      '@redis/client': 1.6.1
+      '@redis/graph': 1.1.1(@redis/client@1.6.1)
+      '@redis/json': 1.0.7(@redis/client@1.6.1)
+      '@redis/search': 1.2.0(@redis/client@1.6.1)
+      '@redis/time-series': 1.1.0(@redis/client@1.6.1)
+
+  require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 
@@ -2347,11 +3069,50 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
 
   scheduler@0.27.0: {}
 
   semver@7.8.5: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -2391,6 +3152,34 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -2406,6 +3195,8 @@ snapshots:
       is-fullwidth-code-point: 5.1.0
 
   source-map-js@1.2.1: {}
+
+  statuses@2.0.2: {}
 
   string-argv@0.3.2: {}
 
@@ -2454,6 +3245,8 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
 
+  toidentifier@1.0.1: {}
+
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
@@ -2465,6 +3258,12 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   types-ramda@0.32.0:
     dependencies:
@@ -2485,9 +3284,13 @@ snapshots:
 
   undici-types@7.24.6: {}
 
+  unpipe@1.0.0: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  vary@1.1.2: {}
 
   which@2.0.2:
     dependencies:
@@ -2507,6 +3310,8 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
+  wrappy@1.0.2: {}
+
   xdg-app-paths@5.5.1:
     dependencies:
       os-paths: 4.4.0
@@ -2522,5 +3327,11 @@ snapshots:
     optional: true
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod@3.25.76: {}
 
   zod@4.1.11: {}

--- a/src/app/.well-known/oauth-protected-resource/[[...resource]]/route.ts
+++ b/src/app/.well-known/oauth-protected-resource/[[...resource]]/route.ts
@@ -1,0 +1,14 @@
+// OAuth 2.0 Protected Resource Metadata (RFC 9728) for the MCP server at
+// /api/mcp. Points MCP clients at Supabase Auth as the authorization server
+// (its RFC 8414 metadata lives at
+// <supabase>/.well-known/oauth-authorization-server/auth/v1). The optional
+// catch-all also serves the path-suffixed form some clients request
+// (/.well-known/oauth-protected-resource/api/mcp/mcp).
+import { metadataCorsOptionsRequestHandler, protectedResourceHandler } from 'mcp-handler'
+
+const handler = protectedResourceHandler({
+  authServerUrls: [`${process.env.NEXT_PUBLIC_SUPABASE_URL}/auth/v1`],
+})
+
+export { handler as GET }
+export const OPTIONS = metadataCorsOptionsRequestHandler()

--- a/src/app/account/login/loginForm.tsx
+++ b/src/app/account/login/loginForm.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useState } from 'react'
+import { redirect } from 'next/navigation'
+
+import { login } from './actions'
+
+// The login form proper; the page (a server component) passes a sanitized
+// same-site `next` path so flows like the OAuth consent page can bounce a
+// logged-out user through login and back.
+export const LoginForm = ({ next }: { next?: string }) => {
+  const [response, setResponse] = useState<string>('')
+
+  const loginAndReturn = async (formData: FormData) => {
+    const error = await login(formData)
+    if (error) {
+      setResponse(error)
+      return
+    }
+    redirect(next ?? '/')
+  }
+
+  return (
+    <>
+      <h1>Login</h1>
+      <p>Login to access your hangar.</p>
+      <form onSubmit={() => setResponse('')}>
+        <label htmlFor="email">Email:</label>
+        <br />
+        <input id="email" name="email" type="email" required />
+        <br />
+        <label htmlFor="password">Password:</label>
+        <br />
+        <input id="password" name="password" type="password" required />
+        <br />
+        <button formAction={loginAndReturn}>Log in</button>
+        {response && (
+          <>
+            <svg height="10" width="20">
+              <circle cx="10" cy="5" r="5" fill="#FF0000" />
+            </svg>
+            {response}
+          </>
+        )}
+        <div>
+          <a href="reset">Forgot Password</a>
+        </div>
+      </form>
+    </>
+  )
+}

--- a/src/app/account/login/page.tsx
+++ b/src/app/account/login/page.tsx
@@ -1,50 +1,13 @@
-'use client'
+import { LoginForm } from './loginForm'
 
-import { useState } from 'react'
-import { redirect } from 'next/navigation'
+// Only same-site absolute paths are honored (no scheme-relative `//host` or
+// absolute URLs), so `next` can't become an open redirect.
+const sanitizeNext = (next: string | undefined): string | undefined =>
+  next?.startsWith('/') && !next.startsWith('//') ? next : undefined
 
-import { login } from './actions'
-
-const Login = () => {
-  const [response, setResponse] = useState<string>('')
-
-  const loginAndReturn = async (formData: FormData) => {
-    const error = await login(formData)
-    if (error) {
-      setResponse(error)
-      return
-    }
-    redirect('/')
-  }
-
-  return (
-    <>
-      <h1>Login</h1>
-      <p>Login to access your hangar.</p>
-      <form onSubmit={() => setResponse('')}>
-        <label htmlFor="email">Email:</label>
-        <br />
-        <input id="email" name="email" type="email" required />
-        <br />
-        <label htmlFor="password">Password:</label>
-        <br />
-        <input id="password" name="password" type="password" required />
-        <br />
-        <button formAction={loginAndReturn}>Log in</button>
-        {response && (
-          <>
-            <svg height="10" width="20">
-              <circle cx="10" cy="5" r="5" fill="#FF0000" />
-            </svg>
-            {response}
-          </>
-        )}
-        <div>
-          <a href="reset">Forgot Password</a>
-        </div>
-      </form>
-    </>
-  )
+const Login = async ({ searchParams }: { searchParams: Promise<{ next?: string }> }) => {
+  const { next } = await searchParams
+  return <LoginForm next={sanitizeNext(next)} />
 }
 
 export default Login

--- a/src/app/api/mcp/[transport]/route.ts
+++ b/src/app/api/mcp/[transport]/route.ts
@@ -1,0 +1,24 @@
+// MCP server endpoint (Streamable HTTP at /api/mcp/mcp). Clients authorize
+// via OAuth 2.1 against Supabase Auth acting as the authorization server (the
+// consent page lives at /oauth/consent; discovery metadata at
+// /.well-known/oauth-protected-resource). Tools are read-only queries over
+// the extracted DB — see tools.ts.
+import { createMcpHandler, withMcpAuth } from 'mcp-handler'
+
+import { verifySupabaseToken } from '../auth'
+import { registerTools } from '../tools'
+
+const handler = createMcpHandler(
+  (server) => {
+    registerTools(server)
+  },
+  { serverInfo: { name: 'edencom-link', version: '1.0.0' } },
+  // No Redis in this deployment, so the (spec-deprecated) SSE transport stays
+  // off; Streamable HTTP keeps everything within a single function invocation.
+  { basePath: '/api/mcp', disableSse: true, maxDuration: 60 }
+)
+
+const authHandler = withMcpAuth(handler, verifySupabaseToken, { required: true })
+
+export { authHandler as GET, authHandler as POST, authHandler as DELETE }
+export const maxDuration = 60

--- a/src/app/api/mcp/auth.ts
+++ b/src/app/api/mcp/auth.ts
@@ -1,0 +1,26 @@
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js'
+
+import { createBearerClient } from '@/utils/supabase/bearer'
+
+// Verify the bearer token an MCP client obtained from Supabase Auth's OAuth
+// 2.1 server (enabled in the dashboard; consent page at /oauth/consent).
+// getClaims verifies the JWT signature (via the project's JWKS for asymmetric
+// keys, falling back to the Auth server for legacy symmetric ones) and
+// expiry. The token is then reused as-is on PostgREST calls, so RLS scopes
+// every tool to the user who authorized the client — a plain session JWT for
+// the same user would grant exactly the same access.
+export const verifySupabaseToken = async (_req: Request, bearerToken?: string): Promise<AuthInfo | undefined> => {
+  if (!bearerToken) return undefined
+  const supabase = createBearerClient(bearerToken)
+  const { data, error } = await supabase.auth.getClaims(bearerToken)
+  const claims = data?.claims
+  if (error || !claims?.sub) return undefined
+  const clientId = (claims as Record<string, unknown>).client_id
+  return {
+    token: bearerToken,
+    clientId: typeof clientId === 'string' ? clientId : 'unknown',
+    scopes: typeof claims.scope === 'string' ? claims.scope.split(' ') : [],
+    expiresAt: claims.exp,
+    extra: { userId: claims.sub },
+  }
+}

--- a/src/app/api/mcp/lib.ts
+++ b/src/app/api/mcp/lib.ts
@@ -1,0 +1,137 @@
+// Shared plumbing for the MCP tools (see tools.ts). Every helper takes the
+// token-scoped Supabase client built from the caller's OAuth access token, so
+// RLS decides what each user can see — the helpers themselves never widen
+// access. Type/system names resolve from the locally generated SDE data
+// (never the stale evesde DB schema), everything else from the same caches
+// the web pages use.
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import { fetchOwners } from '@/app/owners'
+import type { LocationRef } from '@/app/resolveLocations'
+import { getSdeType, searchSdeTypesAll, type SdeSearchResult } from '@/sdeTypes'
+
+// Above this, the substring is too broad to be a useful item filter — same
+// threshold (and rationale) as /asset/search.
+export const MAX_TYPES = 100
+
+// EVE's SDE Blueprint category (BPOs/BPCs and reaction formulas alike).
+// Asset search excludes these by default, mirroring /asset/search.
+export const BLUEPRINT_CATEGORY_ID = 9
+
+// MCP tool results are text content blocks; every tool returns either a plain
+// message or a JSON payload the model can read directly.
+export type ToolResult = { content: Array<{ type: 'text'; text: string }> }
+
+export const textResult = (payload: unknown): ToolResult => ({
+  content: [{ type: 'text', text: typeof payload === 'string' ? payload : JSON.stringify(payload) }],
+})
+
+// Resolve a fuzzy item-name query to SDE type ids, with the same "too many
+// matches" guard as /asset/search so a broad substring can't walk a large
+// chunk of the hangar (or bloat a `.in()` list). `null` query means no filter.
+export type TypeFilter = { ok: true; matches: SdeSearchResult[] | null } | { ok: false; message: string }
+
+export const resolveTypeFilter = (query: string | undefined, { includeBlueprints = true } = {}): TypeFilter => {
+  const trimmed = (query ?? '').trim()
+  if (trimmed === '') return { ok: true, matches: null }
+  const allMatches = searchSdeTypesAll(trimmed)
+  const matches = includeBlueprints
+    ? allMatches
+    : allMatches.filter((m) => getSdeType(m.typeID)?.categoryID !== BLUEPRINT_CATEGORY_ID)
+  if (matches.length === 0) {
+    const blueprintsOnlyMatched = !includeBlueprints && allMatches.length > 0
+    return {
+      ok: false,
+      message: `No item types matched "${trimmed}"${
+        blueprintsOnlyMatched ? ' (only blueprints did — set include_blueprints to search those too).' : '.'
+      }`,
+    }
+  }
+  if (matches.length > MAX_TYPES) {
+    const sample = matches
+      .slice(0, 10)
+      .map((m) => m.name)
+      .sort((a, b) => a.localeCompare(b))
+    return {
+      ok: false,
+      message: `"${trimmed}" matched ${matches.length} item types — too many to search at once. Try a more specific term. A sample of what matched: ${sample.join(', ')}.`,
+    }
+  }
+  return { ok: true, matches }
+}
+
+// Owner (character/corporation) display names for the caller, and an optional
+// name filter over them. Owner ids are registration uuids for characters and
+// corporation ids for corp-owned rows — the same convention the web pages use.
+export type OwnerContext = {
+  nameById: Map<string, string>
+  characterIds: string[]
+  corporationIds: string[]
+}
+
+export const fetchOwnerContext = async (supabase: SupabaseClient): Promise<OwnerContext> => {
+  const owners = await fetchOwners(supabase)
+  return {
+    nameById: new Map([...owners.characters, ...owners.corporations].map((o) => [o.id, o.name])),
+    characterIds: owners.characters.map((o) => o.id),
+    corporationIds: owners.corporations.map((o) => o.id),
+  }
+}
+
+// Case-insensitive substring match of an owner-name filter against the
+// caller's characters and corporations. Returns the matching owner ids, or an
+// error message listing what's available when nothing matches.
+export type OwnerFilter = { ok: true; ownerIds: Set<string> | null } | { ok: false; message: string }
+
+export const resolveOwnerFilter = (owner: string | undefined, ctx: OwnerContext): OwnerFilter => {
+  const trimmed = (owner ?? '').trim().toLowerCase()
+  if (trimmed === '') return { ok: true, ownerIds: null }
+  const ids = [...ctx.nameById].filter(([, name]) => name.toLowerCase().includes(trimmed)).map(([id]) => id)
+  if (ids.length === 0) {
+    const available = [...ctx.nameById.values()].sort((a, b) => a.localeCompare(b))
+    return { ok: false, message: `No character or corporation matched "${owner}". Available: ${available.join(', ')}.` }
+  }
+  return { ok: true, ownerIds: new Set(ids) }
+}
+
+// Orders/jobs/transactions carry a bare location_id with no type column. NPC
+// stations live in a fixed id band, so classify those for the universe_name
+// station cache; anything else resolves via the structure caches (or falls
+// back to a labelled raw id) in resolveLocations.
+export const guessLocationRef = (locationId: number | string | null | undefined): LocationRef | null => {
+  if (locationId == null) return null
+  const id = Number(locationId)
+  return { id: String(locationId), type: id >= 60000000 && id < 64000000 ? 'station' : null }
+}
+
+// Page through a select past PostgREST's max_rows (1000) cap until a short
+// page signals the end (cf. /market's fetchAllRows).
+const PAGE_SIZE = 1000
+
+export const fetchAllRows = async <T>(
+  build: (from: number, to: number) => PromiseLike<{ data: T[] | null; error: unknown }>
+): Promise<T[]> => {
+  const rows: T[] = []
+  for (let from = 0; ; from += PAGE_SIZE) {
+    const { data, error } = await build(from, from + PAGE_SIZE - 1)
+    if (error || !data || data.length === 0) break
+    rows.push(...data)
+    if (data.length < PAGE_SIZE) break
+  }
+  return rows
+}
+
+// When the relevant extract jobs last completed for this user, so the model
+// can caveat answers with how fresh the underlying snapshot is (extracts run
+// on Vercel Cron, not on demand — see /character/refresh).
+export const dataFreshness = async (supabase: SupabaseClient, jobs: string[]): Promise<Record<string, string>> => {
+  const { data } = await supabase.rpc('latest_heartbeats')
+  const rows = (data ?? []) as Array<{ job: string; ended_at: string }>
+  const freshness: Record<string, string> = {}
+  rows
+    .filter((r) => jobs.includes(r.job))
+    .forEach((r) => {
+      if (!freshness[r.job] || r.ended_at > freshness[r.job]) freshness[r.job] = r.ended_at
+    })
+  return freshness
+}

--- a/src/app/api/mcp/tools.ts
+++ b/src/app/api/mcp/tools.ts
@@ -1,0 +1,698 @@
+// The six MCP tools: read-only questions over the extracted EVE data ("where
+// is my titan", "how many fuel blocks do I have in EKPB-3"). Tools accept
+// fuzzy names (items, systems, owners) and return resolved names, mirroring
+// the equivalent web pages' queries — the DB is the only source here; MCP
+// never calls ESI (see the data-flow rule in CLAUDE.md). Auth: withMcpAuth
+// (route.ts) verifies the caller's OAuth bearer token, and every query runs
+// on a client carrying that token, so RLS scopes results to the caller.
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js'
+import { prop, uniqBy } from 'ramda'
+import { z } from 'zod'
+
+import { ACTIVITY_NAMES } from '@/app/industry/jobFields'
+import { resolveLocations, type LocationRef } from '@/app/resolveLocations'
+import { fetchSystemNames } from '@/app/systemNames'
+import { getSdeSystemNames, searchSdeSystems } from '@/sdeSystems'
+import { getSdeTypeNames } from '@/sdeTypes'
+import { createBearerClient } from '@/utils/supabase/bearer'
+
+import {
+  dataFreshness,
+  fetchAllRows,
+  fetchOwnerContext,
+  guessLocationRef,
+  resolveOwnerFilter,
+  resolveTypeFilter,
+  textResult,
+} from './lib'
+
+// Keep individual responses readable — totals/summaries always cover the full
+// result set, only the itemized list is capped.
+const MAX_ROWS = 200
+
+type SupabaseClient = ReturnType<typeof createBearerClient>
+
+const clientFor = (extra: { authInfo?: AuthInfo }): SupabaseClient | null =>
+  extra.authInfo?.token ? createBearerClient(extra.authInfo.token) : null
+
+// Solar-system names resolve from the generated SDE data first (known space),
+// falling back to the universe_name cache for anything the SDE build doesn't
+// carry (e.g. wormhole systems).
+const resolveSystemNames = async (supabase: SupabaseClient, systemIds: number[]): Promise<Record<number, string>> => {
+  const fromSde = getSdeSystemNames(systemIds)
+  const missing = systemIds.filter((id) => !(id in fromSde))
+  const fromDb = await fetchSystemNames(missing, supabase)
+  return { ...fromDb, ...fromSde }
+}
+
+const typeName = (names: Record<number, string>, typeId: number | string | null | undefined): string =>
+  typeId == null ? '—' : (names[Number(typeId)] ?? `Type #${typeId}`)
+
+const capNote = (total: number, shown: number, what: string): string | undefined =>
+  total > shown ? `Showing the first ${shown} of ${total} ${what}; counts and totals cover everything.` : undefined
+
+export const registerTools = (server: McpServer): void => {
+  server.registerTool(
+    'search_assets',
+    {
+      title: 'Search assets',
+      description:
+        'Find items across all of the user\'s character and corporation hangars by item name. Answers questions like "where is my Avatar" or "how many fuel blocks do I have in EKPB-3". The item name is a case-insensitive substring match against EVE item types; optionally narrow to one solar system. Blueprints are excluded unless include_blueprints is set (use list_blueprints for those).',
+      inputSchema: {
+        item: z.string().min(1).describe('Item name or substring, e.g. "nitrogen fuel block", "avatar", "tritanium"'),
+        system: z.string().optional().describe('Only include items in this solar system, e.g. "EKPB-3"'),
+        include_blueprints: z.boolean().optional().describe('Also match blueprints/reaction formulas (default false)'),
+      },
+    },
+    async ({ item, system, include_blueprints }, extra) => {
+      const supabase = clientFor(extra)
+      if (!supabase) return textResult('Missing bearer token.')
+
+      const filter = resolveTypeFilter(item, { includeBlueprints: include_blueprints ?? false })
+      if (!filter.ok) return textResult(filter.message)
+      if (!filter.matches) return textResult('Provide an item name to search for.')
+
+      const typeIds = filter.matches.map((m) => m.typeID)
+      const typeNameById = new Map(filter.matches.map((m) => [m.typeID, m.name]))
+
+      const [{ data: characterRows }, { data: corpRows }, owners] = await Promise.all([
+        supabase.rpc('character_asset_search', { type_ids: typeIds }),
+        supabase.rpc('corp_asset_search', { type_ids: typeIds }),
+        fetchOwnerContext(supabase),
+      ])
+
+      type CharacterSearchRow = {
+        item_id: number | string
+        character_id: string
+        type_id: number | string
+        quantity: number | string | null
+        is_singleton: boolean | null
+        name: string | null
+        location_flag: string | null
+        root_location_id: number | string | null
+        root_location_type: string | null
+        contents: number | string
+      }
+      type CorpSearchRow = Omit<CharacterSearchRow, 'character_id' | 'name'> & { corporation_id: number | string }
+
+      const rows = [
+        ...((characterRows ?? []) as CharacterSearchRow[]).map((r) => ({ ...r, ownerId: r.character_id })),
+        ...((corpRows ?? []) as CorpSearchRow[]).map((r) => ({ ...r, name: null, ownerId: String(r.corporation_id) })),
+      ].map((r) => ({
+        ownerId: r.ownerId,
+        typeId: Number(r.type_id),
+        customName: r.name,
+        // Singletons (assembled ships, containers, …) report a null/1 quantity.
+        quantity: r.is_singleton ? 1 : Number(r.quantity ?? 1),
+        flag: r.location_flag,
+        root:
+          r.root_location_id != null
+            ? ({ id: String(r.root_location_id), type: r.root_location_type } as LocationRef)
+            : null,
+        contents: Number(r.contents),
+      }))
+
+      const rootRefs = uniqBy(
+        prop('id'),
+        rows.map((r) => r.root).filter((r): r is LocationRef => r != null)
+      )
+      const { nameFor, systemFor } = await resolveLocations(rootRefs, supabase)
+
+      // Canonicalize a partial system filter through the SDE search so
+      // "ekpb" still matches items sitting in EKPB-3.
+      const systemFilter = system?.trim() ? (searchSdeSystems(system, 1)[0]?.name ?? system.trim()).toLowerCase() : null
+
+      const located = rows
+        .map((row) => {
+          const floating = row.root?.type === 'solar_system'
+          const stationName = row.root && !floating ? nameFor(row.root) : null
+          const systemName = row.root ? (systemFor(row.root) ?? (floating ? nameFor(row.root) : null)) : null
+          return { row, stationName, systemName }
+        })
+        .filter(({ systemName }) => systemFilter == null || (systemName ?? '').toLowerCase() === systemFilter)
+        .sort(
+          (a, b) =>
+            (a.systemName ?? '').localeCompare(b.systemName ?? '') ||
+            (a.stationName ?? '').localeCompare(b.stationName ?? '') ||
+            (typeNameById.get(a.row.typeId) ?? '').localeCompare(typeNameById.get(b.row.typeId) ?? '')
+        )
+
+      const totalsByItem: Record<string, number> = {}
+      located.forEach(({ row }) => {
+        const name = typeNameById.get(row.typeId) ?? `Type #${row.typeId}`
+        totalsByItem[name] = (totalsByItem[name] ?? 0) + row.quantity
+      })
+
+      const shown = located.slice(0, MAX_ROWS)
+      return textResult({
+        query: item,
+        matched_types: typeIds.length,
+        ...(systemFilter != null && { system_filter: shown[0]?.systemName ?? system }),
+        total_stacks: located.length,
+        totals_by_item: totalsByItem,
+        items: shown.map(({ row, stationName, systemName }) => ({
+          item: typeNameById.get(row.typeId) ?? `Type #${row.typeId}`,
+          quantity: row.quantity,
+          owner: owners.nameById.get(row.ownerId) ?? row.ownerId,
+          system: systemName,
+          station: stationName,
+          hangar: row.flag,
+          ...(row.customName != null && { custom_name: row.customName }),
+          ...(row.contents > 0 && { contains_items: row.contents }),
+        })),
+        ...(capNote(located.length, shown.length, 'stacks') && {
+          note: capNote(located.length, shown.length, 'stacks'),
+        }),
+        data_refreshed: await dataFreshness(supabase, ['character-assets', 'corp-assets']),
+      })
+    }
+  )
+
+  server.registerTool(
+    'list_clones',
+    {
+      title: 'List clones',
+      description:
+        'The user\'s characters with their current location, active implants, jump-clone locations (each with its implants), and when each character can next clone jump. Answers questions like "where is my nearest clone to Jita" or "which clone has my Genolution set".',
+      inputSchema: {},
+    },
+    async (_args, extra) => {
+      const supabase = clientFor(extra)
+      if (!supabase) return textResult('Missing bearer token.')
+
+      const [{ data: cloneRows }, { data: implantRows }, { data: locationRows }, { data: stateRows }, owners] =
+        await Promise.all([
+          supabase
+            .from('character_clone')
+            .select('character_id, jump_clone_id, is_home, location_id, location_type, name, implants, system_id'),
+          supabase.from('character_implant').select('character_id, type_ids'),
+          supabase.from('character_location').select('character_id, solar_system_id, station_id, structure_id'),
+          supabase.from('character_clone_state').select('character_id, last_clone_jump_date'),
+          fetchOwnerContext(supabase),
+        ])
+
+      type CloneRow = {
+        character_id: string
+        jump_clone_id: number | string | null
+        is_home: boolean
+        location_id: number | string
+        location_type: string | null
+        name: string | null
+        implants: number[]
+        system_id: number | string | null
+      }
+      type LocationRow = {
+        character_id: string
+        solar_system_id: number | string
+        station_id: number | string | null
+        structure_id: number | string | null
+      }
+      const clones = (cloneRows ?? []) as CloneRow[]
+      const locations = (locationRows ?? []) as LocationRow[]
+
+      // Clone rows carry their own location type; a character's current
+      // docking spot needs the NPC-station/structure split from the columns.
+      const cloneRefs = clones.map((c): LocationRef => ({ id: String(c.location_id), type: c.location_type }))
+      const dockedRefs = locations.flatMap((l): LocationRef[] => [
+        ...(l.station_id != null ? [{ id: String(l.station_id), type: 'station' }] : []),
+        ...(l.structure_id != null ? [{ id: String(l.structure_id), type: null }] : []),
+      ])
+      const { nameFor } = await resolveLocations(uniqBy(prop('id'), [...cloneRefs, ...dockedRefs]), supabase)
+
+      const systemIds = [
+        ...clones.flatMap((c) => (c.system_id != null ? [Number(c.system_id)] : [])),
+        ...locations.map((l) => Number(l.solar_system_id)),
+      ]
+      const systemNames = await resolveSystemNames(supabase, systemIds)
+
+      const implantTypeIds = [
+        ...clones.flatMap((c) => c.implants ?? []),
+        ...((implantRows ?? []) as Array<{ type_ids: number[] }>).flatMap((r) => r.type_ids ?? []),
+      ].map(Number)
+      const implantNames = getSdeTypeNames(implantTypeIds)
+
+      const implantsByCharacter = new Map(
+        ((implantRows ?? []) as Array<{ character_id: string; type_ids: number[] }>).map((r) => [
+          r.character_id,
+          (r.type_ids ?? []).map((id) => typeName(implantNames, id)),
+        ])
+      )
+      const jumpByCharacter = new Map(
+        ((stateRows ?? []) as Array<{ character_id: string; last_clone_jump_date: string | null }>).map((r) => [
+          r.character_id,
+          r.last_clone_jump_date,
+        ])
+      )
+      const locationByCharacter = new Map(locations.map((l) => [l.character_id, l]))
+
+      const characters = owners.characterIds.map((characterId) => {
+        const location = locationByCharacter.get(characterId)
+        const dockedId = location?.station_id ?? location?.structure_id
+        const lastJump = jumpByCharacter.get(characterId)
+        // Clone jump cooldown is 24h from the last jump (skill-modified
+        // cooldowns aren't tracked, so this is the conservative upper bound).
+        const nextJump = lastJump ? new Date(new Date(lastJump).getTime() + 24 * 60 * 60 * 1000).toISOString() : null
+        return {
+          character: owners.nameById.get(characterId) ?? characterId,
+          current_location: location
+            ? {
+                system: systemNames[Number(location.solar_system_id)] ?? `System #${location.solar_system_id}`,
+                docked_at:
+                  dockedId != null
+                    ? nameFor({ id: String(dockedId), type: location.station_id != null ? 'station' : null })
+                    : null,
+              }
+            : null,
+          active_implants: implantsByCharacter.get(characterId) ?? [],
+          next_clone_jump_available_at: nextJump,
+          clones: clones
+            .filter((c) => c.character_id === characterId)
+            .map((c) => ({
+              home: c.is_home,
+              ...(c.name != null && { name: c.name }),
+              system: c.system_id != null ? (systemNames[Number(c.system_id)] ?? `System #${c.system_id}`) : null,
+              location: nameFor({ id: String(c.location_id), type: c.location_type }),
+              implants: (c.implants ?? []).map((id) => typeName(implantNames, id)),
+            })),
+        }
+      })
+
+      return textResult({
+        characters,
+        data_refreshed: await dataFreshness(supabase, ['character-clones', 'character-implants', 'character-location']),
+      })
+    }
+  )
+
+  server.registerTool(
+    'list_blueprints',
+    {
+      title: 'List blueprints',
+      description:
+        'The user\'s character- and corporation-owned blueprints with ME/TE research levels, remaining runs (for copies), and location. Filter by name — searching by product works too ("naglfar" matches "Naglfar Blueprint") — or by owner.',
+      inputSchema: {
+        item: z.string().optional().describe('Blueprint (or product) name substring, e.g. "naglfar", "fuel block"'),
+        owner: z
+          .string()
+          .optional()
+          .describe('Only blueprints owned by this character or corporation (name substring)'),
+      },
+    },
+    async ({ item, owner }, extra) => {
+      const supabase = clientFor(extra)
+      if (!supabase) return textResult('Missing bearer token.')
+
+      const filter = resolveTypeFilter(item)
+      if (!filter.ok) return textResult(filter.message)
+      const typeIds = filter.matches?.map((m) => m.typeID) ?? null
+
+      const owners = await fetchOwnerContext(supabase)
+      const ownerFilter = resolveOwnerFilter(owner, owners)
+      if (!ownerFilter.ok) return textResult(ownerFilter.message)
+
+      type BlueprintRow = {
+        item_id: number | string
+        type_id: number | string
+        location_id: number | string | null
+        location_flag: string | null
+        quantity: number | string | null
+        material_efficiency: number | null
+        time_efficiency: number | null
+        runs: number | null
+      }
+      const COLUMNS =
+        'item_id, type_id, location_id, location_flag, quantity, material_efficiency, time_efficiency, runs'
+
+      const [characterRows, corpRows] = await Promise.all([
+        fetchAllRows<BlueprintRow & { character_id: string }>((from, to) => {
+          let q = supabase.from('character_blueprint').select(`${COLUMNS}, character_id`)
+          if (typeIds) q = q.in('type_id', typeIds)
+          return q.order('item_id').range(from, to)
+        }),
+        fetchAllRows<BlueprintRow & { corporation_id: number | string }>((from, to) => {
+          let q = supabase.from('corp_blueprint').select(`${COLUMNS}, corporation_id`)
+          if (typeIds) q = q.in('type_id', typeIds)
+          return q.order('item_id').range(from, to)
+        }),
+      ])
+
+      const rows = [
+        ...characterRows.map((r) => ({ ...r, ownerId: r.character_id })),
+        ...corpRows.map((r) => ({ ...r, ownerId: String(r.corporation_id) })),
+      ].filter((r) => ownerFilter.ownerIds == null || ownerFilter.ownerIds.has(r.ownerId))
+
+      const typeNames = getSdeTypeNames(rows.map((r) => Number(r.type_id)))
+      const locationRefs = uniqBy(
+        prop('id'),
+        rows.map((r) => guessLocationRef(r.location_id)).filter((r): r is LocationRef => r != null)
+      )
+      const { nameFor, systemFor } = await resolveLocations(locationRefs, supabase)
+
+      const sorted = rows
+        .map((r) => {
+          const ref = guessLocationRef(r.location_id)
+          // ESI blueprint quantity: -2 is a copy, -1 a researched original,
+          // positive a stack of unresearched originals.
+          const isCopy = Number(r.quantity) === -2
+          return {
+            blueprint: typeName(typeNames, r.type_id),
+            owner: owners.nameById.get(r.ownerId) ?? r.ownerId,
+            kind: isCopy ? 'copy' : 'original',
+            material_efficiency: r.material_efficiency,
+            time_efficiency: r.time_efficiency,
+            ...(isCopy && { runs: r.runs }),
+            quantity: Number(r.quantity) > 0 ? Number(r.quantity) : 1,
+            location: ref ? nameFor(ref) : null,
+            ...(ref && systemFor(ref) != null && { system: systemFor(ref) }),
+            hangar: r.location_flag,
+          }
+        })
+        .sort((a, b) => a.blueprint.localeCompare(b.blueprint) || a.owner.localeCompare(b.owner))
+
+      const shown = sorted.slice(0, MAX_ROWS)
+      return textResult({
+        total_blueprints: sorted.length,
+        originals: sorted.filter((r) => r.kind === 'original').length,
+        copies: sorted.filter((r) => r.kind === 'copy').length,
+        blueprints: shown,
+        ...(capNote(sorted.length, shown.length, 'blueprints') && {
+          note: capNote(sorted.length, shown.length, 'blueprints'),
+        }),
+        data_refreshed: await dataFreshness(supabase, ['character-blueprints', 'corp-blueprints']),
+      })
+    }
+  )
+
+  server.registerTool(
+    'list_industry_jobs',
+    {
+      title: 'List industry jobs',
+      description:
+        'Manufacturing, research, invention, copying, and reaction jobs across the user\'s characters and corporations. Defaults to active jobs; pass a status ("ready", "delivered", …) or "all" for history. Answers "what\'s building right now" or "when does my research finish".',
+      inputSchema: {
+        status: z
+          .enum(['active', 'ready', 'paused', 'delivered', 'cancelled', 'reverted', 'all'])
+          .optional()
+          .describe('Job status to show (default "active")'),
+        owner: z.string().optional().describe('Only jobs for this character or corporation (name substring)'),
+      },
+    },
+    async ({ status, owner }, extra) => {
+      const supabase = clientFor(extra)
+      if (!supabase) return textResult('Missing bearer token.')
+
+      const owners = await fetchOwnerContext(supabase)
+      const ownerFilter = resolveOwnerFilter(owner, owners)
+      if (!ownerFilter.ok) return textResult(ownerFilter.message)
+
+      const wantedStatus = status ?? 'active'
+      type JobRow = {
+        job_id: number | string
+        installer_id: number | string
+        activity_id: number
+        blueprint_type_id: number | string
+        product_type_id: number | string | null
+        runs: number
+        cost: number | string | null
+        probability: number | null
+        status: string
+        start_date: string
+        end_date: string
+        station_id: number | string | null
+        facility_id: number | string | null
+        successful_runs: number | null
+      }
+      const COLUMNS =
+        'job_id, installer_id, activity_id, blueprint_type_id, product_type_id, runs, cost, probability, status, start_date, end_date, station_id, facility_id, successful_runs'
+      const [characterJobs, corpJobs] = await Promise.all([
+        fetchAllRows<JobRow & { character_id: string }>((from, to) => {
+          let q = supabase.from('character_industry_job').select(`${COLUMNS}, character_id`)
+          if (wantedStatus !== 'all') q = q.eq('status', wantedStatus)
+          return q.order('end_date', { ascending: true }).range(from, to)
+        }),
+        fetchAllRows<JobRow & { corporation_id: number | string }>((from, to) => {
+          let q = supabase.from('corp_industry_job').select(`${COLUMNS}, corporation_id`)
+          if (wantedStatus !== 'all') q = q.eq('status', wantedStatus)
+          return q.order('end_date', { ascending: true }).range(from, to)
+        }),
+      ])
+
+      // A corp job installed by one of our own characters shows up in both
+      // extracts under the same job_id; the corp row wins (cf. /industry).
+      const corpJobIds = new Set(corpJobs.map((j) => String(j.job_id)))
+      const rows = [
+        ...characterJobs
+          .filter((j) => !corpJobIds.has(String(j.job_id)))
+          .map((j) => ({ ...j, ownerId: j.character_id })),
+        ...corpJobs.map((j) => ({ ...j, ownerId: String(j.corporation_id) })),
+      ]
+        .filter((j) => ownerFilter.ownerIds == null || ownerFilter.ownerIds.has(j.ownerId))
+        .sort((a, b) => new Date(a.end_date).getTime() - new Date(b.end_date).getTime())
+
+      const typeNames = getSdeTypeNames(
+        rows.flatMap((j) => [
+          Number(j.blueprint_type_id),
+          ...(j.product_type_id != null ? [Number(j.product_type_id)] : []),
+        ])
+      )
+      const locationRefs = uniqBy(
+        prop('id'),
+        rows.map((j) => guessLocationRef(j.station_id ?? j.facility_id)).filter((r): r is LocationRef => r != null)
+      )
+      const { nameFor } = await resolveLocations(locationRefs, supabase)
+
+      // Installers are character ids (not registration uuids); the
+      // universe_name cache resolves the ones it has seen.
+      const installerIds = [...new Set(rows.map((j) => Number(j.installer_id)))]
+      const { data: installerRows } = installerIds.length
+        ? await supabase.from('universe_name').select('id, name').in('id', installerIds)
+        : { data: [] }
+      const installerNames = Object.fromEntries(
+        ((installerRows ?? []) as Array<{ id: number | string; name: string }>).map((r) => [Number(r.id), r.name])
+      )
+
+      const shown = rows.slice(0, MAX_ROWS)
+      return textResult({
+        status: wantedStatus,
+        total_jobs: rows.length,
+        jobs: shown.map((j) => {
+          const ref = guessLocationRef(j.station_id ?? j.facility_id)
+          return {
+            activity: ACTIVITY_NAMES[j.activity_id] ?? `Activity #${j.activity_id}`,
+            blueprint: typeName(typeNames, j.blueprint_type_id),
+            ...(j.product_type_id != null && { product: typeName(typeNames, j.product_type_id) }),
+            runs: j.runs,
+            status: j.status,
+            start_date: j.start_date,
+            end_date: j.end_date,
+            owner: owners.nameById.get(j.ownerId) ?? j.ownerId,
+            ...(installerNames[Number(j.installer_id)] != null && {
+              installer: installerNames[Number(j.installer_id)],
+            }),
+            location: ref ? nameFor(ref) : null,
+            ...(j.cost != null && { cost: Number(j.cost) }),
+            ...(j.probability != null && { probability: j.probability }),
+            ...(j.successful_runs != null && { successful_runs: j.successful_runs }),
+          }
+        }),
+        ...(capNote(rows.length, shown.length, 'jobs') && { note: capNote(rows.length, shown.length, 'jobs') }),
+        data_refreshed: await dataFreshness(supabase, ['character-industry-jobs', 'corp-industry-jobs']),
+      })
+    }
+  )
+
+  server.registerTool(
+    'list_market_orders',
+    {
+      title: 'List market orders',
+      description:
+        'The user\'s open market orders (buys and sells) across all characters, with price, remaining volume, location, and expiry. Answers "what am I selling" or "do I still have that buy order up".',
+      inputSchema: {
+        item: z.string().optional().describe('Only orders for items matching this name substring'),
+      },
+    },
+    async ({ item }, extra) => {
+      const supabase = clientFor(extra)
+      if (!supabase) return textResult('Missing bearer token.')
+
+      const filter = resolveTypeFilter(item)
+      if (!filter.ok) return textResult(filter.message)
+      const typeIds = filter.matches?.map((m) => m.typeID) ?? null
+
+      type OrderRow = {
+        order_id: number | string
+        character_id: string
+        type_id: number | string
+        location_id: number | string
+        is_buy: boolean
+        is_corporation: boolean
+        price: number | string
+        volume_total: number | string
+        volume_remain: number | string
+        min_volume: number | string | null
+        escrow: number | string | null
+        duration: number
+        issued: string
+      }
+      const [orders, owners] = await Promise.all([
+        fetchAllRows<OrderRow>((from, to) => {
+          const q = supabase
+            .from('character_order')
+            .select(
+              'order_id, character_id, type_id, location_id, is_buy, is_corporation, price, volume_total, volume_remain, min_volume, escrow, duration, issued'
+            )
+            .order('issued', { ascending: false })
+            .range(from, to)
+          return typeIds ? q.in('type_id', typeIds) : q
+        }),
+        fetchOwnerContext(supabase),
+      ])
+
+      const typeNames = getSdeTypeNames(orders.map((o) => Number(o.type_id)))
+      const locationRefs = uniqBy(
+        prop('id'),
+        orders.map((o) => guessLocationRef(o.location_id)).filter((r): r is LocationRef => r != null)
+      )
+      const { nameFor } = await resolveLocations(locationRefs, supabase)
+
+      const sells = orders.filter((o) => !o.is_buy)
+      const buys = orders.filter((o) => o.is_buy)
+      const shown = orders.slice(0, MAX_ROWS)
+      return textResult({
+        total_orders: orders.length,
+        sell_orders: sells.length,
+        sell_value_remaining: sells.reduce((sum, o) => sum + Number(o.price) * Number(o.volume_remain), 0),
+        buy_orders: buys.length,
+        buy_escrow: buys.reduce((sum, o) => sum + Number(o.escrow ?? 0), 0),
+        orders: shown.map((o) => {
+          const ref = guessLocationRef(o.location_id)
+          return {
+            item: typeName(typeNames, o.type_id),
+            side: o.is_buy ? 'buy' : 'sell',
+            price: Number(o.price),
+            volume_remain: Number(o.volume_remain),
+            volume_total: Number(o.volume_total),
+            owner: owners.nameById.get(o.character_id) ?? o.character_id,
+            ...(o.is_corporation && { corporation_order: true }),
+            location: ref ? nameFor(ref) : null,
+            issued: o.issued,
+            expires: new Date(new Date(o.issued).getTime() + o.duration * 24 * 60 * 60 * 1000).toISOString(),
+            ...(o.min_volume != null && Number(o.min_volume) > 1 && { min_volume: Number(o.min_volume) }),
+          }
+        }),
+        ...(capNote(orders.length, shown.length, 'orders') && { note: capNote(orders.length, shown.length, 'orders') }),
+        data_refreshed: await dataFreshness(supabase, ['character-orders']),
+      })
+    }
+  )
+
+  server.registerTool(
+    'search_transactions',
+    {
+      title: 'Search market transactions',
+      description:
+        'Past market buys and sells across the user\'s characters and corporations (most recent first). Answers "what did I pay for PLEX last month" or "how much have I sold this week". Corp-division trades made by the user\'s characters are included once, under the corporation.',
+      inputSchema: {
+        item: z.string().optional().describe('Only trades of items matching this name substring'),
+        days: z.number().int().min(1).max(365).optional().describe('Lookback window in days (default 30)'),
+        side: z.enum(['buy', 'sell']).optional().describe('Only buys or only sells (default both)'),
+        limit: z.number().int().min(1).max(500).optional().describe('Maximum rows to return (default 100)'),
+      },
+    },
+    async ({ item, days, side, limit }, extra) => {
+      const supabase = clientFor(extra)
+      if (!supabase) return textResult('Missing bearer token.')
+
+      const filter = resolveTypeFilter(item)
+      if (!filter.ok) return textResult(filter.message)
+      const typeIds = filter.matches?.map((m) => m.typeID) ?? null
+
+      const windowDays = days ?? 30
+      const maxRows = limit ?? 100
+      const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000).toISOString()
+
+      type TransactionRow = {
+        transaction_id: number | string
+        date: string
+        type_id: number | string
+        quantity: number | string
+        unit_price: number | string
+        is_buy: boolean
+        location_id: number | string
+      }
+      const COLUMNS = 'transaction_id, date, type_id, quantity, unit_price, is_buy, location_id'
+
+      // Personal and corp trades live in separate tables; a character's
+      // trades on behalf of their corp (is_personal false) are already
+      // captured in corp_wallet_transaction, so exclude them here to avoid
+      // double-counting (cf. /market).
+      let personalQuery = supabase
+        .from('character_wallet_transaction')
+        .select(`${COLUMNS}, character_id`)
+        .eq('is_personal', true)
+        .gte('date', since)
+      let corpQuery = supabase.from('corp_wallet_transaction').select(`${COLUMNS}, corporation_id`).gte('date', since)
+      if (side != null) {
+        personalQuery = personalQuery.eq('is_buy', side === 'buy')
+        corpQuery = corpQuery.eq('is_buy', side === 'buy')
+      }
+      if (typeIds) {
+        personalQuery = personalQuery.in('type_id', typeIds)
+        corpQuery = corpQuery.in('type_id', typeIds)
+      }
+
+      const [{ data: personalRows }, { data: corpRows }, owners] = await Promise.all([
+        personalQuery.order('date', { ascending: false }).limit(maxRows),
+        corpQuery.order('date', { ascending: false }).limit(maxRows),
+        fetchOwnerContext(supabase),
+      ])
+
+      const rows = [
+        ...((personalRows ?? []) as Array<TransactionRow & { character_id: string }>).map((r) => ({
+          ...r,
+          ownerId: r.character_id,
+        })),
+        ...((corpRows ?? []) as Array<TransactionRow & { corporation_id: number | string }>).map((r) => ({
+          ...r,
+          ownerId: String(r.corporation_id),
+        })),
+      ].sort((a, b) => (a.date < b.date ? 1 : -1))
+
+      const typeNames = getSdeTypeNames(rows.map((r) => Number(r.type_id)))
+      const locationRefs = uniqBy(
+        prop('id'),
+        rows.map((r) => guessLocationRef(r.location_id)).filter((r): r is LocationRef => r != null)
+      )
+      const { nameFor } = await resolveLocations(locationRefs, supabase)
+
+      const shown = rows.slice(0, maxRows)
+      const totalFor = (isBuy: boolean) =>
+        shown.filter((r) => r.is_buy === isBuy).reduce((sum, r) => sum + Number(r.unit_price) * Number(r.quantity), 0)
+
+      return textResult({
+        window_days: windowDays,
+        rows_returned: shown.length,
+        bought_isk: totalFor(true),
+        sold_isk: totalFor(false),
+        ...(rows.length > shown.length && {
+          note: `More transactions matched than the ${maxRows}-row limit; totals cover only the rows returned. Narrow the window or filter by item for complete sums.`,
+        }),
+        transactions: shown.map((r) => {
+          const ref = guessLocationRef(r.location_id)
+          return {
+            date: r.date,
+            item: typeName(typeNames, r.type_id),
+            side: r.is_buy ? 'buy' : 'sell',
+            quantity: Number(r.quantity),
+            unit_price: Number(r.unit_price),
+            total: Number(r.unit_price) * Number(r.quantity),
+            owner: owners.nameById.get(r.ownerId) ?? r.ownerId,
+            location: ref ? nameFor(ref) : null,
+          }
+        }),
+        data_refreshed: await dataFreshness(supabase, ['character-wallet-transactions', 'corp-wallet-transactions']),
+      })
+    }
+  )
+}

--- a/src/app/oauth/consent/actions.ts
+++ b/src/app/oauth/consent/actions.ts
@@ -1,0 +1,29 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+
+import { createClient } from '@/utils/supabase/server'
+
+// Approve/deny an OAuth 2.1 authorization request against Supabase Auth (the
+// authorization server behind the MCP endpoint — see /api/mcp). Both return a
+// redirect_url that carries the authorization code (or the denial error) back
+// to the OAuth client, so the browser leaves the site either way.
+export const approveAuthorization = async (formData: FormData) => {
+  const authorizationId = `${formData.get('authorization_id')}`
+  const supabase = await createClient()
+  const { data, error } = await supabase.auth.oauth.approveAuthorization(authorizationId)
+  if (error || !data) {
+    throw new Error(error?.message ?? 'Approving the authorization failed')
+  }
+  redirect(data.redirect_url)
+}
+
+export const denyAuthorization = async (formData: FormData) => {
+  const authorizationId = `${formData.get('authorization_id')}`
+  const supabase = await createClient()
+  const { data, error } = await supabase.auth.oauth.denyAuthorization(authorizationId)
+  if (error || !data) {
+    throw new Error(error?.message ?? 'Denying the authorization failed')
+  }
+  redirect(data.redirect_url)
+}

--- a/src/app/oauth/consent/page.tsx
+++ b/src/app/oauth/consent/page.tsx
@@ -1,0 +1,69 @@
+import { redirect } from 'next/navigation'
+
+import { createClient } from '@/utils/supabase/server'
+
+import { approveAuthorization, denyAuthorization } from './actions'
+
+// OAuth 2.1 consent page. Supabase Auth (acting as the authorization server
+// for the MCP endpoint at /api/mcp) redirects here with an authorization_id
+// when a client like Claude asks for access; this page shows who's asking and
+// lets the signed-in user approve or deny. The Authorization Path in the
+// Supabase dashboard (Authentication → OAuth Server) must point at
+// /oauth/consent for this to be reached.
+const ConsentPage = async ({ searchParams }: { searchParams: Promise<{ authorization_id?: string }> }) => {
+  const { authorization_id: authorizationId } = await searchParams
+  if (!authorizationId) {
+    redirect('/')
+  }
+
+  const supabase = await createClient()
+  const { data: auth, error: authError } = await supabase.auth.getUser()
+  if (authError || !auth?.user) {
+    redirect(`/account/login?next=${encodeURIComponent(`/oauth/consent?authorization_id=${authorizationId}`)}`)
+  }
+
+  const { data, error } = await supabase.auth.oauth.getAuthorizationDetails(authorizationId)
+  if (error || !data) {
+    return (
+      <>
+        <h1>Authorize Application</h1>
+        <p>This authorization request is invalid or has expired. Start the connection again from the application.</p>
+      </>
+    )
+  }
+
+  // Already-consented requests skip the consent screen entirely.
+  if (!('authorization_id' in data)) {
+    redirect(data.redirect_url)
+  }
+
+  return (
+    <>
+      <h1>Authorize Application</h1>
+      <p>
+        <strong>{data.client.name ?? 'An application'}</strong> is asking for access to your EDENCOM Link account (
+        {data.user.email}).
+      </p>
+      {data.scope && (
+        <>
+          <p>It requests the following scopes:</p>
+          <ul>
+            {data.scope.split(' ').map((scope) => (
+              <li key={scope}>{scope}</li>
+            ))}
+          </ul>
+        </>
+      )}
+      <p>
+        It will be able to read the EVE data linked to your account — assets, blueprints, clones, industry jobs, market
+        orders, and transactions.
+      </p>
+      <form>
+        <input type="hidden" name="authorization_id" value={data.authorization_id} />
+        <button formAction={approveAuthorization}>Approve</button> <button formAction={denyAuthorization}>Deny</button>
+      </form>
+    </>
+  )
+}
+
+export default ConsentPage

--- a/src/app/owners.ts
+++ b/src/app/owners.ts
@@ -4,11 +4,12 @@
 // exactly the corps whose assets/jobs the user can read. Corp names come from
 // the universe_name cache (kept populated by the universe-names job);
 // unresolved ids fall back to a labelled raw id.
+import type { SupabaseClient } from '@supabase/supabase-js'
 import { createClient } from '@/utils/supabase/server'
 import type { Owner, Owners } from './ownerFilter'
 
-export const fetchOwners = async (): Promise<Owners> => {
-  const supabase = await createClient()
+export const fetchOwners = async (client?: SupabaseClient): Promise<Owners> => {
+  const supabase = client ?? (await createClient())
   const { data: registrations } = await supabase.from('registration').select('id, name, corporation_id')
   const rows = (registrations ?? []) as Array<{ id: string; name: string; corporation_id: number | string | null }>
 

--- a/src/app/resolveLocations.ts
+++ b/src/app/resolveLocations.ts
@@ -3,6 +3,7 @@
 // pages share: our own corp's structures (corp_structure) win over the
 // ESI-resolved cache (universe_structure) for player structures; NPC station
 // names and solar system names come from the universe_name cache.
+import type { SupabaseClient } from '@supabase/supabase-js'
 import { chain, filter, map, pipe } from 'ramda'
 import { createClient } from '@/utils/supabase/server'
 import { fetchStationNames, fetchStationSystems } from './stationNames'
@@ -17,8 +18,11 @@ export type ResolvedLocations = {
   systemFor: (loc: LocationRef) => string | undefined
 }
 
-export const resolveLocations = async (locations: LocationRef[]): Promise<ResolvedLocations> => {
-  const supabase = await createClient()
+export const resolveLocations = async (
+  locations: LocationRef[],
+  client?: SupabaseClient
+): Promise<ResolvedLocations> => {
+  const supabase = client ?? (await createClient())
   const locationIds = filter(
     Number.isFinite,
     map((l: LocationRef) => Number(l.id), locations)
@@ -45,7 +49,7 @@ export const resolveLocations = async (locations: LocationRef[]): Promise<Resolv
     map((l: LocationRef) => Number(l.id))
   )(locations)
   const [stationNames, stationSystems] = await Promise.all([
-    fetchStationNames(stationIds),
+    fetchStationNames(stationIds, supabase),
     fetchStationSystems(stationIds),
   ])
 
@@ -61,7 +65,7 @@ export const resolveLocations = async (locations: LocationRef[]): Promise<Resolv
       ].filter((id): id is number => id != null)
     }, locations)
   )
-  const systemNames = await fetchSystemNames(systemIds)
+  const systemNames = await fetchSystemNames(systemIds, supabase)
 
   const nameFor = (loc: LocationRef): string => {
     const structure = structureById.get(loc.id)

--- a/src/app/stationNames.ts
+++ b/src/app/stationNames.ts
@@ -6,13 +6,17 @@
 // recognize; still omits anything neither source has, so callers fall back to
 // showing the raw id (never read the evesde SDE schema). Player Upwell
 // structures are resolved separately from corp_structure/universe_structure.
+import type { SupabaseClient } from '@supabase/supabase-js'
 import { difference, filter, fromPairs, keys, map, mergeRight, uniq } from 'ramda'
 import { createClient } from '@/utils/supabase/server'
 import { getSdeStationNames, getSdeStationSystems } from '@/sdeStations'
 
 const idNamePairs = map((r: { id: number | string; name: string }): [number, string] => [Number(r.id), r.name])
 
-export const fetchStationNames = async (stationIDs: Iterable<number>): Promise<Record<number, string>> => {
+export const fetchStationNames = async (
+  stationIDs: Iterable<number>,
+  client?: SupabaseClient
+): Promise<Record<number, string>> => {
   const ids = uniq(filter(Number.isFinite, [...stationIDs]))
   if (ids.length === 0) return {}
 
@@ -20,7 +24,7 @@ export const fetchStationNames = async (stationIDs: Iterable<number>): Promise<R
   const unresolvedIds = difference(ids, map(Number, keys(sdeNames)))
   if (unresolvedIds.length === 0) return sdeNames
 
-  const supabase = await createClient()
+  const supabase = client ?? (await createClient())
   const { data } = await supabase
     .from('universe_name')
     .select('id, name')

--- a/src/app/systemNames.ts
+++ b/src/app/systemNames.ts
@@ -5,13 +5,17 @@
 // universe_name DB cache only for ids the SDE dump doesn't recognize; still
 // omits anything neither source has, so callers fall back to showing the raw
 // id (never read the evesde SDE schema).
+import type { SupabaseClient } from '@supabase/supabase-js'
 import { difference, filter, fromPairs, keys, map, mergeRight, uniq } from 'ramda'
 import { createClient } from '@/utils/supabase/server'
 import { getSdeSystemNames } from '@/sdeSystems'
 
 const idNamePairs = map((r: { id: number | string; name: string }): [number, string] => [Number(r.id), r.name])
 
-export const fetchSystemNames = async (systemIDs: Iterable<number>): Promise<Record<number, string>> => {
+export const fetchSystemNames = async (
+  systemIDs: Iterable<number>,
+  client?: SupabaseClient
+): Promise<Record<number, string>> => {
   const ids = uniq(filter(Number.isFinite, [...systemIDs]))
   if (ids.length === 0) return {}
 
@@ -19,7 +23,7 @@ export const fetchSystemNames = async (systemIDs: Iterable<number>): Promise<Rec
   const unresolvedIds = difference(ids, map(Number, keys(sdeNames)))
   if (unresolvedIds.length === 0) return sdeNames
 
-  const supabase = await createClient()
+  const supabase = client ?? (await createClient())
   const { data } = await supabase
     .from('universe_name')
     .select('id, name')

--- a/src/utils/supabase/bearer.ts
+++ b/src/utils/supabase/bearer.ts
@@ -1,0 +1,12 @@
+import { createClient } from '@supabase/supabase-js'
+
+// Supabase client authenticated by an OAuth 2.1 access token (issued by
+// Supabase Auth acting as the authorization server — see /api/mcp). The token
+// rides along as the Authorization header on every PostgREST call, so RLS
+// applies exactly as it would for the same user's cookie session. No session
+// persistence: each MCP tool call is stateless and builds a fresh client.
+export const createBearerClient = (accessToken: string) =>
+  createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!, {
+    global: { headers: { Authorization: `Bearer ${accessToken}` } },
+    auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
+  })


### PR DESCRIPTION
Exposes an MCP endpoint so LLM clients (Claude, etc.) can answer questions like "where is my titan?", "where is my nearest clone to this system?", or "how many fuel blocks do I have in EKPB-3?" directly from the extracted data.

## What's included

**MCP server** — `/api/mcp/mcp` (Streamable HTTP via `mcp-handler`; SSE stays off since it's spec-deprecated and needs Redis) with six read-only tools in `src/app/api/mcp/tools.ts`:

| Tool | Answers |
|---|---|
| `search_assets` | "where is my Avatar", "how many fuel blocks in EKPB-3" — per-location stacks + per-item totals, optional system filter |
| `list_clones` | current location, active implants, jump clones (with implants), next clone-jump time per character |
| `list_blueprints` | ME/TE/runs/location for character + corp blueprints; searching "naglfar" matches "Naglfar Blueprint" |
| `list_industry_jobs` | active (or any-status) jobs with activity, product, end date, location |
| `list_market_orders` | open buy/sell orders with price, remaining volume, expiry, escrow totals |
| `search_transactions` | past trades with buy/sell totals over a lookback window |

Tools accept fuzzy names (items via the SDE type search with the same "too many matches" guard as `/asset/search`, systems via the SDE system search, owners by name substring) and return resolved names. Every response carries a `data_refreshed` stamp from `latest_heartbeats()` so the model can caveat stale snapshots. Tools only read the DB — never ESI — per the repo's data-flow rule.

**OAuth 2.1 (no `api_token` reuse)** — Supabase Auth acts as the authorization server:
- `/.well-known/oauth-protected-resource` (RFC 9728) points clients at Supabase for discovery; the optional catch-all also serves the path-suffixed form.
- `/oauth/consent` is the authorization page (`supabase.auth.oauth.getAuthorizationDetails` / `approveAuthorization` / `denyAuthorization`), with already-consented requests redirected straight through.
- `withMcpAuth` verifies bearer tokens via `auth.getClaims`, and every tool query runs on a client carrying the caller's token (`src/utils/supabase/bearer.ts`) — so **RLS scopes results exactly like a cookie session** and the MCP layer never widens access.
- The login page gains a sanitized same-site `?next=` redirect so a logged-out user can complete the consent flow.

**Shared-helper refactor** — `resolveLocations`, `fetchOwners`, `fetchSystemNames`, `fetchStationNames` accept an optional Supabase client (defaulting to the cookie client as before) so the MCP tools reuse the exact location/owner-resolution logic the pages use.

## Deployment prerequisites (one-time, Supabase dashboard)

1. **Authentication → OAuth Server**: enable the OAuth 2.1 server (beta) and set the Authorization Path to `/oauth/consent`.
2. Enable **dynamic client registration** so MCP clients like Claude can self-register.

No new env vars. Client config is then just the URL `https://<host>/api/mcp/mcp` — the OAuth flow is discovered automatically.

## Verification

- `eslint .` clean; `tsc --noEmit` clean apart from pre-existing `@eveshipfit/*` resolution (private GitHub Packages registry isn't reachable from the sandbox — see note below).
- Not runtime-tested against a live Supabase project: this environment has no DB credentials, and the OAuth server + consent path also need the dashboard settings above before the flow can work end-to-end. The Vercel preview build is the real full-build check.

> **Note for @philihp:** the `GH_PACKAGES_TOKEN` in the Claude remote environment is a fine-grained PAT, which GitHub Packages rejects (it needs a classic PAT with `read:packages`). Worth swapping so future sessions can `pnpm install` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kcyj35H112n32DGgrKkz6e

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kcyj35H112n32DGgrKkz6e)_