### PR TITLE
Lower queue function memory to 512MB and log per-invocation usage

### DIFF
--- a/src/app/api/queue/jobs/route.ts
+++ b/src/app/api/queue/jobs/route.ts
@@ -115,64 +115,89 @@ type Msg = {
 
 // A thrown error fails the callback, so the Vercel queue retries the message
 // (per retryAfterSeconds in vercel.json).
+// Log this invocation's memory footprint to the console. Called from a `finally`
+// so it prints on every exit path (success, throw, tracked, untracked) — the
+// point is to see what the job actually needs so the function's `memory` limit
+// (vercel.json) can be sized against real usage rather than guessed. `maxRSS`
+// (process.resourceUsage) is the peak resident set size in KB on Linux; under
+// Vercel Fluid Compute the instance is reused across messages, so it's the
+// high-water mark for the whole worker, which is exactly the number to compare
+// against the configured limit.
+const mb = (bytes: number) => Math.round((bytes / 1024 / 1024) * 10) / 10
+const logMemoryUsage = (job: string) => {
+  const mem = process.memoryUsage()
+  const peakRssMb = Math.round((process.resourceUsage().maxRSS / 1024) * 10) / 10
+  console.log(
+    `[queue/jobs] mem job=${job} rss=${mb(mem.rss)}MB heapUsed=${mb(mem.heapUsed)}MB external=${mb(
+      mem.external
+    )}MB peakRss=${peakRssMb}MB`
+  )
+}
+
+// A thrown error fails the callback, so the Vercel queue retries the message
+// (per retryAfterSeconds in vercel.json).
 export const POST = handleCallback(async (message: Msg) => {
   const { job, characterId, characterIds, taskId } = message
   const ids = characterIds ?? (characterId != null ? [characterId] : undefined)
   console.log(`[queue/jobs] consume job=${job} characterIds=${ids?.join(',') ?? '-'} taskId=${taskId ?? '-'}`)
 
-  const entry = JOBS[job]
-  if (!entry) throw new Error(`unknown job: ${String(job)}`)
+  try {
+    const entry = JOBS[job]
+    if (!entry) throw new Error(`unknown job: ${String(job)}`)
 
-  const runJob = async () => {
-    const run = await entry.load()
-    if (entry.characterIds) {
-      await run(ids ? { characterIds: ids } : undefined)
+    const runJob = async () => {
+      const run = await entry.load()
+      if (entry.characterIds) {
+        await run(ids ? { characterIds: ids } : undefined)
+        return
+      }
+      // Account-wide jobs consume a single whole-job message, so the consumer records
+      // their heartbeat here. Per-character/per-corp jobs record their own instead,
+      // one row per character/corp attributed via character_id/corporation_id/user_id
+      // (see withHeartbeat in src/jobs/lib.js), regardless of whether this queue or a
+      // GitHub Actions cron invoked them.
+      const { recordHeartbeat } = await import('@/supabase.js')
+      const runId = randomInt(1, 2 ** 48)
+      await recordHeartbeat(job, 'start', { runId, source: 'vercel' })
+      try {
+        await run()
+      } finally {
+        await recordHeartbeat(job, 'end', { runId, source: 'vercel' })
+      }
+    }
+
+    // Not part of a tracked "Refresh ESI" run: just run it, letting a throw retry.
+    if (taskId == null) {
+      await runJob()
       return
     }
-    // Account-wide jobs consume a single whole-job message, so the consumer records
-    // their heartbeat here. Per-character/per-corp jobs record their own instead,
-    // one row per character/corp attributed via character_id/corporation_id/user_id
-    // (see withHeartbeat in src/jobs/lib.js), regardless of whether this queue or a
-    // GitHub Actions cron invoked them.
-    const { recordHeartbeat } = await import('@/supabase.js')
-    const runId = randomInt(1, 2 ** 48)
-    await recordHeartbeat(job, 'start', { runId, source: 'vercel' })
+
+    // Tracked: record status on the refresh_task row. Best-effort — a failure is
+    // recorded and swallowed rather than rethrown, so the queue doesn't retry it and
+    // the page settles on a terminal state the user can see.
+    const { sudoSupabase } = await import('@/supabase.js')
+    await sudoSupabase
+      .from('refresh_task')
+      .update({ status: 'running', started_at: new Date().toISOString(), updated_at: new Date().toISOString() })
+      .eq('id', taskId)
     try {
-      await run()
-    } finally {
-      await recordHeartbeat(job, 'end', { runId, source: 'vercel' })
+      await runJob()
+      await sudoSupabase
+        .from('refresh_task')
+        .update({ status: 'done', ended_at: new Date().toISOString(), updated_at: new Date().toISOString() })
+        .eq('id', taskId)
+    } catch (e) {
+      await sudoSupabase
+        .from('refresh_task')
+        .update({
+          status: 'error',
+          ended_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+          error: String(e instanceof Error ? e.message : e).slice(0, 500),
+        })
+        .eq('id', taskId)
     }
-  }
-
-  // Not part of a tracked "Refresh ESI" run: just run it, letting a throw retry.
-  if (taskId == null) {
-    await runJob()
-    return
-  }
-
-  // Tracked: record status on the refresh_task row. Best-effort — a failure is
-  // recorded and swallowed rather than rethrown, so the queue doesn't retry it and
-  // the page settles on a terminal state the user can see.
-  const { sudoSupabase } = await import('@/supabase.js')
-  await sudoSupabase
-    .from('refresh_task')
-    .update({ status: 'running', started_at: new Date().toISOString(), updated_at: new Date().toISOString() })
-    .eq('id', taskId)
-  try {
-    await runJob()
-    await sudoSupabase
-      .from('refresh_task')
-      .update({ status: 'done', ended_at: new Date().toISOString(), updated_at: new Date().toISOString() })
-      .eq('id', taskId)
-  } catch (e) {
-    await sudoSupabase
-      .from('refresh_task')
-      .update({
-        status: 'error',
-        ended_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-        error: String(e instanceof Error ? e.message : e).slice(0, 500),
-      })
-      .eq('id', taskId)
+  } finally {
+    logMemoryUsage(job)
   }
 })

--- a/vercel.json
+++ b/vercel.json
@@ -81,6 +81,7 @@
   "functions": {
     "src/app/api/queue/jobs/route.ts": {
       "maxDuration": 60,
+      "memory": 512,
       "experimentalTriggers": [
         {
           "type": "queue/v2beta",


### PR DESCRIPTION
## What

Two small changes to the Vercel queue consumer (`src/app/api/queue/jobs/route.ts`) aimed at reducing function execution cost:

1. **Lower the function's memory to 512MB** (`vercel.json`). The consumer is I/O-bound — a token refresh, an ESI fetch, and a Supabase write — and does almost no CPU work, so it doesn't need the plan-default memory. Vercel bills GB-seconds, so halving/quartering the memory allocation is a proportional cost reduction across every queued extract job.

2. **Log each invocation's memory footprint to the console.** A `logMemoryUsage()` helper runs from a `finally` block so it prints on every exit path (success, throw, tracked, and untracked runs). It reports current `rss`, `heapUsed`, and `external` from `process.memoryUsage()`, plus the process peak `maxRSS` from `process.resourceUsage()`. Under Fluid Compute the instance is reused across messages, so `peakRss` is the high-water mark for the whole worker — the number to size the `memory` limit against.

Example log line:
```
[queue/jobs] mem job=character-assets rss=118.4MB heapUsed=61.2MB external=3.1MB peakRss=142.7MB
```

## Why

Cost from high function execution time. This is the safest, config-first lever: it can't change job behavior, and the added logging lets us confirm 512MB is comfortable (or tune it further) against real usage before touching anything else.

## Notes

- 512MB is a starting point. Watch the `peakRss` values in the logs after deploy; if they run well under 512MB the limit can drop further, and if any job approaches it we'll see it before an OOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrZ7rkyiNUfe637WrVdoMB

---
_Generated by [Claude Code](https://claude.ai/code/session_01QrZ7rkyiNUfe637WrVdoMB)_