### PR TITLE
Drop the First seen column from the Corpses page

### DIFF
--- a/src/app/corpses/[characterID]/page.tsx
+++ b/src/app/corpses/[characterID]/page.tsx
@@ -3,7 +3,6 @@ import { notFound } from 'next/navigation'
 import { searchSdeTypesAll } from '@/sdeTypes'
 import { createServiceClient } from '@/utils/supabase/service'
 
-import { DateTime } from '../../DateTime'
 import styles from '../corpses.module.css'
 
 // Modern capsuleer corpses are the gendered "Corpse Male"/"Corpse Female"
@@ -116,7 +115,6 @@ const CorpsesPage = async ({ params }: { params: Promise<{ characterID: string }
       return {
         itemId: String(r.item_id),
         pilot: pilotFromName(r.name),
-        firstSeen: r.first_seen_at,
         isNew: Number.isFinite(firstSeenMs) && firstSeenMs >= cutoff,
       }
     })
@@ -134,18 +132,14 @@ const CorpsesPage = async ({ params }: { params: Promise<{ characterID: string }
           <thead>
             <tr>
               <th>Pilot</th>
-              <th>First seen</th>
               <th />
             </tr>
           </thead>
           <tbody>
-            {corpses.map(({ itemId, pilot, firstSeen, isNew }) => (
+            {corpses.map(({ itemId, pilot, isNew }) => (
               <tr key={itemId}>
                 <td className={styles.pilot}>
                   {pilot ?? <span className={styles.unknown}>Unknown (#{itemId})</span>}
-                </td>
-                <td className={styles.seen}>
-                  <DateTime value={firstSeen} />
                 </td>
                 <td>{isNew && <span className={styles.badge}>New!</span>}</td>
               </tr>

--- a/src/app/corpses/corpses.module.css
+++ b/src/app/corpses/corpses.module.css
@@ -44,11 +44,6 @@
   font-weight: 600;
 }
 
-.seen {
-  font-size: 9pt;
-  color: var(--ink-faint);
-}
-
 .unknown {
   color: var(--ink-faint);
   font-style: italic;


### PR DESCRIPTION
## Summary

Removes the **First seen** date column from `/corpses/[characterID]` — it wasn't effective. The **New!** badge stays.

The badge is still derived from `first_seen_at` (kept in the query), so corpses added in the last 48 hours remain flagged — just without the noisy timestamp column. Also drops the now-unused `DateTime` import and `.seen` CSS class.

The table is now **Pilot** + the New! badge cell.

## Testing

- `eslint` clean on the changed file.
- `tsc --noEmit` reports no errors for the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019MTosHHDusu7wxU4nCo66m)_