### PR TITLE
Gate impersonation on /account/debug by Chancellor status

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -596,14 +596,14 @@ alter table public.esi_etag enable row level security;
 grant all on public.esi_etag to service_role;
 
 -- ── impersonation_log ──────────────────────────────────────────────────────
--- Admin-impersonation audit trail: one row per magic-link impersonation session
--- minted via /account/debug (see src/app/account/debug/impersonate.ts).
+-- Chancellor-impersonation audit trail: one row per magic-link impersonation
+-- session minted via /account/debug (see src/app/account/debug/impersonate.ts).
 -- Internal-only, service-role bookkeeping — RLS is on with no policy, mirroring
--- esi_etag, so neither the admin nor the impersonated user can read it through
--- the API.
+-- esi_etag, so neither the impersonating Chancellor nor the impersonated user
+-- can read it through the API.
 create table public.impersonation_log (
   id uuid primary key default gen_random_uuid(),
-  admin_user_id uuid not null references auth.users(id) on delete cascade,
+  chancellor_user_id uuid not null references auth.users(id) on delete cascade,
   target_user_id uuid not null references auth.users(id) on delete cascade,
   created_at timestamptz not null default now()
 );

--- a/src/app/account/debug/adminUserId.ts
+++ b/src/app/account/debug/adminUserId.ts
@@ -1,7 +1,0 @@
-// One hardcoded operator account may impersonate any other account from
-// /account/debug, for support/debugging. No wider admin-role system exists in
-// this app yet; this exists to unblock debugging a specific report without
-// inventing one. Split into its own module because a 'use server' file may
-// only export async functions — a plain constant export there breaks the
-// build ("module has no exports at all").
-export const ADMIN_USER_ID = '167fa36d-5fb1-4bf0-bdc3-847818971649'

--- a/src/app/account/debug/impersonate.ts
+++ b/src/app/account/debug/impersonate.ts
@@ -4,22 +4,22 @@ import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
 import { createServiceClient } from '@/utils/supabase/service'
-import { ADMIN_USER_ID } from './adminUserId'
+import { isChancellor } from '../chancellor/chancellor'
 
 // Swap the caller's own session for a real session as another account, via a
 // server-minted magic link: generateLink() (service role) issues a token
 // without emailing anything, and verifyOtp() redeems it on the cookie-bound
 // client, which writes the resulting session straight into httpOnly cookies —
-// nothing session-related ever reaches client-side JS. The admin's own session
-// is gone once this succeeds; sign back in as the admin to return. Re-checks
-// the caller here — not just by hiding the form on the page — since a server
-// action is reachable independent of what rendered it.
+// nothing session-related ever reaches client-side JS. The caller's own
+// session is gone once this succeeds; sign back in normally to return.
+// Re-checks Chancellor status here — not just by hiding the form on the page
+// — since a server action is reachable independent of what rendered it.
 export const impersonate = async (formData: FormData): Promise<{ error: string } | undefined> => {
   const supabase = await createClient()
   const {
     data: { user },
   } = await supabase.auth.getUser()
-  if (user?.id !== ADMIN_USER_ID) return { error: 'Not authorized.' }
+  if (!user?.id || !(await isChancellor(user.id))) return { error: 'Not authorized.' }
 
   const targetUserId = `${formData.get('userId') ?? ''}`.trim()
   if (!targetUserId) return { error: 'Enter a user ID.' }
@@ -43,7 +43,7 @@ export const impersonate = async (formData: FormData): Promise<{ error: string }
 
   // Best-effort audit trail — the impersonation has already happened by this
   // point, so a logging failure shouldn't block the redirect.
-  await service.from('impersonation_log').insert({ admin_user_id: user.id, target_user_id: targetUserId })
+  await service.from('impersonation_log').insert({ chancellor_user_id: user.id, target_user_id: targetUserId })
 
   redirect('/')
 }

--- a/src/app/account/debug/page.tsx
+++ b/src/app/account/debug/page.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
-import { ADMIN_USER_ID } from './adminUserId'
+import { isChancellor } from '../chancellor/chancellor'
 import ImpersonateForm from './impersonateForm'
 
 const DebugPage = async () => {
@@ -30,6 +30,8 @@ const DebugPage = async () => {
     settings_updated_at: settings?.updated_at ?? null,
   }
 
+  const chancellor = await isChancellor(data.user.id)
+
   return (
     <>
       <Link href="/account/settings">&laquo; Back to settings</Link>
@@ -38,7 +40,7 @@ const DebugPage = async () => {
 
       <pre>{JSON.stringify(debugInfo, null, 2)}</pre>
 
-      {data.user.id === ADMIN_USER_ID && (
+      {chancellor && (
         <>
           <h2>Impersonate</h2>
           <p>Swaps this session for a real session as another account. Sign back in as yourself to return.</p>

--- a/supabase/migrations/20260714020000_impersonation_log_chancellor_gate.sql
+++ b/supabase/migrations/20260714020000_impersonation_log_chancellor_gate.sql
@@ -1,0 +1,5 @@
+-- Impersonation on /account/debug is now gated by Chancellor status
+-- (isChancellor(), see src/app/account/debug/impersonate.ts) instead of one
+-- hardcoded account, so the audit column it writes to no longer means "the
+-- admin" specifically — rename it to say what it actually records.
+alter table public.impersonation_log rename column admin_user_id to chancellor_user_id;


### PR DESCRIPTION
## Summary

Follow-up to #604 (admin impersonation on `/account/debug`, merged): the gate was a single hardcoded account UID. This changes it to the existing Chancellor tier instead — any Chancellor can now impersonate any account, using the same `isChancellor()` gate `chancellor/actions.ts` and `character/refresh` already use.

## Changes

- **`src/app/account/debug/impersonate.ts`** — the server action re-checks `isChancellor(user.id)` instead of comparing against a hardcoded UID. This is the real security boundary (a server action is reachable independent of what rendered it).
- **`src/app/account/debug/page.tsx`** — the impersonation form now renders for any Chancellor (`await isChancellor(data.user.id)`), not just one account.
- **`src/app/account/debug/adminUserId.ts`** — deleted (no longer needed).
- **`impersonation_log.admin_user_id` → `chancellor_user_id`** — the audit column no longer means "the one admin," so it's renamed to say what it records now.

## Why a new migration instead of editing the old one

`20260714010000_impersonation_log.sql` (from #604) had almost certainly already been applied to production by the time this branch restarted (the Migrate workflow runs on every push to `main` touching `supabase/migrations/**`, and #604's merge did). Editing an already-applied migration's content in place wouldn't change the deployed schema — it would just make the repo's migration history lie about what's actually in the database, silently diverging an already-migrated database from `schema.sql`. That's the exact bug class the recent corpses-page fix (`first_seen_at`/`valid_from`) was about, so this PR doesn't repeat it: `20260714010000` is left exactly as originally applied (`admin_user_id`), and a new `20260714020000_impersonation_log_chancellor_gate.sql` does the rename. `schema.sql`, being a from-scratch reset, defines the column as `chancellor_user_id` directly — no rename step needed there.

## Verification

- `eslint .`, `tsc --noEmit`, and `prettier --check` on the changed files are all clean.
- Ran a real `next build` (not just eslint/tsc, which don't catch this) after removing `adminUserId.ts` — `/account/debug` and the rest of the app compile with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DubLumFoEzzvzaNStE5msa)_