### PR TITLE
Add corp-sharing toggle to the Mercenary Dens page

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1756,11 +1756,15 @@ grant all    on public.universe_structure to service_role;
 -- 'mercenary-dens'). 'corpses' both shows the owner's nav link and opts their
 -- account into the public /corpses/[characterID] share page — an account
 -- without it set renders as a 404 there.
+-- `share_mercenary_dens` is the user's opt-in to share their deployed
+-- mercenary dens (character_mercenary_den) with corpmates; toggled from the top
+-- of the /mercenary-dens page. Default false (private).
 create table public.user_settings (
   user_id uuid primary key references auth.users(id) on delete cascade,
   enabled_scopes text[] not null default '{}',
   api_token text unique,
   flags text[] not null default '{}',
+  share_mercenary_dens boolean not null default false,
   updated_at timestamptz not null default now()
 );
 

--- a/src/app/mercenary-dens/actions.ts
+++ b/src/app/mercenary-dens/actions.ts
@@ -1,0 +1,33 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+
+import { createClient } from '@/utils/supabase/server'
+
+// Persist the caller's opt-in to share their deployed mercenary dens with
+// corpmates. Upsert keeps any existing user_settings (enabled_scopes, flags,
+// api_token) intact. RLS scopes the write to the caller's own row. Returns
+// { error } on failure.
+export const setShareMercenaryDens = async (shared: boolean): Promise<{ error?: string }> => {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user?.id) {
+    return { error: 'Not signed in' }
+  }
+
+  const { error } = await supabase
+    .from('user_settings')
+    .upsert(
+      { user_id: user.id, share_mercenary_dens: shared, updated_at: new Date().toISOString() },
+      { onConflict: 'user_id' }
+    )
+  if (error) {
+    return { error: error.message }
+  }
+
+  revalidatePath('/mercenary-dens')
+  return {}
+}

--- a/src/app/mercenary-dens/mercenaryDens.module.css
+++ b/src/app/mercenary-dens/mercenaryDens.module.css
@@ -14,6 +14,37 @@
   margin-top: 4pt;
 }
 
+/* Corp-sharing toggle in the page header. */
+.shareToggle {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2pt;
+}
+
+.shareLabel {
+  display: flex;
+  align-items: center;
+  gap: 6pt;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.shareStatus {
+  font-size: 9pt;
+  color: var(--ink-soft);
+}
+
+.shareError {
+  color: #c0392b;
+}
+
+@media (prefers-color-scheme: dark) {
+  .shareError {
+    color: #ff6b5e;
+  }
+}
+
 /* Network topology diagram — scales to the container, capped so it doesn't
  * balloon on wide screens. */
 .topology {

--- a/src/app/mercenary-dens/page.tsx
+++ b/src/app/mercenary-dens/page.tsx
@@ -4,6 +4,7 @@ import { mercenaryDensFlag } from '@/flags'
 import { createClient } from '@/utils/supabase/server'
 
 import { STAGING, TEMPERATE_PLANETS } from './data'
+import ShareToggle from './shareToggle'
 import { Topology } from './topology'
 import styles from './mercenaryDens.module.css'
 
@@ -23,10 +24,13 @@ const MercenaryDensPage = async () => {
     redirect('/')
   }
 
+  const { data: settings } = await supabase.from('user_settings').select('share_mercenary_dens').maybeSingle()
+
   return (
     <>
       <div className={styles.pageHeader}>
         <h1>Mercenary Dens</h1>
+        <ShareToggle initialShared={settings?.share_mercenary_dens ?? false} />
       </div>
       <p className={styles.subtitle}>
         Systems immediately accessible from our staging system, <span className={styles.system}>{STAGING}</span>.

--- a/src/app/mercenary-dens/shareToggle.tsx
+++ b/src/app/mercenary-dens/shareToggle.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+
+import { setShareMercenaryDens } from './actions'
+import styles from './mercenaryDens.module.css'
+
+// Top-of-page toggle: opts the signed-in user into sharing their deployed
+// mercenary dens with corpmates. Optimistically flips, persists via the server
+// action, and reverts + surfaces the message on error.
+const ShareToggle = ({ initialShared }: { initialShared: boolean }) => {
+  const [shared, setShared] = useState(initialShared)
+  const [error, setError] = useState('')
+  const [pending, startTransition] = useTransition()
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const next = e.target.checked
+    setShared(next)
+    setError('')
+    startTransition(async () => {
+      const result = await setShareMercenaryDens(next)
+      if (result.error) {
+        setShared(!next)
+        setError(result.error)
+      }
+    })
+  }
+
+  return (
+    <div className={styles.shareToggle}>
+      <label className={styles.shareLabel}>
+        <input type="checkbox" checked={shared} onChange={onChange} disabled={pending} />
+        <span>Share my dens with my corp</span>
+      </label>
+      <span className={styles.shareStatus}>
+        {error ? <span className={styles.shareError}>{error}</span> : shared ? 'Shared with corpmates' : 'Private'}
+      </span>
+    </div>
+  )
+}
+
+export default ShareToggle

--- a/supabase/migrations/20260713130000_add_share_mercenary_dens.sql
+++ b/supabase/migrations/20260713130000_add_share_mercenary_dens.sql
@@ -1,0 +1,6 @@
+-- Per-user opt-in to share deployed mercenary dens
+-- (character_mercenary_den) with corpmates. Toggled from the top of the
+-- /mercenary-dens page. Non-destructive: defaults to false (private), so
+-- existing rows keep dens unshared.
+alter table public.user_settings
+  add column if not exists share_mercenary_dens boolean not null default false;


### PR DESCRIPTION
## Summary

Adds a toggle to the top of the `/mercenary-dens` page that controls whether the signed-in user's deployed mercenary dens are shared with their corpmates. The preference is stored per-user on `user_settings` (the profile-preferences table), alongside the existing `flags` / `api_token` fields.

## Changes

- **`schema.sql`** — new `share_mercenary_dens boolean not null default false` column on `user_settings`, with a comment documenting its purpose.
- **`supabase/migrations/20260713130000_add_share_mercenary_dens.sql`** — non-destructive `add column if not exists`, defaulting to `false` (private) so existing rows keep dens unshared.
- **`src/app/mercenary-dens/actions.ts`** — `setShareMercenaryDens(shared)` server action; upserts the caller's `user_settings` row (RLS-scoped to their own `user_id`, existing fields preserved) and revalidates the page.
- **`src/app/mercenary-dens/shareToggle.tsx`** — client toggle rendered in the page header; optimistically flips, persists via the action, and reverts + surfaces the message on error.
- **`src/app/mercenary-dens/page.tsx`** — reads `share_mercenary_dens` and renders the toggle next to the `<h1>`.
- **`src/app/mercenary-dens/mercenaryDens.module.css`** — styling for the header toggle.

## Notes / scope

This wires up the **storage and control** for the preference. Actually *consuming* it — letting corpmates view another player's shared dens — is separate, larger follow-up work, since no UI currently reads `character_mercenary_den` (the extract table populated by the `character-mercenary-dens` job). The `/mercenary-dens` page today renders hand-maintained area intel from `data.ts`, unrelated to this per-user preference.

## Verification

- `pnpm run lint` — clean (exit 0)
- `pnpm exec tsc --noEmit` — 0 errors repo-wide
- Prettier-formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL1hvtH4F7QduankaQPoxz

---
_Generated by [Claude Code](https://claude.ai/code/session_01PL1hvtH4F7QduankaQPoxz)_