### PR TITLE
Add dark-launched Mercenary Dens page behind a feature flag

### DIFF
--- a/src/app/layout/header.tsx
+++ b/src/app/layout/header.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { createClient } from '@/utils/supabase/server'
-import { indexesFlag } from '@/flags'
+import { indexesFlag, mercenaryDensFlag } from '@/flags'
 import { Freshness } from '../Freshness'
 import styles from './header.module.css'
 
@@ -40,7 +40,7 @@ const Header = async () => {
     lastRefreshedAt = latestBeat?.ended_at ?? null
   }
 
-  const showIndexes = await indexesFlag()
+  const [showIndexes, showMercenaryDens] = await Promise.all([indexesFlag(), mercenaryDensFlag()])
   return (
     <header>
       <div className={styles.bar}>
@@ -71,6 +71,12 @@ const Header = async () => {
               {showIndexes && (
                 <>
                   <Link href="/indexes">indexes</Link>
+                  <span className={styles.sep}>|</span>
+                </>
+              )}
+              {showMercenaryDens && (
+                <>
+                  <Link href="/mercenary-dens">mercenary&nbsp;dens</Link>
                   <span className={styles.sep}>|</span>
                 </>
               )}

--- a/src/app/mercenary-dens/data.ts
+++ b/src/app/mercenary-dens/data.ts
@@ -1,0 +1,86 @@
+// Static map data for the dark-launched Mercenary Dens page.
+//
+// There is no ESI feed (nor DB extract) for mercenary-den ownership, reinforced
+// state, or which planets are temperate for arbitrary systems, so this file is
+// hand-maintained. The system links and temperate-planet numbers below were
+// taken from CCP's live universe data (ESI `/universe/systems` +
+// `/universe/planets`, planet type_id 11 = Temperate) and are stable game-map
+// facts. The den ownership fields are the volatile part: edit `den` on a planet
+// as intel changes.
+
+// Our staging system — the root that RXA-W1 is immediately accessible from.
+export const STAGING = 'X1-IZ0'
+
+// Undirected adjacency of the systems reachable out from staging. Listing an
+// edge once (A -> [B]) is enough; the topology treats links as bidirectional.
+export const LINKS: Record<string, string[]> = {
+  'X1-IZ0': ['RXA-W1'],
+  'RXA-W1': ['JVA-FE'],
+  'JVA-FE': ['RXA-W1', 'QFU-4S', '8P-LKL', 'VK6-EZ'],
+  'QFU-4S': ['8P-LKL', 'QQGH-G'],
+  '8P-LKL': ['JVA-FE', 'QFU-4S', 'QQGH-G'],
+  'VK6-EZ': ['JVA-FE', 'Q-UVY6', 'QQGH-G'],
+}
+
+// The current owner of a mercenary den on a temperate planet. `null` den means
+// no den is deployed (or none known). When a den exists, `alliance` is the
+// alliance ticker/name of the owning character's alliance (null if unknown or
+// unaffiliated), and `reinforced` flags a den currently in its reinforcement
+// timer.
+export type Den = {
+  owner: string
+  alliance: string | null
+  reinforced: boolean
+}
+
+export type TemperatePlanet = {
+  system: string
+  // Roman-numeral position of the temperate planet within its system, e.g.
+  // 'III' for the third planet (RXA-W1 III).
+  planet: string
+  den: Den | null
+}
+
+// One row per temperate planet in the area. JVA-FE and 8P-LKL each have two
+// temperate planets, so they appear twice. Ordered to follow the topology
+// outward from staging.
+export const TEMPERATE_PLANETS: TemperatePlanet[] = [
+  { system: 'RXA-W1', planet: 'III', den: null },
+  { system: 'JVA-FE', planet: 'II', den: null },
+  { system: 'JVA-FE', planet: 'VI', den: null },
+  { system: 'QFU-4S', planet: 'III', den: null },
+  { system: '8P-LKL', planet: 'III', den: null },
+  { system: '8P-LKL', planet: 'VI', den: null },
+  { system: 'VK6-EZ', planet: 'IV', den: null },
+  { system: 'QQGH-G', planet: 'V', den: null },
+  { system: 'Q-UVY6', planet: 'II', den: null },
+]
+
+// Fixed 2-D layout for the topology graph, in the SVG's own coordinate space
+// (see topology.tsx's viewBox). Positions are hand-placed so the staging system
+// sits at the top and links fan out without crossing.
+export const NODE_POSITIONS: Record<string, { x: number; y: number }> = {
+  'X1-IZ0': { x: 300, y: 40 },
+  'RXA-W1': { x: 300, y: 120 },
+  'JVA-FE': { x: 300, y: 200 },
+  'QFU-4S': { x: 140, y: 290 },
+  '8P-LKL': { x: 300, y: 300 },
+  'VK6-EZ': { x: 470, y: 285 },
+  'QQGH-G': { x: 285, y: 400 },
+  'Q-UVY6': { x: 520, y: 385 },
+}
+
+// Distinct undirected edges derived from LINKS (each pair once), for drawing.
+export const EDGES: [string, string][] = (() => {
+  const seen = new Set<string>()
+  const edges: [string, string][] = []
+  Object.entries(LINKS).forEach(([from, tos]) => {
+    tos.forEach((to) => {
+      const key = [from, to].sort().join('|')
+      if (seen.has(key)) return
+      seen.add(key)
+      edges.push([from, to])
+    })
+  })
+  return edges
+})()

--- a/src/app/mercenary-dens/mercenaryDens.module.css
+++ b/src/app/mercenary-dens/mercenaryDens.module.css
@@ -1,0 +1,104 @@
+.pageHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12pt;
+}
+
+.pageHeader h1 {
+  margin: 0;
+}
+
+.subtitle {
+  color: var(--ink-soft);
+  margin-top: 4pt;
+}
+
+/* Network topology diagram — scales to the container, capped so it doesn't
+ * balloon on wide screens. */
+.topology {
+  display: block;
+  width: 100%;
+  max-width: 640px;
+  height: auto;
+  margin: 8pt 0 4pt;
+}
+
+.edge {
+  stroke: var(--line);
+  stroke-width: 2;
+}
+
+.nodeBox {
+  fill: var(--paper-raised);
+  stroke: var(--line);
+  stroke-width: 1.5;
+}
+
+.nodeLabel {
+  fill: var(--ink);
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+/* The staging system stands apart with the indigo accent. */
+.nodeStaging .nodeBox {
+  fill: var(--accent-tint);
+  stroke: var(--accent);
+}
+
+.nodeStaging .nodeLabel {
+  fill: var(--accent-strong);
+  font-weight: 600;
+}
+
+.table {
+  border-collapse: collapse;
+  margin-top: 8pt;
+}
+
+.table th {
+  text-align: left;
+  font-size: 9pt;
+  color: var(--ink-soft);
+  padding: 2pt 8pt;
+}
+
+.table td {
+  padding: 2pt 8pt;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+.table tbody tr:hover {
+  background: color-mix(in srgb, currentColor 6%, transparent);
+}
+
+.system {
+  font-weight: 600;
+}
+
+.planet {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.empty {
+  color: var(--ink-faint);
+}
+
+/* A den currently in its reinforcement timer — flagged in a warm alert color. */
+.reinforced {
+  color: #c0392b;
+  font-weight: 600;
+}
+
+@media (prefers-color-scheme: dark) {
+  .reinforced {
+    color: #ff6b5e;
+  }
+}
+
+.stable {
+  color: var(--ink-soft);
+}

--- a/src/app/mercenary-dens/page.tsx
+++ b/src/app/mercenary-dens/page.tsx
@@ -1,0 +1,73 @@
+import { redirect } from 'next/navigation'
+
+import { mercenaryDensFlag } from '@/flags'
+import { createClient } from '@/utils/supabase/server'
+
+import { STAGING, TEMPERATE_PLANETS } from './data'
+import { Topology } from './topology'
+import styles from './mercenaryDens.module.css'
+
+// Hand-maintained static intel; nothing here moves per request, but keep it
+// server-rendered behind the auth + flag gates.
+export const dynamic = 'force-dynamic'
+
+const MercenaryDensPage = async () => {
+  const supabase = await createClient()
+
+  const { data, error: authError } = await supabase.auth.getUser()
+  if (authError || !data?.user) {
+    redirect('/')
+  }
+
+  if (!(await mercenaryDensFlag())) {
+    redirect('/')
+  }
+
+  return (
+    <>
+      <div className={styles.pageHeader}>
+        <h1>Mercenary Dens</h1>
+      </div>
+      <p className={styles.subtitle}>
+        Systems immediately accessible from our staging system, <span className={styles.system}>{STAGING}</span>.
+      </p>
+
+      <Topology />
+
+      <h2>Temperate planets</h2>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>System</th>
+            <th>Planet</th>
+            <th>Den owner</th>
+            <th>Alliance</th>
+            <th>Reinforced</th>
+          </tr>
+        </thead>
+        <tbody>
+          {TEMPERATE_PLANETS.map(({ system, planet, den }, i) => (
+            <tr key={`${system}-${planet}-${i}`}>
+              <td className={styles.system}>{system}</td>
+              <td className={styles.planet}>{planet}</td>
+              <td>{den ? den.owner : <span className={styles.empty}>— none —</span>}</td>
+              <td>{den?.alliance ?? <span className={styles.empty}>—</span>}</td>
+              <td>
+                {den ? (
+                  den.reinforced ? (
+                    <span className={styles.reinforced}>reinforced</span>
+                  ) : (
+                    <span className={styles.stable}>stable</span>
+                  )
+                ) : (
+                  <span className={styles.empty}>—</span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </>
+  )
+}
+export default MercenaryDensPage

--- a/src/app/mercenary-dens/topology.tsx
+++ b/src/app/mercenary-dens/topology.tsx
@@ -1,0 +1,44 @@
+import { EDGES, NODE_POSITIONS, STAGING } from './data'
+import styles from './mercenaryDens.module.css'
+
+// Pill dimensions for each system node, in SVG user units.
+const NODE_W = 66
+const NODE_H = 24
+
+// A static network diagram of the systems reachable out from staging. Pure SVG
+// with a fixed hand-placed layout (see NODE_POSITIONS) — no interactivity — so
+// it renders on the server and scales to the container width.
+export const Topology = () => (
+  <svg
+    className={styles.topology}
+    viewBox="0 0 600 450"
+    role="img"
+    aria-label="Network topology of systems accessible from the staging system"
+  >
+    {EDGES.map(([from, to]) => {
+      const a = NODE_POSITIONS[from]
+      const b = NODE_POSITIONS[to]
+      if (!a || !b) return null
+      return <line key={`${from}-${to}`} className={styles.edge} x1={a.x} y1={a.y} x2={b.x} y2={b.y} />
+    })}
+
+    {Object.entries(NODE_POSITIONS).map(([system, { x, y }]) => {
+      const isStaging = system === STAGING
+      return (
+        <g key={system} className={isStaging ? styles.nodeStaging : styles.node}>
+          <rect
+            x={x - NODE_W / 2}
+            y={y - NODE_H / 2}
+            width={NODE_W}
+            height={NODE_H}
+            rx={6}
+            className={styles.nodeBox}
+          />
+          <text x={x} y={y} className={styles.nodeLabel} textAnchor="middle" dominantBaseline="central">
+            {system}
+          </text>
+        </g>
+      )
+    })}
+  </svg>
+)

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -19,3 +19,21 @@ export const indexesFlag = flag<boolean>({
     return (data?.flags ?? []).includes('indexes')
   },
 })
+
+// Per-user gate for the dark-launched /mercenary-dens page, backed by the
+// 'mercenary-dens' entry in user_settings.flags. Defaults to false for
+// signed-out users and anyone without the flag set.
+export const mercenaryDensFlag = flag<boolean>({
+  key: 'mercenary-dens',
+  description: 'Show the Mercenary Dens page and nav link',
+  decide: async () => {
+    const supabase = await createClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    if (!user) return false
+
+    const { data } = await supabase.from('user_settings').select('flags').eq('user_id', user.id).maybeSingle()
+    return (data?.flags ?? []).includes('mercenary-dens')
+  },
+})


### PR DESCRIPTION
## Summary

Adds a dark-launched `/mercenary-dens` page, structured like the existing Indexes page and gated the same way — a per-user `mercenary-dens` entry in `user_settings.flags`. The nav link only renders in the header when the flag is set, and the page itself redirects to `/` for signed-out users or anyone without the flag.

The page has two parts:

1. **Network topology** — an SVG diagram of the systems immediately accessible out from the `X1-IZ0` staging system: `X1-IZ0 → RXA-W1 → JVA-FE`, with `JVA-FE` fanning out to `QFU-4S`, `8P-LKL`, and `VK6-EZ`, and the lower cluster (`QQGH-G`, `Q-UVY6`) linked as described. Staging is highlighted with the indigo accent; the diagram is a static, server-rendered SVG that scales to the container.

2. **Temperate planets table** — one row per temperate planet in the area (system + planet number). `JVA-FE` and `8P-LKL` each have two temperate planets, so they appear twice. Columns show the mercenary den's owner, the owner's alliance, and whether the den is reinforced.

## Data notes

- System links and temperate-planet numbers are stable game-map facts sourced from CCP's live universe data (ESI `/universe/systems` + `/universe/planets`, planet `type_id` 11 = Temperate). The counts match exactly: 1 temperate per system except `JVA-FE` (II, VI) and `8P-LKL` (III, VI).
- There is **no ESI/DB feed** for mercenary-den ownership, reinforced state, or alliance for arbitrary systems, so that data lives in a hand-maintained structure in `src/app/mercenary-dens/data.ts`, seeded as unowned. Edit the `den` field per planet as intel changes.

## Files

- `src/flags.ts` — new `mercenaryDensFlag`, mirroring `indexesFlag`.
- `src/app/layout/header.tsx` — flag-gated `mercenary dens` nav link.
- `src/app/mercenary-dens/{page,topology,data}.tsx/ts` + `mercenaryDens.module.css` — the page, SVG topology, static data, and styles.

## Verification

`eslint`, `prettier`, and `next build` all pass; the topology layout was rendered and visually checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HsrTz2iETJNaxD4NN4Mv4K)_