### PR TITLE
Add dark-launched Corpses page listing pilot names

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1709,7 +1709,8 @@ grant all    on public.universe_structure to service_role;
 -- and scope the results to their characters. Null until the user generates one
 -- in settings.
 -- `flags` is the set of Vercel Flags (src/flags.ts) a user has enabled, e.g.
--- 'indexes' gates the /indexes page and nav link per-user.
+-- 'indexes' gates the /indexes page and nav link per-user (likewise
+-- 'mercenary-dens' and 'corpses' for their dark-launched pages).
 create table public.user_settings (
   user_id uuid primary key references auth.users(id) on delete cascade,
   enabled_scopes text[] not null default '{}',

--- a/src/app/corpses/corpses.module.css
+++ b/src/app/corpses/corpses.module.css
@@ -1,0 +1,37 @@
+/* Page header: title left, corpse tally right — same arrangement as the
+ * Indexes page's header. */
+.pageHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12pt;
+}
+
+.pageHeader h1 {
+  margin: 0;
+}
+
+.count {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 10pt;
+  color: var(--ink-soft);
+}
+
+.list {
+  margin-top: 8pt;
+  padding-left: 3ch;
+}
+
+.row {
+  padding: 1pt 0;
+}
+
+.unknown {
+  color: var(--ink-faint);
+  font-style: italic;
+}
+
+.empty {
+  color: var(--ink-faint);
+}

--- a/src/app/corpses/page.tsx
+++ b/src/app/corpses/page.tsx
@@ -1,0 +1,68 @@
+import { redirect } from 'next/navigation'
+
+import { corpsesFlag } from '@/flags'
+import { createClient } from '@/utils/supabase/server'
+
+import styles from './corpses.module.css'
+
+// Every player corpse in EVE is the same type — typeID 25, "Corpse". They're
+// singleton items, so the extract job resolves each one's ESI asset name, which
+// for a corpse is the name of the pilot it belongs to.
+const CORPSE_TYPE_ID = 25
+
+// Read fresh — the character_asset view moves underneath this page as new
+// extracts land.
+export const dynamic = 'force-dynamic'
+
+type CorpseRow = {
+  item_id: number | string
+  name: string | null
+}
+
+const CorpsesPage = async () => {
+  const supabase = await createClient()
+
+  const { data, error: authError } = await supabase.auth.getUser()
+  if (authError || !data?.user) {
+    redirect('/')
+  }
+
+  if (!(await corpsesFlag())) {
+    redirect('/')
+  }
+
+  // Every current corpse across the caller's characters (RLS scopes the read).
+  const { data: rows } = await supabase
+    .from('character_asset')
+    .select('item_id, name')
+    .eq('type_id', CORPSE_TYPE_ID)
+    .returns<CorpseRow[]>()
+
+  // The pilot name lives in the asset name; a corpse whose name hasn't been
+  // resolved yet falls back to its item id so it still shows in the tally.
+  const corpses = (rows ?? [])
+    .map((r) => ({ itemId: String(r.item_id), pilot: r.name?.trim() || null }))
+    .sort((a, b) => (a.pilot ?? '').localeCompare(b.pilot ?? '', undefined, { sensitivity: 'base' }))
+
+  return (
+    <>
+      <div className={styles.pageHeader}>
+        <h1>Corpses</h1>
+        {corpses.length > 0 && <span className={styles.count}>{corpses.length}</span>}
+      </div>
+
+      {corpses.length > 0 ? (
+        <ol className={styles.list}>
+          {corpses.map(({ itemId, pilot }) => (
+            <li key={itemId} className={styles.row}>
+              {pilot ?? <span className={styles.unknown}>Unknown (#{itemId})</span>}
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <p className={styles.empty}>No corpses in your hangars.</p>
+      )}
+    </>
+  )
+}
+export default CorpsesPage

--- a/src/app/layout/header.tsx
+++ b/src/app/layout/header.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { createClient } from '@/utils/supabase/server'
-import { indexesFlag, mercenaryDensFlag } from '@/flags'
+import { corpsesFlag, indexesFlag, mercenaryDensFlag } from '@/flags'
 import { Freshness } from '../Freshness'
 import styles from './header.module.css'
 
@@ -40,7 +40,11 @@ const Header = async () => {
     lastRefreshedAt = latestBeat?.ended_at ?? null
   }
 
-  const [showIndexes, showMercenaryDens] = await Promise.all([indexesFlag(), mercenaryDensFlag()])
+  const [showIndexes, showMercenaryDens, showCorpses] = await Promise.all([
+    indexesFlag(),
+    mercenaryDensFlag(),
+    corpsesFlag(),
+  ])
   return (
     <header>
       <div className={styles.bar}>
@@ -77,6 +81,12 @@ const Header = async () => {
               {showMercenaryDens && (
                 <>
                   <Link href="/mercenary-dens">mercenary&nbsp;dens</Link>
+                  <span className={styles.sep}>|</span>
+                </>
+              )}
+              {showCorpses && (
+                <>
+                  <Link href="/corpses">corpses</Link>
                   <span className={styles.sep}>|</span>
                 </>
               )}

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -37,3 +37,21 @@ export const mercenaryDensFlag = flag<boolean>({
     return (data?.flags ?? []).includes('mercenary-dens')
   },
 })
+
+// Per-user gate for the dark-launched /corpses page, backed by the 'corpses'
+// entry in user_settings.flags. Defaults to false for signed-out users and
+// anyone without the flag set.
+export const corpsesFlag = flag<boolean>({
+  key: 'corpses',
+  description: 'Show the Corpses page and nav link',
+  decide: async () => {
+    const supabase = await createClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    if (!user) return false
+
+    const { data } = await supabase.from('user_settings').select('flags').eq('user_id', user.id).maybeSingle()
+    return (data?.flags ?? []).includes('corpses')
+  },
+})


### PR DESCRIPTION
## Summary

Adds a new dark-launched `/corpses` page that lists every player corpse you're holding, showing the name of the pilot each corpse belongs to.

Every player corpse in EVE is the same type — `typeID 25` ("Corpse") — and corpses are singleton items, so the `character-assets` extract job already resolves each one's ESI asset name, which for a corpse is the deceased pilot's name. The page reads the `character_asset` view (RLS-scoped to the caller), filters to `type_id = 25`, and renders the resolved names as an alphabetized list. A corpse whose name hasn't been resolved yet falls back to its item id so it still counts toward the tally.

## Changes

- **`src/flags.ts`** — new per-user `corpsesFlag` (`corpses` entry in `user_settings.flags`), mirroring `indexesFlag` / `mercenaryDensFlag`. Defaults to `false` for signed-out users and anyone without the flag.
- **`src/app/corpses/page.tsx`** — the page itself, gated behind auth + the flag (redirects to `/` otherwise), same as `/indexes` and `/mercenary-dens`.
- **`src/app/corpses/corpses.module.css`** — minimal styling matching the indexes header/list conventions.
- **`src/app/layout/header.tsx`** — flag-gated `corpses` nav link.
- **`schema.sql`** — extend the `user_settings.flags` comment to note the `corpses` flag.

## Enabling

Like the other dark-launched pages, add `corpses` to a user's `user_settings.flags` array to reveal the page and nav link. No schema migration is required — flags are just array entries.

## Testing

- `eslint` clean on the changed files.
- `tsc --noEmit` reports no errors for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019MTosHHDusu7wxU4nCo66m)_