### PR TITLE
Migrate pnpm build-script approval to pnpm-workspace.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,6 @@
 .pnp.js
 .yarn/install-state.gz
 
-# pnpm-generated build-script approvals (`pnpm approve-builds`) — committing
-# this breaks Vercel's build (missing "packages" field, pnpm/pnpm#9361); the
-# approval only needs to exist locally, not in the repo
-/pnpm-workspace.yaml
-
 # testing
 /coverage
 

--- a/package.json
+++ b/package.json
@@ -66,11 +66,6 @@
     "start": "next start"
   },
   "prettier": "@philihp/prettier-config",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "sharp"
-    ]
-  },
   "devDependencies": {
     "@eslint/eslintrc": "3.3.5",
     "@eslint/js": "^10.0.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,14 @@
+# pnpm 11 (used locally and in CI via the pinned `packageManager`) no longer
+# reads the `pnpm` field from package.json, so build-script approvals must live
+# here. `allowBuilds` lets sharp run its install script (its predecessor,
+# `pnpm.onlyBuiltDependencies` in package.json, is ignored by pnpm 11).
+#
+# The `packages` list is required only to keep Vercel's builds green: Vercel
+# still installs with pnpm 9, which aborts with "packages field missing or
+# empty" when it finds a pnpm-workspace.yaml without one (pnpm/pnpm#9361, the
+# breakage reverted in #528). This is a single-package repo, so `.` is the sole
+# member; pnpm 9 ignores the unknown `allowBuilds` key.
+packages:
+  - .
+allowBuilds:
+  sharp: true


### PR DESCRIPTION
## What & why

pnpm 11 (what we run locally and in CI via the pinned `packageManager: pnpm@11.10.0`) no longer reads the `pnpm` field from `package.json`, so `pnpm.onlyBuiltDependencies` has been silently ignored. With no build approval that pnpm 11 can see, `pnpm install` **aborts** with `ERR_PNPM_IGNORED_BUILDS` on sharp's build script.

That's not just a cosmetic warning — it's been breaking things:

- **The `Heartbeat` workflow has failed on every run since the pnpm 11 upgrade** (last green 2026-07-06; the failing step is `pnpm install --frozen-lockfile`, which then skips the heartbeat).
- **Local `pnpm` commands error too** — husky's pre-commit `pnpm run lint` hits the same `ERR_PNPM_IGNORED_BUILDS`.

## The fix

Move the approval to its pnpm 11 home — `pnpm-workspace.yaml` — as an `allowBuilds` entry (the successor to the removed `onlyBuiltDependencies`), and drop the dead `package.json` field.

This file used to be gitignored because committing a bare `pnpm-workspace.yaml` broke Vercel: **Vercel still installs with pnpm 9** (corepack off — it ignores the pinned `packageManager` and picks pnpm 9 "based on project creation date"), and pnpm 9 aborts with `packages field missing or empty` when it finds a workspace file without one (pnpm/pnpm#9361, the breakage reverted in #528).

Adding a `packages` list (just `.` — this is a single-package repo) satisfies pnpm 9's workspace validation, while pnpm 9 harmlessly ignores the unknown `allowBuilds` key. So a single committed file works on **both** pnpm versions with **no Vercel dashboard change** (corepack stays off).

```yaml
packages:
  - .
allowBuilds:
  sharp: true
```

## Verification

Tested both interpreters against the committed file:

| | pnpm 9.15.9 (Vercel) | pnpm 11.10.0 (CI/local) |
|---|---|---|
| workspace parse | ✅ single-package, `allowBuilds` ignored | ✅ |
| `pnpm install --frozen-lockfile` | ✅ | ✅ exit 0, sharp builds |
| lockfile | unchanged (still up to date) | unchanged |

- `pnpm install --frozen-lockfile` → exit 0 (previously exit 1).
- `pnpm run lint` (the pre-commit hook) → exit 0.
- A `packages`-less workspace file still reproduces pnpm 9's `packages field missing or empty`, confirming the guard is what keeps Vercel green.

On Vercel (pnpm 9), sharp's own build script is no longer explicitly approved after dropping the `package.json` field; it resolves through its prebuilt `@img/sharp-*` binaries as it does today. The Vercel preview build for this branch exercises that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015nQPAwHhFfdH7xmPbwzefE)_