### PR TITLE
Add copy-Discord-ping button to enemy den intel timers

### DIFF
--- a/src/app/mercenary-dens/enemyDenIntel.tsx
+++ b/src/app/mercenary-dens/enemyDenIntel.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from 'react'
 
 import { addEnemyDenIntel, deleteEnemyDenIntel } from './actions'
+import CopyDiscordPing from './copyDiscordPing'
 import { formatDuration, formatUtc } from './duration'
 import styles from './mercenaryDens.module.css'
 
@@ -112,6 +113,11 @@ const EnemyDenIntel = ({ rows, defaultReportedBy }: { rows: EnemyDenIntelRow[]; 
                           reinforced {formatDuration(new Date(row.reinforcementEnd).getTime() - now)}
                         </span>
                         <span className={styles.timestamp}> {formatUtc(row.reinforcementEnd)}</span>
+                        <CopyDiscordPing
+                          system={row.system}
+                          planet={row.planet}
+                          reinforcementEnd={row.reinforcementEnd}
+                        />
                       </>
                     ) : (
                       <span className={styles.stable}>timer expired {formatUtc(row.reinforcementEnd)}</span>


### PR DESCRIPTION
## Summary

- The enemy den intel table (`/mercenary-dens`, added in #612) shows a reinforcement countdown but had no way to quickly share it in Discord, unlike the real dens table above it.
- Reuses the existing `CopyDiscordPing` button — it was already generic over `system`/`planet`/`reinforcementEnd` — so a reinforced enemy sighting gets the same one-click 📋 copy button next to its timestamp as the real dens table.

## Test plan

- [x] `pnpm run lint`
- [x] `pnpm run build`


---
_Generated by [Claude Code](https://claude.ai/code/session_01PnoXvLyAHYSJmXNTDZfgLF)_