### PR TITLE
Resolve corp industry job installer names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,7 @@ All functions take `(accessToken, id, ...)` unless noted. Returns raw ESI respon
 - `resolveBatch(ids[])` / `resolveAllIds(ids[])` — bulk ESI `universeNames` with bisect-on-error fallback
 - `resolveCorpJournalNames()` — resolve first/second party IDs seen in corp wallet journal rows into `universe_name`
 - `resolveKnownCorpNames()` — resolve+cache corp names seen in `corp_wallet_transaction`/`character_affiliation`/`corp_structure`
+- `resolveCorpIndustryJobInstallerNames()` — resolve+cache the character name of every `corp_industry_job.installer_id` (whichever corp member ran the job, not necessarily one of this app's linked characters)
 - `resolveCorpStructureSystemNames()` — resolve system IDs for corp structures
 - `resolveAssetStationNames()` — resolve+cache NPC station names (location_type 'station' in assets) into `universe_name`
 - `resolveAssetSystemNames()` — resolve+cache solar system names for assets floating directly in space (location_type 'solar_system') into `universe_name`

--- a/src/jobs/universeNames.js
+++ b/src/jobs/universeNames.js
@@ -1,6 +1,7 @@
 import {
   resolveAssetStationNames,
   resolveAssetSystemNames,
+  resolveCorpIndustryJobInstallerNames,
   resolveCorpJournalNames,
   resolveCorpStructureSystemNames,
   resolveKnownCorpNames,
@@ -12,10 +13,11 @@ const TAG = 'universe-names'
 // POST /universe/names/ → universe_name. Resolves and caches a name for every
 // id the other extracts have surfaced but that universe_name doesn't know yet:
 // corp wallet journal parties, corporations seen in transactions/affiliations,
-// NPC stations holding assets, the solar systems our structures sit in, and the
-// solar systems any asset is floating in directly. Cheap in steady state — each
-// resolver only asks ESI for missing ids — so it can run often. Account-wide
-// batch work, so it takes no character scope.
+// NPC stations holding assets, the solar systems our structures sit in, the
+// solar systems any asset is floating in directly, and the characters who
+// installed each corp industry job. Cheap in steady state — each resolver
+// only asks ESI for missing ids — so it can run often. Account-wide batch
+// work, so it takes no character scope.
 export const runUniverseNames = async () => {
   const resolvers = [
     ['corp journal parties', resolveCorpJournalNames],
@@ -23,6 +25,7 @@ export const runUniverseNames = async () => {
     ['asset stations', resolveAssetStationNames],
     ['corp structure systems', resolveCorpStructureSystemNames],
     ['asset systems', resolveAssetSystemNames],
+    ['corp industry job installers', resolveCorpIndustryJobInstallerNames],
   ]
   let failed = 0
   await forEachSequential(resolvers, async ([what, resolve]) => {

--- a/src/resolveNames.js
+++ b/src/resolveNames.js
@@ -268,6 +268,34 @@ export const resolveAssetSystemNames = async () => {
   console.log(`[names] upserted ${rows.length} asset system name(s)`)
 }
 
+// Cache (in universe_name) the name of every character who has installed a
+// corp industry job. installer_id there is whichever corp member ran the
+// job — not necessarily one of this app's linked characters — unlike
+// character_industry_job, where installer is always the owning character and
+// so needs no separate resolution. Only resolves ids missing from
+// universe_name, so steady-state runs do nothing.
+export const resolveCorpIndustryJobInstallerNames = async () => {
+  const rows = await selectAllRows((from, to) =>
+    sudoSupabase.from('corp_industry_job').select('installer_id').order('job_id', { ascending: true }).range(from, to)
+  )
+
+  const installerId = pipe(prop('installer_id'), Number)
+  const ids = new Set(map(installerId, reject(pipe(prop('installer_id'), isNil), rows)))
+
+  const knownIds = await knownIdsAmong(ids)
+  const toResolve = filter((n) => Number.isFinite(n) && n > 0 && !knownIds.has(n), [...ids])
+  console.log(`[names] corp industry job installers: ${toResolve.length} to resolve`)
+  if (toResolve.length === 0) return
+
+  const resolved = await resolveAllIds(toResolve)
+  if (resolved.length === 0) return
+
+  const nameRows = map(toNameRow, resolved)
+  const { error: upErr } = await sudoSupabase.from('universe_name').upsert(nameRows, { onConflict: 'id' })
+  if (upErr) throw upErr
+  console.log(`[names] upserted ${nameRows.length} installer name(s)`)
+}
+
 // Cache (in universe_name) the name of every solar system we currently have a
 // corp structure in. Only resolves ids missing from universe_name, so
 // steady-state runs do nothing. The structures page reads universe_name to label


### PR DESCRIPTION
## Summary
- `corp_industry_job.installer_id` (the character who ran a corp industry job) was never fed into the `universe-names` resolution pipeline — none of the existing resolvers touched it, so a corp job's installer never got an entry in `universe_name` and consumers fell back to the corp's own name instead of the character who actually ran it.
- Added `resolveCorpIndustryJobInstallerNames()` in `src/resolveNames.js`, which resolves+caches the name for every distinct `installer_id` seen in `corp_industry_job` that isn't already known.
- Wired it into the `universe-names` job (`src/jobs/universeNames.js`) alongside the existing resolvers, and updated `CLAUDE.md`'s codebase map.

`character_industry_job` doesn't need the same fix — its `installer_id` is always the owning character's own id, which the app already knows by name via `registration`.

## Test plan
- [x] Verified via a live sample (MCP `list_industry_jobs`) that corp jobs currently show the corp's own name as "installer" when the actual installing character isn't already cached in `universe_name` — the gap this fixes
- [ ] `pnpm run universe-names` not run in this session — no local Supabase/ESI credentials available in the sandbox


---
_Generated by [Claude Code](https://claude.ai/code/session_01V4tCskYS7aoS76vPCCWZa9)_