### PR TITLE
Let IMPORTDATA endpoints reorder/subset columns via ?columns=

### DIFF
--- a/src/app/api/character/assets/route.ts
+++ b/src/app/api/character/assets/route.ts
@@ -2,7 +2,22 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { resolvePlayer } from '@/utils/apiToken'
 import { AT_PARAM_ERROR, parseAtParam } from '@/utils/atParam'
+import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
 import { toCsv } from '@/utils/csv'
+
+// Default column set/order, matching character_asset_snapshot_at()'s
+// json_build_object in schema.sql. ?columns= can reorder/subset these.
+const ALLOWED_COLUMNS = [
+  'is_blueprint_copy',
+  'is_singleton',
+  'item_id',
+  'location_flag',
+  'location_id',
+  'location_type',
+  'quantity',
+  'type_id',
+  'character_name',
+] as const
 
 // Public CSV endpoint for Google Sheets =IMPORTDATA(): the player's raw asset
 // rows (one per item stack) with the owning character's name, as of an optional
@@ -25,6 +40,11 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
   }
   const atIso = at.iso
 
+  const columnsResult = parseColumnsParam(searchParams.get('columns'), ALLOWED_COLUMNS)
+  if (!columnsResult.ok) {
+    return NextResponse.json({ error: columnsResult.error }, { status: 400 })
+  }
+
   const player = await resolvePlayer(searchParams.get('token')?.trim())
   if (!player.ok) {
     return NextResponse.json({ error: player.error }, { status: player.status })
@@ -42,7 +62,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
 
-  return new NextResponse(toCsv(rows ?? []), {
+  return new NextResponse(toCsv(selectColumns(rows ?? [], columnsResult.columns)), {
     headers: { 'Content-Type': 'text/csv; charset=utf-8' },
   })
 }

--- a/src/app/api/character/blueprints/route.ts
+++ b/src/app/api/character/blueprints/route.ts
@@ -1,7 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { resolvePlayer } from '@/utils/apiToken'
+import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
 import { toCsv } from '@/utils/csv'
+
+// Default column set/order, matching character_blueprints()'s json_build_object
+// in schema.sql. ?columns= can reorder/subset these.
+const ALLOWED_COLUMNS = [
+  'item_id',
+  'location_flag',
+  'location_id',
+  'material_efficiency',
+  'quantity',
+  'runs',
+  'time_efficiency',
+  'type_id',
+  'character_name',
+] as const
 
 // Public CSV endpoint for Google Sheets =IMPORTDATA(): the player's current
 // blueprint rows (one per blueprint stack) across all of their characters,
@@ -13,6 +28,11 @@ export const maxDuration = 60
 
 export const GET = async (request: NextRequest): Promise<NextResponse> => {
   const { searchParams } = new URL(request.url)
+
+  const columnsResult = parseColumnsParam(searchParams.get('columns'), ALLOWED_COLUMNS)
+  if (!columnsResult.ok) {
+    return NextResponse.json({ error: columnsResult.error }, { status: 400 })
+  }
 
   const player = await resolvePlayer(searchParams.get('token')?.trim())
   if (!player.ok) {
@@ -29,7 +49,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
 
-  return new NextResponse(toCsv(rows ?? []), {
+  return new NextResponse(toCsv(selectColumns(rows ?? [], columnsResult.columns)), {
     headers: { 'Content-Type': 'text/csv; charset=utf-8' },
   })
 }

--- a/src/app/api/character/jobs/route.ts
+++ b/src/app/api/character/jobs/route.ts
@@ -2,7 +2,36 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { resolvePlayer } from '@/utils/apiToken'
 import { AT_PARAM_ERROR, parseAtParam } from '@/utils/atParam'
+import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
 import { toCsv } from '@/utils/csv'
+
+// Default column set/order, matching character_industry_jobs()'s
+// json_build_object in schema.sql. ?columns= can reorder/subset these.
+const ALLOWED_COLUMNS = [
+  'activity_id',
+  'blueprint_id',
+  'blueprint_location_id',
+  'blueprint_type_id',
+  'completed_character_id',
+  'completed_date',
+  'cost',
+  'duration',
+  'end_date',
+  'facility_id',
+  'installer_id',
+  'job_id',
+  'licensed_runs',
+  'output_location_id',
+  'pause_date',
+  'probability',
+  'product_type_id',
+  'runs',
+  'start_date',
+  'station_id',
+  'status',
+  'successful_runs',
+  'character_name',
+] as const
 
 // Public CSV endpoint for Google Sheets =IMPORTDATA(): the player's industry jobs
 // across all of their characters, with the owning character's name, as of an
@@ -21,6 +50,11 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
   const at = parseAtParam(searchParams.get('at'))
   if (!at.ok) {
     return NextResponse.json({ error: AT_PARAM_ERROR }, { status: 400 })
+  }
+
+  const columnsResult = parseColumnsParam(searchParams.get('columns'), ALLOWED_COLUMNS)
+  if (!columnsResult.ok) {
+    return NextResponse.json({ error: columnsResult.error }, { status: 400 })
   }
 
   const player = await resolvePlayer(searchParams.get('token')?.trim())
@@ -45,7 +79,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
 
-  return new NextResponse(toCsv(rows ?? []), {
+  return new NextResponse(toCsv(selectColumns(rows ?? [], columnsResult.columns)), {
     headers: { 'Content-Type': 'text/csv; charset=utf-8' },
   })
 }

--- a/src/app/api/character/orders/route.ts
+++ b/src/app/api/character/orders/route.ts
@@ -2,7 +2,28 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { resolvePlayer } from '@/utils/apiToken'
 import { AT_PARAM_ERROR, parseAtParam } from '@/utils/atParam'
+import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
 import { toCsv } from '@/utils/csv'
+
+// Default column set/order, matching character_orders()'s json_build_object
+// in schema.sql. ?columns= can reorder/subset these.
+const ALLOWED_COLUMNS = [
+  'duration',
+  'escrow',
+  'is_buy_order',
+  'is_corporation',
+  'issued',
+  'location_id',
+  'min_volume',
+  'order_id',
+  'price',
+  'range',
+  'region_id',
+  'type_id',
+  'volume_remain',
+  'volume_total',
+  'character_name',
+] as const
 
 // Public CSV endpoint for Google Sheets =IMPORTDATA(): the player's open market
 // orders across all of their characters, with the owning character's name, as of
@@ -23,6 +44,11 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
     return NextResponse.json({ error: AT_PARAM_ERROR }, { status: 400 })
   }
 
+  const columnsResult = parseColumnsParam(searchParams.get('columns'), ALLOWED_COLUMNS)
+  if (!columnsResult.ok) {
+    return NextResponse.json({ error: columnsResult.error }, { status: 400 })
+  }
+
   const player = await resolvePlayer(searchParams.get('token')?.trim())
   if (!player.ok) {
     return NextResponse.json({ error: player.error }, { status: player.status })
@@ -38,7 +64,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
 
-  return new NextResponse(toCsv(rows ?? []), {
+  return new NextResponse(toCsv(selectColumns(rows ?? [], columnsResult.columns)), {
     headers: { 'Content-Type': 'text/csv; charset=utf-8' },
   })
 }

--- a/src/app/api/corp/assets/route.ts
+++ b/src/app/api/corp/assets/route.ts
@@ -1,7 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { resolvePlayer } from '@/utils/apiToken'
+import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
 import { toCsv } from '@/utils/csv'
+
+// Default column set/order, matching corp_assets()'s json_build_object in
+// schema.sql. ?columns= can reorder/subset these.
+const ALLOWED_COLUMNS = [
+  'item_id',
+  'corporation_id',
+  'type_id',
+  'location_id',
+  'location_flag',
+  'location_type',
+  'quantity',
+  'is_singleton',
+  'is_blueprint_copy',
+] as const
 
 // Public CSV endpoint for Google Sheets =IMPORTDATA(): the current live asset
 // rows (one per item stack) for the corporation(s) the caller's characters
@@ -14,6 +29,11 @@ export const maxDuration = 60
 
 export const GET = async (request: NextRequest): Promise<NextResponse> => {
   const { searchParams } = new URL(request.url)
+
+  const columnsResult = parseColumnsParam(searchParams.get('columns'), ALLOWED_COLUMNS)
+  if (!columnsResult.ok) {
+    return NextResponse.json({ error: columnsResult.error }, { status: 400 })
+  }
 
   const player = await resolvePlayer(searchParams.get('token')?.trim())
   if (!player.ok) {
@@ -29,7 +49,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
 
-  return new NextResponse(toCsv(rows ?? []), {
+  return new NextResponse(toCsv(selectColumns(rows ?? [], columnsResult.columns)), {
     headers: { 'Content-Type': 'text/csv; charset=utf-8' },
   })
 }

--- a/src/app/api/corp/blueprints/route.ts
+++ b/src/app/api/corp/blueprints/route.ts
@@ -1,7 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { resolvePlayer } from '@/utils/apiToken'
+import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
 import { toCsv } from '@/utils/csv'
+
+// Default column set/order, matching corp_blueprints()'s json_build_object in
+// schema.sql. ?columns= can reorder/subset these.
+const ALLOWED_COLUMNS = [
+  'item_id',
+  'corporation_id',
+  'location_flag',
+  'location_id',
+  'material_efficiency',
+  'quantity',
+  'runs',
+  'time_efficiency',
+  'type_id',
+] as const
 
 // Public CSV endpoint for Google Sheets =IMPORTDATA(): the current live
 // blueprint rows (one per blueprint stack) for the corporation(s) the
@@ -13,6 +28,11 @@ export const maxDuration = 60
 
 export const GET = async (request: NextRequest): Promise<NextResponse> => {
   const { searchParams } = new URL(request.url)
+
+  const columnsResult = parseColumnsParam(searchParams.get('columns'), ALLOWED_COLUMNS)
+  if (!columnsResult.ok) {
+    return NextResponse.json({ error: columnsResult.error }, { status: 400 })
+  }
 
   const player = await resolvePlayer(searchParams.get('token')?.trim())
   if (!player.ok) {
@@ -29,7 +49,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
 
-  return new NextResponse(toCsv(rows ?? []), {
+  return new NextResponse(toCsv(selectColumns(rows ?? [], columnsResult.columns)), {
     headers: { 'Content-Type': 'text/csv; charset=utf-8' },
   })
 }

--- a/src/app/api/corp/jobs/route.ts
+++ b/src/app/api/corp/jobs/route.ts
@@ -2,7 +2,36 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { resolvePlayer } from '@/utils/apiToken'
 import { AT_PARAM_ERROR, parseAtParam } from '@/utils/atParam'
+import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
 import { toCsv } from '@/utils/csv'
+
+// Default column set/order, matching corp_industry_jobs()'s json_build_object
+// in schema.sql. ?columns= can reorder/subset these.
+const ALLOWED_COLUMNS = [
+  'activity_id',
+  'blueprint_id',
+  'blueprint_location_id',
+  'blueprint_type_id',
+  'completed_character_id',
+  'completed_date',
+  'corporation_id',
+  'cost',
+  'duration',
+  'end_date',
+  'facility_id',
+  'installer_id',
+  'job_id',
+  'licensed_runs',
+  'output_location_id',
+  'pause_date',
+  'probability',
+  'product_type_id',
+  'runs',
+  'start_date',
+  'station_id',
+  'status',
+  'successful_runs',
+] as const
 
 // Public CSV endpoint for Google Sheets =IMPORTDATA(): industry jobs for the
 // corporation(s) the caller's characters belong to, as of an optional `at`
@@ -21,6 +50,11 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
   const at = parseAtParam(searchParams.get('at'))
   if (!at.ok) {
     return NextResponse.json({ error: AT_PARAM_ERROR }, { status: 400 })
+  }
+
+  const columnsResult = parseColumnsParam(searchParams.get('columns'), ALLOWED_COLUMNS)
+  if (!columnsResult.ok) {
+    return NextResponse.json({ error: columnsResult.error }, { status: 400 })
   }
 
   const player = await resolvePlayer(searchParams.get('token')?.trim())
@@ -45,7 +79,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
 
-  return new NextResponse(toCsv(rows ?? []), {
+  return new NextResponse(toCsv(selectColumns(rows ?? [], columnsResult.columns)), {
     headers: { 'Content-Type': 'text/csv; charset=utf-8' },
   })
 }

--- a/src/utils/columnsParam.ts
+++ b/src/utils/columnsParam.ts
@@ -1,0 +1,42 @@
+// Shared parsing for the `columns` query param on the IMPORTDATA endpoints
+// (/api/character/*, /api/corp/*): lets a caller reorder/subset the columns a
+// endpoint returns, e.g. ?columns=type_id,quantity. A missing/empty value
+// defaults to the endpoint's normal column set and order, unchanged.
+
+// Parse an optional `columns` query param against an endpoint's own allowed
+// column list. A missing/empty value returns `{ columns: null }`, meaning "use
+// the default". Returns `{ ok: false }` with a message naming the unknown
+// column(s) so the route can answer 400.
+export const parseColumnsParam = (
+  raw: string | null | undefined,
+  allowed: readonly string[]
+): { ok: true; columns: string[] | null } | { ok: false; error: string } => {
+  const trimmed = raw?.trim()
+  if (!trimmed) return { ok: true, columns: null }
+
+  const requested = trimmed
+    .split(',')
+    .map((c) => c.trim())
+    .filter(Boolean)
+  const allowedSet = new Set<string>(allowed)
+  const unknown = requested.filter((c) => !allowedSet.has(c))
+  if (unknown.length > 0) {
+    return {
+      ok: false,
+      error: `Unknown column(s): ${unknown.join(', ')}. Valid columns: ${allowed.join(', ')}`,
+    }
+  }
+
+  return { ok: true, columns: requested }
+}
+
+// Reorders/subsets each row to just `columns`, in that order. `columns: null`
+// (no override requested) returns rows unchanged, preserving the endpoint's
+// default json_build_object key order.
+export const selectColumns = (
+  rows: Record<string, unknown>[],
+  columns: string[] | null
+): Record<string, unknown>[] => {
+  if (columns === null) return rows
+  return rows.map((row) => Object.fromEntries(columns.map((c) => [c, row[c]])))
+}


### PR DESCRIPTION
## Summary
- Adds an optional `columns` query param to all `/api/character/*` and `/api/corp/*` IMPORTDATA CSV endpoints (assets, blueprints, orders, jobs), letting a Sheets formula reorder/subset returned columns, e.g. `?columns=type_id,quantity,location_id`.
- No `columns` param preserves each endpoint's existing default column set/order — fully backward compatible with existing IMPORTDATA formulas.
- An unrecognized column name responds `400` naming the bad column(s) and listing the valid ones for that endpoint.
- New shared `src/utils/columnsParam.ts` (`parseColumnsParam` / `selectColumns`), mirroring the existing `atParam.ts` convention used by the same routes.
- No SQL/schema changes — reordering happens in JS after Postgres returns its normal default-ordered json.

## Test plan
- [ ] `pnpm run lint` passes
- [ ] `pnpm run build` succeeds
- [ ] Manually hit `/api/character/assets?token=...` with and without `?columns=` to confirm default behavior is unchanged and the override reorders/subsets as expected
- [ ] Confirm an invalid `columns` value returns 400 with a helpful message

🤖 Generated with [Claude Code](https://claude.com/claude-code)