### PR TITLE
Add at= time-travel to the market-orders and industry-jobs API endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,11 +284,11 @@ Key Postgres functions (callable via RPC or SQL):
 - `corp_asset_search(type_ids[])` — mirrors `character_asset_search()` over corp assets (used by `/asset/search`)
 - `latest_heartbeats()` — most recent completed heartbeat per job per owner (character/corp/whole-job), RLS-scoped to the caller; feeds the `/character/refresh` freshness matrix
 - `character_asset_snapshot_at(character_ids[], as_of)` — time-travel asset snapshot as JSON (used by `/api/character/assets`)
-- `character_industry_jobs(character_ids[], include_delivered)` — export for Sheets IMPORTDATA (used by `/api/character/jobs`)
-- `character_orders(character_ids[])` — export for Sheets IMPORTDATA (used by `/api/character/orders`)
+- `character_industry_jobs(character_ids[], include_delivered, as_of)` — time-travel industry-job snapshot as JSON (used by `/api/character/jobs`; `as_of` defaults to now, reconstructed from the SCD-2 history like `character_asset_snapshot_at`)
+- `character_orders(character_ids[], as_of)` — time-travel open-order snapshot as JSON (used by `/api/character/orders`; `as_of` defaults to now)
 - `character_blueprints(character_ids[])` — current blueprint snapshot as JSON, export for Sheets IMPORTDATA (used by `/api/character/blueprints`)
 - `corp_assets(character_ids[])` — corp asset snapshot for the caller's corp(s), export for Sheets IMPORTDATA (used by `/api/corp/assets`)
-- `corp_industry_jobs(character_ids[], include_delivered)` — corp industry jobs for the caller's corp(s), export for Sheets IMPORTDATA (used by `/api/corp/jobs`)
+- `corp_industry_jobs(character_ids[], include_delivered, as_of)` — time-travel corp industry-job snapshot for the caller's corp(s) as JSON (used by `/api/corp/jobs`; `as_of` defaults to now)
 - `corp_blueprints(character_ids[])` — corp blueprint snapshot for the caller's corp(s), export for Sheets IMPORTDATA (used by `/api/corp/blueprints`)
 
 ## Design patterns

--- a/schema.sql
+++ b/schema.sql
@@ -427,7 +427,7 @@ as $$
   join public.registration r on r.id = a.character_id
   where a.character_id = any(character_ids)
     and a.valid_from <= as_of
-    and (a.valid_until >= as_of or a.is_current)
+    and (a.is_current or a.valid_until >= as_of)
     and (not a.is_singleton or a.is_blueprint_copy);
 $$;
 
@@ -780,7 +780,7 @@ as $$
   join public.registration r on r.id = o.character_id
   where o.character_id = any(character_ids)
     and o.valid_from <= as_of
-    and (o.valid_until >= as_of or o.is_current);
+    and (o.is_current or o.valid_until >= as_of);
 $$;
 
 grant execute on function public.character_orders(uuid[], timestamptz) to service_role;
@@ -906,7 +906,7 @@ as $$
   join public.registration r on r.id = j.character_id
   where j.character_id = any(character_ids)
     and j.valid_from <= as_of
-    and (j.valid_until >= as_of or j.is_current)
+    and (j.is_current or j.valid_until >= as_of)
     and (include_delivered or j.status not in ('delivered', 'cancelled', 'archived'));
 $$;
 
@@ -1892,7 +1892,7 @@ as $$
     where id = any(character_ids) and corporation_id is not null
   )
   and j.valid_from <= as_of
-  and (j.valid_until >= as_of or j.is_current)
+  and (j.is_current or j.valid_until >= as_of)
   and (include_delivered or j.status not in ('delivered', 'cancelled', 'archived'));
 $$;
 

--- a/schema.sql
+++ b/schema.sql
@@ -32,8 +32,12 @@ drop function if exists public.corp_asset_location_summary()             cascade
 drop function if exists public.corp_asset_location_contents(bigint)      cascade;
 drop function if exists public.asset_ancestors(bigint)                   cascade;
 drop function if exists public.character_asset_snapshot_at(uuid[], timestamptz) cascade;
-drop function if exists public.character_industry_jobs(uuid[], boolean)  cascade;
+drop function if exists public.character_industry_jobs(uuid[], boolean)             cascade;
+drop function if exists public.character_industry_jobs(uuid[], boolean, timestamptz) cascade;
+drop function if exists public.corp_industry_jobs(uuid[], boolean)                  cascade;
+drop function if exists public.corp_industry_jobs(uuid[], boolean, timestamptz)     cascade;
 drop function if exists public.character_orders(uuid[])                  cascade;
+drop function if exists public.character_orders(uuid[], timestamptz)     cascade;
 drop function if exists public.latest_heartbeats()                       cascade;
 drop view  if exists public.asset                cascade;
 drop table if exists public.asset_over_time      cascade;
@@ -733,12 +737,18 @@ grant select on public.character_order           to authenticated;
 grant all    on public.character_order_over_time to service_role;
 
 -- /api/character/orders IMPORTDATA endpoint: the player's open market orders
--- across all of their characters, with the owning character's name. Returns the
--- whole result as a single json array (json, not jsonb, so json_build_object's
--- key order is preserved for the sheet's columns) and sidesteps PostgREST's
--- max-rows cap. The stored `is_buy` flag is exposed as `is_buy_order` to match
--- ESI's field name.
-create or replace function public.character_orders(character_ids uuid[])
+-- across all of their characters, with the owning character's name, as of an
+-- optional `as_of` timestamp (default now). Reconstructed from the SCD-2 history
+-- exactly like character_asset_snapshot_at: the version of each order valid at
+-- `as_of` is the one that had started by then and was either still open then
+-- (valid_until >= as_of) or is the current version (its state extends forward to
+-- now) — and versions of one order never overlap, so at most one matches. At the
+-- default now() this returns precisely the still-open orders (the is_current
+-- set), matching the character_order view. Returns the whole result as a single
+-- json array (json, not jsonb, so json_build_object's key order is preserved for
+-- the sheet's columns) and sidesteps PostgREST's max-rows cap. The stored
+-- `is_buy` flag is exposed as `is_buy_order` to match ESI's field name.
+create or replace function public.character_orders(character_ids uuid[], as_of timestamptz default now())
 returns json
 language sql
 stable
@@ -766,12 +776,14 @@ as $$
     ),
     '[]'::json
   )
-  from public.character_order o
+  from public.character_order_over_time o
   join public.registration r on r.id = o.character_id
-  where o.character_id = any(character_ids);
+  where o.character_id = any(character_ids)
+    and o.valid_from <= as_of
+    and (o.valid_until >= as_of or o.is_current);
 $$;
 
-grant execute on function public.character_orders(uuid[]) to service_role;
+grant execute on function public.character_orders(uuid[], timestamptz) to service_role;
 
 -- ── character_industry_job_over_time ──────────────────────────────────────
 -- ESI /characters/{id}/industry/jobs/ (include_completed), written by the
@@ -847,7 +859,14 @@ grant all    on public.character_industry_job_over_time to service_role;
 -- order is preserved for the sheet's columns; one scalar also sidesteps
 -- PostgREST's max-rows cap). Called with the service role over the caller's own
 -- registration ids, so it takes them as a parameter rather than leaning on RLS.
-create or replace function public.character_industry_jobs(character_ids uuid[], include_delivered boolean default false)
+-- `as_of` (default now) time-travels through the SCD-2 history like
+-- character_asset_snapshot_at: the version of each job valid then is the one
+-- that had started by `as_of` and was either still open then or is the current
+-- version. The include_delivered filter is applied to that version's status, so
+-- a job that is delivered now but was active at `as_of` shows as active. At the
+-- default now() this returns the is_current set, matching the
+-- character_industry_job view.
+create or replace function public.character_industry_jobs(character_ids uuid[], include_delivered boolean default false, as_of timestamptz default now())
 returns json
 language sql
 stable
@@ -883,13 +902,15 @@ as $$
     ),
     '[]'::json
   )
-  from public.character_industry_job j
+  from public.character_industry_job_over_time j
   join public.registration r on r.id = j.character_id
   where j.character_id = any(character_ids)
+    and j.valid_from <= as_of
+    and (j.valid_until >= as_of or j.is_current)
     and (include_delivered or j.status not in ('delivered', 'cancelled', 'archived'));
 $$;
 
-grant execute on function public.character_industry_jobs(uuid[], boolean) to service_role;
+grant execute on function public.character_industry_jobs(uuid[], boolean, timestamptz) to service_role;
 
 -- ── character_location ────────────────────────────────────────────────────
 -- ESI /characters/{id}/location/, written by the character-location job. Live
@@ -1827,7 +1848,9 @@ grant all    on public.corp_industry_job_over_time to service_role;
 -- endpoint. Returns json (not jsonb) so json_build_object's key order is
 -- preserved for the sheet's columns, and a single scalar sidesteps PostgREST's
 -- max-rows cap.
-create or replace function public.corp_industry_jobs(character_ids uuid[], include_delivered boolean default false)
+-- `as_of` (default now) time-travels through the SCD-2 history exactly like the
+-- per-character character_industry_jobs above.
+create or replace function public.corp_industry_jobs(character_ids uuid[], include_delivered boolean default false, as_of timestamptz default now())
 returns json
 language sql
 stable
@@ -1863,15 +1886,17 @@ as $$
     ),
     '[]'::json
   )
-  from public.corp_industry_job j
+  from public.corp_industry_job_over_time j
   where j.corporation_id in (
     select corporation_id from public.registration
     where id = any(character_ids) and corporation_id is not null
   )
+  and j.valid_from <= as_of
+  and (j.valid_until >= as_of or j.is_current)
   and (include_delivered or j.status not in ('delivered', 'cancelled', 'archived'));
 $$;
 
-grant execute on function public.corp_industry_jobs(uuid[], boolean) to service_role;
+grant execute on function public.corp_industry_jobs(uuid[], boolean, timestamptz) to service_role;
 
 -- ── universe_name ─────────────────────────────────────────────────────────
 -- ESI /universe/names/, written by the universe-names job: cache of resolved

--- a/src/app/api/character/assets/route.ts
+++ b/src/app/api/character/assets/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { resolvePlayer } from '@/utils/apiToken'
+import { AT_PARAM_ERROR, parseAtParam } from '@/utils/atParam'
 import { toCsv } from '@/utils/csv'
 
 // Public CSV endpoint for Google Sheets =IMPORTDATA(): the player's raw asset
@@ -12,33 +13,17 @@ export const dynamic = 'force-dynamic'
 // Headroom over Vercel's default function timeout for a large inventory.
 export const maxDuration = 60
 
-// Pad a partial ISO date/time out to a full UTC timestamp so callers can pass
-// just the precision they care about: 2026 → 2026-01-01T00:00:00Z, 2026-05 →
-// 2026-05-01T00:00:00Z, 2026-05-30T18 → 2026-05-30T18:00:00Z, etc. Inputs that
-// already carry fractional seconds or a timezone (e.g. a full toISOString) don't
-// match the bare-prefix pattern and are returned untouched for Date to parse.
-const completePartialAt = (value: string): string => {
-  const m = /^(\d{4})(?:-(\d{2}))?(?:-(\d{2}))?(?:[T ](\d{2}))?(?::(\d{2}))?(?::(\d{2}))?$/.exec(value)
-  if (!m) return value
-  const [, year, month = '01', day = '01', hour = '00', minute = '00', second = '00'] = m
-  return `${year}-${month}-${day}T${hour}:${minute}:${second}Z`
-}
-
 export const GET = async (request: NextRequest): Promise<NextResponse> => {
   const { searchParams } = new URL(request.url)
 
   // `at` is the moment to reconstruct the inventory at; default to now (the live
   // inventory). character_asset_over_time keeps full SCD-2 history, so any past
   // time works.
-  const atParam = searchParams.get('at')
-  const at = atParam ? new Date(completePartialAt(atParam.trim())) : new Date()
-  if (Number.isNaN(at.getTime())) {
-    return NextResponse.json(
-      { error: 'Invalid `at` timestamp; use ISO 8601 (e.g. 2026-06-01T00:00:00Z)' },
-      { status: 400 }
-    )
+  const at = parseAtParam(searchParams.get('at'))
+  if (!at.ok) {
+    return NextResponse.json({ error: AT_PARAM_ERROR }, { status: 400 })
   }
-  const atIso = at.toISOString()
+  const atIso = at.iso
 
   const player = await resolvePlayer(searchParams.get('token')?.trim())
   if (!player.ok) {

--- a/src/app/api/character/jobs/route.ts
+++ b/src/app/api/character/jobs/route.ts
@@ -1,18 +1,27 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { resolvePlayer } from '@/utils/apiToken'
+import { AT_PARAM_ERROR, parseAtParam } from '@/utils/atParam'
 import { toCsv } from '@/utils/csv'
 
 // Public CSV endpoint for Google Sheets =IMPORTDATA(): the player's industry jobs
-// across all of their characters, with the owning character's name. The first row
-// is the column headers. Authenticated by the per-user api_token in the query
-// string (Sheets carries no session cookie), so it always recomputes — no caching.
+// across all of their characters, with the owning character's name, as of an
+// optional `at` timestamp. The first row is the column headers. Authenticated by
+// the per-user api_token in the query string (Sheets carries no session cookie),
+// so it always recomputes — no caching.
 export const dynamic = 'force-dynamic'
 // Headroom over Vercel's default function timeout.
 export const maxDuration = 60
 
 export const GET = async (request: NextRequest): Promise<NextResponse> => {
   const { searchParams } = new URL(request.url)
+
+  // `at` time-travels the SCD-2 history (character_industry_job_over_time) to the
+  // job versions valid at that moment; default now is the live set.
+  const at = parseAtParam(searchParams.get('at'))
+  if (!at.ok) {
+    return NextResponse.json({ error: AT_PARAM_ERROR }, { status: 400 })
+  }
 
   const player = await resolvePlayer(searchParams.get('token')?.trim())
   if (!player.ok) {
@@ -30,6 +39,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
   const { data: rows, error: rowsError } = await player.supabase.rpc('character_industry_jobs', {
     character_ids: player.characterIds,
     include_delivered: includeDelivered,
+    as_of: at.iso,
   })
   if (rowsError) {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })

--- a/src/app/api/character/orders/route.ts
+++ b/src/app/api/character/orders/route.ts
@@ -1,19 +1,27 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { resolvePlayer } from '@/utils/apiToken'
+import { AT_PARAM_ERROR, parseAtParam } from '@/utils/atParam'
 import { toCsv } from '@/utils/csv'
 
 // Public CSV endpoint for Google Sheets =IMPORTDATA(): the player's open market
-// orders across all of their characters, with the owning character's name. The
-// first row is the column headers. Authenticated by the per-user api_token in the
-// query string (Sheets carries no session cookie), so it always recomputes — no
-// caching.
+// orders across all of their characters, with the owning character's name, as of
+// an optional `at` timestamp. The first row is the column headers. Authenticated
+// by the per-user api_token in the query string (Sheets carries no session
+// cookie), so it always recomputes — no caching.
 export const dynamic = 'force-dynamic'
 // Headroom over Vercel's default function timeout.
 export const maxDuration = 60
 
 export const GET = async (request: NextRequest): Promise<NextResponse> => {
   const { searchParams } = new URL(request.url)
+
+  // `at` reconstructs which orders were open at that moment from the SCD-2
+  // history (character_order_over_time); default now is the live open set.
+  const at = parseAtParam(searchParams.get('at'))
+  if (!at.ok) {
+    return NextResponse.json({ error: AT_PARAM_ERROR }, { status: 400 })
+  }
 
   const player = await resolvePlayer(searchParams.get('token')?.trim())
   if (!player.ok) {
@@ -24,6 +32,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
   // the field order for the sheet's columns and sidesteps PostgREST's max-rows cap.
   const { data: rows, error: rowsError } = await player.supabase.rpc('character_orders', {
     character_ids: player.characterIds,
+    as_of: at.iso,
   })
   if (rowsError) {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })

--- a/src/app/api/corp/jobs/route.ts
+++ b/src/app/api/corp/jobs/route.ts
@@ -1,18 +1,27 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { resolvePlayer } from '@/utils/apiToken'
+import { AT_PARAM_ERROR, parseAtParam } from '@/utils/atParam'
 import { toCsv } from '@/utils/csv'
 
 // Public CSV endpoint for Google Sheets =IMPORTDATA(): industry jobs for the
-// corporation(s) the caller's characters belong to. The first row is the
-// column headers. Authenticated by the per-user api_token in the query string
-// (Sheets carries no session cookie), so it always recomputes — no caching.
+// corporation(s) the caller's characters belong to, as of an optional `at`
+// timestamp. The first row is the column headers. Authenticated by the per-user
+// api_token in the query string (Sheets carries no session cookie), so it always
+// recomputes — no caching.
 export const dynamic = 'force-dynamic'
 // Headroom over Vercel's default function timeout.
 export const maxDuration = 60
 
 export const GET = async (request: NextRequest): Promise<NextResponse> => {
   const { searchParams } = new URL(request.url)
+
+  // `at` time-travels the SCD-2 history (corp_industry_job_over_time) to the job
+  // versions valid at that moment; default now is the live set.
+  const at = parseAtParam(searchParams.get('at'))
+  if (!at.ok) {
+    return NextResponse.json({ error: AT_PARAM_ERROR }, { status: 400 })
+  }
 
   const player = await resolvePlayer(searchParams.get('token')?.trim())
   if (!player.ok) {
@@ -30,6 +39,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
   const { data: rows, error: rowsError } = await player.supabase.rpc('corp_industry_jobs', {
     character_ids: player.characterIds,
     include_delivered: includeDelivered,
+    as_of: at.iso,
   })
   if (rowsError) {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })

--- a/src/utils/atParam.ts
+++ b/src/utils/atParam.ts
@@ -1,0 +1,29 @@
+// Shared parsing for the `at` query param on the IMPORTDATA endpoints backed by
+// SCD-2 history (/api/character/assets, /api/character/orders,
+// /api/character/jobs, /api/corp/jobs): the moment to reconstruct the snapshot
+// at, defaulting to now (the live snapshot).
+
+// Pad a partial ISO date/time out to a full UTC timestamp so callers can pass
+// just the precision they care about: 2026 → 2026-01-01T00:00:00Z, 2026-05 →
+// 2026-05-01T00:00:00Z, 2026-05-30T18 → 2026-05-30T18:00:00Z, etc. Inputs that
+// already carry fractional seconds or a timezone (e.g. a full toISOString) don't
+// match the bare-prefix pattern and are returned untouched for Date to parse.
+const completePartialAt = (value: string): string => {
+  const m = /^(\d{4})(?:-(\d{2}))?(?:-(\d{2}))?(?:[T ](\d{2}))?(?::(\d{2}))?(?::(\d{2}))?$/.exec(value)
+  if (!m) return value
+  const [, year, month = '01', day = '01', hour = '00', minute = '00', second = '00'] = m
+  return `${year}-${month}-${day}T${hour}:${minute}:${second}Z`
+}
+
+// Human-readable hint returned on an invalid `at`.
+export const AT_PARAM_ERROR = 'Invalid `at` timestamp; use ISO 8601 (e.g. 2026-06-01T00:00:00Z)'
+
+// Parse an optional `at` query param into an ISO timestamp. A missing/empty
+// value defaults to now. Returns `{ ok: false }` on an unparseable value so the
+// route can answer 400 with AT_PARAM_ERROR.
+export const parseAtParam = (raw: string | null | undefined): { ok: true; iso: string } | { ok: false } => {
+  const trimmed = raw?.trim()
+  const at = trimmed ? new Date(completePartialAt(trimmed)) : new Date()
+  if (Number.isNaN(at.getTime())) return { ok: false }
+  return { ok: true, iso: at.toISOString() }
+}

--- a/supabase/migrations/20260713160000_industry_jobs_orders_snapshot_at.sql
+++ b/supabase/migrations/20260713160000_industry_jobs_orders_snapshot_at.sql
@@ -3,12 +3,55 @@
 -- param and reconstruct the snapshot at any past moment from the SCD-2 history,
 -- exactly like character_asset_snapshot_at already does for assets. Each reads
 -- its *_over_time history table and keeps the version of every order/job that
--- was valid at `as_of` (started by then, and either still open then or the
--- current version). At the default now() this returns the same is_current set
--- the views exposed, so existing callers are unaffected.
+-- was valid at `as_of`: it had started by then (valid_from <= as_of) and was
+-- either the current version or still open then (valid_until >= as_of). At the
+-- default now() this returns the same is_current set the views exposed, so
+-- existing callers are unaffected.
+--
+-- The validity predicate is written is_current-first — `valid_from <= as_of AND
+-- (is_current OR valid_until >= as_of)`. Gating is_current behind
+-- valid_from <= as_of matters: hoisting is_current to the top level
+-- (`is_current OR (window)`) would return a currently-open row twice for any
+-- order/job that changed after `as_of` (its as-of version via the window plus
+-- its current version) and would leak rows created after `as_of` into older
+-- snapshots. character_asset_snapshot_at is re-created here with the same
+-- is_current-first ordering so all four snapshot functions read alike; its
+-- behavior is unchanged (the reorder is a commutative no-op).
 --
 -- Adding a parameter creates a new overload that would make the old one-/two-arg
 -- form ambiguous, so drop the prior signatures first.
+
+create or replace function public.character_asset_snapshot_at(character_ids uuid[], as_of timestamptz)
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'is_blueprint_copy', a.is_blueprint_copy,
+        'is_singleton',      a.is_singleton,
+        'item_id',           a.item_id,
+        'location_flag',     a.location_flag,
+        'location_id',       a.location_id,
+        'location_type',     a.location_type,
+        'quantity',          a.quantity,
+        'type_id',           a.type_id,
+        'character_name',    r.name
+      )
+      order by a.item_id
+    ),
+    '[]'::json
+  )
+  from public.character_asset_over_time a
+  join public.registration r on r.id = a.character_id
+  where a.character_id = any(character_ids)
+    and a.valid_from <= as_of
+    and (a.is_current or a.valid_until >= as_of)
+    and (not a.is_singleton or a.is_blueprint_copy);
+$$;
+
+grant execute on function public.character_asset_snapshot_at(uuid[], timestamptz) to service_role;
 
 drop function if exists public.character_orders(uuid[]);
 create or replace function public.character_orders(character_ids uuid[], as_of timestamptz default now())
@@ -43,7 +86,7 @@ as $$
   join public.registration r on r.id = o.character_id
   where o.character_id = any(character_ids)
     and o.valid_from <= as_of
-    and (o.valid_until >= as_of or o.is_current);
+    and (o.is_current or o.valid_until >= as_of);
 $$;
 
 grant execute on function public.character_orders(uuid[], timestamptz) to service_role;
@@ -89,7 +132,7 @@ as $$
   join public.registration r on r.id = j.character_id
   where j.character_id = any(character_ids)
     and j.valid_from <= as_of
-    and (j.valid_until >= as_of or j.is_current)
+    and (j.is_current or j.valid_until >= as_of)
     and (include_delivered or j.status not in ('delivered', 'cancelled', 'archived'));
 $$;
 
@@ -138,7 +181,7 @@ as $$
     where id = any(character_ids) and corporation_id is not null
   )
   and j.valid_from <= as_of
-  and (j.valid_until >= as_of or j.is_current)
+  and (j.is_current or j.valid_until >= as_of)
   and (include_delivered or j.status not in ('delivered', 'cancelled', 'archived'));
 $$;
 

--- a/supabase/migrations/20260713160000_industry_jobs_orders_snapshot_at.sql
+++ b/supabase/migrations/20260713160000_industry_jobs_orders_snapshot_at.sql
@@ -1,0 +1,145 @@
+-- Give the market-orders and industry-jobs IMPORTDATA functions an `as_of`
+-- parameter (default now) so their /api endpoints can accept an `at=` query
+-- param and reconstruct the snapshot at any past moment from the SCD-2 history,
+-- exactly like character_asset_snapshot_at already does for assets. Each reads
+-- its *_over_time history table and keeps the version of every order/job that
+-- was valid at `as_of` (started by then, and either still open then or the
+-- current version). At the default now() this returns the same is_current set
+-- the views exposed, so existing callers are unaffected.
+--
+-- Adding a parameter creates a new overload that would make the old one-/two-arg
+-- form ambiguous, so drop the prior signatures first.
+
+drop function if exists public.character_orders(uuid[]);
+create or replace function public.character_orders(character_ids uuid[], as_of timestamptz default now())
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'duration',       o.duration,
+        'escrow',         o.escrow,
+        'is_buy_order',   o.is_buy,
+        'is_corporation', o.is_corporation,
+        'issued',         o.issued,
+        'location_id',    o.location_id,
+        'min_volume',     o.min_volume,
+        'order_id',       o.order_id,
+        'price',          o.price,
+        'range',          o.range,
+        'region_id',      o.region_id,
+        'type_id',        o.type_id,
+        'volume_remain',  o.volume_remain,
+        'volume_total',   o.volume_total,
+        'character_name', r.name
+      )
+      order by o.issued desc
+    ),
+    '[]'::json
+  )
+  from public.character_order_over_time o
+  join public.registration r on r.id = o.character_id
+  where o.character_id = any(character_ids)
+    and o.valid_from <= as_of
+    and (o.valid_until >= as_of or o.is_current);
+$$;
+
+grant execute on function public.character_orders(uuid[], timestamptz) to service_role;
+
+drop function if exists public.character_industry_jobs(uuid[], boolean);
+create or replace function public.character_industry_jobs(character_ids uuid[], include_delivered boolean default false, as_of timestamptz default now())
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'activity_id',            j.activity_id,
+        'blueprint_id',           j.blueprint_id,
+        'blueprint_location_id',  j.blueprint_location_id,
+        'blueprint_type_id',      j.blueprint_type_id,
+        'completed_character_id', j.completed_character_id,
+        'completed_date',         j.completed_date,
+        'cost',                   j.cost,
+        'duration',               j.duration,
+        'end_date',               j.end_date,
+        'facility_id',            j.facility_id,
+        'installer_id',           j.installer_id,
+        'job_id',                 j.job_id,
+        'licensed_runs',          j.licensed_runs,
+        'output_location_id',     j.output_location_id,
+        'pause_date',             j.pause_date,
+        'probability',            j.probability,
+        'product_type_id',        j.product_type_id,
+        'runs',                   j.runs,
+        'start_date',             j.start_date,
+        'station_id',             j.station_id,
+        'status',                 j.status,
+        'successful_runs',        j.successful_runs,
+        'character_name',         r.name
+      )
+      order by j.start_date desc
+    ),
+    '[]'::json
+  )
+  from public.character_industry_job_over_time j
+  join public.registration r on r.id = j.character_id
+  where j.character_id = any(character_ids)
+    and j.valid_from <= as_of
+    and (j.valid_until >= as_of or j.is_current)
+    and (include_delivered or j.status not in ('delivered', 'cancelled', 'archived'));
+$$;
+
+grant execute on function public.character_industry_jobs(uuid[], boolean, timestamptz) to service_role;
+
+drop function if exists public.corp_industry_jobs(uuid[], boolean);
+create or replace function public.corp_industry_jobs(character_ids uuid[], include_delivered boolean default false, as_of timestamptz default now())
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'activity_id',            j.activity_id,
+        'blueprint_id',           j.blueprint_id,
+        'blueprint_location_id',  j.blueprint_location_id,
+        'blueprint_type_id',      j.blueprint_type_id,
+        'completed_character_id', j.completed_character_id,
+        'completed_date',         j.completed_date,
+        'corporation_id',         j.corporation_id,
+        'cost',                   j.cost,
+        'duration',               j.duration,
+        'end_date',               j.end_date,
+        'facility_id',            j.facility_id,
+        'installer_id',           j.installer_id,
+        'job_id',                 j.job_id,
+        'licensed_runs',          j.licensed_runs,
+        'output_location_id',     j.output_location_id,
+        'pause_date',             j.pause_date,
+        'probability',            j.probability,
+        'product_type_id',        j.product_type_id,
+        'runs',                   j.runs,
+        'start_date',             j.start_date,
+        'station_id',             j.station_id,
+        'status',                 j.status,
+        'successful_runs',        j.successful_runs
+      )
+      order by j.start_date desc
+    ),
+    '[]'::json
+  )
+  from public.corp_industry_job_over_time j
+  where j.corporation_id in (
+    select corporation_id from public.registration
+    where id = any(character_ids) and corporation_id is not null
+  )
+  and j.valid_from <= as_of
+  and (j.valid_until >= as_of or j.is_current)
+  and (include_delivered or j.status not in ('delivered', 'cancelled', 'archived'));
+$$;
+
+grant execute on function public.corp_industry_jobs(uuid[], boolean, timestamptz) to service_role;


### PR DESCRIPTION
## What

Now that market orders and industry jobs are SCD Type 2 histories (#587), the three IMPORTDATA endpoints that read them can time-travel like `/api/character/assets` already does. `/api/character/orders`, `/api/character/jobs`, and `/api/corp/jobs` now accept an optional `?at=` timestamp and reconstruct the snapshot as of that moment.

```
/api/character/orders?token=…&at=2026-06-01
/api/character/jobs?token=…&at=2026-06-01T12:00:00Z&include_delivered=true
```

## How

- **schema.sql** — `character_orders`, `character_industry_jobs`, and `corp_industry_jobs` each gain an `as_of timestamptz default now()` parameter and read their `*_over_time` history table (not the live view) with the same validity predicate `character_asset_snapshot_at` uses:
  ```
  valid_from <= as_of AND (valid_until >= as_of OR is_current)
  ```
  i.e. keep the version of each order/job that had started by `as_of` and was either still open then or is the current version. Versions of one order/job never overlap, so at most one matches.
- For jobs, the `include_delivered` filter is applied to the **as-of version's** status, so a job that is delivered now but was active at `as_of` shows as active.
- At the default `now()` each function returns exactly the `is_current` set the views exposed, so existing callers (and Sheets that don't pass `at`) are unaffected.
- **Routes** — all four endpoints share the `at` parsing (partial-ISO padding like `2026`, `2026-05`, `2026-05-30T18`; default now; 400 on garbage), factored out of the assets route into `src/utils/atParam.ts`.

## Migration

`supabase/migrations/20260713160000_industry_jobs_orders_snapshot_at.sql` — an added defaulted parameter would make the old signature ambiguous, so it drops the prior function signatures and recreates them. No data change.

## Testing

Validated against a throwaway Postgres with multi-version seed data (an order mid-fill, a job that went active → delivered), on both the final `schema.sql` and through the migration applied on top of the current `main` schema:
- **now()** — orders returns the current open version (`volume_remain` 400, not the earlier 1000); the filled order is gone; jobs with `include_delivered=false` return nothing (the delivered job is filtered), with `=true` return the delivered row.
- **past `at`** — returns the version valid then: the order's earlier open state (`volume_remain` 1000) plus the since-filled order, and the job as **active** even though it's delivered now.
- The migration drops the old 1-/2-arg signatures and installs the new ones (verified `pg_proc`); `eslint` and `prettier --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TtjvyygzRHtThCDDRYJwQ

---
_Generated by [Claude Code](https://claude.ai/code/session_016TtjvyygzRHtThCDDRYJwQ)_