### PR TITLE
Retitle corpses page to "The Many Corpses of &lt;pilot&gt;"

### DIFF
--- a/src/app/corpses/[characterID]/page.tsx
+++ b/src/app/corpses/[characterID]/page.tsx
@@ -125,7 +125,7 @@ const CorpsesPage = async ({ params }: { params: Promise<{ characterID: string }
   return (
     <>
       <div className={styles.pageHeader}>
-        <h1>{accountName ? `${accountName}'s corpses` : 'Corpses'}</h1>
+        <h1>{accountName ? `The Many Corpses of ${accountName}` : 'The Many Corpses'}</h1>
         {corpses.length > 0 && <span className={styles.count}>{corpses.length}</span>}
       </div>
 


### PR DESCRIPTION
## Summary

Changes the corpses page heading from `<pilot>'s corpses` to `The Many Corpses of <pilot>`, and the no-account fallback from `Corpses` to `The Many Corpses`.

## Changes

- `src/app/corpses/[characterID]/page.tsx` — update the `<h1>` text.

## Testing

- `pnpm run lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DubLumFoEzzvzaNStE5msa)_