### PR TITLE
Ship fit view: add stat readout and fix wheel module-icon offset

### DIFF
--- a/src/app/ship/[itemId]/page.tsx
+++ b/src/app/ship/[itemId]/page.tsx
@@ -166,7 +166,7 @@ const ShipPage = async ({
         Owner: <span className="serif">{ownerName}</span>
       </p>
       <ShareControls itemId={itemId} initialToken={share?.token ?? null} />
-      <ShipFitViewDynamic esiFit={toEsiFit(Number(self.type_id), self.name ?? null, rows)} />
+      <ShipFitViewDynamic esiFit={toEsiFit(Number(self.type_id), self.name ?? null, rows)} editable />
       <ShipCargo rows={rows} typeNamesPromise={typeNamesPromise} />
     </>
   )

--- a/src/app/ship/[itemId]/shipFit.module.css
+++ b/src/app/ship/[itemId]/shipFit.module.css
@@ -33,3 +33,30 @@
   flex: 1 1 18rem;
   min-width: 16rem;
 }
+
+/* Interactive (owner-only) hardware browser used to drag modules/ammo onto the
+ * wheel. Collapsed by default so the big listing doesn't dominate the page. */
+.hardware {
+  margin-top: 1.5rem;
+  max-width: min(90vw, 42rem);
+}
+.hardware > summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+.hardwareHint {
+  font-size: 0.85rem;
+  opacity: 0.75;
+  margin: 0.5rem 0;
+}
+.hardwareListing {
+  height: 28rem;
+  overflow: auto;
+  border: 1px solid var(--rule, #cbb8a0);
+  border-radius: 6px;
+}
+/* Same global-img override the wheel needs: keep the listing's icons at their
+ * intended size instead of the app-wide max-width: 100% clamp. */
+.hardwareListing img {
+  max-width: none;
+}

--- a/src/app/ship/[itemId]/shipFit.module.css
+++ b/src/app/ship/[itemId]/shipFit.module.css
@@ -1,0 +1,35 @@
+/* Layout for the eveship.fit wheel + its statistics readout. */
+.layout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.wheel {
+  width: min(90vw, 42rem);
+  aspect-ratio: 1;
+  flex: 0 0 auto;
+  /* eveship.fit sizes the wheel's ring items relative to a 15px baseline. */
+  font-size: 15px;
+}
+
+/*
+ * The eveship.fit wheel is authored against the browser defaults — content-box
+ * sizing and unconstrained <img> dimensions. This app's globals.css sets
+ * `* { box-sizing: border-box }` and `img { max-width: 100% }` globally, which
+ * leak into the wheel: the slot icons are drawn at `width: 120%` with negative
+ * margins, so clamping them to 100% shifts every module up and to the left.
+ * Restore the defaults the library expects, scoped to the wheel only.
+ */
+.wheel * {
+  box-sizing: content-box;
+}
+.wheel img {
+  max-width: none;
+}
+
+.stats {
+  flex: 1 1 18rem;
+  min-width: 16rem;
+}

--- a/src/app/ship/[itemId]/shipFitView.tsx
+++ b/src/app/ship/[itemId]/shipFitView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import type { ReactNode } from 'react'
 
 import {
@@ -10,82 +10,13 @@ import {
   DogmaEngineProvider,
   EveDataProvider,
   ShipFit,
+  ShipStatistics,
   StatisticsProvider,
-  useCurrentCharacter,
-  useDogmaEngine,
-  useEveData,
   useImportEsiFitting,
-  useStatistics,
 } from '@eveshipfit/react'
 import type { EsiFit } from '@eveshipfit/react'
 
-// DogmaEngineProvider dynamic-imports the @eveshipfit/dogma-engine wasm and
-// then calls `m.init()` in a `.then()` with no `.catch()`: if the import loads
-// but `init()` is missing (ESM-namespace interop) or throws (wasm not linked),
-// the provider stays null forever and the wheel silently renders without
-// modules, slot arcs, or stats. The runtime diagnostic showed the import
-// resolves but the engine context is null, so replicate the provider's exact
-// init path here — reporting whether `init` exists and the precise throw — and
-// listen for the provider's own swallowed rejection, so the failure is visible
-// in devtools instead of silent.
-let probeStarted = false
-const probeDogmaEngine = () => {
-  if (probeStarted) return
-  probeStarted = true
-
-  // Surface the library provider's own uncaught `m.init()` rejection/throw.
-  const mentionsEngine = (text: string) => /dogma|wasm|init|webassembly/i.test(text)
-  window.addEventListener('unhandledrejection', (e) => {
-    const reason = e.reason
-    const text = reason instanceof Error ? `${reason.name}: ${reason.message}` : String(reason)
-    if (mentionsEngine(text)) console.error('esf: unhandled rejection near engine init:', reason)
-  })
-  window.addEventListener('error', (e) => {
-    if (e.message && mentionsEngine(e.message)) console.error('esf: window error near engine init:', e.error ?? e.message)
-  })
-
-  // Replicate DogmaEngineProvider's import(...).then(m => m.init()) so the
-  // failure it swallows is printed: is `init` even a function here, and if so
-  // what does calling it throw?
-  import('@eveshipfit/dogma-engine')
-    .then((m) => {
-      const mod = m as unknown as Record<string, unknown>
-      console.log('esf: dogma module keys:', Object.keys(mod), '— typeof init:', typeof mod.init)
-      try {
-        ;(mod.init as (() => void) | undefined)?.()
-        console.log('esf: dogma init() ok')
-      } catch (e) {
-        console.error('esf: dogma init() threw:', e)
-      }
-    })
-    .catch((e) => console.error('esf: dogma-engine import rejected:', e))
-}
-
-// Module icons on the wheel come from StatisticsProvider's dogma-engine
-// output, not the fit itself, so "statistics stuck at null" IS the
-// empty-wheel bug. When it persists after the type/dogma data is ready, name
-// the dependency that's null so devtools shows where the chain broke.
-const EngineDiagnostics = () => {
-  const eveData = useEveData()
-  const dogmaEngine = useDogmaEngine()
-  const { character } = useCurrentCharacter()
-  const statistics = useStatistics()
-
-  useEffect(probeDogmaEngine, [])
-
-  useEffect(() => {
-    if (eveData === null || statistics !== null) return
-    const timer = setTimeout(() => {
-      console.warn(
-        `esf: fit statistics unavailable — dogma engine ${dogmaEngine === null ? 'NOT loaded' : 'ok'}, ` +
-          `character skills ${character?.skills ? 'ok' : 'MISSING'}`
-      )
-    }, 3000)
-    return () => clearTimeout(timer)
-  }, [eveData, statistics, dogmaEngine, character])
-
-  return null
-}
+import styles from './shipFit.module.css'
 
 // eveship.fit computes fit statistics (and thus which module icons land on the
 // wheel's slots) against a character's skills. It picks the character from the
@@ -132,11 +63,12 @@ type ShipFitViewProps = {
 }
 
 // eveship.fit's own hosted data is deliberately CORS-locked to their site, so
-// this points at our own build-time mirror (see src/buildEsfData.js).
-// ShipFit's root CSS is `width: 100%; height: 100%` — it fills its container,
-// and positions its ring elements absolutely within it. Without a sized
-// square wrapper it inflates to the whole viewport (the wheel is circular, so
-// the container must be square for the rings to line up).
+// EveDataProvider points at our own build-time mirror (see src/buildEsfData.js).
+// `ShipFit` is only the fitting wheel (slots + CPU/PG/rig usage arcs); the
+// numeric readout (EHP, DPS, resistances, capacitor, speed, targeting, drones)
+// is the separate `ShipStatistics` component, rendered alongside it here — both
+// read the same StatisticsProvider output.
+//
 // The character providers are load-bearing even though we never show a
 // character picker: StatisticsProvider computes nothing (returns null, so no
 // slots and no modules render) unless a current character with skills exists.
@@ -156,9 +88,13 @@ export const ShipFitView = ({ esiFit }: ShipFitViewProps) => {
           <CurrentCharacterProvider initialCharacterId={DEFAULT_CHARACTER_ID}>
             <FitFromEsi esiFit={esiFit}>
               <StatisticsProvider>
-                <EngineDiagnostics />
-                <div style={{ width: 'min(90vw, 42rem)', aspectRatio: '1' }}>
-                  <ShipFit withStats readOnly />
+                <div className={styles.layout}>
+                  <div className={styles.wheel}>
+                    <ShipFit withStats readOnly />
+                  </div>
+                  <div className={styles.stats}>
+                    <ShipStatistics />
+                  </div>
                 </div>
               </StatisticsProvider>
             </FitFromEsi>

--- a/src/app/ship/[itemId]/shipFitView.tsx
+++ b/src/app/ship/[itemId]/shipFitView.tsx
@@ -9,6 +9,8 @@ import {
   DefaultCharactersProvider,
   DogmaEngineProvider,
   EveDataProvider,
+  FitManagerProvider,
+  HardwareListing,
   ShipFit,
   ShipStatistics,
   StatisticsProvider,
@@ -60,7 +62,26 @@ const FitFromEsi = ({ esiFit, children }: FitFromEsiProps) => {
 
 type ShipFitViewProps = {
   esiFit: EsiFit
+  /**
+   * When true, the wheel is interactive: modules/charges can be dragged from
+   * the hardware browser onto slots (e.g. loading ammo to simulate DPS). Edits
+   * are client-side only — never persisted back to ESI. Gated to the
+   * authenticated owner view; the anonymous share-token view stays read-only.
+   */
+  editable?: boolean
 }
+
+// The wheel + numeric readout, shared by the read-only and editable layouts.
+const WheelAndStats = ({ readOnly }: { readOnly: boolean }) => (
+  <div className={styles.layout}>
+    <div className={styles.wheel}>
+      <ShipFit withStats readOnly={readOnly} />
+    </div>
+    <div className={styles.stats}>
+      <ShipStatistics />
+    </div>
+  </div>
+)
 
 // eveship.fit's own hosted data is deliberately CORS-locked to their site, so
 // EveDataProvider points at our own build-time mirror (see src/buildEsfData.js).
@@ -76,7 +97,7 @@ type ShipFitViewProps = {
 // we pin all-skills-L5 both via initialCharacterId (fresh-load default) and by
 // normalizing the localStorage key first (which otherwise wins) — the standard
 // "assume max skills" baseline fitting tools use.
-export const ShipFitView = ({ esiFit }: ShipFitViewProps) => {
+export const ShipFitView = ({ esiFit, editable = false }: ShipFitViewProps) => {
   // Lazy initializer: runs once, synchronously, on first render — before the
   // child CurrentCharacterProvider reads localStorage in its own initializer.
   useState(ensureDefaultCharacter)
@@ -88,14 +109,27 @@ export const ShipFitView = ({ esiFit }: ShipFitViewProps) => {
           <CurrentCharacterProvider initialCharacterId={DEFAULT_CHARACTER_ID}>
             <FitFromEsi esiFit={esiFit}>
               <StatisticsProvider>
-                <div className={styles.layout}>
-                  <div className={styles.wheel}>
-                    <ShipFit withStats readOnly />
-                  </div>
-                  <div className={styles.stats}>
-                    <ShipStatistics />
-                  </div>
-                </div>
+                {editable ? (
+                  // FitManagerProvider must sit inside CurrentFit/Statistics/
+                  // EveData (all above). It backs the drag-to-fit interactions:
+                  // dragging a charge from HardwareListing onto a weapon slot
+                  // calls setCharge, and the stats/wheel recompute live.
+                  <FitManagerProvider>
+                    <WheelAndStats readOnly={false} />
+                    <details className={styles.hardware}>
+                      <summary>Load modules &amp; ammo (simulate)</summary>
+                      <p className={styles.hardwareHint}>
+                        Drag a charge onto a weapon slot to load ammo and see damage update. Changes here are a local
+                        simulation and are never saved back to the game.
+                      </p>
+                      <div className={styles.hardwareListing}>
+                        <HardwareListing />
+                      </div>
+                    </details>
+                  </FitManagerProvider>
+                ) : (
+                  <WheelAndStats readOnly />
+                )}
               </StatisticsProvider>
             </FitFromEsi>
           </CurrentCharacterProvider>


### PR DESCRIPTION
## Summary

Follow-up to the eveship.fit wheel fixes. Two visible improvements on `/ship/[itemId]`:

- **Stat readout (EHP/HP, DPS, resistances, capacitor, speed, targeting, drones).** The embedded `ShipFit` is only the fitting *wheel*; the numeric readout is the library's separate `ShipStatistics` component, which we weren't rendering. It's now shown beside the wheel — both read the same `StatisticsProvider` output, no new providers needed.
- **Module-icon offset fixed.** The slot icons sat ~a few px up-and-left because the app's global `img { max-width: 100% }` clamped the wheel's slot icons (authored at `width: 120%` with negative margins) down to 100%. A scoped CSS module (`shipFit.module.css`) restores the browser defaults eveship.fit is built against (content-box, unconstrained `<img>`) within the wheel only.

Also removes the temporary `EngineDiagnostics` probe now that the wasm-load root cause is understood (Vercel's deployment-id `?dpl` query was mangling the `.wasm` URL into a 404; resolved by disabling Skew Protection).

Interactive ammo loading (load charges to simulate DPS) is a larger follow-up and will land as additional commits here.

## Test plan

- [ ] Preview builds green
- [ ] `/ship/[itemId]` shows the `ShipStatistics` readout with real numbers next to the wheel
- [ ] Module icons on the wheel are centered/aligned (no up-left offset)
- [ ] `ShipCargo` list and the authenticated view otherwise unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LHQH6ZhuVv9AtrJkZHoPEf)_