### PR TITLE
Document the remaining SDE-to-database cutover work

### DIFF
--- a/docs/sde-db-cutover/00-drop-evesde-schema.md
+++ b/docs/sde-db-cutover/00-drop-evesde-schema.md
@@ -1,0 +1,51 @@
+# PR 0 (tiny): drop the legacy `evesde` schema
+
+**Check first whether this already happened** — look for an existing migration
+matching `supabase/migrations/*drop_evesde*` or ask the repo owner. If it's
+done, skip this document entirely.
+
+## Context
+
+A schema named `evesde` exists in the hosted Supabase database. It was loaded
+out-of-band years ago (a Fuzzwork-style SDE dump), has been stale ever since,
+and **nothing in this repo queries it** — CLAUDE.md has long marked it
+off-limits. The fresh SDE data now lives in the `public` schema's `sde_*`
+tables (nightly `sde-mirror` workflow), so the dead schema should be removed
+to avoid confusion. The repo owner explicitly requested this drop.
+
+## Changes
+
+1. New migration `supabase/migrations/<timestamp>_drop_evesde_schema.sql`
+   (pick a 14-digit UTC timestamp later than every existing migration):
+
+```sql
+-- Remove the legacy `evesde` schema. It was loaded out-of-band years ago (a
+-- Fuzzwork-style SDE dump), has been stale ever since, and nothing in this
+-- codebase queries it — CLAUDE.md has long marked it off-limits. The fresh
+-- SDE mirror lives in the `public` schema's `sde_*` tables (nightly
+-- sde-mirror workflow), so the dead schema goes to avoid any confusion
+-- between the two.
+--
+-- Destructive by design: the stale data has no consumers and no other source
+-- of truth to preserve.
+drop schema if exists evesde cascade;
+```
+
+2. `schema.sql` needs **no** change — it never contained `evesde`.
+
+3. `CLAUDE.md`: update the two rules that still tell agents to avoid a schema
+   that no longer exists (if PR 1 of this series — the loader cutover — has
+   already merged, these lines may already read differently; adapt):
+   - In **# Data sources**, replace the "NEVER query the `evesde` SDE schema…"
+     bullet with wording like: "The legacy `evesde` DB schema has been dropped
+     (stale out-of-band data) — do not recreate or reference it. SDE lookups go
+     through the `src/sde*.ts` loaders."
+   - In **# Architecture**, the bullet starting "Avoid using the `evesde`
+     schema…": remove the `evesde` references, keeping the rest of the bullet's
+     content (where type lookups come from) intact.
+
+## Done when
+
+- `pnpm run lint` passes (only markdown/SQL changed, but run it anyway).
+- The PR description states clearly that the migration is destructive to the
+  stale schema by design and was explicitly requested.

--- a/docs/sde-db-cutover/01-loader-cutover.md
+++ b/docs/sde-db-cutover/01-loader-cutover.md
@@ -1,0 +1,347 @@
+# PR 1 (large): cut the SDE loaders over to the database, stop downloading the SDE at build time
+
+## Goal
+
+After this PR, `pnpm run build` no longer downloads CCP's SDE for the app:
+
+- The five loader modules — `src/sdeTypes.ts`, `src/sdeSystems.ts`,
+  `src/sdeStations.ts`, `src/sdeBlueprints.ts`, `src/sdePlanets.ts` — stop
+  reading `src/generated/*.json` (`readFileSync`) and instead query the
+  `sde_*` views/RPCs in Supabase. Their exported function names stay the
+  same, but **every data function becomes `async`**.
+- Every consumer of those functions gains `await` (and, where a sync
+  predicate was used inside `.map()`, switches to a bulk-fetch-then-Set
+  pattern; details per file below).
+- `src/buildSde.js` is deleted; the `sde:build` script is removed;
+  `predev`/`prebuild` become `"pnpm run esf:build"` only.
+- `esf:build` / `src/buildEsfData.js` (ship-fitting protobufs) are **not
+  touched** — that's a separate, optional, later PR (doc 03).
+
+## Prerequisite
+
+The mirror must be populated: run
+`select count(*) from sde_types;` — expect tens of thousands of rows — and
+`select count(*) from sde_blueprint_product;` — expect thousands. If empty,
+kick the ingest first:
+`curl -H "Authorization: Bearer $CRON_SECRET" "https://<app>/api/cron/sde-mirror?force=1"`.
+
+## Step 1 — a dedicated Supabase client for SDE reads
+
+The SDE tables are public-read (see the README), so the loaders don't need
+the cookie-session client (`src/utils/supabase/server.ts`), the bearer client
+(MCP), or the service role. A plain anon client works identically from server
+components, route handlers, server actions, MCP tool handlers, and anonymous
+pages (`/corpses/[characterID]`), and avoids threading a client parameter
+through every loader signature.
+
+New file `src/utils/supabase/sde.ts`:
+
+```ts
+import { createClient, SupabaseClient } from '@supabase/supabase-js'
+
+// The SDE mirror tables (sde_*) are public-read static data — RLS grants
+// SELECT to anon — so one module-level anon client serves every context
+// (server components, route handlers, MCP tools, anonymous share pages)
+// without cookie or bearer plumbing. Never used for writes.
+let client: SupabaseClient | null = null
+
+export const sdeSupabase = (): SupabaseClient => {
+  if (client) return client
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? process.env.SUPABASE_KEY
+  if (!url || !key) throw new Error('sde: missing NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY')
+  client = createClient(url, key, { auth: { persistSession: false, autoRefreshToken: false } })
+  return client
+}
+```
+
+(Lazy so importing the module never throws at build time when env vars are
+absent — the same reason the queue consumer lazy-imports job modules.)
+
+## Step 2 — caching policy (applies to all five loaders)
+
+- SDE data changes at most once per game patch and the mirror refreshes
+  nightly, so a **module-level `Map` cache with a 6-hour TTL** on *by-id*
+  lookups is safe and keeps hot paths (type names render on every page) at
+  zero DB round-trips after warm-up.
+- **Cache only found rows. Never cache misses.** On a fresh deploy before the
+  first ingest the tables are empty; caching `null` for 6 hours would keep
+  names broken long after the ingest lands. A miss must re-query next call.
+- Searches (`sde_search_*` RPCs) and blueprint lookups are **not** cached —
+  they're user-action paths, not per-row render paths.
+- Suggested shared shape (put a tiny helper in each loader or a shared
+  `src/sdeCache.ts`; keep it simple):
+
+```ts
+const TTL_MS = 6 * 60 * 60 * 1000
+type Cached<T> = { value: T; at: number }
+// get: hit if (Date.now() - at) < TTL_MS
+```
+
+- Bulk lookups: PostgREST caps responses at 1000 rows (`max_rows`), so chunk
+  `.in('col', ids)` queries at **500 ids per request** (ramda `splitEvery`)
+  and merge. Filter the id list through the cache first so only unknown ids
+  hit the DB.
+
+## Step 3 — rewrite the loaders
+
+Keep each module's exported names and TypeScript shapes identical except
+where noted. Full template for `sdeTypes.ts` (the others follow the same
+pattern):
+
+```ts
+// DB-backed lookup over the nightly SDE mirror (sde_published_type view and
+// sde_search_type RPC — see supabase/migrations/20260716010000_sde_mirror.sql
+// and src/jobs/sdeMirror.js). Replaces the build-time generated JSON: data
+// now refreshes nightly without a rebuild. By-id lookups are cached per
+// server process for 6h; misses are never cached (a fresh DB before the
+// first ingest must not poison the cache).
+import { splitEvery } from 'ramda'
+
+import { sdeSupabase } from '@/utils/supabase/sde'
+
+export type SdeType = { typeID: number; name: string; groupID: number; categoryID: number | null }
+
+const TTL_MS = 6 * 60 * 60 * 1000
+const cache = new Map<number, { value: SdeType; at: number }>()
+
+const cached = (id: number): SdeType | null => {
+  const hit = cache.get(id)
+  if (hit && Date.now() - hit.at < TTL_MS) return hit.value
+  return null
+}
+
+const rowToType = (r: { type_id: number; name: string; group_id: number; category_id: number | null }): SdeType => ({
+  typeID: r.type_id,
+  name: r.name,
+  groupID: r.group_id,
+  categoryID: r.category_id,
+})
+
+// Bulk fetch: cache-filter, then chunked .in() queries (PostgREST caps
+// responses at 1000 rows; 500 keeps well clear).
+export const getSdeTypes = async (typeIDs: Iterable<number>): Promise<Record<number, SdeType>> => {
+  const result: Record<number, SdeType> = {}
+  const missing: number[] = []
+  for (const id of new Set(typeIDs)) {
+    const hit = cached(id)
+    if (hit) result[id] = hit
+    else missing.push(id)
+  }
+  for (const chunk of splitEvery(500, missing)) {
+    const { data, error } = await sdeSupabase()
+      .from('sde_published_type')
+      .select('type_id, name, group_id, category_id')
+      .in('type_id', chunk)
+    if (error) {
+      console.error(`[sdeTypes] lookup failed: ${error.message}`)
+      continue // degrade to raw-id fallbacks, don't take the page down
+    }
+    for (const r of data ?? []) {
+      const t = rowToType(r)
+      result[t.typeID] = t
+      cache.set(t.typeID, { value: t, at: Date.now() })
+    }
+  }
+  return result
+}
+
+export const getSdeType = async (typeID: number): Promise<SdeType | null> =>
+  (await getSdeTypes([typeID]))[typeID] ?? null
+
+export const getSdeTypeNames = async (typeIDs: Iterable<number>): Promise<Record<number, string>> => {
+  const types = await getSdeTypes(typeIDs)
+  return Object.fromEntries(Object.entries(types).map(([id, t]) => [id, t.name]))
+}
+
+export type SdeSearchResult = { typeID: number; name: string; coverage: number; categoryID: number | null }
+
+// Search via the sde_search_type RPC, which reproduces the old in-memory
+// ranking exactly (coverage desc, shorter name, then id) and now also returns
+// category_id so callers can filter without per-row getSdeType calls.
+// CHANGE from the JSON era: results cap at 1000 (PostgREST max_rows). Every
+// existing "too many results" guard triggers far below that — verify the
+// constant at the call site (src/app/asset/search/page.tsx) is < 1000.
+export const searchSdeTypesAll = async (query: string): Promise<SdeSearchResult[]> => {
+  if (query.trim() === '') return []
+  const { data, error } = await sdeSupabase().rpc('sde_search_type', { q: query, lim: 1000 })
+  if (error) {
+    console.error(`[sdeTypes] search failed: ${error.message}`)
+    return []
+  }
+  return (data ?? []).map((r: any) => ({
+    typeID: r.type_id,
+    name: r.name,
+    coverage: r.coverage,
+    categoryID: r.category_id,
+  }))
+}
+
+export const searchSdeTypes = async (query: string, limit = 25): Promise<SdeSearchResult[]> => {
+  if (query.trim() === '') return []
+  const { data, error } = await sdeSupabase().rpc('sde_search_type', { q: query, lim: limit })
+  if (error) {
+    console.error(`[sdeTypes] search failed: ${error.message}`)
+    return []
+  }
+  return (data ?? []).map((r: any) => ({
+    typeID: r.type_id,
+    name: r.name,
+    coverage: r.coverage,
+    categoryID: r.category_id,
+  }))
+}
+```
+
+Error philosophy: a DB hiccup logs and returns empty — every consumer already
+renders `#id` fallbacks (see `src/app/names.tsx`) — it must never throw a page
+into the error boundary. Follow this in all five loaders.
+
+### `src/sdeSystems.ts`
+
+- `SdeSystem = { systemID: number; name: string; security: number }`.
+- `getSdeSystems(ids)` (new bulk helper) + `getSdeSystem(id)` +
+  `getSdeSystemNames(ids)` over `sde_kspace_system`
+  (`system_id, name, security`), same cache pattern as types.
+- `searchSdeSystems(query, limit = 25)` → `rpc('sde_search_system', { q, lim })`,
+  mapping `system_id → systemID`; return shape stays `(SdeSystem & { coverage })[]`.
+- `formatSecurity(security)` stays **sync and pure** — untouched.
+
+### `src/sdeStations.ts`
+
+- `SdeStation = { stationID: number; name: string; systemID: number }`.
+- One bulk fetch over the `sde_station` view (`station_id, name, system_id`)
+  feeds all three exports: `getSdeStation(id)`, `getSdeStationNames(ids)`,
+  `getSdeStationSystems(ids)`. Same cache pattern.
+- Note: `sde_station` inner-joins the ESI-resolved name table, so a station
+  missing a name is simply absent — exactly the old JSON behavior (the build
+  filtered out unnamed stations).
+
+### `src/sdeBlueprints.ts`
+
+- Keep `MANUFACTURING = 1`, `REACTION = 11`, and the `Blueprint` /
+  `BlueprintMaterial` types exactly as they are
+  (`Blueprint = { blueprintTypeID, activityID, productTypeID, productQuantity,
+  materials: BlueprintMaterial[] }`, `BlueprintMaterial = { typeID, quantity }`).
+- Row mapping from `sde_blueprint_product`: `blueprint_type_id`,
+  `activity_id`, `product_type_id`, `product_quantity`, and `materials` is
+  already CCP's `[{typeID, quantity}, …]` jsonb — map it defensively
+  (`(m: any) => ({ typeID: m.typeID, quantity: m.quantity })`) and sort by
+  `typeID` to preserve the old deterministic order.
+- `getBlueprintForProduct(productTypeID)`:
+  `.from('sde_blueprint_product').select('*').eq('product_type_id', id)`,
+  then pick in JS: prefer `activity_id === MANUFACTURING` over `REACTION`,
+  tie-break lowest `blueprint_type_id` (this reproduces the old selection
+  exactly).
+- `getBlueprintsForMaterial(materialTypeID)`:
+  `.contains('materials', [{ typeID: materialTypeID }])` (the GIN
+  `jsonb_path_ops` index serves this containment probe), sorted by
+  `product_type_id` in JS.
+- No cache needed (used by the two MCP blueprint tools and the blueprint
+  pages — low volume).
+
+### `src/sdePlanets.ts`
+
+- Keep `TEMPERATE_PLANET_TYPE_ID = 11` and `toRoman(n)` sync/pure.
+- `getSdePlanets(ids)` / `getSdePlanet(id)` over the `sde_planet` view, which
+  already carries `system_name` — **drop the import of `getSdeSystem` from
+  sdeSystems** (the old cross-loader dependency). Derive
+  `name = system_name ? `${system_name} ${toRoman(celestial_index)}` : `Planet #${id}``
+  matching the current fallback behavior. Same cache pattern.
+- Keep the returned `SdePlanet` shape identical
+  (`{ planetID, systemID, systemName, celestialIndex, typeID, roman, name }` —
+  verify the exact current fields in the file before rewriting).
+
+## Step 4 — ripple `await` through the consumers
+
+Every call site below is in an async server context already (server
+components, route handlers, server actions, MCP handlers), so adding `await`
+is mechanical. The non-mechanical ones are flagged. **Grep for every import
+from the five loaders when done** (`rg "from '@/sde"` and relative variants)
+to be sure nothing was missed.
+
+| File | Change |
+|---|---|
+| `src/app/typeNames.ts` | `fetchTypeNames` already returns a Promise; body becomes `await getSdeTypeNames(ids)` |
+| `src/app/systemNames.ts` | `await getSdeSystemNames(...)` first, then the existing `universe_name` DB fallback for ids the SDE didn't resolve (wormhole systems) — keep that fallback |
+| `src/app/stationNames.ts` | `await getSdeStationNames(...)` + keep `universe_name` fallback; `fetchStationSystems` awaits `getSdeStationSystems` |
+| `src/app/blueprint/api.ts` | `await searchSdeTypes(...)` in `searchBlueprints`/`resolveProductTypeID`; `await getSdeType(...)` in `fetchType`. The `.name.endsWith('Blueprint')` filtering keeps working on RPC results |
+| `src/app/api/type/search/route.ts` | `NextResponse.json(await searchSdeTypes(q))` |
+| `src/app/asset/search/page.tsx` | `await searchSdeTypesAll(query)`. **Simplification**: the page currently calls `getSdeType` per match to read `categoryID` for its exclude-blueprints filter — the search results now carry `categoryID`, so filter on that directly (no per-row lookups). The "too many results" check keeps using `.length`; verify its threshold constant is < 1000 (the new hard cap) |
+| `src/app/asset/[locationId]/page.tsx` | The sync `isShip(typeId)`-style predicate (categoryID === ship category) is used inside row mapping. Bulk-fetch once: `const types = await getSdeTypes(uniqueTypeIds)` then build a `Set<number>` of ship type ids and use sync `Set.has` in the map |
+| `src/app/ship/[itemId]/page.tsx` | Same bulk-then-Set treatment as above |
+| `src/app/indexes/page.tsx` | Per-row `getSdeSystem(id)` → one `await getSdeSystems(ids)` before mapping; `formatSecurity` unchanged |
+| `src/app/indexes/actions.ts` | `await searchSdeSystems(query, 8)`; the watch-system validation awaits `getSdeSystem` |
+| `src/app/corpses/[characterID]/page.tsx` | `await searchSdeTypesAll('corpse')`. Note this page runs for anonymous visitors — the anon SDE client covers it |
+| `src/app/mercenary-dens/page.tsx` | `await getSdeTypeNames(...)`; per-den `getSdePlanet(planet_id)` → one bulk `await getSdePlanets(planetIds)` then index into the record |
+| `src/app/api/mcp/lib.ts` | **Exported-signature change**: the shared type-resolution helper (`resolveTypeFilter` and friends) becomes `async` — it currently uses `searchSdeTypesAll` + per-result `getSdeType` for blueprint-category filtering; use the `categoryID` now on each search result instead. Update every caller in `tools.ts` |
+| `src/app/api/mcp/tools.ts` | `await` at each of the ~12 SDE call sites (`getSdeTypeNames`, `getSdeSystem`, `getSdeSystemNames`, `searchSdeSystems`, `getSdeType`, `getBlueprintForProduct`, `getBlueprintsForMaterial`); all inside async tool handlers already. Where a sync per-row lookup feeds a `.map()`, use the bulk-then-index pattern |
+
+## Step 5 — delete the build-time pipeline
+
+- Delete `src/buildSde.js`.
+- `package.json`: remove the `"sde:build"` script; change **both**
+  `"predev"` and `"prebuild"` to `"pnpm run esf:build"`.
+- `.gitignore`: if `/src/generated/` is listed solely for the SDE JSON (check
+  — `esf:build` writes to `public/esf-data/`, not `src/generated/`), remove
+  the entry; nothing writes there anymore.
+- Grep for any straggler references to `src/generated/sde` or `buildSde`
+  (comments included) and clean them up.
+
+## Step 6 — CLAUDE.md
+
+Update every section that describes the old pipeline (grep CLAUDE.md for
+`sde:build`, `buildSde`, `src/generated`, `sdeTypes.json`):
+
+- **Commands**: delete the `pnpm run sde:build` bullet; note `predev`/
+  `prebuild` now run only `esf:build`.
+- **Data sources / Architecture**: lookups now come from the nightly-mirrored
+  `sde_*` tables via the async loaders in `src/sde*.ts`; the `sde-mirror` job
+  keeps them fresh; still never Fuzzwork.
+- **Codebase map → buildSde.js section**: delete it. Rewrite the five
+  `src/sde*.ts` entries as async DB-backed (note the new bulk helpers
+  `getSdeTypes`/`getSdeSystems` and that `SdeSearchResult` gained
+  `categoryID`).
+- Mention `src/utils/supabase/sde.ts` alongside the other client factories.
+
+## Verification (all of it, in order)
+
+1. `pnpm run lint`.
+2. `rm -rf src/generated && pnpm run build` — must succeed (proves nothing
+   reads the JSON anymore; `esf:build` still runs for `public/esf-data/`).
+3. Against a DB with a completed ingest (`sde_mirror_state.completed_at` set),
+   `pnpm run dev` and exercise:
+   - `/asset` and `/asset/[locationId]` — type/station/system names render.
+   - `/asset/search?...` with a common term (`rifter`) and a huge one
+     (`blueprint`) — results and the "too many" guard both behave.
+   - `/ship/[itemId]` — the isShip redirect logic works both directions.
+   - `/blueprint` search + a `/blueprint/[typeID]` page.
+   - `/indexes` — security decimals + the watch-a-system autocomplete
+     (server action).
+   - `/mercenary-dens` and `/corpses/[characterID]` (the latter in a
+     logged-out window).
+   - `/api/type/search?q=trit` returns JSON results.
+   - MCP: `blueprint_for_product` and `search_assets` via an MCP client.
+4. Cold-start check: against an **empty** `sde_types` (truncate on a scratch
+   DB or point at a fresh project), pages must render with `#id` fallbacks —
+   no 500s — and after populating, names must appear **without a server
+   restart** (this is the never-cache-misses rule working).
+5. Latency sanity: `/asset` should add roughly one round-trip for the bulk
+   name query on a cold cache and ~zero warm. If a page got visibly slower,
+   look for a per-row `await` that should be a bulk call.
+
+## Gotchas
+
+- **Do not** import the loaders from client components (`'use client'`) —
+  they're server-only. Today nothing does; keep it that way (names flow to
+  the client as resolved strings/promise props, e.g. `src/app/typeName.tsx`).
+- PostgREST returns bigint columns as JSON numbers — fine for every EVE id
+  (they're far below 2^53), no string handling needed.
+- The old `searchSdeTypesAll` was truly unbounded; the RPC caps at 1000.
+  Checked call sites: the asset-search "too many" guard (threshold well under
+  1000) and the corpse-type lookup (a handful of matches). If a future call
+  site genuinely needs >1000 matches, it needs a different query, not a
+  bigger cap.
+- `sdePlanets` must not import from `sdeSystems` anymore — the view provides
+  `system_name`. Removing the cross-import also removes a subtle
+  double-cache.

--- a/docs/sde-db-cutover/02-sql-name-joins.md
+++ b/docs/sde-db-cutover/02-sql-name-joins.md
@@ -1,0 +1,106 @@
+# PR 2 (medium): JOIN SDE names inside the Postgres functions
+
+**Do this after the loader cutover (doc 01) has merged.** It's independent of
+the loaders at runtime, but sequencing it second avoids two PRs fighting over
+the same pages.
+
+## Goal
+
+Several Postgres functions return raw `type_id` / `location_id` /
+`system_id` values that the app (or the user's spreadsheet) then has to
+decorate. Now that fresh SDE data lives in the same database, those functions
+can LEFT JOIN the `sde_*` views and return names directly. This has two
+payoffs:
+
+1. **The CSV / Google Sheets endpoints finally carry names.** Today
+   `/api/character/assets`, `/api/character/blueprints`,
+   `/api/character/orders`, `/api/character/jobs`, `/api/corp/assets`,
+   `/api/corp/blueprints`, `/api/corp/jobs` emit bare ids — a spreadsheet user
+   can't tell what item a row is. This is the single biggest win; do it first.
+2. App pages/MCP tools can drop some app-side decoration passes later
+   (follow-up simplification, not required in this PR).
+
+## Ground rules
+
+- **Additive columns only, appended at the END of each result row.** The CSV
+  endpoints feed Google Sheets `IMPORTDATA` formulas that reference columns by
+  position — inserting a column in the middle silently breaks users'
+  spreadsheets. New name columns go last.
+- Every function change is **dual-write**: `create or replace function` in a
+  new migration under `supabase/migrations/` **and** the same change in
+  `schema.sql`. Match each function's existing style (language sql/plpgsql,
+  `security invoker`, explicit `grant execute … to authenticated` at the end —
+  copy what's there).
+- JOIN targets are the views, not the raw jsonb tables:
+  - type names: `left join public.sde_published_type t on t.type_id = x.type_id`
+  - system name + security: `left join public.sde_kspace_system s on s.system_id = x.system_id`
+  - NPC station name/system: `left join public.sde_station st on st.station_id = x.location_id`
+  - Always LEFT JOIN with the name possibly NULL — unpublished types,
+    wormhole systems, and player structures won't match, and the caller's
+    existing raw-id fallback must keep working.
+- The views are `security_invoker` over RLS-enabled tables whose only policy
+  is public SELECT — they are safe to reference from the existing
+  SECURITY INVOKER functions for any caller, including `anon`.
+- Player structures (`location_id` >= ~1_000_000_000_000) are NOT in the SDE —
+  their names live in `universe_structure` / `corp_structure` (already in
+  `public`). Joining those too is allowed where a function already has the
+  RLS context for it, but keep scope tight: SDE joins are the point of this
+  PR.
+
+## Work list, in priority order
+
+For each function: read its current definition in `schema.sql` (the
+authoritative copy), find the migration that last touched it for style, and
+append the new output columns.
+
+1. **CSV snapshot functions** (all return JSON consumed by
+   `src/app/api/{character,corp}/*/route.ts`, which converts to CSV via
+   `toCsv` — appended JSON keys become appended CSV columns; verify `toCsv`
+   preserves key order from the first row):
+   - `character_asset_snapshot_at(character_ids, as_of)` → add `type_name`.
+   - `character_blueprints(character_ids)` → add `type_name` (the blueprint's
+     own type).
+   - `character_orders(character_ids, as_of)` → add `type_name`.
+   - `character_industry_jobs(character_ids, include_delivered, as_of)` → add
+     `blueprint_type_name` and `product_type_name` (join
+     `sde_published_type` twice — industry job rows carry blueprint and
+     product type ids; check the exact column names in the function body).
+   - `corp_assets(character_ids)` → add `type_name`.
+   - `corp_blueprints(character_ids)` → add `type_name`.
+   - `corp_industry_jobs(character_ids, include_delivered, as_of)` → same two
+     names as the character variant.
+2. **Asset search**: `character_asset_search(type_ids)` and
+   `corp_asset_search(type_ids)` → add `type_name`, and where the row carries
+   a root NPC station id, `root_location_name` + `system_id` via
+   `sde_station`. This lets `/asset/search` skip part of its
+   `resolveLocations` pass later.
+3. **`asset_ancestors(start_id)`** → add `type_name` per ancestor row (feeds
+   the `assetPath.tsx` breadcrumb).
+4. *(Optional, only if cheap)* `character_asset_location_summary()` /
+   `corp_asset_location_summary()` → station name/system for NPC-station
+   roots.
+
+Do NOT rework the app pages/MCP tools to consume the new columns in this PR —
+land the SQL additively, verify the endpoints, and leave consumer
+simplification for a small follow-up. (Exception: if a page change is
+literally deleting a now-redundant `fetchTypeNames` call with no other
+restructuring, it may ride along.)
+
+## Verification
+
+- `pnpm run lint` && `pnpm run build`.
+- Apply the migration to a dev/branch database (`pnpm run db:push`), then:
+  - `select * from character_asset_snapshot_at(array[...]::uuid[], now()) limit 3;`
+    — new keys present, existing keys in unchanged order.
+  - Hit each CSV endpoint with a valid `api_token` and diff the header row
+    against production: identical except new columns at the end.
+  - `/asset/search` and an asset breadcrumb page still render.
+- Confirm an id with no SDE match (a player structure location, an
+  unpublished type) yields NULL/empty-string name and the UI/CSV still shows
+  the raw id.
+
+## Follow-up candidates (note in the PR description, don't do)
+
+- Pages dropping `fetchTypeNames` where the RPC now returns names.
+- MCP tools reading names from the RPCs instead of decorating.
+- `resolveLocations` slimming down for NPC-station roots.

--- a/docs/sde-db-cutover/03-esf-data-nightly.md
+++ b/docs/sde-db-cutover/03-esf-data-nightly.md
@@ -1,0 +1,42 @@
+# PR 3 (optional, needs a design decision): move `esf:build` off the build
+
+**Status: deferred.** Do not start this without the repo owner confirming the
+storage approach — it introduces new infrastructure (Vercel Blob) that the
+SDE mirror deliberately avoided.
+
+## Context
+
+After doc 01 merges, the only remaining build-time SDE download is
+`esf:build` (`src/buildEsfData.js`): it builds the six protobuf files
+(`public/esf-data/*.pb2`, per `src/esf.proto`) that the vendored
+`@eveshipfit/react` `EveDataProvider` fetches client-side from
+`dataUrl="/esf-data/"` for the ship-fitting wheel on `/ship/[itemId]`.
+It downloads CCP's SDE zip once per build (skips when the files already
+exist, but Vercel build containers start clean).
+
+## Sketch (to be validated)
+
+- Add a step to the nightly `sde-mirror` workflow (or a sibling workflow on
+  the same cron) that, when a new SDE build lands, rebuilds the six `.pb2`
+  files and uploads them to **Vercel Blob** (`@vercel/blob`, new dependency,
+  needs a Blob store + `BLOB_READ_WRITE_TOKEN` in the project). Reuse
+  `src/buildEsfData.js`'s encode logic — refactor it so download and encode
+  are separable, and reuse the Range-read zip helpers from
+  `src/jobs/sdeMirror.js` (`listEntries` / `fetchEntryBuffer`) instead of its
+  current `unzip` binary spawn, which doesn't exist at runtime.
+- Point the fitting UI at the Blob: `EveDataProvider`'s `dataUrl` prop (set
+  where the component is rendered — grep for `dataUrl="/esf-data/"`) becomes
+  the Blob base URL (env var), or keep `/esf-data/` as a same-origin path via
+  a small route/redirect so the client bundle needs no env plumbing.
+- Then `esf:build` leaves `prebuild`, and builds download nothing from CCP.
+
+## Open questions for the repo owner
+
+1. Vercel Blob vs. committing the `.pb2` files to the repo (they're a few MB
+   and change once per patch — a weekly bot PR like `bump-eveshipfit.yml`
+   could refresh them) vs. leaving `esf:build` at build time permanently.
+2. Memory budget: `typeDogma.jsonl` inflated is the largest input; the encode
+   step must fit a workflow function invocation.
+3. Cache headers/versioning on the Blob objects so a patched SDE doesn't
+   fight browser caches (the current same-origin files get Vercel's static
+   asset caching).

--- a/docs/sde-db-cutover/README.md
+++ b/docs/sde-db-cutover/README.md
@@ -1,0 +1,74 @@
+# SDE → database cutover: remaining work
+
+The nightly `sde-mirror` Vercel Workflow (merged in
+[#607](https://github.com/philihp/edencom-link/pull/607)) mirrors CCP's full
+Static Data Export into the `public` schema's `sde_*` tables every day at
+12:21 UTC. The app, however, **still downloads the SDE on every build**
+(`sde:build` in `predev`/`prebuild`) and reads it from generated JSON via the
+in-memory loaders in `src/sde*.ts`. These documents specify the follow-up
+pull requests that finish the migration. Each document is a self-contained
+implementation spec: do them as **separate PRs, in order**.
+
+| Doc | PR | What | Status / dependency |
+|---|---|---|---|
+| [00-drop-evesde-schema.md](00-drop-evesde-schema.md) | tiny | Drop the legacy `evesde` Postgres schema | Independent; may already be done — check first |
+| [01-loader-cutover.md](01-loader-cutover.md) | large | Rewrite the 5 SDE loaders to read the `sde_*` tables; delete `sde:build` from the build | **The main event.** Requires one successful `sde-mirror` run in production first |
+| [02-sql-name-joins.md](02-sql-name-joins.md) | medium | JOIN SDE names inside the Postgres functions (CSV exports, asset search) | After 01 |
+| [03-esf-data-nightly.md](03-esf-data-nightly.md) | optional | Move the ship-fitting `esf:build` off the build too | Deferred; needs a design decision from the repo owner |
+
+## What already exists (build on this, don't reinvent it)
+
+Everything below merged with #607 and is live after the first ingest run:
+
+- **Mirror tables** `public.sde_<snake_case_stem>` — one per JSONL file in
+  CCP's export (78 today: `sde_types`, `sde_groups`, `sde_map_solar_systems`,
+  `sde_npc_stations`, `sde_blueprints`, `sde_map_planets`, …), each just
+  `(_key bigint primary key, data jsonb, sde_build bigint)`. `data` is the raw
+  JSONL line (localized names are objects: `data->'name'->>'en'`).
+- **App-shaped views** (these are what the app should query — not the raw
+  jsonb tables):
+  - `sde_published_type(type_id, name, group_id, category_id)` — published,
+    named types only; the exact cut `src/generated/sdeTypes.json` has today.
+  - `sde_kspace_system(system_id, name, security)` — known-space systems
+    (30.0M–31.0M id band), same cut as `sdeSystems.json`.
+  - `sde_station(station_id, name, system_id)` — NPC stations joined to their
+    ESI-resolved names (`sde_npc_station_name`).
+  - `sde_planet(planet_id, system_id, celestial_index, type_id, system_name)`.
+- **Materialized view** `sde_blueprint_product(blueprint_type_id, activity_id,
+  product_type_id, product_quantity, materials jsonb)` — manufacturing (1) and
+  reaction (11) rows only, one per (blueprint, activity, product);
+  `materials` is CCP's raw `[{"typeID": n, "quantity": n}, …]` array. Indexed
+  on `product_type_id`, `blueprint_type_id`, and GIN `jsonb_path_ops` on
+  `materials`. Refreshed by the ingest's finalize step.
+- **Search RPCs** `sde_search_type(q text, lim int)` →
+  `(type_id, name, group_id, category_id, coverage)` and
+  `sde_search_system(q text, lim int)` → `(system_id, name, security,
+  coverage)`. Case-insensitive substring, ranked identically to the current
+  in-memory search (`coverage = char_length(q) / char_length(name)` DESC,
+  shorter name, then id), ILIKE metacharacters escaped, capped at 1000 rows.
+- **Access model**: every `sde_*` table/view/MV is readable by `anon` and
+  `authenticated` (RLS with a bare `FOR SELECT USING (true)` policy,
+  SELECT-only grants) and written **only** by the service-role ingest. App
+  code can query them with any Supabase client — no cookie session, no bearer
+  token, no `.schema()` qualifier needed.
+- **Freshness**: `sde_mirror_state` has one row per CCP build;
+  `completed_at IS NOT NULL` means that build fully landed. CCP ships a new
+  build per game patch (not nightly), so data changes at most every few weeks.
+
+## House rules (from CLAUDE.md — read it first, these bite)
+
+- **No test runner.** The gates are `pnpm run lint` and `pnpm run build`, plus
+  manually exercising the affected pages/routes. Every PR must pass both.
+- **Schema changes are dual-write**: edit `schema.sql` (full-reset source of
+  truth) **and** add an incremental migration under `supabase/migrations/`
+  (`YYYYMMDDHHMMSS_name.sql`; merging to main auto-applies it via the
+  `Migrate` GitHub workflow).
+- **Ramda over `for`/`while`** for synchronous iteration; sequential async
+  iteration uses `forEachSequential` (`src/jobs/lib.js`) in job code. App/TS
+  code follows the same spirit.
+- **`git fetch origin && git rebase origin/main`** immediately before pushing
+  and opening a PR. No exceptions.
+- **Never** use Fuzzwork's third-party SDE mirror for anything.
+- Pre-commit hooks (husky + lint-staged) auto-format; don't fight them.
+- Line numbers in these docs may drift — anchor on the quoted code, not the
+  numbers, and re-verify each call site before editing it.


### PR DESCRIPTION
Markdown implementation specs under `docs/sde-db-cutover/` for the PRs that finish what the nightly `sde-mirror` workflow (#607) started. They're written to be executed by another engineer or agent without this repo's full context in their head: exact files, function signatures, code templates, gotchas, and verification steps.

- **README.md** — index, inventory of the already-merged `sde_*` views/RPCs to build on (so nothing gets reinvented), and the house rules that bite (dual-write schema changes, lint+build gates, rebase before push, never Fuzzwork).
- **00-drop-evesde-schema.md** — drop the legacy `evesde` schema (tiny; full migration text included; "check whether it already happened" guard).
- **01-loader-cutover.md** — the main event: rewrite the five `src/sde*.ts` loaders as async DB-backed modules (dedicated anon client, 6h TTL cache that never caches misses, chunked bulk lookups, search via the RPCs), ripple `await` through every consumer (full file-by-file table, with the two non-mechanical spots flagged: async `resolveTypeFilter` in `api/mcp/lib.ts` and the bulk-then-Set `isShip` pattern), then delete `src/buildSde.js` and `sde:build` from `predev`/`prebuild`. This is the PR that actually makes builds cheap.
- **02-sql-name-joins.md** — LEFT JOIN `sde_published_type`/`sde_kspace_system`/`sde_station` inside the Postgres functions so the CSV/Sheets endpoints and asset search return names instead of bare ids — with the hard rule that new columns append at the END (Sheets IMPORTDATA users reference columns by position).
- **03-esf-data-nightly.md** — deferred: moving `esf:build` off the build; documents the sketch and the open storage decision (Vercel Blob vs committing the .pb2s vs leaving it) rather than prescribing one.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Q8qAC4PdpJn3sVmRj8ARe

---
_Generated by [Claude Code](https://claude.ai/code/session_014Q8qAC4PdpJn3sVmRj8ARe)_