### PR TITLE
Merc dens: copy-to-Discord button beside the reinforcement timer

### DIFF
--- a/src/app/mercenary-dens/copyDiscordPing.tsx
+++ b/src/app/mercenary-dens/copyDiscordPing.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useRef, useState } from 'react'
+
+import styles from './mercenaryDens.module.css'
+
+// Small clipboard button next to a reinforced den's timer. Copies a
+// Discord-ready ping, e.g.
+//   Mercenary Den Reinforced - `JVA-FE` planet `II` at <t:1784057275:s> @ <t:1784057275:R>
+// where <t:…:s> renders in Discord as the viewer's local wall-clock time and
+// <t:…:R> as a live relative countdown ("in 26 hours"). Flashes a ✓ on success.
+const CopyDiscordPing = ({
+  system,
+  planet,
+  reinforcementEnd,
+}: {
+  system: string
+  planet: string
+  reinforcementEnd: string
+}) => {
+  const [copied, setCopied] = useState(false)
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const onClick = async () => {
+    const unix = Math.floor(new Date(reinforcementEnd).getTime() / 1000)
+    const text = `Mercenary Den Reinforced - \`${system}\` planet \`${planet}\` at <t:${unix}:s> @ <t:${unix}:R>`
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      if (resetTimer.current) clearTimeout(resetTimer.current)
+      resetTimer.current = setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard access can be denied (permissions, insecure context) — this
+      // is a convenience button, so fail silently rather than alerting.
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      className={styles.copyButton}
+      onClick={onClick}
+      title="Copy Discord ping"
+      aria-label="Copy Discord ping for this reinforcement timer"
+    >
+      {copied ? '✓' : '📋'}
+    </button>
+  )
+}
+
+export default CopyDiscordPing

--- a/src/app/mercenary-dens/mercenaryDens.module.css
+++ b/src/app/mercenary-dens/mercenaryDens.module.css
@@ -162,6 +162,22 @@
   font-size: 9pt;
 }
 
+/* Tiny inline clipboard button beside a reinforcement timer. */
+.copyButton {
+  border: none;
+  background: none;
+  padding: 0 2pt;
+  margin-left: 4pt;
+  font-size: 9pt;
+  line-height: 1;
+  cursor: pointer;
+  vertical-align: middle;
+}
+
+.copyButton:hover {
+  opacity: 0.7;
+}
+
 /* Row + node status colours (shared scheme): red = reinforced, green = our/corp
  * den, yellow = a den owned outside our corps (from intel). Rows get a faint
  * left border + tint; nodes fill the pill. */

--- a/src/app/mercenary-dens/page.tsx
+++ b/src/app/mercenary-dens/page.tsx
@@ -6,6 +6,7 @@ import { getSdeTypeNames } from '@/sdeTypes'
 import { createClient } from '@/utils/supabase/server'
 
 import { fetchOwners } from '../owners'
+import CopyDiscordPing from './copyDiscordPing'
 import { STAGING, TEMPERATE_PLANETS } from './data'
 import { formatDuration, formatUtc } from './duration'
 import ShareCorps from './shareCorps'
@@ -213,7 +214,14 @@ const MercenaryDensPage = async () => {
                             : ''}
                         </span>
                         {den?.reinforcement_end ? (
-                          <span className={styles.timestamp}> {formatUtc(den.reinforcement_end)}</span>
+                          <>
+                            <span className={styles.timestamp}> {formatUtc(den.reinforcement_end)}</span>
+                            <CopyDiscordPing
+                              system={row.system}
+                              planet={row.planet}
+                              reinforcementEnd={den.reinforcement_end}
+                            />
+                          </>
                         ) : null}
                       </>
                     ) : den || row.intel ? (


### PR DESCRIPTION
## Summary

A small clipboard button (📋) to the right of a reinforced den's timer on `/mercenary-dens`. Clicking it copies a Discord-ready ping:

```
Mercenary Den Reinforced - `JVA-FE` planet `II` at <t:1784057275:s> @ <t:1784057275:R>
```

The unix stamp is the den's `reinforcement_end`; in Discord `<t:…:s>` renders as the viewer's local wall-clock time and `<t:…:R>` as a live relative countdown ("in 26 hours").

## Details

- **`copyDiscordPing.tsx`** (new client component) — builds the message from system, planet roman, and `reinforcement_end`; copies via `navigator.clipboard.writeText`; flashes ✓ for 2s on success. Clipboard failures (permissions, insecure context) stay silent — it's a convenience control.
- **`page.tsx`** — renders the button after the countdown + UTC stamp, only when the row is reinforced **and** carries an ESI `reinforcement_end` (intel-only reinforced rows have no timestamp to stamp, so no button).
- **`mercenaryDens.module.css`** — tiny borderless inline button style.

## Verification

- Confirmed the generated message reproduces the example exactly: `2026-07-14T19:27:55Z` → `1784057275` → ``Mercenary Den Reinforced - `JVA-FE` planet `II` at <t:1784057275:s> @ <t:1784057275:R>``.
- `pnpm run lint` clean; `pnpm exec tsc --noEmit` 0 errors repo-wide.
- Clipboard interaction itself needs a browser click — worth one tap on the Vercel preview with a reinforced den.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL1hvtH4F7QduankaQPoxz

---
_Generated by [Claude Code](https://claude.ai/code/session_01PL1hvtH4F7QduankaQPoxz)_