### PR TITLE
Attribute corp-run job tax to structures on the /structure page

### DIFF
--- a/src/app/structure/page.tsx
+++ b/src/app/structure/page.tsx
@@ -68,20 +68,25 @@ const StructuresPage = async () => {
   const list = (structures ?? []) as Structure[]
 
   // Tax revenue each structure generates. Each industry-tax journal entry references its job via
-  // context_id (context_id_type = industry_job_id); outer-join those job ids to the
-  // character_industry_job table to find the structure (station_id, falling back to facility_id)
-  // the job is installed in, then sum the journal amounts. Bigint ids can come back from PostgREST
-  // as strings, so key every map by string.
+  // context_id (context_id_type = industry_job_id); outer-join those job ids to the industry-job
+  // tables to find the structure (station_id, falling back to facility_id) the job is installed in,
+  // then sum the journal amounts. The installer pays the tax and isn't necessarily one of this app's
+  // linked characters (character_industry_job only covers those) — anyone in the corp can run a job
+  // here (reactions in a refinery are often run by a dedicated alt), so corp_industry_job (pulled by
+  // a director, covering every corp member) is unioned in too, mirroring /structure/revenue.
+  // Otherwise a corp-run job's tax lands in "unaccounted" instead of its structure. Bigint ids can
+  // come back from PostgREST as strings, so key every map by string.
   const structureIds = list.map((s) => Number(s.structure_id))
-  const { data: jobs } = structureIds.length
-    ? await supabase
-        .from('character_industry_job')
-        .select('job_id, station_id, facility_id')
-        .or(`station_id.in.(${structureIds.join(',')}),facility_id.in.(${structureIds.join(',')})`)
-    : { data: [] }
+  const jobStructureFilter = `station_id.in.(${structureIds.join(',')}),facility_id.in.(${structureIds.join(',')})`
+  const [{ data: characterJobs }, { data: corpJobs }] = structureIds.length
+    ? await Promise.all([
+        supabase.from('character_industry_job').select('job_id, station_id, facility_id').or(jobStructureFilter),
+        supabase.from('corp_industry_job').select('job_id, station_id, facility_id').or(jobStructureFilter),
+      ])
+    : [{ data: [] }, { data: [] }]
 
   const structureByJob = new Map<string, string>()
-  for (const j of (jobs ?? []) as JobRow[]) {
+  for (const j of [...((characterJobs ?? []) as JobRow[]), ...((corpJobs ?? []) as JobRow[])]) {
     const structureId = j.station_id ?? j.facility_id
     if (structureId != null) structureByJob.set(String(j.job_id), String(structureId))
   }


### PR DESCRIPTION
## Problem

On the `/structure` page, tax revenue from reaction jobs (e.g. on Tataras) wasn't being attributed to the structure — it was landing in the "Unaccounted tax revenue" bucket instead.

## Root cause

Not an `activity_id` / job-type issue — reactions use the same `industry_job_tax` journal `ref_type` as manufacturing, and no code filters revenue by activity.

The real cause: the `/structure` page built its job→structure map from **only** `character_industry_job`:

```ts
const { data: jobs } = ... supabase.from('character_industry_job')...
```

That table only covers this app's **linked** characters. A job run by any other corp member — reactions on a refinery are commonly run by a dedicated alt — exists only in `corp_industry_job` (pulled by a director, covering every corp member). So its tax couldn't be tied to a structure and fell into "unaccounted".

The `/structure/revenue` detail page already queries **both** tables and documents exactly this, which is why revenue looked correct there but not on the main page.

## Fix

Union `corp_industry_job` into the lookup on `/structure`, mirroring `/structure/revenue`:

```ts
const [{ data: characterJobs }, { data: corpJobs }] = await Promise.all([
  supabase.from('character_industry_job').select('job_id, station_id, facility_id').or(jobStructureFilter),
  supabase.from('corp_industry_job').select('job_id, station_id, facility_id').or(jobStructureFilter),
])
```

Both tables are merged into `structureByJob` (keyed by `job_id`, so a job in both dedupes to the same structure — no double counting).

## Testing

- `tsc --noEmit` passes across the project (0 errors); the destructuring mirrors the existing, working pattern in `/structure/revenue`.
- `eslint` and `prettier --check` pass.

Note (not fixed here, pre-existing): the per-structure job fetch and the `industry_job_tax` journal fetch on this page aren't paginated, so a corp with >1000 rows could still see some truncation — orthogonal to this categorical fix, happy to follow up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TtjvyygzRHtThCDDRYJwQ

---
_Generated by [Claude Code](https://claude.ai/code/session_016TtjvyygzRHtThCDDRYJwQ)_