### PR TITLE
Fix Corpses page showing no corpses (wrong item type)

### DIFF
--- a/src/app/corpses/[characterID]/page.tsx
+++ b/src/app/corpses/[characterID]/page.tsx
@@ -1,14 +1,23 @@
 import { notFound } from 'next/navigation'
 
+import { searchSdeTypesAll } from '@/sdeTypes'
 import { createServiceClient } from '@/utils/supabase/service'
 
 import { DateTime } from '../../DateTime'
 import styles from '../corpses.module.css'
 
-// Every player corpse in EVE is the same type — typeID 25, "Corpse". They're
-// singleton items, so the extract job resolves each one's ESI asset name, which
-// for a corpse reads "<pilot>'s Frozen Corpse".
-const CORPSE_TYPE_ID = 25
+// Modern capsuleer corpses are the gendered "Corpse Male"/"Corpse Female"
+// types; "Corpse" is the legacy generic. They're singleton items, so the
+// extract job resolves each one's ESI asset name, which for a corpse reads
+// "<pilot>'s Frozen Corpse". Match on the SDE type name rather than a
+// hardcoded id so a game patch adding a variant is picked up automatically
+// (and NPC "…Frozen Corpse" types, which aren't named exactly this, stay out).
+const CORPSE_TYPE_NAMES = new Set(['corpse', 'corpse male', 'corpse female'])
+
+const corpseTypeIds = (): number[] =>
+  searchSdeTypesAll('corpse')
+    .filter((t) => CORPSE_TYPE_NAMES.has(t.name.toLowerCase()))
+    .map((t) => t.typeID)
 
 // A corpse first seen within this window is flagged "New!".
 const NEW_WINDOW_MS = 48 * 60 * 60 * 1000
@@ -83,14 +92,17 @@ const CorpsesPage = async ({ params }: { params: Promise<{ characterID: string }
     (registrations ?? [])[0]?.name ??
     null
 
-  const { data: rows } = characterIds.length
-    ? await service
-        .from('character_asset')
-        .select('item_id, name, first_seen_at')
-        .in('character_id', characterIds)
-        .eq('type_id', CORPSE_TYPE_ID)
-        .returns<CorpseRow[]>()
-    : { data: [] as CorpseRow[] }
+  const typeIds = corpseTypeIds()
+
+  const { data: rows } =
+    characterIds.length && typeIds.length
+      ? await service
+          .from('character_asset')
+          .select('item_id, name, first_seen_at')
+          .in('character_id', characterIds)
+          .in('type_id', typeIds)
+          .returns<CorpseRow[]>()
+      : { data: [] as CorpseRow[] }
 
   const cutoff = Date.now() - NEW_WINDOW_MS
 


### PR DESCRIPTION
## Summary

The `/corpses/[characterID]` page always came back empty. It filtered assets on `type_id = 25` ("Corpse"), but player corpses in modern EVE are actually two gendered types — **"Corpse Male"** and **"Corpse Female"** — so the filter matched nothing.

Confirmed against live data: an asset search for "corpse" returns 308 stacks, all `Corpse Male` / `Corpse Female`, with the pilot in each item's custom name (`"<pilot>'s Frozen Corpse"`).

## Fix

Derive the corpse type ids from the generated SDE **by type name** (`Corpse`, `Corpse Male`, `Corpse Female`) instead of a hardcoded id, and filter the query with `.in('type_id', …)`. Matching by name means:

- a future game-patch corpse variant is picked up automatically, and
- NPC "…Frozen Corpse" types (whose type name isn't exactly one of these) stay out.

The name-stripping and table/New! logic are unchanged — those were already correct; only the type filter was wrong.

## Testing

- `eslint` clean on the changed file.
- `tsc --noEmit` reports no errors for the changed file.
- Cross-checked the type names against the account's actual corpse assets via the app's asset search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019MTosHHDusu7wxU4nCo66m)_