### PR TITLE
docs: scope the Discord bot reinforced-den notification project

### DIFF
--- a/docs/discord-bot/01-legal-pages.md
+++ b/docs/discord-bot/01-legal-pages.md
@@ -1,0 +1,63 @@
+# Stage 01 — Privacy policy & terms of service pages
+
+**PR size:** tiny · **Depends on:** nothing · **Blocks:** stage 02 (the
+Discord app registration form asks for these URLs)
+
+## Goal
+
+Two static pages, `/privacy` and `/terms`, so the Discord application can be
+registered with real Privacy Policy / Terms of Service URLs. Independently
+useful: the site stores EVE character data and OAuth tokens and currently
+says nothing about it.
+
+## Deliverables
+
+- `src/app/privacy/page.tsx` — server component, static content, standard
+  `metadata` export for the title. No client JS.
+- `src/app/terms/page.tsx` — same shape.
+- Links to both from the footer (`src/app/layout/` — Footer component).
+- No schema changes, no env vars, no new dependencies.
+
+## Content scope (what the privacy page must actually cover)
+
+Write it plainly and truthfully for what the app does today plus what this
+project adds. At minimum:
+
+- **What we collect:** email + password (Supabase Auth); EVE character
+  identity and OAuth refresh tokens (EVE SSO); the game data the extract
+  jobs pull via ESI on the user's behalf (assets, wallet, industry jobs,
+  clones, mercenary dens, …) and its history (the SCD-2 tables keep old
+  versions); and — once stage 03 lands — Discord guild/channel ids and the
+  Discord user id that ran the link command.
+- **What we do with it:** show it back to the account that linked it;
+  corp-scoped sharing where the user opts in (den shares, corp tables);
+  public share pages only where explicitly enabled (`/corpses`, ship share
+  tokens). No selling, no third-party analytics.
+- **Third parties data transits:** Supabase (storage), Vercel (hosting),
+  CCP/ESI (source), Discord (once notifications post to a channel — note
+  that messages posted to a Discord channel are governed by Discord's own
+  terms and visible to that channel's members).
+- **Removal:** how to unlink a character / delete an account, and that
+  revoking the EVE SSO grant at CCP's side kills our token.
+- **Contact:** an email or GitHub issues link.
+
+The terms page can be short: personal-use tool, no warranty, not affiliated
+with CCP (include CCP's required copyright notice for EVE IP — the standard
+"EVE Online and the EVE logo are the registered trademarks of CCP hf." text
+already used by community sites), Discord's brand likewise.
+
+This is a hobby project, not a law firm's client — keep the pages honest and
+readable rather than boilerplate-maximal. If the wording matters to you,
+have a human review it; that review is outside this PR's scope.
+
+## Milestone / acceptance
+
+- `pnpm run lint` + `pnpm run build` pass.
+- `/privacy` and `/terms` render on production, reachable from the footer.
+- The URLs are stable enough to paste into the Discord developer portal in
+  stage 02 (don't plan to move them later).
+
+## Out of scope
+
+- Cookie banners / consent tooling (no third-party analytics exist).
+- A data-export endpoint (candidate follow-up if anyone ever asks).

--- a/docs/discord-bot/02-interactions-endpoint.md
+++ b/docs/discord-bot/02-interactions-endpoint.md
@@ -1,0 +1,81 @@
+# Stage 02 — Discord application + interactions endpoint
+
+**PR size:** small · **Depends on:** 01 (portal wants the legal URLs) ·
+**Blocks:** 03 (slash commands arrive through this endpoint)
+
+## Goal
+
+Register the Discord application and stand up the one route Discord calls
+into us: `POST /api/discord/interactions`. After this stage the app exists,
+the endpoint passes Discord's validation, and every interaction type gets a
+polite "not implemented yet" — the plumbing that lets Discord talk to the
+website, with no behavior behind it.
+
+## Portal setup (manual, documented in the PR description)
+
+1. Create the application at discord.com/developers → note the
+   **Application ID** and **Public Key**; add the stage-01 URLs in App
+   Information.
+2. Bot tab → create the bot user, note the **Token**. No privileged gateway
+   intents — this bot never connects to the gateway at all (HTTP-only
+   interactions + REST), which keeps hosting serverless-friendly on Vercel.
+3. Set **Interactions Endpoint URL** to
+   `https://edencom.link/api/discord/interactions`. Discord immediately
+   fires a `PING` and several deliberately invalid-signature probes; the
+   save only succeeds if we answer the PING correctly **and** reject the bad
+   signatures with a 401. (This means the route must be deployed before the
+   URL can be saved — deploy first, configure second.)
+4. Vercel env vars + `.env.example` entries: `DISCORD_APP_ID`,
+   `DISCORD_PUBLIC_KEY`, `DISCORD_BOT_TOKEN` (token unused until stage 05
+   but set it now while in the portal).
+
+## The route — `src/app/api/discord/interactions/route.ts`
+
+- **Node runtime** (not edge): we need `node:crypto` and, later, the
+  service-role Supabase client.
+- **Signature verification first, before anything else.** Discord signs
+  every request: headers `X-Signature-Ed25519` and `X-Signature-Timestamp`;
+  the signed message is `timestamp + rawBody`. Verification needs the **raw
+  body string** — read `await request.text()` and `JSON.parse` manually;
+  never let anything consume the body as JSON first. Invalid signature ⇒
+  `401` with no body processing.
+- **Ed25519 verification, zero-dependency:** Node 24's `node:crypto`
+  verifies Ed25519 natively — import the hex `DISCORD_PUBLIC_KEY` as a raw
+  key (via a one-line JWK wrap: `{ kty: 'OKP', crv: 'Ed25519', x:
+  base64url(hexToBytes(key)) }`) and `crypto.verify(null, message, key,
+  sig)`. This matches the repo's zero-dependency preference
+  (`src/observability.js` precedent). Fallback if the raw-key import proves
+  fiddly: the official `discord-interactions` npm package is tiny and does
+  exactly this — acceptable, but try without it first.
+- **Dispatch by interaction `type`:**
+  - `1` (PING) → `{ type: 1 }` (PONG). This is what portal validation
+    exercises.
+  - `2` (APPLICATION_COMMAND) → for now, type-4 ephemeral response
+    ("Nothing here yet — commands arrive in a later release"). Stage 03
+    replaces this with the real command router.
+  - anything else → type-4 ephemeral or 400.
+- **Respond within 3 seconds** — Discord's hard deadline for the initial
+  interaction response. Nothing in this stage comes close, but stage 03's
+  handlers must keep DB work inside that budget (or defer with a type-5
+  acknowledge; note it as a constraint, don't build deferral yet).
+- Helper seam: put verification + response helpers in
+  `src/app/api/discord/lib.ts` so stage 03's command handlers and any
+  future routes share them.
+
+No schema changes in this stage. Consider an `discord.interaction` metric
+line via `src/observability.js` (`{ metric, type, outcome }`) from day one —
+it makes the stage-03 debugging loop visible in Vercel Observability.
+
+## Milestone / acceptance
+
+- `pnpm run lint` + `pnpm run build` pass.
+- The Discord developer portal accepts the Interactions Endpoint URL
+  against production (its validation probes pass — this is the real test,
+  and it's binary).
+- A hand-crafted unsigned `curl` to the route gets a 401.
+
+## Out of scope
+
+- Any actual command behavior (stage 03).
+- Gateway/websocket presence, message-content intent, DMs.
+- Outbound REST calls (stage 05).

--- a/docs/discord-bot/03-account-linking.md
+++ b/docs/discord-bot/03-account-linking.md
@@ -1,0 +1,101 @@
+# Stage 03 — Bot install, account linking, channel configuration
+
+**PR size:** medium (the schema + UI stage) · **Depends on:** 02 ·
+**Blocks:** 04 (detection needs to know someone is listening), 05
+
+## Goal
+
+A signed-in edencom.link user can (a) invite the bot to their Discord
+server, (b) prove to the bot which edencom.link account they are, and
+(c) pick the channel that gets den pings — all via one slash command run in
+the target channel. After this stage, `/account/settings` shows the linked
+channel(s); nothing posts to them yet.
+
+## Design: link codes, not Discord OAuth
+
+Two identities need joining: the edencom.link account (Supabase `user_id`)
+and a Discord channel. Full Discord OAuth2 sign-in would work but drags in a
+second OAuth client, callback route, and token storage for something we need
+exactly once. Instead, mirror the invite-code pattern the repo already has
+(`invite_code`):
+
+1. Settings page mints a short-lived, single-use **link code** (server
+   action; `randomBytes` like `generateApiToken`), shown with copy button
+   and the bot-install link.
+2. User clicks the install link (`https://discord.com/oauth2/authorize?client_id=<DISCORD_APP_ID>&scope=bot+applications.commands&permissions=<perms>` —
+   permissions: Send Messages + Embed Links only; request nothing else) and
+   adds the bot to their server.
+3. In the channel that should receive pings, user runs
+   `/edencom link <code>`. The interaction carries the guild id, channel id,
+   and the invoking Discord user's id — everything needed to bind.
+4. The interactions handler (service-role client, after signature
+   verification) burns the code and inserts the channel link row. Ephemeral
+   confirmation reply.
+
+`/edencom unlink` in the same channel removes the row; the settings page
+also lists links with a remove button (belt and braces — the user may have
+lost access to the Discord server).
+
+## Schema (dual-write: `schema.sql` + migration)
+
+Two tables, names indicative — final shapes belong to the implementing PR:
+
+- **`discord_link_code`** — `code` (unique), `user_id`, `created_at`,
+  `expires_at` (~10 min), `redeemed_at`. RLS: owner reads own; inserts via
+  server action; redemption via service role.
+- **`discord_channel`** — `id`, `user_id`, `guild_id`, `channel_id`,
+  `guild_name`, `channel_name` (display only, denormalized at link time from
+  the interaction payload), `linked_by_discord_user_id`, `created_at`,
+  `disabled_at` (stage 05 sets this when Discord says the channel is gone).
+  Unique `(user_id, channel_id)`. RLS: owner reads/deletes own rows; writes
+  via service role only (the interactions route is the writer).
+
+Keeping `discord_channel` per-**user** (not per-corp) matches the ntfy
+plan's stance: whoever links, their dens ping there. Multiple users may link
+the same channel; each binding is independent.
+
+## Slash command registration
+
+Commands are data registered with Discord, not code: a one-off utility
+script (`src/discordRegisterCommands.js`, alongside `connect`/`ping`/
+`refresh` in the DB/token-utilities family, run manually via
+`node src/discordRegisterCommands.js`) that PUTs the global command list
+(`/edencom` with `link <code>` and `unlink` subcommands) to
+`applications/{DISCORD_APP_ID}/commands` using the bot token. Global
+commands can take up to ~1h to propagate; the script should also support a
+`--guild <id>` flag for instant registration on a test server.
+
+## Interactions handler additions (`src/app/api/discord/`)
+
+Replace stage 02's stub type-2 response with a small command router:
+
+- `link`: validate code (exists, unexpired, unredeemed) → insert
+  `discord_channel` → mark code redeemed → ephemeral success naming the
+  channel. Failure modes get distinct ephemeral messages (expired code,
+  already linked, …). All comfortably inside the 3-second budget.
+- `unlink`: delete rows for this channel where `linked_by_discord_user_id`
+  matches the invoker (or any row if the invoker owns the link code trail —
+  keep it simple: match on channel + invoking Discord user).
+
+## Settings UI (`/account/settings`)
+
+New "Discord" section (pattern: the existing `apiToken.tsx` component):
+install-bot link, generate-code button with countdown, list of linked
+channels (`guild_name` / `#channel_name`, linked date, remove button).
+Server actions in the existing settings `actions.ts`.
+
+## Milestone / acceptance
+
+- `pnpm run lint` + `pnpm run build` pass; migration applies.
+- On a test Discord server: install bot → generate code → `/edencom link`
+  → ephemeral confirmation → the channel appears in `/account/settings`;
+  remove from settings and via `/edencom unlink` both work.
+- An expired or reused code gets a clear ephemeral error.
+
+## Out of scope
+
+- Choosing *which* events go to *which* channel (all den reinforcements to
+  every linked channel is the MVP; per-den or per-event routing is a
+  follow-up).
+- Discord OAuth2 website sign-in.
+- Role-mention configuration.

--- a/docs/discord-bot/04-reinforcement-detection.md
+++ b/docs/discord-bot/04-reinforcement-detection.md
@@ -1,0 +1,119 @@
+# Stage 04 — Reinforcement detection + notification outbox
+
+**PR size:** medium (the interesting one) · **Depends on:** 03 only for
+end-to-end usefulness — technically independent and testable on its own ·
+**Blocks:** 05
+
+## Goal
+
+When an extract run observes a den entering reinforcement, exactly one
+pending notification row appears in an outbox table. No Discord traffic in
+this stage; the milestone is verified in the database.
+
+## Where detection lives
+
+`src/jobs/characterMercenaryDens.js` already appends one
+`character_mercenary_den_status` observation per den per run, carrying
+`reinforcement_end` (null when not reinforced). The transition is therefore
+visible at extract time by comparing the fresh observation against the den's
+**previous latest** observation:
+
+- previous `reinforcement_end` null (or in the past) **and** new
+  `reinforcement_end` non-null and in the future ⇒ **newly reinforced** —
+  enqueue.
+- both non-null but the timestamp moved ⇒ a new/changed timer — treat as
+  newly reinforced too (dedupe key below makes this safe).
+- anything else ⇒ no event.
+
+Do the comparison inside `syncCharacterMercenaryDens` (it already has the
+detail payload in hand; one extra select of the previous observation per den
+— dens per character are single digits, so this is cheap). Detection at
+extract time — not a separate scanner job — means the on-demand "Refresh
+ESI" queue path and the CLI get detection for free, since they run the same
+sync function.
+
+**First-observation rule:** a den whose *first ever* observation is already
+reinforced should still enqueue (user links mid-reinforcement and wants the
+ping). A den that vanishes from the listing with a pending outbox row: leave
+the row — the den being transferred/unanchored mid-timer is itself worth a
+ping (the message just states the facts as observed).
+
+## The outbox table — decision
+
+The ntfy plan (`docs/ntfy-notifications.md`, unimplemented) designed a
+generic `notification` table keyed by `source`, delivering via the user's
+ntfy topic. This project needs a different delivery target (a
+`discord_channel` row). **Decision: mint the generic `notification` table
+now, ntfy-plan shape plus two columns:**
+
+- `transport text not null` — `'discord'` now; `'ntfy'` when that project
+  lands (its sweep then filters on its own transport).
+- `discord_channel_id` — nullable FK to `discord_channel`, set when
+  `transport = 'discord'`. (If a user has N linked channels, detection
+  fans out N rows, one per channel — delivery state is per-message.)
+
+Everything else follows the ntfy doc's design verbatim: `user_id`,
+`source`, `subject`, `body`, `scheduled_at`, `sent_at`, `attempts`,
+`created_at`, the partial unique index on pending `(user_id, source)`
+(extended with `discord_channel_id`), the due-rows partial index, RLS
+owner-scoped with service-role writes. Dual-write `schema.sql` + migration
+as always.
+
+**Dedupe key:** `source = 'mercenary-den:<den_id>:<reinforcement_end unix>'`
+— one ping per den per distinct timer. Re-observing the same reinforcement
+on the next 6-hourly run hits the partial unique index (and, once sent, the
+sent row simply exists); a *changed* timer mints a new source and pings
+again, which is the desired behavior. Treat the `23505` duplicate error as
+success, as the ntfy doc prescribes.
+
+`scheduled_at = now()` — reinforcement pings are immediate, the column
+exists for transports/sources that schedule ahead (ntfy industry jobs,
+future pre-timer reminders).
+
+## Message content (composed at detection time, stored in the row)
+
+Reuse the exact format users already paste by hand
+(`src/app/mercenary-dens/copyDiscordPing.tsx`):
+
+```
+Mercenary Den Reinforced - `JVA-FE` planet `II` at <t:1784057275:s> @ <t:1784057275:R>
+```
+
+`<t:…:s>`/`<t:…:R>` are Discord timestamp markups (viewer-local wall clock +
+live countdown) — they belong in the body string as-is. System + roman
+resolve via `getSdePlanet` (`src/sdePlanets.ts`) from the den's `planet_id`;
+subject: `Mercenary Den Reinforced`. Composing at detection keeps the sender
+dumb (stage 05 just posts `body`).
+
+## Detection latency — cadence decision
+
+`character-mercenary-dens` runs every 6h (`:30`). A den reinforced just
+after a run pings up to ~6h late; EVE reinforcement timers run ~1–1.5 days,
+so a 6h-late ping still leaves most of the timer, but it's a real chunk.
+The pull is cheap (one listing + one detail request per den, single-digit
+dens per character). **Recommendation: bump the cron to hourly in this PR**
+(`vercel.json` schedule change only; the fan-out shape already scales) and
+note ESI's own cache time on these endpoints as the effective floor. If
+hourly feels too chatty for ESI etiquette, every 2–3h is still a big
+improvement. Decide in the PR, but decide deliberately — this bounds the
+product's usefulness.
+
+## Milestone / acceptance
+
+- `pnpm run lint` + `pnpm run build` pass; migration applies.
+- Simulation (no real reinforced den needed — ESI has to report an actual
+  timer for the live path, which can't be arranged on demand): factor the
+  compare-and-enqueue step into a small exported function taking (previous
+  observation, new observation, linked channels) so it can be exercised
+  directly from a throwaway harness script against a dev database.
+  Acceptance is: **given** prev-null/new-future observations, **exactly
+  one** pending outbox row per linked channel exists, and re-running the
+  detection produces no duplicates.
+- A character with no linked channels produces no rows (detection consults
+  `discord_channel` before writing).
+
+## Out of scope
+
+- Sending anything (stage 05).
+- Repair/anarchy/state-change events other than reinforcement.
+- Shared-den (corp) notifications, corkboard-intel notifications.

--- a/docs/discord-bot/05-notification-sender.md
+++ b/docs/discord-bot/05-notification-sender.md
@@ -1,0 +1,81 @@
+# Stage 05 — Sender sweep: outbox → Discord channel
+
+**PR size:** small · **Depends on:** 03 + 04 · **Completes the MVP**
+
+## Goal
+
+A cron sweep that posts pending `transport = 'discord'` outbox rows to
+their linked channels via the Discord REST API. After this stage the
+end-to-end loop is closed: den reinforced → extract detects → message
+appears in the corp channel.
+
+## The job — `discord-notification-send`
+
+Follows the extract-job conventions (name = npm script = heartbeat label =
+cron path) even though it reads our own DB, exactly like the ntfy plan's
+sender:
+
+- **`src/jobs/discordNotificationSend.js`** exporting
+  `runDiscordNotificationSend()`, CLI-runnable via `cli(...)`. Logic
+  (ramda style, `forEachSequential`):
+  1. `sudoSupabase` select due rows: `transport = 'discord'`,
+     `sent_at is null`, `scheduled_at <= now()`, `attempts < 10`, joined to
+     `discord_channel` for the target (skip rows whose channel is
+     `disabled_at`-stamped or deleted — bump attempts so they eventually
+     stop being selected).
+  2. Per row: `POST https://discord.com/api/v10/channels/{channel_id}/messages`
+     with `Authorization: Bot ${DISCORD_BOT_TOKEN}`, body
+     `{ content: row.body, allowed_mentions: { parse: [] } }` (no pings of
+     any kind until role-mention config exists — the timestamp markup does
+     the urgency work).
+  3. Outcome handling:
+     - **2xx** → stamp `sent_at = now()`.
+     - **403/404** (bot kicked, channel deleted, permissions revoked) →
+       stamp the `discord_channel.disabled_at` and bump `attempts`; these
+       are permanent, don't burn 10 retries. Settings UI shows the channel
+       as disabled so the user can re-link.
+     - **429** → respect `retry_after` from the response body within reason
+       (sequential sends at this volume make real rate-limiting unlikely);
+       otherwise bump `attempts` and let the next sweep retry.
+     - other failure → bump `attempts` (cap 10, then abandoned-but-visible,
+       per the ntfy design).
+  4. Per-run summary log line + a `discord.send` metric via
+     `src/observability.js` (`{ metric, outcome, status, duration_ms }`),
+     matching the `esi.conditional_request` precedent.
+- **Cron route** `src/app/api/cron/discord-notification-send/route.ts` —
+  `requireCronSecret` + `runDirectCronJob` (the direct dispatch shape:
+  tiny working set, nothing to fan out, heartbeat for free).
+- **`vercel.json`**: `*/5 * * * *`. Five-minute delivery lag on top of
+  detection is noise against the extract cadence.
+- **`package.json`**: `"discord-notification-send": "node src/jobs/discordNotificationSend.js"`.
+
+Not on `/character/refresh`'s matrix (not per-character, not an ESI
+extract); the heartbeat row still proves liveness.
+
+## Settings polish riding along
+
+- A **"Send test message"** button per linked channel in the Discord
+  settings section — server action that posts directly (not via the outbox)
+  so users verify the pipe before trusting it. Mirrors the ntfy plan's
+  test-notification button.
+- Linked-channel list shows `disabled_at` state ("bot lost access — remove
+  and re-link").
+
+## Milestone / acceptance
+
+- `pnpm run lint` + `pnpm run build` pass.
+- Hand-insert a pending outbox row (or run the stage-04 simulation) → the
+  message appears in the linked test channel within one sweep, rendered
+  with Discord's live countdown; the row is `sent_at`-stamped; re-running
+  the sweep sends nothing.
+- Kick the bot from the test server, enqueue again → channel row gets
+  `disabled_at`, no crash-looping, settings shows the state.
+- Test button works; a message to a channel the bot can't see fails
+  gracefully.
+
+## Out of scope (see README follow-ups)
+
+- Embeds/rich formatting (plain content with timestamp markup is already
+  the format the corp uses).
+- Role mentions, per-event channel routing, reminders before timer end,
+  `/edencom dens` query command, shared-den notifications.

--- a/docs/discord-bot/README.md
+++ b/docs/discord-bot/README.md
@@ -1,0 +1,132 @@
+# Discord bot: reinforced-den notifications
+
+Scope for making edencom.link double as a Discord application, so that when
+an extract run detects that one of a user's Mercenary Dens has been
+reinforced, a message is posted automatically to a Discord channel the user
+configured. Today this is manual: the `/mercenary-dens` page has a 📋 button
+(`src/app/mercenary-dens/copyDiscordPing.tsx`) that copies a Discord-ready
+ping the user pastes into their corp channel themselves. This project closes
+that loop.
+
+This is a scoping document set, not an implementation spec. Each stage is
+one PR with its own milestone; do them **in order** (each builds on the
+previous). Stage docs deliberately stay at scoping depth — enough to size
+and sequence the work — and the implementing PR should firm up the details
+against the code as it stands then.
+
+| Doc | PR | What | Milestone |
+|---|---|---|---|
+| [01-legal-pages.md](01-legal-pages.md) | tiny | Privacy policy + terms of service pages (Discord requires the URLs) | Pages live at `/privacy` and `/terms`, linked from the footer |
+| [02-interactions-endpoint.md](02-interactions-endpoint.md) | small | Discord application registration + the signed interactions endpoint | Discord's developer-portal endpoint validation passes against production |
+| [03-account-linking.md](03-account-linking.md) | medium | Bot install flow, account↔Discord linking, channel configuration via `/edencom link` | A linked channel row appears in settings after running the slash command |
+| [04-reinforcement-detection.md](04-reinforcement-detection.md) | medium | Detect the unreinforced→reinforced transition at extract time; notification outbox table | A simulated reinforcement produces exactly one pending outbox row |
+| [05-notification-sender.md](05-notification-sender.md) | small | Cron sweep that posts pending notifications to the linked channel | End-to-end: reinforced den → message in the Discord channel |
+
+Follow-ups (out of scope for all five stages) are collected at the bottom of
+this file.
+
+## Why a bot and not just a webhook
+
+The cheapest possible version of this is a Discord **incoming webhook**: the
+user creates a webhook on their channel (two clicks in Discord's UI), pastes
+the URL into `/account/settings`, and we POST to it — no application, no
+interactions endpoint, no signature verification, no privacy-policy
+requirement. That is a legitimate fallback if the bot route stalls, and
+stages 04–05 are designed so the delivery target could be swapped without
+touching detection.
+
+The project still targets a real Discord **application/bot** because:
+
+- Slash commands (`/edencom link`, later `/edencom dens`) make channel
+  configuration self-serve inside Discord, where the corp already lives —
+  no copying webhook URLs into a website.
+- A bot identity can later *answer* questions (den status, timers) in
+  channel, not just push.
+- Webhook URLs are bearer secrets users paste around; a bot posting via its
+  own token with per-channel rows we control is easier to revoke and audit.
+
+## Architecture at a glance
+
+```
+Discord ──(signed POST)──▶ /api/discord/interactions ──▶ link/unlink channels
+                                                              │
+character-mercenary-dens extract ─▶ detects un→reinforced ─▶ notification outbox row
+                                                              │
+Vercel Cron (*/5) ─▶ /api/cron/discord-notification-send ─▶ POST Discord REST
+                                                              │ (bot token)
+                                                        linked channel message
+```
+
+Two independent halves meet at the outbox table:
+
+- **Inbound** (stages 02–03): Discord calls us. The interactions endpoint is
+  the only place Discord initiates contact; it verifies Ed25519 signatures
+  and handles slash commands. This is where "endpoints that let Discord talk
+  to the website" lives.
+- **Outbound** (stages 04–05): we call Discord. Detection happens inside the
+  existing `character-mercenary-dens` extract (which already appends one
+  `character_mercenary_den_status` observation per den per run — the
+  transition is visible by comparing consecutive observations), and a
+  sweep job delivers pending rows via the Discord REST API.
+
+## Relationship to the ntfy plan
+
+[docs/ntfy-notifications.md](../ntfy-notifications.md) (unimplemented as of
+this writing) designs a generic `notification` outbox delivered via ntfy.sh,
+and explicitly lists mercenary-den reinforcement as a future source. This
+project and that one want the same detection but different transports. The
+outbox design decision — one shared table with a transport discriminator vs.
+a Discord-specific table — is made in
+[04-reinforcement-detection.md](04-reinforcement-detection.md); whichever
+project lands first mints the table, and the other adds its transport.
+
+## Discord platform prerequisites (why stage 01 exists)
+
+Registering the application in the Discord developer portal asks for a
+**Privacy Policy URL** and **Terms of Service URL**; they are mandatory for
+app verification (required past 100 servers, and for any App Directory
+listing) and are shown on the bot's profile and OAuth consent screen. We
+want real pages before the app exists, hence legal pages first. The app
+itself is expected to stay tiny (one corp's servers), so verification is not
+an early concern — but the URLs are cheap and the site should have these
+pages anyway.
+
+New secrets (Vercel env vars + `.env.example`), introduced in stage 02:
+
+- `DISCORD_APP_ID` — the application id (public, but env-configured)
+- `DISCORD_PUBLIC_KEY` — verifies interaction signatures (public key, hex)
+- `DISCORD_BOT_TOKEN` — authenticates outbound REST calls (secret)
+
+## House rules (from CLAUDE.md — these bite)
+
+- **No test runner.** Gates are `pnpm run lint` + `pnpm run build`, plus
+  manually exercising the affected routes. Every PR must pass both.
+- **Schema changes are dual-write**: edit `schema.sql` (full-reset source of
+  truth) **and** add an incremental migration under `supabase/migrations/`
+  (never rename an existing migration file).
+- **Ramda over `for`/`while`** for synchronous iteration; sequential async
+  iteration uses `forEachSequential` (`src/jobs/lib.js`).
+- **Server components never call ESI directly** — and by extension, the
+  Discord REST calls live in jobs/route handlers, never in page renders.
+- **`git fetch origin && git rebase origin/main`** immediately before
+  pushing and opening each PR.
+
+## Follow-ups (explicitly out of scope for stages 01–05)
+
+- `/edencom dens` slash command answering den status/timers in channel
+  (needs the Discord-user→account mapping from stage 03 plus a carefully
+  scoped service-role read, like the `/corpses` share page).
+- Pre-timer reminders ("timer ends in 30 minutes") — a second outbox row
+  scheduled at `reinforcement_end - interval`, cancelled if the den leaves
+  reinforcement.
+- Role mentions in the ping (`@dens` etc.) via `allowed_mentions` — needs
+  per-channel config for which role to ping.
+- Notifications for dens *shared to my corp* (the
+  `character_mercenary_den_share` table), not just my own dens.
+- Notifications from the enemy-den intel corkboard (user-submitted
+  reinforcements, `enemyDenIntel.tsx`).
+- Other notification sources riding the same outbox: industry-job
+  completion (the ntfy plan), clone-jump cooldown, structure fuel.
+- Incoming-webhook delivery as an alternative transport for users who don't
+  want the bot in their server.
+- Discord App Directory listing / verification.


### PR DESCRIPTION
Scoping docs only — no implementation. Adds `docs/discord-bot/` (README index + five per-stage docs, following the `docs/sde-db-cutover/` convention) for turning the manual "📋 copy Discord ping" flow on `/mercenary-dens` into an automatic Discord notification when an extract run detects a den entering reinforcement.

## The five staged PRs

1. **Legal pages** (`/privacy`, `/terms`) — the Discord developer portal asks for Privacy Policy / ToS URLs, so these come first. Milestone: pages live, linked from the footer.
2. **Interactions endpoint** — register the Discord application; `POST /api/discord/interactions` with Ed25519 signature verification (zero-dep via `node:crypto`), answering PING. Milestone: Discord's portal endpoint validation passes against production.
3. **Account linking + channel config** — bot install link, short-lived link codes minted in settings (mirroring the `invite_code` pattern), `/edencom link <code>` run in the target channel binds it; `discord_link_code` + `discord_channel` tables; settings UI section. Milestone: linked channel visible in `/account/settings`.
4. **Reinforcement detection + outbox** — detect the unreinforced→reinforced transition inside `characterMercenaryDens.js` by comparing consecutive `character_mercenary_den_status` observations; mint the generic `notification` outbox from the ntfy plan (`docs/ntfy-notifications.md`) with a `transport` discriminator so both projects share it; recommends bumping the extract cron from 6h toward hourly. Milestone: a simulated reinforcement yields exactly one pending row per linked channel, idempotently.
5. **Sender sweep** — `discord-notification-send` job + `*/5` cron posting via the Discord REST API with the bot token, reusing the exact `copyDiscordPing.tsx` message format; 403/404 disables the channel row; per-channel test-message button. Milestone: end-to-end message in the channel.

The README also covers why a real bot rather than plain incoming webhooks (slash-command self-serve config, future in-channel queries, revocability — with webhooks noted as the cheap fallback), the new env vars (`DISCORD_APP_ID`/`DISCORD_PUBLIC_KEY`/`DISCORD_BOT_TOKEN`), and a follow-up list (pre-timer reminders, role mentions, shared-den and corkboard-intel notifications, `/edencom dens`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRxxVyXXBDc1hv4nupxsQ1

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRxxVyXXBDc1hv4nupxsQ1)_