### PR TITLE
Point MCP 401 challenge at path-suffixed resource metadata

### DIFF
--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -22,7 +22,17 @@ const handler = createMcpHandler(
   { basePath: '/api', disableSse: true, maxDuration: 60 }
 )
 
-const authHandler = withMcpAuth(handler, verifySupabaseToken, { required: true })
+// Point the 401 WWW-Authenticate challenge at the path-suffixed protected-
+// resource metadata (served by the [[...resource]] catch-all under
+// .well-known), whose `resource` is the full server URL https://<host>/api/mcp.
+// The default ('/.well-known/oauth-protected-resource') resolves to a document
+// declaring just the origin, which fails the RFC 8707/9728 canonical-resource
+// match that spec-compliant MCP clients (e.g. Claude) enforce — surfacing as
+// "Authorization with the MCP server failed" only after discovery succeeds.
+const authHandler = withMcpAuth(handler, verifySupabaseToken, {
+  required: true,
+  resourceMetadataPath: '/.well-known/oauth-protected-resource/api/mcp',
+})
 
 export { authHandler as GET, authHandler as POST, authHandler as DELETE }
 export const maxDuration = 60


### PR DESCRIPTION
Fixes an "Authorization with the MCP server failed" error connecting Claude to `https://edencom.link/api/mcp`, even though OAuth discovery, dynamic client registration, PKCE, and the consent page all work.

## Root cause

Spec-compliant MCP clients (Claude included) enforce the RFC 8707/9728 **canonical-resource match**: the `resource` value in the protected-resource metadata must equal the MCP server URL they connected to.

The 401 `WWW-Authenticate` challenge from `withMcpAuth` pointed at the default `/.well-known/oauth-protected-resource`, whose derived `resource` is just the origin:

```
resource: "https://edencom.link"          ← origin, from the root metadata doc
```

…but the server the client actually connected to is `https://edencom.link/api/mcp`. Origin ≠ endpoint, so the client rejects authorization **after** discovery and registration have already succeeded — which is why it surfaces as a confusing auth failure rather than a 404 or a discovery error.

The path-suffixed metadata document (already served by the `[[...resource]]` catch-all under `.well-known`) declares the correct value:

```
resource: "https://edencom.link/api/mcp"  ← full server URL, matches
```

## Fix

Set `resourceMetadataPath` on `withMcpAuth` so the challenge points at that path-suffixed document. Verified by invoking the handler directly:

| | `resource_metadata` in WWW-Authenticate | that doc's `resource` |
|---|---|---|
| before | `…/.well-known/oauth-protected-resource` | `https://edencom.link` ❌ |
| after | `…/.well-known/oauth-protected-resource/api/mcp` | `https://edencom.link/api/mcp` ✅ |

No other behavior changes; both metadata documents are still served.

> **Note for @philihp:** after this deploys, remove and re-add the connector in Claude so it re-runs discovery against the corrected challenge — a cached registration/token from the earlier failed attempt would otherwise stick around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kcyj35H112n32DGgrKkz6e

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kcyj35H112n32DGgrKkz6e)_