### PR TITLE
Add appraisals project docs: innomin.at MCP tool + asset-viewer pricing

### DIFF
--- a/docs/appraisals/01-mcp-appraise-tool.md
+++ b/docs/appraisals/01-mcp-appraise-tool.md
@@ -1,0 +1,200 @@
+# 01 — `src/innominate.ts` client + `appraise_items` MCP tool
+
+**Milestone 1.** One PR. Adds the single shared client for the Innominate
+Appraisal API and the first consumer: an MCP tool that appraises a batch of
+items by name. Read the [README](README.md) first — the API reference, the
+`save: false` invariant, and the 200 req/hour rate limit all live there.
+
+## Deliverables
+
+1. `src/innominate.ts` — the only module in the repo that talks to
+   innomin.at.
+2. `appraise_items` MCP tool in `src/app/api/mcp/tools.ts`.
+3. `INNOMINATE_API_KEY` added to `.env.example` (and set in Vercel before
+   merge — the tool should degrade gracefully if unset, see below).
+
+## 1. The client — `src/innominate.ts`
+
+TypeScript (it's imported from app-router code), same top-level placement as
+`src/esi.js`/`src/supabase.js`. Exports:
+
+```ts
+export type AppraisalItemInput = { name: string; quantity: number }
+
+export type AppraisedItem = {
+  name: string
+  itemId: number | null
+  quantity: number
+  itemVol: number | null
+  totalItemVol: number | null
+  sellPrice: number | null
+  buyPrice: number | null
+  totalSellPrice: number | null
+  totalBuyPrice: number | null
+  error: string | null            // "Item not found" etc.
+  possibleMatches: string[]       // suggestions when error is set
+}
+
+export type Appraisal = {
+  items: AppraisedItem[]          // in request order
+  totalVol: number
+  totalSellValue: number
+  totalBuyValue: number
+  priceSplit: number
+  market: string
+  marketStatus: string
+  rateLimitRemaining: number | null   // from x-ratelimit-remaining
+  cached: boolean                     // true when served from the TTL cache
+}
+
+export type AppraisalError =
+  | { ok: false; kind: 'unconfigured'; message: string }  // no INNOMINATE_API_KEY
+  | { ok: false; kind: 'rate_limited'; message: string; retryAfterSeconds: number | null }
+  | { ok: false; kind: 'upstream'; message: string }      // 4xx/5xx/network/timeout
+
+export type AppraisalResult = { ok: true; appraisal: Appraisal } | AppraisalError
+
+export const MARKETS = ['jita', 'amarr', 'rens', 'dodi', 'hek', 'ualx', 'cj6mt'] as const
+export type Market = (typeof MARKETS)[number]
+
+export const appraise = async (items: AppraisalItemInput[], market: Market = 'jita'): Promise<AppraisalResult>
+```
+
+Implementation requirements:
+
+- `POST https://innomin.at/api/v1/appraise/` with headers `X-API-Key:
+  process.env.INNOMINATE_API_KEY`, `Content-Type: application/json`, and a
+  `User-Agent` identifying us (`edencom-link (philihp@gmail.com)` — matches
+  the etiquette `src/esi.js` follows).
+- Body: `{ items, market, save: false }`. **`save: false` is hard-coded.**
+  It is not a parameter of `appraise()`, not configurable, and a code
+  comment must state why (side-effect-free on the provider's server, per
+  the API-key agreement).
+- Never mutate/merge caller input; map the response snake_case fields to the
+  camelCase shapes above. Missing `possible_matches` → `[]`; missing/absent
+  `item_id` → `null`.
+- If `INNOMINATE_API_KEY` is unset/empty, return `kind: 'unconfigured'`
+  without attempting a request (keeps local dev without the key working).
+- On `429`, parse `x-ratelimit-reset-after` into `retryAfterSeconds`
+  (null if absent). **No automatic retries** — with a 200/hour budget a
+  retry loop is how the budget dies.
+- On any other non-200, or a network error, return `kind: 'upstream'` with
+  the response's `error` field when parseable (never throw). Apply an
+  `AbortSignal.timeout` of ~10s.
+- Read `x-ratelimit-remaining` into `rateLimitRemaining` on success.
+
+### In-process TTL cache (part of the client, from day one)
+
+Both consumers (MCP now, the asset viewer in doc 03) will re-request the
+same batches; the rate limit makes that expensive. Cache **successful**
+results in module scope:
+
+- Key: `market` + the JSON of the item list sorted by name (so equal batches
+  hit regardless of input order).
+- TTL: 5 minutes. Cap: 200 entries, evict oldest-inserted beyond that (a
+  plain `Map` insertion-order sweep is fine — no LRU library).
+- A cache hit returns the stored `Appraisal` with `cached: true` and the
+  stored `rateLimitRemaining` (stale but indicative).
+- Errors are never cached.
+- On Vercel this is per-lambda-instance and evaporates on cold starts —
+  that's acceptable; it exists to absorb bursts (double-clicks, an LLM
+  re-asking), not to be a durable price store. A code comment should say so.
+
+Ramda house style applies (`map`/`sortBy`/`zipWith` over loops) for the
+request/response mapping.
+
+## 2. The MCP tool — `appraise_items`
+
+Registered in `src/app/api/mcp/tools.ts` alongside the existing tools
+(follow their structure exactly: `server.registerTool`, zod `inputSchema`,
+`textResult` payloads from `./lib`).
+
+```
+appraise_items
+  title: Appraise items
+  description: Estimate the ISK market value of a batch of items via the
+    innomin.at appraisal service (Jita by default). Answers "what's 3 Rifters
+    and 100k Tritanium worth" or follows up a search_assets result with
+    prices. Item names are matched fuzzily against EVE types. Prices are
+    live market data, not the user's own orders.
+  inputSchema:
+    items: array of { item: string (min 1), quantity: int ≥ 1 default 1 },
+           min 1, max 100 entries
+    market: enum MARKETS, optional, default 'jita'
+      describe: 'Market hub to price against (default jita). Others: amarr,
+                 rens, dodi, hek, plus player markets ualx, cj6mt.'
+```
+
+No Supabase client and no auth-token use — the tool reads nothing from the
+DB. (It still only runs for authenticated MCP callers because the whole
+server sits behind `withMcpAuth`; that's what gates our 200/hour budget.)
+
+### Name canonicalization (before calling the API)
+
+The API wants exact names. LLM callers write approximations ("trit",
+"nitrogen fuel block"). Resolve each input through the SDE the same way the
+blueprint tools do (`resolveOneType` in tools.ts — best coverage match via
+`searchSdeTypesAll`):
+
+- SDE match found → send the canonical SDE name; remember when it differs
+  from the input so the response can note `Interpreted "trit" as Tritanium`.
+- No SDE match → **send the raw name anyway.** The API's own fuzzy handling
+  returns `possible_matches` for it, which flow back to the model — better
+  than failing locally.
+- Duplicate resolved names in one call: merge quantities before sending
+  (the API would otherwise price them as separate lines and inflate the
+  batch).
+
+### Tool output (via `textResult`)
+
+```jsonc
+{
+  "market": "jita",
+  "total_sell_value": 800030.0,
+  "total_buy_value": 699350.0,
+  "price_split": 749690.0,
+  "total_volume_m3": 5010.0,
+  "items": [
+    {
+      "item": "Tritanium", "quantity": 1000,
+      "sell_price": 4.03, "buy_price": 3.95,
+      "total_sell": 4030.0, "total_buy": 3950.0,
+      "volume_m3": 10.0
+    }
+  ],
+  "unpriced": [                    // omit key when empty
+    { "item": "Not A Real Item", "possible_matches": ["…", "…"] }
+  ],
+  "notes": ["Interpreted \"trit\" as Tritanium."],   // omit when empty
+  "cached": false,                  // omit when false
+  "rate_limit_remaining": 198,      // omit when null
+  "source": "innomin.at"
+}
+```
+
+Error mapping: `unconfigured` → "Appraisals aren't configured on this
+deployment (missing INNOMINATE_API_KEY)."; `rate_limited` → include
+`retryAfterSeconds`; `upstream` → pass the message through. All as plain
+`textResult` strings, matching how the other tools report failures.
+
+## 3. Env plumbing
+
+- `.env.example`: add `INNOMINATE_API_KEY=` with a one-line comment pointing
+  at https://innomin.at/api/docs/ (key issued via their Discord).
+- Vercel: the repo owner sets the var (already present in the dev
+  environment here).
+
+## Verification (no test runner — do these by hand)
+
+1. `pnpm run lint` and `pnpm run build` pass.
+2. `pnpm run dev`, connect an MCP client (or drive
+   `/api/mcp` with a bearer token) and call `appraise_items` with:
+   - a normal batch (`Tritanium` ×1000, `Rifter` ×2) → totals match a
+     manual curl;
+   - a garbage name → lands in `unpriced` with `possible_matches`;
+   - a fuzzy name ("trit") → canonicalized note appears;
+   - the same batch twice within 5 minutes → second response has
+     `"cached": true`;
+   - `market: "amarr"` → different prices, `market` echoed.
+3. Temporarily unset `INNOMINATE_API_KEY` → tool answers with the
+   unconfigured message, no crash.

--- a/docs/appraisals/02-asset-subtree-items.md
+++ b/docs/appraisals/02-asset-subtree-items.md
@@ -1,0 +1,100 @@
+# 02 — Subtree item-aggregation Postgres functions
+
+Small DB-only PR. Adds the two functions the asset-viewer appraisal (doc 03)
+needs: given a container/ship item id **or** a bare location id (station /
+structure / solar system), return everything inside it — the whole nested
+subtree — aggregated to `(type_id, quantity)` rows ready to be priced.
+Independent of doc 01; can land in parallel.
+
+## Why a new function shape
+
+The existing walk functions almost fit but don't:
+
+- `character_asset_location_contents(parent)` (`schema.sql`) does exactly the
+  right **descend** over `location_id` chains, but returns per-child counts,
+  not type/quantity aggregates.
+- `character_asset_search(type_ids[])` descends too, but is seeded by type
+  filter, not by location.
+
+Per the design-pattern note in CLAUDE.md, this is a **seeded recursion**: it
+starts from one parent id and touches only that subtree, so it stays cheap
+regardless of hangar size.
+
+## The functions
+
+Dual-write: add to `schema.sql` (next to
+`character_asset_location_contents`, reusing its style) **and** as one new
+migration via `pnpm run db:new asset_subtree_items`. Never rename existing
+migration files.
+
+```sql
+-- Appraisal support (/asset/[locationId], doc 03): every item in the subtree
+-- under `parent` — a container/ship item id or a bare location id — summed
+-- into one row per item type. Singletons (assembled ships, containers)
+-- count as quantity 1. Seeded from `parent` only, so cost scales with the
+-- subtree, not the hangar (cf. character_asset_search's descend CTE).
+create or replace function public.character_asset_subtree_items(parent bigint)
+returns table (type_id bigint, quantity bigint)
+language sql
+stable
+as $$
+  with recursive descend as (
+    select a.item_id, a.type_id, a.quantity, a.is_singleton, 1 as depth
+    from public.character_asset a
+    where a.location_id = parent
+    union all
+    select c.item_id, c.type_id, c.quantity, c.is_singleton, d.depth + 1
+    from descend d
+    join public.character_asset c on c.location_id = d.item_id
+    where d.depth < 64
+  )
+  select type_id, sum(case when is_singleton then 1 else coalesce(quantity, 1) end)::bigint as quantity
+  from descend
+  group by type_id;
+$$;
+```
+
+`corp_asset_subtree_items(parent bigint)` is the identical query over
+`public.corp_asset` (mirroring how every character/corp function pair in
+`schema.sql` is structured — put it next to
+`corp_asset_location_contents`).
+
+Grants, matching the neighbors:
+
+```sql
+grant execute on function public.character_asset_subtree_items(bigint) to authenticated;
+grant execute on function public.corp_asset_subtree_items(bigint)      to authenticated;
+```
+
+Both query the `character_asset` / `corp_asset` **views** (not the
+`_over_time` tables), so RLS scopes results to the caller exactly like the
+existing functions — a service-role caller would walk unscoped, so doc 03's
+route must use the cookie-session client only (it does; the share-token path
+gets no appraisal button).
+
+## Decisions baked in (don't relitigate in the PR)
+
+- **The parent itself is excluded.** The function returns strictly the
+  contents. When the appraisal target is an item (a ship or container), the
+  caller adds the parent's own `(type_id, 1)` line — it already has that
+  row in hand. When the target is a bare location, there is nothing to add.
+- **Quantity semantics** match the MCP `search_assets` mapping: singleton
+  rows (assembled ships, containers, fitted modules) are 1 apiece;
+  otherwise `coalesce(quantity, 1)`.
+- **No filtering in SQL.** Blueprint exclusion (BPCs are indistinguishable
+  from BPOs in asset rows and would mis-price) happens app-side via the SDE
+  category lookup — doc 03 owns that. The function reports the raw truth.
+- **Depth cap 64**, same as every other walk in `schema.sql`.
+
+## Verification
+
+1. `pnpm run lint` / `pnpm run build` (unchanged code paths, but the gates
+   always run).
+2. Apply the migration to the linked project (`pnpm run db:push`) or let the
+   `Migrate` workflow do it on merge.
+3. Sanity-check in SQL (as an authenticated user via the app or the SQL
+   editor impersonating one): pick a ship with fitted modules + cargo from
+   `/asset`, run `select * from character_asset_subtree_items(<item_id>)`,
+   and eyeball the rows against the `/ship/[itemId]` page. Confirm a bare
+   station id returns that hangar's aggregate, and an id you don't own
+   returns zero rows.

--- a/docs/appraisals/03-asset-viewer-appraisal.md
+++ b/docs/appraisals/03-asset-viewer-appraisal.md
@@ -1,0 +1,147 @@
+# 03 — Appraise buttons in the asset viewer
+
+**Milestone 2.** One PR. A button on each row of the asset location page —
+and one for the whole location — that lazy-loads an ISK appraisal: for a
+plain stack, that stack; for a container or ship, the item **plus everything
+nested inside it**. Requires doc 01 (`src/innominate.ts`) and doc 02 (the
+`*_asset_subtree_items` functions) to be merged first.
+
+## UX
+
+On `/asset/[locationId]` (`src/app/asset/[locationId]/locationAssets.tsx`):
+
+- New rightmost column **Value** in the assets table. Each row gets a small
+  "appraise" button (text button in the retro table style — see
+  `retro.module.css` usage; no icon fonts in this codebase).
+- Click → button shows a busy state → replaced in place by the result:
+  `4.03 bISK / 3.95 bISK` (sell / buy, via `formatBisk` from
+  `src/app/isk.ts`; use `formatKisk` under 0.1b — match whichever the
+  neighboring pages use for mixed magnitudes, `formatBisk` is the default).
+  Add a `title` tooltip with the exact ISK figures, the line count, and any
+  skips ("12 types · 3 blueprints skipped · 1 unpriced").
+- Next to the page heading: an **Appraise everything here** button that
+  appraises the whole location (`locationId` as the target). Same component,
+  same endpoint.
+- Errors render inline in the cell, small and quiet: `rate limited — retry
+  in 42s`, `appraisal unavailable`. No toasts, no retries.
+- The share-token (anonymous) path renders **no** Value column and no header
+  button: the endpoint requires a session (see below), and the page already
+  hides drill-down links in that mode. `page.tsx` passes a `canAppraise`
+  boolean (simply `!scope`) down to `LocationAssets`.
+
+Repeated clicks are absorbed by the client-module TTL cache (doc 01), but
+also disable the button while a request is in flight.
+
+## The endpoint — `POST /api/appraisal`
+
+`src/app/api/appraisal/route.ts`, a plain route handler (this is a
+client-triggered lazy fetch, so a route beats a server action — it wants
+JSON, status codes, and no form semantics).
+
+Request body: `{ "target": "<id>" }` — an item id (ship/container/stack) or
+a bare location id (station / structure / solar system). Optional
+`"market"` (validated against `MARKETS`, default `jita`) so the UI can grow
+a picker later without an API change.
+
+Auth: cookie session via `createClient` from `@/utils/supabase/server`;
+`401` when there's no user. **Never** the service-role client — the doc-02
+functions rely on RLS to scope the walk, and walking unscoped as
+service_role would leak other users' items (same caveat the existing
+`*_location_contents` calls document in `page.tsx`).
+
+Server flow:
+
+1. **Classify the target.** Query `character_asset` then `corp_asset` for
+   `item_id = target` (mirror the `self` lookup in
+   `src/app/asset/[locationId]/page.tsx`). Found → it's an item; keep its
+   `(type_id, quantity, is_singleton)`. Not found → treat as a location id.
+2. **Collect the subtree.** Call both RPCs in parallel —
+   `character_asset_subtree_items` and `corp_asset_subtree_items` with
+   `parent = target` — and merge the rows, summing quantities per
+   `type_id`. (An item lives in exactly one table, so the union
+   double-counts nothing.) If the target is an item, add its own line:
+   singleton → 1, else its quantity.
+3. **Filter blueprints.** Drop types whose SDE category is
+   `BLUEPRINT_CATEGORY_ID` (9, exported by `src/app/api/mcp/lib.ts`) —
+   asset rows can't distinguish worthless copies from originals, so pricing
+   them would be wrong more often than right. Count them as
+   `skipped_blueprints`.
+4. **Guard the batch.** Zero lines → `{ ok: false, error: "nothing to
+   appraise" }` (e.g. a container of only blueprints). More than **500
+   distinct types** → refuse with a clear error rather than truncating (a
+   silently partial total is worse than no total). 500 is a guess at the
+   API's comfortable batch size — verify once with a real large request
+   while implementing, and adjust the constant + this doc.
+5. **Resolve names and appraise.** `getSdeTypeNames` over the type ids;
+   types the SDE can't name are dropped into an `unpriced` list (the API is
+   name-keyed, so an unnamed type can't be priced). One `appraise(lines,
+   market)` call — never more.
+6. **Respond.**
+
+```jsonc
+// 200
+{
+  "ok": true,
+  "market": "jita",
+  "total_sell_value": 4030000000,
+  "total_buy_value": 3950000000,
+  "price_split": 3990000000,
+  "total_volume_m3": 5010.0,
+  "line_count": 12,
+  "skipped_blueprints": 3,            // omit when 0
+  "unpriced": ["SomeType"],           // names the API couldn't price; omit when empty
+  "cached": true,                     // omit when false
+  "rate_limit_remaining": 197         // omit when null
+}
+```
+
+Map `AppraisalError` kinds to statuses: `unconfigured` → `503`,
+`rate_limited` → `429` with `retry_after_seconds`, `upstream` → `502`; the
+zero-lines/too-many cases → `422`. Body always `{ ok: false, error, … }`.
+
+Per-line prices are **not** returned in v1 — the UI only shows totals, and
+the payload for a 500-type hangar would be pointless weight. The MCP tool
+(doc 01) is the itemized view. If a drill-down UI is ever wanted, add an
+`include_lines` flag then.
+
+## Client component — `AppraiseButton`
+
+`src/app/asset/[locationId]/appraiseButton.tsx`, `'use client'`, used both
+per-row and (with the location id) next to the heading:
+
+```tsx
+export const AppraiseButton = ({ target }: { target: string }) => { … }
+```
+
+- `useState<'idle' | 'loading' | Result | Err>`; on click, `fetch('/api/appraisal',
+  { method: 'POST', body: JSON.stringify({ target }) })`.
+- Renders: idle → `<button>appraise</button>`; loading → `…`; success →
+  the sell/buy figures (tooltip as described above; append `*` when
+  `cached` — cheap honesty about staleness); error → the quiet inline
+  message. State is per-mount; navigating away discards it (deliberate — no
+  client-side store).
+- Styling: a `.module.css` next to it if needed; follow `quantity.tsx` in
+  the same directory as the pattern for a tiny presentational client
+  component.
+
+`LocationAssets` gains the column behind `canAppraise` (keep the
+`colSpan` on the empty-state row in sync), and `page.tsx` renders the
+header button only when `!scope`.
+
+## Verification
+
+1. `pnpm run lint` + `pnpm run build`.
+2. `pnpm run dev`, sign in, open a station on `/asset`:
+   - appraise a plain stack → value appears, matches `appraise_items` for
+     the same type/quantity;
+   - appraise a ship with fitted modules and cargo → total exceeds hull
+     price; tooltip shows the line count;
+   - appraise a container holding only blueprints → the 422
+     "nothing to appraise" path renders sanely;
+   - click the same target twice → second answer is instant and marked
+     cached;
+   - "Appraise everything here" on the station → plausible hangar total;
+   - open a `/asset/[id]?token=…` share link → no Value column, no header
+     button; `POST /api/appraisal` without a session → 401.
+3. Watch `x-ratelimit-remaining` in the dev logs while testing — the whole
+   session should cost a handful of requests, not dozens.

--- a/docs/appraisals/README.md
+++ b/docs/appraisals/README.md
@@ -1,0 +1,133 @@
+# Price appraisals via innomin.at
+
+Add ISK price appraisals to the app, powered by the
+[Innominate Appraisal API](https://innomin.at/api/docs/) (an
+Evepraisal-style service; the repo owner has an API key, provisioned as the
+`INNOMINATE_API_KEY` env var). Two user-facing deliverables, shipped as
+**separate PRs, in order** — each numbered document is a self-contained
+implementation spec:
+
+| Doc | PR | What | Status / dependency |
+|---|---|---|---|
+| [01-mcp-appraise-tool.md](01-mcp-appraise-tool.md) | **Milestone 1** | The shared `src/innominate.ts` API client + an `appraise_items` MCP tool (batch appraisal by item name) | Independent; do first |
+| [02-asset-subtree-items.md](02-asset-subtree-items.md) | small | Postgres functions that aggregate a container/location subtree into `(type_id, quantity)` rows | Independent of 01 (pure DB); needed by 03 |
+| [03-asset-viewer-appraisal.md](03-asset-viewer-appraisal.md) | **Milestone 2** | Appraise buttons in the asset viewer: lazy-load the appraisal of one stack, or a container/ship and everything inside it | After 01 (client) **and** 02 (DB functions) |
+
+Future ideas deliberately **not** in scope (park them unless asked): a market
+picker in the UI (everything defaults to Jita), appraising a `/asset/search`
+result set, historical price tracking in our DB, and appraisal support on the
+anonymous share-token pages.
+
+## The API (validated 2026-07-17 against the live service)
+
+OpenAPI schema: `https://innomin.at/api/schema/` (the `/api/docs/` page is a
+Swagger UI over it). Everything below was confirmed with real requests using
+our key.
+
+### `POST /api/v1/appraise/` — the only endpoint we use
+
+- **Auth:** `X-API-Key: <INNOMINATE_API_KEY>` header.
+- **Request** (`application/json`):
+
+  ```json
+  {
+    "items": [{ "name": "Tritanium", "quantity": 1000 }],
+    "market": "jita",
+    "save": false
+  }
+  ```
+
+  - `items` — required, `minItems: 1`, each `{ name (required), quantity (int ≥ 1, default 1) }`.
+    Appraisal is **by item name**, not type id; the service resolves the name
+    itself and echoes the resolved `item_id` back.
+  - `market` — default `jita`. Available: `jita`, `amarr`, `rens`, `dodi`,
+    `hek`, `ualx`, `cj6mt` (the last two are player nullsec markets).
+  - `save` — **always send `false`.** This is a hard requirement from the
+    repo owner: `save: false` makes the call side-effect free on the
+    provider's server (nothing stored, no appraisal id minted). Never expose
+    it as a parameter; hard-code it in the client.
+  - `comment` — irrelevant when not saving; omit.
+
+- **Response 200** (`AppraisalResponse`): `appraisals[]` (one entry per
+  requested item, **in request order**), plus totals across the batch:
+
+  ```json
+  {
+    "appraisals": [
+      {
+        "name": "Tritanium", "item_id": 34, "quantity": 1000,
+        "item_vol": 0.01, "total_item_vol": 10.0,
+        "sell_price": 4.03, "buy_price": 3.95,
+        "sell_average": 3.74, "buy_average": 3.68,
+        "total_sell_price": 4030.0, "total_buy_price": 3950.0,
+        "error": null
+      }
+    ],
+    "total_vol": 10.0, "total_sell_value": 4030.0, "total_buy_value": 3950.0,
+    "price_split": 3990.0,
+    "market": "jita", "market_status": "Ready",
+    "corp_id": null, "comment": "", "current_count": 177609
+  }
+  ```
+
+  - `sell_price` = current lowest sell, `buy_price` = current highest buy,
+    `*_average` = historical averages, `price_split` = (sell+buy)/2 total.
+  - **Unknown names don't fail the batch.** The entry comes back with
+    `item_id` absent/null, every price field `null`,
+    `"error": "Item not found"`, and a `possible_matches` string array of
+    suggested names. Totals cover only the priced items.
+  - `current_count` is the key's lifetime request counter (undocumented;
+    don't rely on it).
+
+- **Errors:** `400` invalid request, `401` bad/missing key, `429` rate
+  limited — all `{ "error": "…" }` JSON bodies.
+
+### Rate limit — the central design constraint
+
+Response headers (confirmed): `x-ratelimit-limit: 200/hour`,
+`x-ratelimit-remaining`, `x-ratelimit-reset` (epoch seconds),
+`x-ratelimit-reset-after` (seconds). **200 requests per hour, total, for the
+whole deployment.** Consequences baked into the designs:
+
+1. **One API call per appraisal action, always.** The endpoint is a batch
+   endpoint — a whole container/hangar of distinct types goes in a single
+   request. Never loop per item.
+2. **Cache responses in-process** (5-minute TTL — see doc 01). Market prices
+   don't move fast enough to matter, and repeated clicks on the same
+   container must not spend the budget.
+3. **Surface the remaining budget** (`x-ratelimit-remaining`) in tool/route
+   responses, and turn a `429` into a friendly "try again in Ns" using
+   `x-ratelimit-reset-after` — never retry automatically.
+
+### Privacy note
+
+Requests to innomin.at carry **only type names and quantities** — never
+owner, character, corporation, or location data. That's inherent to the
+request shape, but keep it true: don't add comments or metadata to the
+payload.
+
+## Where this sits in the architecture
+
+The CLAUDE.md data-flow rule says UI/MCP read the DB and never call ESI.
+This project adds a **deliberate, narrow exception for a third-party price
+API**: market prices are not in our DB at all, so both the MCP tool and the
+asset-viewer route call innomin.at server-side at request time (they still
+never call ESI, and nothing from innomin.at is persisted). All calls go
+through the single client module `src/innominate.ts` (doc 01) so the
+`save: false` invariant, auth header, caching, and rate-limit handling live
+in exactly one place.
+
+## House rules (from CLAUDE.md — these bite)
+
+- **No test runner.** Gates are `pnpm run lint` + `pnpm run build`, plus
+  manually exercising the MCP tool / pages touched. Every PR passes both.
+- **Schema changes are dual-write:** edit `schema.sql` (full-reset source of
+  truth) **and** add an incremental migration under `supabase/migrations/`
+  (`pnpm run db:new <name>`); never rename an existing migration file.
+- **Ramda over `for`/`while`** for synchronous iteration.
+- **`git fetch origin && git rebase origin/main`** immediately before
+  pushing and opening each PR. No exceptions.
+- `INNOMINATE_API_KEY` goes in `.env.example` (doc 01) and must be set in
+  the Vercel project before Milestone 1 deploys.
+- Line numbers quoted in these docs will drift — anchor on the quoted code,
+  not the numbers, and re-verify each call site before editing.


### PR DESCRIPTION
## What

Starts the **appraisals** project (`docs/appraisals/`): a multi-PR plan for ISK price appraisals powered by the [Innominate Appraisal API](https://innomin.at/api/docs/), in the same self-contained-spec style as `docs/sde-db-cutover/`. Docs only — no code changes.

- **README.md** — project overview, milestone/PR table, and the API reference **validated against the live service with the provisioned `INNOMINATE_API_KEY`** (endpoint shapes, per-item error/`possible_matches` behavior, and the confirmed `x-ratelimit-limit: 200/hour` budget that drives the design). Documents the two hard invariants: `save: false` on every request (side-effect free on the provider's server, per the key agreement) and payloads that carry only type names + quantities (no owner/location data).
- **01-mcp-appraise-tool.md** — Milestone 1: the single shared `src/innominate.ts` client (hard-coded `save: false`, no auto-retry on 429, 5-minute in-process TTL cache) plus an `appraise_items` MCP tool with SDE name canonicalization, following the existing `tools.ts` patterns.
- **02-asset-subtree-items.md** — small DB PR: `character_asset_subtree_items(parent)` / `corp_asset_subtree_items(parent)` seeded-recursion functions that aggregate a container/ship/location subtree into `(type_id, quantity)` rows, RLS-scoped via the existing views, dual-written to `schema.sql` + a migration.
- **03-asset-viewer-appraisal.md** — Milestone 2: per-row and whole-location appraise buttons on `/asset/[locationId]` lazy-loading totals through a new `POST /api/appraisal` route (one batched API call per click, blueprint rows skipped, share-token pages excluded).

## Why

Prices aren't in our DB anywhere; this wires in a rate-limited third-party source once, behind one client module, so both the MCP surface and the asset viewer can answer "what is this worth".

## Verification

- API behavior in the README was confirmed with live requests (batch pricing, unknown-name suggestions, rate-limit headers).
- Docs-only change; `pnpm run lint` / `pnpm run build` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9EMtUDUjRddC2UvzcqCSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9EMtUDUjRddC2UvzcqCSk)_