### PR TITLE
feat: persist execution-path source on heartbeat rows

### DIFF
--- a/docs/workflow-jobs-page.md
+++ b/docs/workflow-jobs-page.md
@@ -217,8 +217,11 @@ lists as it adds the registry entry, so no job is ever listed in both places.
 
 ## Open decisions
 
-1. **Heartbeat `source` column.** Take the optional provenance column now, or
-   skip until something needs it (registry suffices for the UI).
+1. **Heartbeat `source` column.** ~~Take the optional provenance column now, or
+   skip until something needs it (registry suffices for the UI).~~ Taken:
+   `heartbeat.source` now persists the value callers pass (see the
+   `20260717084000_heartbeat_source` migration). The registry remains the
+   UI's source of truth for workflow membership.
 
 ## Verification (no test runner; gates are lint + build + manual)
 

--- a/schema.sql
+++ b/schema.sql
@@ -566,6 +566,11 @@ create table public.heartbeat (
   corporation_id bigint,
   user_id uuid references auth.users(id) on delete cascade,
   owner_key text generated always as (coalesce(character_id::text, '') || '|' || coalesce(corporation_id::text, '')) stored,
+  -- Which execution path recorded the run: 'vercel' (queue consumer),
+  -- 'vercel-cron' (direct cron routes), 'vercel-workflow' (workflow steps),
+  -- 'github' (Actions). Null for local CLI runs and the per-character/per-corp
+  -- loop rows, which don't know how they were invoked.
+  source text,
   started_at timestamptz,
   ended_at timestamptz,
   -- How long the run took for that job/entity; null until ended_at lands.

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -28,12 +28,12 @@ export const sudoSupabaseAdmin = sudoSupabase.auth.admin
 // straight to it. Used to land a run's start/end heartbeats on one row.
 const githubRun = () => {
   const runId = process.env.GITHUB_RUN_ID
-  if (!runId) return { run_id: null, run_attempt: null, run_url: null }
+  if (!runId) return { run_id: null, run_attempt: null, run_url: null, source: null }
   const server = process.env.GITHUB_SERVER_URL ?? 'https://github.com'
   const repo = process.env.GITHUB_REPOSITORY ?? ''
   const attempt = process.env.GITHUB_RUN_ATTEMPT ? Number(process.env.GITHUB_RUN_ATTEMPT) : null
   const run_url = `${server}/${repo}/actions/runs/${runId}${attempt ? `/attempts/${attempt}` : ''}`
-  return { run_id: Number(runId), run_attempt: attempt, run_url }
+  return { run_id: Number(runId), run_attempt: attempt, run_url, source: 'github' }
 }
 
 // Record a scheduled job's progress in public.heartbeat. Workflows call this as
@@ -50,6 +50,12 @@ const githubRun = () => {
 // in src/jobs/lib.js, which pass these so a run's duration can later be broken
 // down per job/character-or-corp/user rather than just per whole job invocation).
 // Leave them unset for whole-job/account-wide jobs.
+//
+// opts.source records which execution path ran the job ('vercel' from the
+// queue consumer, 'vercel-cron' from the direct cron routes, 'vercel-workflow'
+// from workflow steps); GitHub Actions runs are stamped 'github' automatically.
+// Callers were already passing this — until the heartbeat.source column landed
+// it was silently dropped.
 export const recordHeartbeat = async (job, phase = 'end', opts = {}) => {
   // GitHub Actions path: derive run identity from the environment so the two steps
   // of one workflow run land on a single row. Vercel queue path (and the
@@ -70,6 +76,10 @@ export const recordHeartbeat = async (job, phase = 'end', opts = {}) => {
     character_id: opts.characterId ?? null,
     corporation_id: opts.corporationId ?? null,
     user_id: opts.userId ?? null,
+    // Execution-path provenance ('vercel' / 'vercel-cron' / 'vercel-workflow'
+    // from callers, 'github' derived from the Actions env). Null when neither
+    // is known (local CLI runs, the per-character/per-corp loop rows).
+    source: opts.source ?? gh.source,
     ...(phase === 'start' ? { started_at: now } : { ended_at: now }),
   }
   const table = sudoSupabase.from('heartbeat')

--- a/supabase/migrations/20260717084000_heartbeat_source.sql
+++ b/supabase/migrations/20260717084000_heartbeat_source.sql
@@ -1,0 +1,9 @@
+-- Persist the execution-path provenance callers already pass to
+-- recordHeartbeat (src/supabase.js): the queue consumer sends 'vercel', the
+-- direct cron routes 'vercel-cron', and workflow steps 'vercel-workflow',
+-- but until now recordHeartbeat dropped the value because the table had no
+-- column for it. GitHub Actions runs are stamped 'github' (derived from
+-- GITHUB_RUN_ID). Null for local CLI runs and the per-character/per-corp
+-- loop rows, which don't know how they were invoked. Existing rows stay
+-- null — provenance starts accruing from deploy.
+alter table public.heartbeat add column source text;


### PR DESCRIPTION
## Summary

Three call sites already pass a `source` into `recordHeartbeat` — the queue consumer (`'vercel'`), the direct-cron helper (`'vercel-cron'`), and the sde-mirror workflow steps (`'vercel-workflow'`) — but the `heartbeat` table had no `source` column and `recordHeartbeat`'s row object omitted it, so the value was silently dropped. This makes run provenance queryable, e.g. "did this run come from the workflow or the old queue path" while both exist during a job's cutover to Vercel Workflows (see `docs/workflow-jobs-page.md`).

## Changes

- **`schema.sql`** — add `source text` to `public.heartbeat` (with a comment documenting the values).
- **`supabase/migrations/20260717084000_heartbeat_source.sql`** — the incremental `alter table … add column`, per the dual-write rule. Existing rows stay null; provenance accrues from deploy.
- **`src/supabase.js`** — `recordHeartbeat` persists `opts.source ?? gh.source`, where `githubRun()` now derives `'github'` alongside the run identity it already derives from the Actions env. Null when neither is known (local CLI runs, and the per-character/per-corp loop rows from `withHeartbeat`, which don't know how they were invoked).
- **`docs/workflow-jobs-page.md`** — mark the plan's one open decision (this column) as taken.

No behavior change beyond the extra column value: the start/end upsert key and all existing columns are untouched, and both phases of every caller pass the same source, so the paired-row upsert semantics are unchanged.

## Verification

- `pnpm run lint` ✓ and `pnpm run build` ✓ (the repo's gates; no test runner).
- The migration applies via the `Migrate` workflow on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXBimdhySZU9Hr6mXJxnta)_