### PR TITLE
Drop the legacy evesde schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,12 +41,12 @@ EVE Online hangar/wallet/industry tracker. Package name `edencom-link` (private)
 
 # Data sources
 
-- NEVER query the `evesde` SDE schema in the database. That data is out of date and must not be used for any work. Resolve type/name lookups via `fetchTypeNames` (`src/app/typeNames.ts`), which reads the locally generated SDE data (`src/sdeTypes.ts`), instead. If a needed lookup has no non-SDE source, show the raw ID rather than reading the SDE.
+- The legacy `evesde` DB schema has been dropped (stale out-of-band data) — do not recreate or reference it. SDE lookups go through the `src/sde*.ts` loaders. If a needed lookup has no non-SDE source, show the raw ID rather than reading the SDE.
 
 # Architecture
 
 - Data from ESI flows into the database via the per-endpoint extract jobs in `src/jobs/`. The UI then reads from the database. The UI/Next.js server components must never call ESI directly.
-- Avoid using the `evesde` schema in the database for new work — it can be out of date. Instead, type/group/category lookups are resolved from `src/generated/sdeTypes.json`, generated at build time by `src/buildSde.js` (`pnpm run sde:build`, wired as `predev`/`prebuild`) from CCP's official Static Data Export (`developers.eveonline.com/static-data`, JSONL format, refreshed each game patch — never Fuzzwork's third-party mirror, which is off-limits for this project). `src/sdeTypes.ts` loads that file once per server process and exposes `getSdeType`/`getSdeTypeNames`/`searchSdeTypes`, used by `src/app/typeNames.ts`, `src/app/blueprint/api.ts`, and `src/app/api/type/search/route.ts`. If a needed field isn't in the generated dataset, extend `src/buildSde.js` to include it rather than reaching into the `evesde` schema.
+- Type/group/category lookups are resolved from `src/generated/sdeTypes.json`, generated at build time by `src/buildSde.js` (`pnpm run sde:build`, wired as `predev`/`prebuild`) from CCP's official Static Data Export (`developers.eveonline.com/static-data`, JSONL format, refreshed each game patch — never Fuzzwork's third-party mirror, which is off-limits for this project). `src/sdeTypes.ts` loads that file once per server process and exposes `getSdeType`/`getSdeTypeNames`/`searchSdeTypes`, used by `src/app/typeNames.ts`, `src/app/blueprint/api.ts`, and `src/app/api/type/search/route.ts`. If a needed field isn't in the generated dataset, extend `src/buildSde.js` to include it.
 
 # Codebase map
 

--- a/supabase/migrations/20260716020000_drop_evesde_schema.sql
+++ b/supabase/migrations/20260716020000_drop_evesde_schema.sql
@@ -1,0 +1,10 @@
+-- Remove the legacy `evesde` schema. It was loaded out-of-band years ago (a
+-- Fuzzwork-style SDE dump), has been stale ever since, and nothing in this
+-- codebase queries it — CLAUDE.md has long marked it off-limits. The fresh
+-- SDE mirror lives in the `public` schema's `sde_*` tables (nightly
+-- sde-mirror workflow), so the dead schema goes to avoid any confusion
+-- between the two.
+--
+-- Destructive by design: the stale data has no consumers and no other source
+-- of truth to preserve.
+drop schema if exists evesde cascade;


### PR DESCRIPTION
## Summary
- Implements PR 0 of the sde-db-cutover plan (`docs/sde-db-cutover/00-drop-evesde-schema.md`).
- Adds `supabase/migrations/20260716020000_drop_evesde_schema.sql`, which runs `drop schema if exists evesde cascade;`. **This migration is destructive by design**: the `evesde` schema was loaded out-of-band years ago (a Fuzzwork-style SDE dump), has been stale ever since, nothing in this codebase queries it, and the drop was explicitly requested by the repo owner. Fresh SDE data now lives in the `public` schema's `sde_*` tables via the nightly `sde-mirror` workflow.
- `schema.sql` needs no change — it never contained `evesde`.
- Updates the two `CLAUDE.md` rules that told agents to avoid the (now-removed) `evesde` schema, so they no longer reference a schema that no longer exists.

## Test plan
- [x] `pnpm run lint`
- [ ] `Migrate` GitHub Actions workflow applies the new migration cleanly on merge to `main`


---
_Generated by [Claude Code](https://claude.ai/code/session_017xtn3Ya6Bw65h7GMM9pUZr)_