### PR TITLE
Fix Corpses page still empty (scoped assets by wrong id)

### DIFF
--- a/src/app/corpses/[characterID]/page.tsx
+++ b/src/app/corpses/[characterID]/page.tsx
@@ -38,6 +38,7 @@ const pilotFromName = (name: string | null): string | null => {
 export const dynamic = 'force-dynamic'
 
 type RegistrationRow = {
+  id: string
   user_id: string
   character_id: number | string | null
   name: string
@@ -76,13 +77,14 @@ const CorpsesPage = async ({ params }: { params: Promise<{ characterID: string }
   // Every character on the account, for both the corpse scope and the label.
   const { data: registrations } = await service
     .from('registration')
-    .select('user_id, character_id, name, is_main')
+    .select('id, user_id, character_id, name, is_main')
     .eq('user_id', owner.user_id)
     .returns<RegistrationRow[]>()
 
-  const characterIds = (registrations ?? [])
-    .map((r) => r.character_id)
-    .filter((id): id is number | string => id != null)
+  // The asset tables key on the registration row's uuid (character_asset.
+  // character_id → registration.id), not the EVE character id, so scope the
+  // corpse query by those uuids.
+  const registrationIds = (registrations ?? []).map((r) => r.id)
 
   // Label the account by its main character, falling back to the character in
   // the URL, then any character on the account.
@@ -95,11 +97,11 @@ const CorpsesPage = async ({ params }: { params: Promise<{ characterID: string }
   const typeIds = corpseTypeIds()
 
   const { data: rows } =
-    characterIds.length && typeIds.length
+    registrationIds.length && typeIds.length
       ? await service
           .from('character_asset')
           .select('item_id, name, first_seen_at')
-          .in('character_id', characterIds)
+          .in('character_id', registrationIds)
           .in('type_id', typeIds)
           .returns<CorpseRow[]>()
       : { data: [] as CorpseRow[] }


### PR DESCRIPTION
## Summary

Even after the type fix, `/corpses/[characterID]` still showed nothing. Root cause: `character_asset.character_id` is the **registration row's UUID** (`references registration(id)`), not the EVE character id.

The page collected the EVE character ids from the account's registrations and filtered the corpse query with `.in('character_id', <eve ids>)` — which never matches the UUID column, so the result was always empty.

## Fix

Select the registration rows' `id` (UUID) and scope the corpse query by those instead:

```diff
-.select('user_id, character_id, name, is_main')
+.select('id, user_id, character_id, name, is_main')
 ...
-.in('character_id', characterIds)   // EVE character ids — never match
+.in('character_id', registrationIds) // registration uuids — the real FK
```

This mirrors how the existing `/ship` share page scopes its service-client asset queries. The initial owner lookup (`registration.character_id = <URL id>`) is unchanged and correct — that column *is* the EVE character id.

## Testing

- `eslint` clean on the changed file.
- `tsc --noEmit` reports no errors for the changed file.
- Verified the id semantics against `schema.sql` (`character_asset_over_time.character_id uuid references registration(id)`) and the `/ship` share page's registration lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019MTosHHDusu7wxU4nCo66m)_