### PR TITLE
Dedupe the pnpm lock file after Renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,7 @@
   "lockFileMaintenance": {
     "enabled": true
   },
+  "postUpdateOptions": ["pnpmDedupe"],
   "packageRules": [
     {
       "description": "Automerge minor, patch, pin, and digest updates",


### PR DESCRIPTION
## What

Add `"postUpdateOptions": ["pnpmDedupe"]` to `.github/renovate.json`.

## Why

This repo uses pnpm exclusively (`pnpm-lock.yaml` at lockfileVersion 9.0, `packageManager: pnpm@11.10.0`, no npm/yarn lockfile). Renovate already detects `pnpm-lock.yaml` via its npm manager, but it doesn't tidy the lock file on its own. `pnpmDedupe` is the pnpm-specific post-update option that runs `pnpm dedupe` after each dependency update, so Renovate keeps `pnpm-lock.yaml` deduplicated and clean instead of accumulating redundant entries across update PRs.

## Notes

- `pnpmDedupe` is a documented, valid `postUpdateOptions` value.
- `.github/renovate.json` validated as well-formed JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJt2G7UNPDjDpHsjba6B5A

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJt2G7UNPDjDpHsjba6B5A)_