### PR TITLE
Remove indexes feature flag, show /indexes to all signed-in users

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1752,10 +1752,10 @@ grant all    on public.universe_structure to service_role;
 -- and scope the results to their characters. Null until the user generates one
 -- in settings.
 -- `flags` is the set of Vercel Flags (src/flags.ts) a user has enabled, e.g.
--- 'indexes' gates the /indexes page and nav link per-user (likewise
--- 'mercenary-dens'). 'corpses' both shows the owner's nav link and opts their
--- account into the public /corpses/[characterID] share page — an account
--- without it set renders as a 404 there.
+-- 'mercenary-dens' gates the /mercenary-dens page and nav link per-user.
+-- 'corpses' both shows the owner's nav link and opts their account into the
+-- public /corpses/[characterID] share page — an account without it set renders
+-- as a 404 there.
 -- `share_mercenary_dens` is the user's opt-in to share their deployed
 -- mercenary dens (character_mercenary_den) with corpmates; toggled from the top
 -- of the /mercenary-dens page. Default false (private).

--- a/src/app/indexes/page.tsx
+++ b/src/app/indexes/page.tsx
@@ -1,6 +1,5 @@
 import { redirect } from 'next/navigation'
 
-import { indexesFlag } from '@/flags'
 import { formatSecurity, getSdeSystem } from '@/sdeSystems'
 import { createClient } from '@/utils/supabase/server'
 
@@ -33,10 +32,6 @@ const IndexesPage = async ({ searchParams }: { searchParams: Promise<{ days?: st
 
   const { data, error: authError } = await supabase.auth.getUser()
   if (authError || !data?.user) {
-    redirect('/')
-  }
-
-  if (!(await indexesFlag())) {
     redirect('/')
   }
 

--- a/src/app/layout/header.tsx
+++ b/src/app/layout/header.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { createClient } from '@/utils/supabase/server'
-import { corpsesFlag, indexesFlag, mercenaryDensFlag } from '@/flags'
+import { corpsesFlag, mercenaryDensFlag } from '@/flags'
 import { Freshness } from '../Freshness'
 import styles from './header.module.css'
 
@@ -44,11 +44,7 @@ const Header = async () => {
     lastRefreshedAt = latestBeat?.ended_at ?? null
   }
 
-  const [showIndexes, showMercenaryDens, showCorpses] = await Promise.all([
-    indexesFlag(),
-    mercenaryDensFlag(),
-    corpsesFlag(),
-  ])
+  const [showMercenaryDens, showCorpses] = await Promise.all([mercenaryDensFlag(), corpsesFlag()])
   return (
     <header>
       <div className={styles.bar}>
@@ -76,12 +72,8 @@ const Header = async () => {
             </>
           ) : (
             <>
-              {showIndexes && (
-                <>
-                  <Link href="/indexes">indexes</Link>
-                  <span className={styles.sep}>|</span>
-                </>
-              )}
+              <Link href="/indexes">indexes</Link>
+              <span className={styles.sep}>|</span>
               {showMercenaryDens && (
                 <>
                   <Link href="/mercenary-dens">mercenary&nbsp;dens</Link>

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -2,24 +2,6 @@ import { flag } from 'flags/next'
 
 import { createClient } from '@/utils/supabase/server'
 
-// Per-user gate for the /indexes page, backed by the 'indexes' entry in
-// user_settings.flags (see schema.sql). Defaults to false for signed-out
-// users and anyone without a row yet.
-export const indexesFlag = flag<boolean>({
-  key: 'indexes',
-  description: 'Show the Indexes page and nav link',
-  decide: async () => {
-    const supabase = await createClient()
-    const {
-      data: { user },
-    } = await supabase.auth.getUser()
-    if (!user) return false
-
-    const { data } = await supabase.from('user_settings').select('flags').eq('user_id', user.id).maybeSingle()
-    return (data?.flags ?? []).includes('indexes')
-  },
-})
-
 // Per-user gate for the dark-launched /mercenary-dens page, backed by the
 // 'mercenary-dens' entry in user_settings.flags. Defaults to false for
 // signed-out users and anyone without the flag set.


### PR DESCRIPTION
## Summary

The `/indexes` page and its nav link were gated per-user behind the `indexes` Vercel flag (`user_settings.flags`). This drops the flag entirely so every signed-in user can view the page.

## Changes

- **`src/flags.ts`** — removed the `indexesFlag` definition.
- **`src/app/indexes/page.tsx`** — dropped the `indexesFlag` import and the `redirect('/')` gate. The page still requires an authenticated user (watched systems are RLS-scoped per user).
- **`src/app/layout/header.tsx`** — removed `indexesFlag` from the imports and the `Promise.all` resolve; the `indexes` nav link now always renders for signed-in users.
- **`schema.sql`** — refreshed the `user_settings.flags` comment, which used `indexes` as its example, to point at `mercenary-dens` instead.

The `mercenary-dens` and `corpses` flags are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019HiXGgQmqWugH8JbSihLp7)_