### PR TITLE
Add admin impersonation on /account/debug

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -97,6 +97,7 @@ drop table if exists public.refresh_task         cascade;
 drop table if exists public.shared_asset_token   cascade;
 drop table if exists public.heartbeat            cascade;
 drop table if exists public.esi_etag             cascade;
+drop table if exists public.impersonation_log    cascade;
 drop table if exists public.token                cascade;
 drop table if exists public.registration         cascade;
 
@@ -593,6 +594,23 @@ create table public.esi_etag (
 
 alter table public.esi_etag enable row level security;
 grant all on public.esi_etag to service_role;
+
+-- ── impersonation_log ──────────────────────────────────────────────────────
+-- Admin-impersonation audit trail: one row per magic-link impersonation session
+-- minted via /account/debug (see src/app/account/debug/impersonate.ts).
+-- Internal-only, service-role bookkeeping — RLS is on with no policy, mirroring
+-- esi_etag, so neither the admin nor the impersonated user can read it through
+-- the API.
+create table public.impersonation_log (
+  id uuid primary key default gen_random_uuid(),
+  admin_user_id uuid not null references auth.users(id) on delete cascade,
+  target_user_id uuid not null references auth.users(id) on delete cascade,
+  created_at timestamptz not null default now()
+);
+create index impersonation_log_target_user_id_idx on public.impersonation_log (target_user_id);
+
+alter table public.impersonation_log enable row level security;
+grant all on public.impersonation_log to service_role;
 
 -- The most recent completed heartbeat per job per owner (character, corp, or
 -- whole-job), driving the freshness dots on /character/refresh. DISTINCT ON

--- a/src/app/account/debug/adminUserId.ts
+++ b/src/app/account/debug/adminUserId.ts
@@ -1,0 +1,7 @@
+// One hardcoded operator account may impersonate any other account from
+// /account/debug, for support/debugging. No wider admin-role system exists in
+// this app yet; this exists to unblock debugging a specific report without
+// inventing one. Split into its own module because a 'use server' file may
+// only export async functions — a plain constant export there breaks the
+// build ("module has no exports at all").
+export const ADMIN_USER_ID = '167fa36d-5fb1-4bf0-bdc3-847818971649'

--- a/src/app/account/debug/impersonate.ts
+++ b/src/app/account/debug/impersonate.ts
@@ -1,0 +1,53 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+
+import { createClient } from '@/utils/supabase/server'
+import { createServiceClient } from '@/utils/supabase/service'
+
+// One hardcoded operator account may impersonate any other account from
+// /account/debug, for support/debugging. Gated here — not just by hiding the
+// form on the page — since a server action is reachable independent of what
+// rendered it. No wider admin-role system exists in this app yet; this exists
+// to unblock debugging a specific report without inventing one.
+export const ADMIN_USER_ID = '167fa36d-5fb1-4bf0-bdc3-847818971649'
+
+// Swap the caller's own session for a real session as another account, via a
+// server-minted magic link: generateLink() (service role) issues a token
+// without emailing anything, and verifyOtp() redeems it on the cookie-bound
+// client, which writes the resulting session straight into httpOnly cookies —
+// nothing session-related ever reaches client-side JS. The admin's own session
+// is gone once this succeeds; sign back in as the admin to return.
+export const impersonate = async (formData: FormData): Promise<{ error: string } | undefined> => {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (user?.id !== ADMIN_USER_ID) return { error: 'Not authorized.' }
+
+  const targetUserId = `${formData.get('userId') ?? ''}`.trim()
+  if (!targetUserId) return { error: 'Enter a user ID.' }
+
+  const service = createServiceClient()
+
+  const { data: target, error: lookupError } = await service.auth.admin.getUserById(targetUserId)
+  if (lookupError || !target?.user?.email) return { error: 'No user with that ID.' }
+
+  const { data: link, error: linkError } = await service.auth.admin.generateLink({
+    type: 'magiclink',
+    email: target.user.email,
+  })
+  if (linkError || !link?.properties?.hashed_token) return { error: linkError?.message ?? 'Could not mint a link.' }
+
+  const { error: verifyError } = await supabase.auth.verifyOtp({
+    token_hash: link.properties.hashed_token,
+    type: 'email',
+  })
+  if (verifyError) return { error: verifyError.message }
+
+  // Best-effort audit trail — the impersonation has already happened by this
+  // point, so a logging failure shouldn't block the redirect.
+  await service.from('impersonation_log').insert({ admin_user_id: user.id, target_user_id: targetUserId })
+
+  redirect('/')
+}

--- a/src/app/account/debug/impersonate.ts
+++ b/src/app/account/debug/impersonate.ts
@@ -4,20 +4,16 @@ import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
 import { createServiceClient } from '@/utils/supabase/service'
-
-// One hardcoded operator account may impersonate any other account from
-// /account/debug, for support/debugging. Gated here — not just by hiding the
-// form on the page — since a server action is reachable independent of what
-// rendered it. No wider admin-role system exists in this app yet; this exists
-// to unblock debugging a specific report without inventing one.
-export const ADMIN_USER_ID = '167fa36d-5fb1-4bf0-bdc3-847818971649'
+import { ADMIN_USER_ID } from './adminUserId'
 
 // Swap the caller's own session for a real session as another account, via a
 // server-minted magic link: generateLink() (service role) issues a token
 // without emailing anything, and verifyOtp() redeems it on the cookie-bound
 // client, which writes the resulting session straight into httpOnly cookies —
 // nothing session-related ever reaches client-side JS. The admin's own session
-// is gone once this succeeds; sign back in as the admin to return.
+// is gone once this succeeds; sign back in as the admin to return. Re-checks
+// the caller here — not just by hiding the form on the page — since a server
+// action is reachable independent of what rendered it.
 export const impersonate = async (formData: FormData): Promise<{ error: string } | undefined> => {
   const supabase = await createClient()
   const {

--- a/src/app/account/debug/impersonateForm.tsx
+++ b/src/app/account/debug/impersonateForm.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { useState } from 'react'
+
+import Dot from '../settings/dot'
+import { impersonate } from './impersonate'
+
+// On success this navigates away (the server action redirects home with the
+// impersonated session), so the only outcome this form ever renders itself is
+// an error.
+const ImpersonateForm = () => {
+  const [error, setError] = useState('')
+
+  const submit = async (formData: FormData) => {
+    const result = await impersonate(formData)
+    setError(result?.error ?? '')
+  }
+
+  return (
+    <>
+      <form>
+        <label htmlFor="userId">User ID: </label>
+        <input id="userId" name="userId" type="text" required /> <button formAction={submit}>Impersonate</button>
+      </form>
+      <p>{error && <Dot color="#FF0000" response={error} />}</p>
+    </>
+  )
+}
+
+export default ImpersonateForm

--- a/src/app/account/debug/page.tsx
+++ b/src/app/account/debug/page.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
-import { ADMIN_USER_ID } from './impersonate'
+import { ADMIN_USER_ID } from './adminUserId'
 import ImpersonateForm from './impersonateForm'
 
 const DebugPage = async () => {

--- a/src/app/account/debug/page.tsx
+++ b/src/app/account/debug/page.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
+import { ADMIN_USER_ID } from './impersonate'
+import ImpersonateForm from './impersonateForm'
 
 const DebugPage = async () => {
   const supabase = await createClient()
@@ -35,6 +37,14 @@ const DebugPage = async () => {
       <h1>Debug</h1>
 
       <pre>{JSON.stringify(debugInfo, null, 2)}</pre>
+
+      {data.user.id === ADMIN_USER_ID && (
+        <>
+          <h2>Impersonate</h2>
+          <p>Swaps this session for a real session as another account. Sign back in as yourself to return.</p>
+          <ImpersonateForm />
+        </>
+      )}
     </>
   )
 }

--- a/supabase/migrations/20260714010000_impersonation_log.sql
+++ b/supabase/migrations/20260714010000_impersonation_log.sql
@@ -1,0 +1,15 @@
+-- Admin-impersonation audit trail: one row per magic-link impersonation session
+-- minted via /account/debug (see src/app/account/debug/impersonate.ts).
+-- Internal-only, service-role bookkeeping — RLS is on with no policy, mirroring
+-- esi_etag, so neither the admin nor the impersonated user can read it through
+-- the API.
+create table public.impersonation_log (
+  id uuid primary key default gen_random_uuid(),
+  admin_user_id uuid not null references auth.users(id) on delete cascade,
+  target_user_id uuid not null references auth.users(id) on delete cascade,
+  created_at timestamptz not null default now()
+);
+create index impersonation_log_target_user_id_idx on public.impersonation_log (target_user_id);
+
+alter table public.impersonation_log enable row level security;
+grant all on public.impersonation_log to service_role;


### PR DESCRIPTION
## Summary

Adds an impersonation tool to `/account/debug`, visible only to one hardcoded operator account (`167fa36d-5fb1-4bf0-bdc3-847818971649`). It lets that account swap its own session for a real session as any other account by user ID — for support/debugging.

## How it works

1. `impersonate()` (server action, `src/app/account/debug/impersonate.ts`) re-checks the caller is the operator account — the page-level conditional render is not itself a security boundary, since server actions are reachable independent of what rendered them.
2. Resolves the target's email via `service.auth.admin.getUserById(targetUserId)`.
3. Mints a magic-link token server-side via `service.auth.admin.generateLink({ type: 'magiclink', email })` — no email is sent.
4. Redeems the `hashed_token` via `supabase.auth.verifyOtp({ token_hash, type: 'email' })` on the **cookie-bound** server client (`@/utils/supabase/server`, the same client `login`/`account/confirm` already use). This writes the resulting session straight into httpOnly cookies and replaces the operator's own session — nothing session-related (tokens, hashed_token) ever reaches client-side JS, which is stricter than passing a session object to the frontend.
5. On success, logs `{ admin_user_id, target_user_id }` to a new `impersonation_log` table (best-effort — a logging failure doesn't block the redirect) and redirects home as the impersonated user.

Sign back in as the operator account normally to return.

## Changes

- **`src/app/account/debug/impersonate.ts`** — the server action + the hardcoded `ADMIN_USER_ID` gate.
- **`src/app/account/debug/impersonateForm.tsx`** — the text box + submit form, rendered only for the operator account.
- **`src/app/account/debug/page.tsx`** — renders the form when `data.user.id === ADMIN_USER_ID`.
- **`schema.sql` + `supabase/migrations/20260714010000_impersonation_log.sql`** — new `impersonation_log` table: `admin_user_id`, `target_user_id`, `created_at`. RLS on, no policy (mirrors `esi_etag`) — only the service-role client used by the action can read/write it; the Migrate workflow applies it on merge.

## Verification

- Dry-ran the exact migration DDL against production inside a rolled-back transaction: table/index/grant created cleanly, and a `set local role authenticated` read of the fresh row returned 0 rows, confirming RLS blocks non-service-role access as intended.
- `eslint .` and `tsc --noEmit` are clean (one pre-existing, unrelated `workflow/api` module error reproduces identically on a stashed clean `main`, so it isn't from this change).
- `prettier --check` passes on the changed TS/TSX files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DubLumFoEzzvzaNStE5msa)_