### PR TITLE
Fix empty corpses page: select first_seen_at instead of valid_from

### DIFF
--- a/src/app/corpses/[characterID]/page.tsx
+++ b/src/app/corpses/[characterID]/page.tsx
@@ -48,7 +48,7 @@ type CorpseRow = {
   item_id: number | string
   type_id: number | string
   name: string | null
-  valid_from: string | null
+  first_seen_at: string | null
 }
 
 const CorpsesPage = async ({ params }: { params: Promise<{ characterID: string }> }) => {
@@ -100,7 +100,7 @@ const CorpsesPage = async ({ params }: { params: Promise<{ characterID: string }
     registrationIds.length && typeIds.length
       ? await service
           .from('character_asset')
-          .select('item_id, type_id, name, valid_from')
+          .select('item_id, type_id, name, first_seen_at')
           .in('character_id', registrationIds)
           .in('type_id', typeIds)
           .returns<CorpseRow[]>()
@@ -112,7 +112,7 @@ const CorpsesPage = async ({ params }: { params: Promise<{ characterID: string }
   // resolved yet falls back to its item id so it still shows in the tally.
   const corpses = (rows ?? [])
     .map((r) => {
-      const firstSeenMs = r.valid_from ? new Date(r.valid_from).getTime() : NaN
+      const firstSeenMs = r.first_seen_at ? new Date(r.first_seen_at).getTime() : NaN
       return {
         itemId: String(r.item_id),
         typeId: Number(r.type_id),


### PR DESCRIPTION
## Problem

`/corpses/[characterID]` always rendered **"No corpses in this collection"** even for accounts with corpses (e.g. `/corpses/1903238489`, which has 308 current corpse assets in the DB).

## Root cause

PR #587 ("Back market orders and industry jobs with SCD Type 2 views") renamed the `character_asset_over_time` base-table timestamp columns to `valid_from`/`valid_until`. The `character_asset` **view** keeps its public interface stable by aliasing them back:

```sql
character_asset_over_time.valid_from  AS first_seen_at,
character_asset_over_time.valid_until AS last_seen_at,
```

That same PR also changed the corpses page to `.select('item_id, type_id, name, valid_from')` **from the view** — but the view exposes `first_seen_at`, not `valid_from`. PostgREST rejected the unknown column, so the query returned `null`, `rows` fell back to `[]`, and the page rendered the empty state. The heading still showed the account name because the (separate) `registration` queries were unaffected, which is why the failure looked like "no data" rather than an error.

## Fix

Select the column the view actually exposes — `first_seen_at` — in all three spots (the `CorpseRow` type, the `.select()`, and the `firstSeenMs` read). No other consumer of `character_asset` selects `valid_from` from a view, so this is the only page affected.

## Verification

- Ran the corrected query as `service_role` (what the page uses) against production data: it returns the corpse rows with populated `first_seen_at` timestamps.
- `eslint` passes on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DubLumFoEzzvzaNStE5msa)_