### PR TITLE
Ship fit owner cleanup + materialized-path breadcrumb

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -30,6 +30,7 @@ drop function if exists public.character_asset_location_summary()        cascade
 drop function if exists public.character_asset_location_contents(bigint) cascade;
 drop function if exists public.corp_asset_location_summary()             cascade;
 drop function if exists public.corp_asset_location_contents(bigint)      cascade;
+drop function if exists public.asset_ancestors(bigint)                   cascade;
 drop function if exists public.character_asset_snapshot_at(uuid[], timestamptz) cascade;
 drop function if exists public.character_industry_jobs(uuid[], boolean)  cascade;
 drop function if exists public.character_orders(uuid[])                  cascade;
@@ -1382,6 +1383,41 @@ $$;
 grant execute on function public.corp_asset_location_summary()        to authenticated;
 grant execute on function public.corp_asset_location_contents(bigint) to authenticated;
 grant execute on function public.corp_asset_search(bigint[])          to authenticated;
+
+-- breadcrumb (/asset/[locationId], /ship/[itemId]): the materialized path of
+-- one item — the item itself, then each enclosing container outward, ordered
+-- by depth. The last row's location_id/location_type is the root place (a
+-- station, structure or solar system that isn't one of the caller's items).
+-- Climbs the live character_asset ∪ corp_asset views, so RLS scopes every
+-- hop to the caller; a parent the caller can't see just ends the walk early.
+-- Seeded from a single item (like the *_asset_search functions), so it stays
+-- cheap regardless of hangar size.
+create or replace function public.asset_ancestors(start_id bigint)
+returns table (item_id bigint, type_id bigint, name text, location_id bigint, location_type text, depth int)
+language sql
+stable
+as $$
+  with recursive parent_of as (
+    select item_id, type_id, name, location_id, location_type
+    from public.character_asset
+    union all
+    select item_id, type_id, null::text as name, location_id, location_type
+    from public.corp_asset
+  ),
+  walk as (
+    select p.item_id, p.type_id, p.name, p.location_id, p.location_type, 1 as depth
+    from parent_of p
+    where p.item_id = start_id
+    union all
+    select p.item_id, p.type_id, p.name, p.location_id, p.location_type, w.depth + 1
+    from walk w
+    join parent_of p on p.item_id = w.location_id
+    where w.depth < 16
+  )
+  select * from walk order by depth;
+$$;
+
+grant execute on function public.asset_ancestors(bigint) to authenticated;
 
 -- /api/corp/assets IMPORTDATA endpoint: the caller's corporation(s) current
 -- asset rows (one per item stack), mirroring character_asset_snapshot_at()'s

--- a/src/app/asset/[locationId]/page.tsx
+++ b/src/app/asset/[locationId]/page.tsx
@@ -1,9 +1,9 @@
-import Link from 'next/link'
 import { notFound, redirect } from 'next/navigation'
 
 import { getSdeType } from '@/sdeTypes'
 import { createClient } from '@/utils/supabase/server'
 import { createServiceClient } from '@/utils/supabase/service'
+import { AssetPath, fetchAssetPath, type Crumb } from '../../assetPath'
 import { fetchOwners } from '../../owners'
 import { resolveShareToken } from '../../ship/access'
 import { fetchStationNames, fetchStationSystems } from '../../stationNames'
@@ -164,19 +164,21 @@ const AssetLocationPage = async ({
   }
 
   let heading: string
-  let backHref = '/asset'
-  let backLabel = 'Back to Assets'
+  // Where this location lives: the full container chain up to its root place,
+  // rendered as the breadcrumb above the heading. A bare place (station /
+  // structure / system) has no ancestry, so its path is just the Assets root.
+  // Skipped in the token path: the RPC would walk unscoped as service_role,
+  // and a shared hangar shouldn't reveal where it lives anyway.
+  let crumbs: Crumb[] = [{ href: '/asset', label: 'Assets' }]
   let systemName: string | undefined
 
   if (self) {
-    // A container: title it by its custom name (if any) plus type, and step
-    // back to whatever holds it.
+    // A container: title it by its custom name (if any) plus type.
     const typeNames = await fetchTypeNames([Number(self.type_id)])
     const typeName = typeNames[Number(self.type_id)] ?? `#${self.type_id}`
     heading = self.name && self.name !== typeName ? `${self.name} (${typeName})` : typeName
-    if (self.location_id != null) {
-      backHref = `/asset/${self.location_id}`
-      backLabel = 'Back'
+    if (!scope) {
+      crumbs = await fetchAssetPath(locationId, supabase)
     }
   } else {
     // Resolve the location's own name/system the same way the index page does:
@@ -265,15 +267,11 @@ const AssetLocationPage = async ({
 
   return (
     <>
+      {!scope ? <AssetPath crumbs={crumbs} current={heading} /> : null}
       <h1 className="serif">{heading}</h1>
       {systemName && systemName !== heading ? (
         <p>
           System: <span className="serif">{systemName}</span>
-        </p>
-      ) : null}
-      {!scope ? (
-        <p>
-          <Link href={backHref}>&laquo; {backLabel}</Link>
         </p>
       ) : null}
 

--- a/src/app/assetPath.module.css
+++ b/src/app/assetPath.module.css
@@ -1,0 +1,20 @@
+/*
+ * Breadcrumb showing the materialized path of where an item lives (see
+ * assetPath.tsx), sitting above the page heading in the app's flat/paper
+ * visual language.
+ */
+
+.path {
+  margin: 0 0 12px;
+  font-size: 12px;
+  color: var(--ink-faint);
+}
+
+.separator {
+  margin: 0 6px;
+  color: var(--ink-faint);
+}
+
+.current {
+  color: var(--ink);
+}

--- a/src/app/assetPath.tsx
+++ b/src/app/assetPath.tsx
@@ -1,0 +1,77 @@
+// The materialized path of where an item lives, shown as a breadcrumb at the
+// top of /asset/[locationId] and /ship/[itemId]: Assets › root place ›
+// enclosing containers › the page's subject. The ancestor chain comes from
+// the asset_ancestors() Postgres function (one RPC for the whole climb,
+// RLS-scoped to the caller); the root place is named via resolveLocations and
+// containers via their custom name or SDE type name.
+import Link from 'next/link'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { map, reverse } from 'ramda'
+import { createClient } from '@/utils/supabase/server'
+import { resolveLocations } from './resolveLocations'
+import { fetchTypeNames } from './typeNames'
+import styles from './assetPath.module.css'
+
+export type Crumb = { href: string | null; label: string }
+
+type AncestorRow = {
+  item_id: number | string
+  type_id: number | string
+  name: string | null
+  location_id: number | string | null
+  location_type: string | null
+  depth: number
+}
+
+const ASSETS_CRUMB: Crumb = { href: '/asset', label: 'Assets' }
+
+export const fetchAssetPath = async (itemId: string, client?: SupabaseClient): Promise<Crumb[]> => {
+  const supabase = client ?? (await createClient())
+
+  // Rows come back depth-ascending: the subject itself first, then each
+  // enclosing container outward. The outermost row's location_id is the root
+  // place (station / structure / solar system) — or, on an RLS gap, the first
+  // parent the caller can't see, which nameFor falls back to `Location #id`.
+  const { data } = await supabase.rpc('asset_ancestors', { start_id: itemId })
+  const rows = (data ?? []) as AncestorRow[]
+  const outermost = rows[rows.length - 1]
+  if (!outermost || outermost.location_id == null) return [ASSETS_CRUMB]
+
+  // The subject renders as the page's own non-link `current` crumb; only the
+  // rows above it become linked ancestors.
+  const ancestors = rows.slice(1)
+  const root = { id: String(outermost.location_id), type: outermost.location_type }
+  const [resolved, typeNames] = await Promise.all([
+    resolveLocations([root], supabase),
+    fetchTypeNames(map((a: AncestorRow) => Number(a.type_id), ancestors)),
+  ])
+
+  return [
+    ASSETS_CRUMB,
+    { href: `/asset/${root.id}`, label: resolved.nameFor(root) },
+    ...map(
+      (a: AncestorRow) => ({
+        href: `/asset/${a.item_id}`,
+        label: a.name ?? typeNames[Number(a.type_id)] ?? `#${a.type_id}`,
+      }),
+      reverse(ancestors)
+    ),
+  ]
+}
+
+export const AssetPath = ({ crumbs, current }: { crumbs: Crumb[]; current?: string }) => (
+  <nav aria-label="Breadcrumb" className={styles.path}>
+    {crumbs.map((crumb, i) => (
+      <span key={`${crumb.href}-${i}`}>
+        {i > 0 && <span className={styles.separator}>›</span>}
+        {crumb.href ? <Link href={crumb.href}>{crumb.label}</Link> : <span>{crumb.label}</span>}
+      </span>
+    ))}
+    {current != null && (
+      <span>
+        <span className={styles.separator}>›</span>
+        <span className={styles.current}>{current}</span>
+      </span>
+    )}
+  </nav>
+)

--- a/src/app/ship/[itemId]/page.tsx
+++ b/src/app/ship/[itemId]/page.tsx
@@ -1,12 +1,9 @@
-import Link from 'next/link'
 import { notFound, redirect } from 'next/navigation'
 
 import { getSdeType } from '@/sdeTypes'
 import { createClient } from '@/utils/supabase/server'
 import { createServiceClient } from '@/utils/supabase/service'
-import { fetchOwners } from '../../owners'
-import type { Owners } from '../../ownerFilter'
-import { resolveLocations } from '../../resolveLocations'
+import { AssetPath, fetchAssetPath } from '../../assetPath'
 import { fetchTypeNames } from '../../typeNames'
 import { type ItemRow } from '../../asset/[locationId]/locationAssets'
 import { resolveShareToken } from '../access'
@@ -128,18 +125,14 @@ const ShipPage = async ({
     ownerName = corpName?.name ?? `Corporation #${corporationId}`
   }
 
-  // Location: the hangar the ship sits in (station / structure / system).
-  const location =
-    self.location_id != null
-      ? await resolveLocations([{ id: String(self.location_id), type: self.location_type }])
-      : null
-  const locationRef = self.location_id != null ? { id: String(self.location_id), type: self.location_type } : null
+  // Where the ship lives: the full container chain up to its station /
+  // structure / system, rendered as the breadcrumb above the heading.
+  const crumbs = await fetchAssetPath(itemId, supabase)
 
   const typeNames = await fetchTypeNames([Number(self.type_id)])
   const typeName = typeNames[Number(self.type_id)] ?? `#${self.type_id}`
   const heading = self.name && self.name !== typeName ? `${self.name} (${typeName})` : typeName
 
-  const owners = await fetchOwners()
   const typeNamesPromise = fetchTypeNames(children.map((c) => Number(c.type_id)))
   const rows: ItemRow[] = children
     .map((c) => {
@@ -167,22 +160,14 @@ const ShipPage = async ({
 
   return (
     <>
+      <AssetPath crumbs={crumbs} current={heading} />
       <h1 className="serif">{heading}</h1>
       <p>
         Owner: <span className="serif">{ownerName}</span>
-        {location && locationRef ? (
-          <>
-            {' '}
-            — <Link href={`/asset/${locationRef.id}`}>{location.nameFor(locationRef)}</Link>
-            {location.systemFor(locationRef) && location.systemFor(locationRef) !== location.nameFor(locationRef) ? (
-              <> ({location.systemFor(locationRef)})</>
-            ) : null}
-          </>
-        ) : null}
       </p>
       <ShareControls itemId={itemId} initialToken={share?.token ?? null} />
       <ShipFitViewDynamic esiFit={toEsiFit(Number(self.type_id), self.name ?? null, rows)} />
-      <ShipCargo rows={rows} owners={owners} typeNamesPromise={typeNamesPromise} />
+      <ShipCargo rows={rows} typeNamesPromise={typeNamesPromise} />
     </>
   )
 }
@@ -241,11 +226,6 @@ const SharedShipPage = async ({ itemId, token }: { itemId: string; token: string
       .maybeSingle<{ name: string }>()
     ownerName = corpName?.name ?? `Corporation #${corporationId}`
   }
-  // ShipCargo's owner filter wants an Owners shape; a shared ship has exactly
-  // one owner, so build a single-entry list on the correct side.
-  const owners: Owners = characterSelf?.character_id
-    ? { characters: [{ id: ownerId, name: ownerName }], corporations: [] }
-    : { characters: [], corporations: [{ id: ownerId, name: ownerName }] }
 
   const typeNames = await fetchTypeNames([Number(self.type_id)])
   const typeName = typeNames[Number(self.type_id)] ?? `#${self.type_id}`
@@ -276,7 +256,7 @@ const SharedShipPage = async ({ itemId, token }: { itemId: string; token: string
         Owner: <span className="serif">{ownerName}</span>
       </p>
       <ShipFitViewDynamic esiFit={toEsiFit(Number(self.type_id), self.name ?? null, rows)} />
-      <ShipCargo rows={rows} owners={owners} typeNamesPromise={typeNamesPromise} />
+      <ShipCargo rows={rows} typeNamesPromise={typeNamesPromise} />
     </>
   )
 }

--- a/src/app/ship/[itemId]/shipCargo.module.css
+++ b/src/app/ship/[itemId]/shipCargo.module.css
@@ -80,8 +80,3 @@
   line-height: 1.25;
   overflow-wrap: anywhere;
 }
-
-.owner {
-  font-size: 10px;
-  color: var(--ink-faint);
-}

--- a/src/app/ship/[itemId]/shipCargo.tsx
+++ b/src/app/ship/[itemId]/shipCargo.tsx
@@ -9,7 +9,6 @@ import {
   complement,
   cond,
   equals,
-  filter,
   groupBy,
   gt,
   isNil,
@@ -24,10 +23,7 @@ import {
   view,
 } from 'ramda'
 
-import { ALL_OWNERS, OwnerSelect, ownerNames, useOwnerFilter, type Owners } from '../../ownerFilter'
 import { TypeName } from '../../typeName'
-import styles from '../../asset/assets.module.css'
-import { OWNER_STORAGE_KEY } from '../../asset/filterKey'
 import { type ItemRow } from '../../asset/[locationId]/locationAssets'
 import bayStyles from './shipCargo.module.css'
 
@@ -108,27 +104,19 @@ const hasVisibleQuantity: (item: ItemRow) => boolean = allPass([
 
 type ShipCargoProps = {
   rows: ItemRow[]
-  owners: Owners
   typeNamesPromise: Promise<Record<number, string>>
 }
 
 // Item icons/quantity tiles grouped by hold/slot, echoing the EVE client's
 // fitting-and-cargo layout — the bays a ship actually has (only sections with
-// at least one item render) rather than a blank slot-by-slot mockup.
-export const ShipCargo = ({ rows, owners, typeNamesPromise }: ShipCargoProps) => {
-  const [ownerId, setOwnerId] = useOwnerFilter(OWNER_STORAGE_KEY, owners)
-
-  const filtered = filter((r: ItemRow) => equals(ownerId, ALL_OWNERS) || equals(r.ownerId, ownerId), rows)
-  const ownerMap = ownerNames(owners)
-  const bays = groupIntoBays(filtered)
+// at least one item render) rather than a blank slot-by-slot mockup. No owner
+// filter or per-tile owner labels: everything inside a ship belongs to
+// whoever owns the ship.
+export const ShipCargo = ({ rows, typeNamesPromise }: ShipCargoProps) => {
+  const bays = groupIntoBays(rows)
 
   return (
     <section>
-      <label className={styles.filter}>
-        Owner:&nbsp;
-        <OwnerSelect owners={owners} value={ownerId} onChange={setOwnerId} />
-      </label>
-
       {bays.length > 0 ? (
         map(
           (bay: Bay) => (
@@ -151,9 +139,6 @@ export const ShipCargo = ({ rows, owners, typeNamesPromise }: ShipCargoProps) =>
                       <span className={bayStyles.name}>
                         <TypeName id={item.typeId} name={item.name} promise={typeNamesPromise} />
                       </span>
-                      {equals(ownerId, ALL_OWNERS) && (
-                        <span className={bayStyles.owner}>{ownerMap.get(item.ownerId) ?? item.ownerId}</span>
-                      )}
                     </>
                   )
                   return (
@@ -174,7 +159,7 @@ export const ShipCargo = ({ rows, owners, typeNamesPromise }: ShipCargoProps) =>
           bays
         )
       ) : (
-        <p>Nothing in this ship for this owner.</p>
+        <p>Nothing in this ship.</p>
       )}
     </section>
   )

--- a/supabase/migrations/20260712130000_add_asset_ancestors.sql
+++ b/supabase/migrations/20260712130000_add_asset_ancestors.sql
@@ -1,0 +1,34 @@
+-- breadcrumb (/asset/[locationId], /ship/[itemId]): the materialized path of
+-- one item — the item itself, then each enclosing container outward, ordered
+-- by depth. The last row's location_id/location_type is the root place (a
+-- station, structure or solar system that isn't one of the caller's items).
+-- Climbs the live character_asset ∪ corp_asset views, so RLS scopes every
+-- hop to the caller; a parent the caller can't see just ends the walk early.
+-- Seeded from a single item (like the *_asset_search functions), so it stays
+-- cheap regardless of hangar size.
+create or replace function public.asset_ancestors(start_id bigint)
+returns table (item_id bigint, type_id bigint, name text, location_id bigint, location_type text, depth int)
+language sql
+stable
+as $$
+  with recursive parent_of as (
+    select item_id, type_id, name, location_id, location_type
+    from public.character_asset
+    union all
+    select item_id, type_id, null::text as name, location_id, location_type
+    from public.corp_asset
+  ),
+  walk as (
+    select p.item_id, p.type_id, p.name, p.location_id, p.location_type, 1 as depth
+    from parent_of p
+    where p.item_id = start_id
+    union all
+    select p.item_id, p.type_id, p.name, p.location_id, p.location_type, w.depth + 1
+    from walk w
+    join parent_of p on p.item_id = w.location_id
+    where w.depth < 16
+  )
+  select * from walk order by depth;
+$$;
+
+grant execute on function public.asset_ancestors(bigint) to authenticated;


### PR DESCRIPTION
## What

Two UX changes to the asset/ship browsing pages:

### 1. No more per-module owners on the ship fit page

Everything inside a ship belongs to whoever owns the ship, so the per-tile owner badge in the cargo/fitting view was noise — removed. The owner **filter dropdown** in that section is gone too: under the same invariant it could only ever show all or nothing, and since it persisted its choice under the same localStorage key as the asset pages, a filter picked on `/asset` could blank out a ship's modules entirely. The page header still shows the ship's owner.

### 2. Materialized-path breadcrumb on `/asset/[locationId]` and `/ship/[itemId]`

A new breadcrumb above the heading shows where the item lives, e.g.

> Assets › Jita IV - Moon 4 - Caldari Navy Assembly Plant › Big Container › *Rifter*

with each ancestor linking to its own asset page (ship ancestors forward to `/ship/[id]` via the existing redirect).

## How

- **New `asset_ancestors(start_id)` Postgres function** (`schema.sql` + migration `20260712130000_add_asset_ancestors.sql`): walks an item's `location_id` chain upward through the `character_asset` ∪ `corp_asset` views with a recursive CTE — the same pattern as the existing `*_asset_location_summary` functions, but returning every level (ordered by depth) instead of only the root. `SECURITY INVOKER`, so RLS scopes the walk to the caller; depth capped at 16.
- **New `src/app/assetPath.tsx`**: `fetchAssetPath(itemId)` calls the RPC once, names the root place via the existing `resolveLocations`, and labels container crumbs by custom name or SDE type name; `AssetPath` renders the crumbs.
- The breadcrumb subsumes the asset page's one-level "Back" link and the ship page's inline location link, so both are removed.
- Share-token views keep hiding location: no breadcrumb is rendered there, and the RPC is never run on the service client (it would walk unscoped).

## Edge cases

- Item directly in a station → `Assets › Station › item`.
- Viewing a bare place (station/structure/system) → `Assets › place`.
- Corp containers (no custom-name column) → type-name labels.
- Mid-chain RLS gap (e.g. an item inside a container the caller can't see) → the walk ends there and the crumb falls back to `Location #id`.

## Notes

- Dependencies can't install in this environment (`@eveshipfit/*` needs GitHub Packages auth), so `lint`/`build` couldn't run locally — the touched files were syntax-checked with esbuild; please let CI confirm.
- The migration is applied by the `Migrate` workflow on merge; nothing was pushed to the database from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016WZnCoTD8PMvogVRKrj5nF

---
_Generated by [Claude Code](https://claude.ai/code/session_016WZnCoTD8PMvogVRKrj5nF)_