### PR TITLE
Realign SCD current-snapshot views to select *, restore corpses valid_from

### DIFF
--- a/src/app/corpses/[characterID]/page.tsx
+++ b/src/app/corpses/[characterID]/page.tsx
@@ -48,7 +48,7 @@ type CorpseRow = {
   item_id: number | string
   type_id: number | string
   name: string | null
-  first_seen_at: string | null
+  valid_from: string | null
 }
 
 const CorpsesPage = async ({ params }: { params: Promise<{ characterID: string }> }) => {
@@ -100,7 +100,7 @@ const CorpsesPage = async ({ params }: { params: Promise<{ characterID: string }
     registrationIds.length && typeIds.length
       ? await service
           .from('character_asset')
-          .select('item_id, type_id, name, first_seen_at')
+          .select('item_id, type_id, name, valid_from')
           .in('character_id', registrationIds)
           .in('type_id', typeIds)
           .returns<CorpseRow[]>()
@@ -112,7 +112,9 @@ const CorpsesPage = async ({ params }: { params: Promise<{ characterID: string }
   // resolved yet falls back to its item id so it still shows in the tally.
   const corpses = (rows ?? [])
     .map((r) => {
-      const firstSeenMs = r.first_seen_at ? new Date(r.first_seen_at).getTime() : NaN
+      // valid_from is this asset version's debut (the SCD-2 validity window's
+      // start) — for a corpse, effectively when it was first seen in the hangar.
+      const firstSeenMs = r.valid_from ? new Date(r.valid_from).getTime() : NaN
       return {
         itemId: String(r.item_id),
         typeId: Number(r.type_id),

--- a/supabase/migrations/20260714000000_recreate_scd_views_select_star.sql
+++ b/supabase/migrations/20260714000000_recreate_scd_views_select_star.sql
@@ -1,0 +1,69 @@
+-- Recreate every SCD Type 2 "current snapshot" view as `select *` so it exposes
+-- the base table's real columns — including the validity window valid_from /
+-- valid_until renamed in 20260713150000_rename_scd_validity_columns.sql.
+--
+-- That rename migration renamed the *_over_time columns first_seen_at →
+-- valid_from and last_seen_at → valid_until and noted "views are select * and
+-- update automatically" — true for a fresh schema.sql reset, where every view
+-- below is `select * ... where is_current`. But the incrementally-migrated
+-- databases had these views created with an *explicit* column list that aliased
+-- the timestamps back (`valid_from as first_seen_at`, `valid_until as
+-- last_seen_at`), so the rename never reached the view output: the base tables
+-- moved to valid_from/valid_until while the views kept exposing
+-- first_seen_at/last_seen_at. Any query selecting valid_from *from a view* (e.g.
+-- the corpses page) then hit an unknown column, which PostgREST surfaces as an
+-- error the caller reads as an empty result.
+--
+-- Recreate each view as the plain `select *` schema.sql already defines, closing
+-- the drift so the views expose valid_from/valid_until directly. The views stay
+-- security_invoker so RLS is still evaluated as the querying role against the
+-- underlying *_over_time table. No object depends on these views (the asset-walk
+-- SQL functions reference them by name but hold no catalog dependency), so a
+-- drop/recreate is safe. SELECT is re-granted explicitly to preserve read access
+-- for every role (drop clears the view's grants); row visibility is still gated
+-- by the base tables' RLS.
+
+drop view if exists public.character_asset;
+create view public.character_asset with (security_invoker = on) as
+  select * from public.character_asset_over_time where is_current;
+grant select on public.character_asset to anon, authenticated, service_role;
+
+drop view if exists public.character_blueprint;
+create view public.character_blueprint with (security_invoker = on) as
+  select * from public.character_blueprint_over_time where is_current;
+grant select on public.character_blueprint to anon, authenticated, service_role;
+
+drop view if exists public.character_order;
+create view public.character_order with (security_invoker = on) as
+  select * from public.character_order_over_time where is_current;
+grant select on public.character_order to anon, authenticated, service_role;
+
+drop view if exists public.character_industry_job;
+create view public.character_industry_job with (security_invoker = on) as
+  select * from public.character_industry_job_over_time where is_current;
+grant select on public.character_industry_job to anon, authenticated, service_role;
+
+drop view if exists public.character_clone;
+create view public.character_clone with (security_invoker = on) as
+  select * from public.character_clone_over_time where is_current;
+grant select on public.character_clone to anon, authenticated, service_role;
+
+drop view if exists public.character_ship;
+create view public.character_ship with (security_invoker = on) as
+  select * from public.character_ship_over_time where is_current;
+grant select on public.character_ship to anon, authenticated, service_role;
+
+drop view if exists public.corp_asset;
+create view public.corp_asset with (security_invoker = on) as
+  select * from public.corp_asset_over_time where is_current;
+grant select on public.corp_asset to anon, authenticated, service_role;
+
+drop view if exists public.corp_blueprint;
+create view public.corp_blueprint with (security_invoker = on) as
+  select * from public.corp_blueprint_over_time where is_current;
+grant select on public.corp_blueprint to anon, authenticated, service_role;
+
+drop view if exists public.corp_industry_job;
+create view public.corp_industry_job with (security_invoker = on) as
+  select * from public.corp_industry_job_over_time where is_current;
+grant select on public.corp_industry_job to anon, authenticated, service_role;


### PR DESCRIPTION
## Background

This is the proper follow-up to the corpses-page-empty fix (#598), which was a stopgap that queried `first_seen_at`. The design we want:

- **View = current state** (`select * ... where is_current`) — normal UI reads.
- **`_over_time` table = temporal** — API routes time-travel with `valid_from`/`valid_until` (as `character_asset_snapshot_at(ids, as_of)` already does).

So `valid_from`/`valid_until` are the intended column names, and the views should expose them via `select *`.

## Root cause

Migration `20260713150000_rename_scd_validity_columns.sql` renamed the `*_over_time` validity columns `first_seen_at → valid_from` / `last_seen_at → valid_until`, and assumed *"views are select \* and update automatically."* That holds for a fresh `schema.sql` reset (every SCD view there is `select *`), but the incrementally-migrated production database had these views created with an **explicit column list that aliased the timestamps back** (`valid_from as first_seen_at`). So the rename reached the base tables but never the view output: base tables moved to `valid_from`, views kept exposing `first_seen_at`.

Selecting `valid_from` from a view then hit an unknown column, which PostgREST returns as an error the caller reads as an empty result — the corpses page rendered "No corpses in this collection" despite 308 rows in the DB. All nine SCD views drifted identically; the corpses page was just the only reader of a validity column from a view.

## Changes

- **`supabase/migrations/20260714000000_recreate_scd_views_select_star.sql`** — recreate all nine SCD current-snapshot views (`character_asset`, `character_blueprint`, `character_order`, `character_industry_job`, `character_clone`, `character_ship`, `corp_asset`, `corp_blueprint`, `corp_industry_job`) as the plain `select * ... where is_current` that `schema.sql` already defines, closing the drift so they expose `valid_from`/`valid_until`. Views stay `security_invoker`; `SELECT` is re-granted to `anon`/`authenticated`/`service_role` (a drop clears grants), with row visibility still gated by the base tables' RLS.
- **`src/app/corpses/[characterID]/page.tsx`** — switch the corpse query back to `valid_from`.

`schema.sql` already matches this state, so it needs no change — this migration only realigns already-migrated databases.

## Verification

- Ran the full migration on production inside a transaction and rolled it back: the recreated `character_asset` view exposed `valid_from` and returned all **308** corpses, then rolled back leaving prod unchanged (confirmed the view still aliases `first_seen_at` afterward).
- Confirmed no view/matview/rule depends on the nine views, so drop/recreate is safe (the asset-walk SQL functions reference them by name but hold no catalog dependency).
- `eslint` passes on the changed page.

The `Migrate` workflow applies the migration on merge to `main`; Vercel redeploys the `valid_from` code from the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DubLumFoEzzvzaNStE5msa)_