### PR TITLE
Fix Migrate workflow: drop primary keys by their real constraint names

### DIFF
--- a/supabase/migrations/20260713140000_industry_jobs_orders_scd.sql
+++ b/supabase/migrations/20260713140000_industry_jobs_orders_scd.sql
@@ -17,7 +17,19 @@
 -- ── character_order → character_order_over_time + view ─────────────────────
 alter table public.character_order rename to character_order_over_time;
 
-alter table public.character_order_over_time drop constraint character_order_pkey;
+-- Drop the existing primary key by its real name. This table was renamed from
+-- market_order (see 20260702150000_endpoint_naming.sql), and renaming a table
+-- leaves its PK constraint named after the original table — so the constraint is
+-- market_order_pkey, not character_order_pkey. Look it up rather than guess.
+do $$
+declare cname text;
+begin
+  select conname into cname from pg_constraint
+   where conrelid = 'public.character_order_over_time'::regclass and contype = 'p';
+  if cname is not null then
+    execute format('alter table public.character_order_over_time drop constraint %I', cname);
+  end if;
+end $$;
 alter table public.character_order_over_time
   add column id bigint generated always as identity,
   add column is_current boolean not null default true,
@@ -40,7 +52,17 @@ grant select on public.character_order to authenticated;
 -- ── character_industry_job → character_industry_job_over_time + view ───────
 alter table public.character_industry_job rename to character_industry_job_over_time;
 
-alter table public.character_industry_job_over_time drop constraint character_industry_job_pkey;
+-- Drop the existing primary key by its real name (renamed from industry_job, so
+-- the constraint is industry_job_pkey). Look it up rather than guess.
+do $$
+declare cname text;
+begin
+  select conname into cname from pg_constraint
+   where conrelid = 'public.character_industry_job_over_time'::regclass and contype = 'p';
+  if cname is not null then
+    execute format('alter table public.character_industry_job_over_time drop constraint %I', cname);
+  end if;
+end $$;
 alter table public.character_industry_job_over_time
   add column id bigint generated always as identity,
   add column is_current boolean not null default true,
@@ -63,7 +85,16 @@ grant select on public.character_industry_job to authenticated;
 -- ── corp_industry_job → corp_industry_job_over_time + view ─────────────────
 alter table public.corp_industry_job rename to corp_industry_job_over_time;
 
-alter table public.corp_industry_job_over_time drop constraint corp_industry_job_pkey;
+-- Drop the existing primary key by its real name. Look it up rather than guess.
+do $$
+declare cname text;
+begin
+  select conname into cname from pg_constraint
+   where conrelid = 'public.corp_industry_job_over_time'::regclass and contype = 'p';
+  if cname is not null then
+    execute format('alter table public.corp_industry_job_over_time drop constraint %I', cname);
+  end if;
+end $$;
 alter table public.corp_industry_job_over_time
   add column id bigint generated always as identity,
   add column is_current boolean not null default true,

--- a/supabase/migrations/20260713170000_mercenary_den_redesign.sql
+++ b/supabase/migrations/20260713170000_mercenary_den_redesign.sql
@@ -44,7 +44,17 @@ alter table public.character_mercenary_den rename to character_mercenary_den_ove
 
 -- Swap the composite PK for a surrogate id and add SCD-2 bookkeeping; the
 -- existing rows become the current (is_current = true) versions.
-alter table public.character_mercenary_den_over_time drop constraint character_mercenary_den_pkey;
+-- Drop the existing composite primary key by its real name (look it up rather
+-- than guess — this table wasn't renamed, but be robust regardless).
+do $$
+declare cname text;
+begin
+  select conname into cname from pg_constraint
+   where conrelid = 'public.character_mercenary_den_over_time'::regclass and contype = 'p';
+  if cname is not null then
+    execute format('alter table public.character_mercenary_den_over_time drop constraint %I', cname);
+  end if;
+end $$;
 alter table public.character_mercenary_den_over_time
   add column id bigint generated always as identity primary key,
   add column is_current boolean not null default true,


### PR DESCRIPTION
## Problem

The `Migrate` workflow has been failing on every push to `main`:

```
Applying migration 20260713140000_industry_jobs_orders_scd.sql...
ERROR: constraint "character_order_pkey" of relation "character_order_over_time" does not exist (SQLSTATE 42704)
At statement: alter table public.character_order_over_time drop constraint character_order_pkey
```

`character_order` was originally created as `market_order` and renamed by `20260702150000_endpoint_naming.sql`. **Renaming a table leaves its primary-key constraint named after the original table**, so the constraint is actually `market_order_pkey`, not `character_order_pkey`. `20260713140000_industry_jobs_orders_scd.sql` (from #587) guessed the post-rename name for all three of its tables (`character_order` ← `market_order`, `character_industry_job` ← `industry_job`, `corp_industry_job`), so its first `drop constraint` threw. The migration runs in a transaction, so it rolled back completely and **blocked every later migration** — including the mercenary-den redesign (#586) and the SCD column rename.

## Fix

- Drop each primary key by looking up its **real** name from `pg_constraint` (a small `DO` block per table) instead of hardcoding a guessed name — in `20260713140000_industry_jobs_orders_scd.sql` for `character_order` / `character_industry_job` / `corp_industry_job`, and in the mercenary-den migration for good measure (its name was already correct, but this is robust to any rename history).
- Rename `20260713150000_mercenary_den_redesign.sql` → `20260713170000_mercenary_den_redesign.sql` so it no longer shares the `20260713150000` version prefix with `20260713150000_rename_scd_validity_columns.sql`. Two migrations with the same version collide in Supabase's migration-history table; they're independent, so bumping the timestamp is safe (this one hadn't applied yet).

Both edited migrations had failed/never applied in prod (the workflow stopped at the first `drop constraint`), so editing them in place is safe — the next `supabase db push` retries from a clean, rolled-back state.

## Notes

- No schema/behavior change — `schema.sql` (the full-reset source of truth) already defines these tables in their final shape; only the incremental migrations' constraint-drop mechanics change.
- No local Postgres to execute against; the `Migrate` workflow will apply the corrected chain on merge. The `DO`-block PK lookup is standard and name-agnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL1hvtH4F7QduankaQPoxz

---
_Generated by [Claude Code](https://claude.ai/code/session_01PL1hvtH4F7QduankaQPoxz)_