### PR TITLE
Add weekly GitHub Action to auto-bump the vendored @eveshipfit packages

### DIFF
--- a/.github/scripts/bump-eveshipfit.mjs
+++ b/.github/scripts/bump-eveshipfit.mjs
@@ -1,0 +1,107 @@
+// Checks GitHub Packages for newer releases of the vendored @eveshipfit
+// packages and, when found, packs the new tarball into vendor/eveshipfit/,
+// rewrites the file: specifier in package.json, and (if react's @eveshipfit/data
+// peer major changed) bumps the local data stub to a version that still
+// satisfies it. Run by .github/workflows/bump-eveshipfit.yml, which then
+// regenerates the lockfile and opens a PR. See the "Vendored @eveshipfit/*
+// packages" note in CLAUDE.md for the manual version of this flow.
+//
+// npm auth for npm.pkg.github.com is expected via NPM_CONFIG_USERCONFIG
+// pointing at a runner-temp .npmrc (kept out of the repo so no token is ever
+// committed). Reads/writes files relative to the repo root; emits `changed`
+// (and, when changed, a PR body file at PR_BODY_PATH) to $GITHUB_OUTPUT.
+
+import { execFileSync } from 'node:child_process'
+import { appendFileSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const pkgPath = join(repoRoot, 'package.json')
+const vendorDir = join(repoRoot, 'vendor', 'eveshipfit')
+const stubDir = join(vendorDir, 'data-stub')
+
+// The two packages we actually vendor. @eveshipfit/data is intentionally not
+// here — it's a local stub (see below), not a tracked upstream release.
+const PACKAGES = ['@eveshipfit/react', '@eveshipfit/dogma-engine']
+
+const npm = (args) => execFileSync('npm', args, { cwd: repoRoot, encoding: 'utf8' }).trim()
+const readJson = (p) => JSON.parse(readFileSync(p, 'utf8'))
+const writeJson = (p, obj) => writeFileSync(p, JSON.stringify(obj, null, 2) + '\n')
+// npm flattens the scope in the packed filename: @eveshipfit/react -> eveshipfit-react
+const flatten = (name) => name.replace('@', '').replace('/', '-')
+// "file:vendor/eveshipfit/eveshipfit-react-4.7.2.tgz" -> "4.7.2"
+const versionOf = (spec) => spec?.match(/-(\d[\w.-]*)\.tgz$/)?.[1] ?? null
+
+const pkg = readJson(pkgPath)
+const changes = []
+
+for (const name of PACKAGES) {
+  const current = versionOf(pkg.dependencies[name])
+  const latest = npm(['view', name, 'version'])
+  if (!latest) throw new Error(`could not resolve latest version of ${name}`)
+  if (latest === current) {
+    console.log(`${name}: up to date (${current})`)
+    continue
+  }
+  console.log(`${name}: ${current} -> ${latest}`)
+
+  // Pack the new release straight into the vendor dir, then drop the old one.
+  const { filename } = JSON.parse(npm(['pack', `${name}@${latest}`, '--pack-destination', vendorDir, '--json']))[0]
+  const prefix = `${flatten(name)}-`
+  for (const f of readdirSync(vendorDir)) {
+    if (f.startsWith(prefix) && f.endsWith('.tgz') && f !== filename) rmSync(join(vendorDir, f))
+  }
+  pkg.dependencies[name] = `file:vendor/eveshipfit/${filename}`
+  changes.push({ name, from: current, to: latest })
+}
+
+// react imports one constant (ESF_DATA_VERSION) from @eveshipfit/data and
+// declares it as a `^N` peer. Our stub stands in for it (data URL is overridden
+// anyway). Only touch the stub when react moves to a new peer major — otherwise
+// data's ~monthly releases would churn the stub for no reason.
+const reactChange = changes.find((c) => c.name === '@eveshipfit/react')
+if (reactChange) {
+  const peers = JSON.parse(npm(['view', `@eveshipfit/react@${reactChange.to}`, 'peerDependencies', '--json']) || '{}')
+  const wantMajor = peers['@eveshipfit/data']?.match(/\d+/)?.[0]
+  const stubPkgPath = join(stubDir, 'package.json')
+  const stubPkg = readJson(stubPkgPath)
+  const haveMajor = stubPkg.version.match(/^\d+/)?.[0]
+  if (wantMajor && wantMajor !== haveMajor) {
+    // Use @eveshipfit/data's real latest version — it's guaranteed to satisfy
+    // react's peer range and keeps the (inert) ESF_DATA_VERSION honest.
+    const dataLatest = npm(['view', '@eveshipfit/data', 'version'])
+    stubPkg.version = dataLatest
+    writeJson(stubPkgPath, stubPkg)
+    for (const f of ['index.mjs', 'index.cjs']) {
+      const p = join(stubDir, f)
+      writeFileSync(p, readFileSync(p, 'utf8').replace(/ESF_DATA_VERSION = '[^']*'/, `ESF_DATA_VERSION = '${dataLatest}'`))
+    }
+    changes.push({ name: '@eveshipfit/data (stub)', from: `${haveMajor}.x`, to: dataLatest })
+    console.log(`data stub: bumped to ${dataLatest} to satisfy react's ^${wantMajor} peer`)
+  }
+}
+
+const out = process.env.GITHUB_OUTPUT
+if (!changes.length) {
+  console.log('No @eveshipfit updates available.')
+  if (out) appendFileSync(out, 'changed=false\n')
+} else {
+  writeJson(pkgPath, pkg)
+  const list = changes.map((c) => `- \`${c.name}\`: ${c.from} → **${c.to}**`).join('\n')
+  const body = `## Automated \`@eveshipfit\` vendor bump
+
+${list}
+
+The published tarball(s) were re-packed into \`vendor/eveshipfit/\` and the \`file:\` specifiers in \`package.json\` updated; the lockfile was regenerated. See the "Vendored @eveshipfit/* packages" note in \`CLAUDE.md\`.
+
+⚠️ These packages ship a WASM fit engine that Vercel Skew Protection breaks under Turbopack — verify the Vercel preview's \`/ship/[itemId]\` wheel renders (with stats) before merging.
+
+_Opened by \`.github/workflows/bump-eveshipfit.yml\`._
+`
+  if (process.env.PR_BODY_PATH) writeFileSync(process.env.PR_BODY_PATH, body)
+  if (out) {
+    appendFileSync(out, 'changed=true\n')
+    appendFileSync(out, `title=Bump vendored @eveshipfit packages (${changes.map((c) => `${c.name.split('/').pop()}@${c.to}`).join(', ')})\n`)
+  }
+}

--- a/.github/workflows/bump-eveshipfit.yml
+++ b/.github/workflows/bump-eveshipfit.yml
@@ -1,0 +1,85 @@
+name: Bump vendored @eveshipfit
+
+# Renovate can't track the vendored @eveshipfit tarballs (they're `file:`
+# specifiers pointing at committed .tgz blobs, and the upstream registry is
+# GitHub Packages behind auth), so this replaces it for those two packages:
+# weekly it checks npm.pkg.github.com for a newer @eveshipfit/react or
+# @eveshipfit/dogma-engine, re-packs the tarball into vendor/eveshipfit/,
+# rewrites package.json + the lockfile, and opens (or updates) a PR.
+# See .github/scripts/bump-eveshipfit.mjs and the "Vendored @eveshipfit/*
+# packages" note in CLAUDE.md.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 8 * * 1' # Mondays 08:00 UTC
+
+concurrency:
+  group: bump-eveshipfit
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  packages: read
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    env:
+      BUMP_BRANCH: automation/eveshipfit-bump
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24.x
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      # npm auth for GitHub Packages, written to a runner-temp file so the token
+      # never lands in the repo working tree (and can't be committed). Public
+      # @eveshipfit packages read fine with the default GITHUB_TOKEN; set the
+      # EVESHIPFIT_PACKAGES_TOKEN secret (a PAT with read:packages) only if that
+      # ever 403s.
+      - name: Configure GitHub Packages auth
+        run: |
+          {
+            echo "@eveshipfit:registry=https://npm.pkg.github.com"
+            echo "//npm.pkg.github.com/:_authToken=${TOKEN}"
+          } > "${RUNNER_TEMP}/npmrc"
+        env:
+          TOKEN: ${{ secrets.EVESHIPFIT_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Check for and apply updates
+        id: bump
+        run: node .github/scripts/bump-eveshipfit.mjs
+        env:
+          NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/npmrc
+          PR_BODY_PATH: ${{ runner.temp }}/pr-body.md
+
+      - name: Regenerate lockfile
+        if: steps.bump.outputs.changed == 'true'
+        run: pnpm install --no-frozen-lockfile
+        env:
+          HUSKY: '0'
+
+      - name: Open or update PR
+        if: steps.bump.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: ${{ steps.bump.outputs.title }}
+          BODY_PATH: ${{ runner.temp }}/pr-body.md
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git switch -C "$BUMP_BRANCH"
+          git add -A package.json pnpm-lock.yaml vendor/eveshipfit
+          git commit -m "$TITLE"
+          git push --force origin "$BUMP_BRANCH"
+          if [ -z "$(gh pr list --head "$BUMP_BRANCH" --state open --json number --jq '.[].number')" ]; then
+            gh pr create --base main --head "$BUMP_BRANCH" --title "$TITLE" --body-file "$BODY_PATH"
+          else
+            echo "PR already open for $BUMP_BRANCH; the force-push updated it."
+          fi


### PR DESCRIPTION
## Why

Vendoring `@eveshipfit/react` + `@eveshipfit/dogma-engine` (#581) removed the build-time token, but it also put them outside Renovate's reach: they're `file:` specifiers pointing at committed `.tgz` blobs, and upstream lives on GitHub Packages behind auth. This workflow closes that gap so the vendored tarballs don't silently drift out of date.

## What

A new workflow (`.github/workflows/bump-eveshipfit.yml`) + script (`.github/scripts/bump-eveshipfit.mjs`) that runs **weekly (Mondays 08:00 UTC) and on demand** (`workflow_dispatch`):

1. Queries `npm.pkg.github.com` for the latest `@eveshipfit/react` and `@eveshipfit/dogma-engine`.
2. For each that's newer than the vendored version: `npm pack`s the release into `vendor/eveshipfit/`, removes the old tarball, and rewrites the `file:` specifier in `package.json`.
3. Regenerates `pnpm-lock.yaml`.
4. Opens (or updates) a PR via the preinstalled `gh` CLI.

If nothing is newer, it no-ops (no branch, no PR).

## Design notes

- **`@eveshipfit/data` stays a stub.** The script only touches it when react's declared `@eveshipfit/data` peer changes *major*, in which case it bumps the stub to `@eveshipfit/data`'s real latest version so the `^N` peer range stays satisfied. Data's ~monthly releases otherwise cause no churn.
- **No token in the repo tree.** GitHub Packages auth is written to a `${RUNNER_TEMP}/npmrc` (never the working tree, so it can't be committed), defaulting to `GITHUB_TOKEN`. If reading the public `@eveshipfit` packages ever 403s, set an `EVESHIPFIT_PACKAGES_TOKEN` secret (PAT with `read:packages`) — the workflow prefers it automatically.
- **`gh` for the PR** instead of a third-party action, so there's no unpinned dependency to vet.
- Action versions reuse the exact commit-pinned SHAs already vetted in `heartbeat.yml`.

## Verification

- `node --check` on the script passes; the version-parse / scope-flatten logic is unit-exercised.
- `pnpm lint` clean.
- The live `npm view`/`npm pack`/PR path runs on the first invocation — trigger it manually via **Actions → Bump vendored @eveshipfit → Run workflow** to validate against the real registry.

---

Separately (not in this PR): the `/ship/[itemId]` fitting wheel is broken in production because Vercel **Skew Protection** appends `?dpl=` to the dogma-engine `.wasm` URL, which Turbopack mangles into a 404 ([vercel/next.js#73789](https://github.com/vercel/next.js/issues/73789)). That's pre-existing (predates the vendoring; the WASM bytes are identical) and the fix is a dashboard toggle — **Settings → Skew Protection → off**, then redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016qChug9hrP8af5mSaMu2qv)_