### PR TITLE
Redesign corpses page as a tiled item grid

### DIFF
--- a/src/app/corpses/[characterID]/page.tsx
+++ b/src/app/corpses/[characterID]/page.tsx
@@ -46,6 +46,7 @@ type RegistrationRow = {
 
 type CorpseRow = {
   item_id: number | string
+  type_id: number | string
   name: string | null
   first_seen_at: string | null
 }
@@ -99,7 +100,7 @@ const CorpsesPage = async ({ params }: { params: Promise<{ characterID: string }
     registrationIds.length && typeIds.length
       ? await service
           .from('character_asset')
-          .select('item_id, name, first_seen_at')
+          .select('item_id, type_id, name, first_seen_at')
           .in('character_id', registrationIds)
           .in('type_id', typeIds)
           .returns<CorpseRow[]>()
@@ -114,6 +115,7 @@ const CorpsesPage = async ({ params }: { params: Promise<{ characterID: string }
       const firstSeenMs = r.first_seen_at ? new Date(r.first_seen_at).getTime() : NaN
       return {
         itemId: String(r.item_id),
+        typeId: Number(r.type_id),
         pilot: pilotFromName(r.name),
         isNew: Number.isFinite(firstSeenMs) && firstSeenMs >= cutoff,
       }
@@ -128,24 +130,23 @@ const CorpsesPage = async ({ params }: { params: Promise<{ characterID: string }
       </div>
 
       {corpses.length > 0 ? (
-        <table className={styles.table}>
-          <thead>
-            <tr>
-              <th>Pilot</th>
-              <th />
-            </tr>
-          </thead>
-          <tbody>
-            {corpses.map(({ itemId, pilot, isNew }) => (
-              <tr key={itemId}>
-                <td className={styles.pilot}>
-                  {pilot ?? <span className={styles.unknown}>Unknown (#{itemId})</span>}
-                </td>
-                <td>{isNew && <span className={styles.badge}>New!</span>}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <ul className={styles.grid}>
+          {corpses.map(({ itemId, typeId, pilot, isNew }) => (
+            <li key={itemId} className={styles.tile}>
+              {isNew && <span className={styles.badge}>New!</span>}
+              <img
+                className={styles.icon}
+                src={`https://images.evetech.net/types/${typeId}/icon?size=64`}
+                alt=""
+                width={48}
+                height={48}
+              />
+              <span className={styles.name}>
+                {pilot ?? <span className={styles.unknown}>Unknown (#{itemId})</span>}
+              </span>
+            </li>
+          ))}
+        </ul>
       ) : (
         <p className={styles.empty}>No corpses in this collection.</p>
       )}

--- a/src/app/corpses/corpses.module.css
+++ b/src/app/corpses/corpses.module.css
@@ -18,46 +18,64 @@
   color: var(--ink-soft);
 }
 
-.table {
-  border-collapse: collapse;
-  margin-top: 8pt;
+/* Tiled corpse collection: item-icon tiles echoing the ship cargo/asset view
+ * (see shipCargo.module.css), one tile per dead pilot. */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
+  gap: 8px;
+  list-style: none;
+  padding: 0;
+  margin: 16px 0 0;
 }
 
-.table th {
-  text-align: left;
-  font-size: 9pt;
-  color: var(--ink-soft);
-  padding: 2pt 12pt 2pt 0;
+.tile {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 6px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--paper-raised);
+  text-align: center;
+  min-width: 0;
 }
 
-.table td {
-  padding: 2pt 12pt 2pt 0;
-  white-space: nowrap;
-  vertical-align: middle;
+.icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 4px;
 }
 
-.table tbody tr:hover {
-  background: color-mix(in srgb, currentColor 6%, transparent);
-}
-
-.pilot {
+.name {
+  font-size: 11px;
+  line-height: 1.25;
   font-weight: 600;
+  overflow-wrap: anywhere;
 }
 
 .unknown {
   color: var(--ink-faint);
   font-style: italic;
+  font-weight: 400;
 }
 
-/* "New!" flag for corpses first seen within the last 48 hours. */
+/* "New!" flag for corpses first seen within the last 48 hours; pinned to the
+ * tile's top-right corner like the quantity badge on cargo tiles. */
 .badge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
   font-size: 8pt;
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--ink);
+  background: var(--paper);
   border: 1px solid currentColor;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   padding: 0 4pt;
 }
 


### PR DESCRIPTION
## Summary

Redesigns the public corpses share page to display corpses as tiled items, matching the look of the ship/asset cargo view instead of the previous plain pilot table.

Each corpse now renders as a tile with:
- the corpse's type icon (pulled from `images.evetech.net`, using the corpse's `type_id`)
- the dead pilot's name beneath it
- the `New!` flag repositioned as a corner badge (for corpses first seen in the last 48h)

Unresolved corpses still fall back to `Unknown (#itemId)`, and the empty state is unchanged.

## Changes

- `src/app/corpses/[characterID]/page.tsx` — select `type_id` for each corpse, carry `typeId` through the mapping, and replace the `<table>` markup with a responsive `<ul>` tile grid.
- `src/app/corpses/corpses.module.css` — swap the table styles for a tile-grid layout (`.grid`/`.tile`/`.icon`/`.name`) mirroring `shipCargo.module.css`, and reposition `.badge` as an absolutely-positioned corner flag.

## Testing

- `pnpm run lint` passes.
- `tsc --noEmit` reports no errors in the changed page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DubLumFoEzzvzaNStE5msa)_