### PR TITLE
Show clone systems as region/constellation/system, sorted

### DIFF
--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -1,10 +1,10 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
-import { reduce, uniq } from 'ramda'
+import { ascend, reduce, sort, uniq } from 'ramda'
 
 import { createClient } from '@/utils/supabase/server'
 import { formatBisk } from '../isk'
-import { fetchSystemNames } from '../systemNames'
+import { fetchSystemNames, fetchSystemPaths } from '../systemNames'
 import { fetchTypeNames } from '../typeNames'
 import { register } from './actions'
 import { requiredScopes } from './scopes'
@@ -42,17 +42,26 @@ const CharacterPage = async () => {
   )
 
   const { data: clones } = await supabase.from('character_clone').select('character_id, system_id')
-  const cloneSystemNames = await fetchSystemNames((clones ?? []).map((c) => Number(c.system_id)))
-  const cloneSystems = reduce(
+  const cloneSystemPaths = await fetchSystemPaths((clones ?? []).map((c) => Number(c.system_id)))
+  const cloneSystemsByCharacter = reduce(
     (acc, c) => {
       const system =
-        c.system_id != null ? (cloneSystemNames[Number(c.system_id)] ?? `System #${c.system_id}`) : 'Unknown'
+        c.system_id != null ? (cloneSystemPaths[Number(c.system_id)] ?? `System #${c.system_id}`) : 'Unknown'
       const existing = acc.get(c.character_id as string) ?? []
       acc.set(c.character_id as string, uniq([...existing, system]))
       return acc
     },
     new Map<string, string[]>(),
     clones ?? []
+  )
+  const cloneSystems = new Map(
+    [...cloneSystemsByCharacter.entries()].map(([characterId, systems]) => [
+      characterId,
+      sort(
+        ascend((s: string) => s),
+        systems
+      ),
+    ])
   )
 
   const { data: implantRows } = await supabase.from('character_implant').select('character_id, type_ids')

--- a/src/app/systemNames.ts
+++ b/src/app/systemNames.ts
@@ -7,7 +7,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { difference, filter, fromPairs, keys, map, mergeRight, uniq } from 'ramda'
 import { createClient } from '@/utils/supabase/server'
-import { getSdeSystemNames } from '@/sdeSystems'
+import { getSdeSystemNames, getSdeSystemPaths } from '@/sdeSystems'
 
 const idNamePairs = map((r: { id: number | string; name: string }): [number, string] => [Number(r.id), r.name])
 
@@ -30,4 +30,27 @@ export const fetchSystemNames = async (
     .in('id', unresolvedIds)
   const dbNames = fromPairs(idNamePairs((data ?? []) as Array<{ id: number | string; name: string }>))
   return mergeRight(dbNames, sdeNames)
+}
+
+// "[region]/[constellation]/[system]" for known-space systems; falls back to
+// the bare universe_name for ids the SDE mirror can't place (e.g. wormholes).
+export const fetchSystemPaths = async (
+  systemIDs: Iterable<number>,
+  client?: SupabaseClient
+): Promise<Record<number, string>> => {
+  const ids = uniq(filter(Number.isFinite, [...systemIDs]))
+  if (ids.length === 0) return {}
+
+  const sdePaths = await getSdeSystemPaths(ids)
+  const unresolvedIds = difference(ids, map(Number, keys(sdePaths)))
+  if (unresolvedIds.length === 0) return sdePaths
+
+  const supabase = client ?? (await createClient())
+  const { data } = await supabase
+    .from('universe_name')
+    .select('id, name')
+    .eq('category', 'solar_system')
+    .in('id', unresolvedIds)
+  const dbNames = fromPairs(idNamePairs((data ?? []) as Array<{ id: number | string; name: string }>))
+  return mergeRight(dbNames, sdePaths)
 }

--- a/src/sdeSystems.ts
+++ b/src/sdeSystems.ts
@@ -9,19 +9,37 @@
 import { bulkLookup, createByIdCache } from './sdeCache'
 import { sdeSupabase } from './utils/supabase/sde'
 
-export type SdeSystem = { systemID: number; name: string; security: number }
+export type SdeSystem = {
+  systemID: number
+  name: string
+  security: number
+  constellationName: string | null
+  regionName: string | null
+}
 
-type SystemRow = { system_id: number; name: string; security: number }
+type SystemRow = {
+  system_id: number
+  name: string
+  security: number
+  constellation_name: string | null
+  region_name: string | null
+}
 
 const cache = createByIdCache<SdeSystem>()
 
-const rowToSystem = (r: SystemRow): SdeSystem => ({ systemID: r.system_id, name: r.name, security: r.security })
+const rowToSystem = (r: SystemRow): SdeSystem => ({
+  systemID: r.system_id,
+  name: r.name,
+  security: r.security,
+  constellationName: r.constellation_name,
+  regionName: r.region_name,
+})
 
 export const getSdeSystems = (systemIDs: Iterable<number>): Promise<Record<number, SdeSystem>> =>
   bulkLookup(cache, systemIDs, async (chunk) => {
     const { data, error } = await sdeSupabase()
       .from('sde_kspace_system')
-      .select('system_id, name, security')
+      .select('system_id, name, security, constellation_name, region_name')
       .in('system_id', chunk)
     if (error) {
       console.error(`[sdeSystems] lookup failed: ${error.message}`)
@@ -41,11 +59,22 @@ export const getSdeSystemNames = async (systemIDs: Iterable<number>): Promise<Re
   return Object.fromEntries(Object.entries(systems).map(([id, s]) => [id, s.name]))
 }
 
+// "[region]/[constellation]/[system]" — falls back to just the system name
+// for systems the mirror can't place in a constellation/region (shouldn't
+// happen for known-space systems, but the join is a left join).
+export const formatSystemPath = (system: SdeSystem): string =>
+  [system.regionName, system.constellationName, system.name].filter((part): part is string => Boolean(part)).join('/')
+
+export const getSdeSystemPaths = async (systemIDs: Iterable<number>): Promise<Record<number, string>> => {
+  const systems = await getSdeSystems(systemIDs)
+  return Object.fromEntries(Object.entries(systems).map(([id, s]) => [id, formatSystemPath(s)]))
+}
+
 // EVE shows a system's security status rounded to one decimal. Pure and sync —
 // callers already have the security number in hand.
 export const formatSecurity = (security: number): string => security.toFixed(1)
 
-export type SdeSystemSearchResult = SdeSystem & { coverage: number }
+export type SdeSystemSearchResult = { systemID: number; name: string; security: number; coverage: number }
 
 type SearchRow = { system_id: number; name: string; security: number; coverage: number }
 

--- a/supabase/migrations/20260719120000_sde_kspace_system_region_path.sql
+++ b/supabase/migrations/20260719120000_sde_kspace_system_region_path.sql
@@ -1,0 +1,20 @@
+-- Extend sde_kspace_system with constellation/region name+id so callers can
+-- build a "[region]/[constellation]/[system]" path without a second round
+-- trip. Additive (existing `select system_id, name, security` callers are
+-- unaffected by the new trailing columns).
+create or replace view public.sde_kspace_system
+with (security_invoker = true) as
+select
+  s._key as system_id,
+  s.data -> 'name' ->> 'en' as name,
+  (s.data ->> 'securityStatus')::real as security,
+  c._key as constellation_id,
+  c.data -> 'name' ->> 'en' as constellation_name,
+  r._key as region_id,
+  r.data -> 'name' ->> 'en' as region_name
+from public.sde_map_solar_systems s
+left join public.sde_map_constellations c on c._key = (s.data ->> 'constellationID')::bigint
+left join public.sde_map_regions r on r._key = (c.data ->> 'regionID')::bigint
+where s._key >= 30000000
+  and s._key < 31000000
+  and coalesce(trim(s.data -> 'name' ->> 'en'), '') <> '';


### PR DESCRIPTION
## Summary
- Extends the `sde_kspace_system` SDE-mirror view (new migration) to also carry `constellation_name`/`region_name`, joined from `sde_map_constellations`/`sde_map_regions`.
- Adds `getSdeSystemPaths()` (`src/sdeSystems.ts`) and `fetchSystemPaths()` (`src/app/systemNames.ts`) to build a `"[region]/[constellation]/[system]"` path per system id, mirroring the existing name-lookup helpers (SDE-first, `universe_name` fallback for ids the mirror can't place).
- The character list (`/character`) now renders each character's clone systems using this path format and sorts them alphabetically by the full path.

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm exec tsc --noEmit`
- [ ] Manual check on `/character` against a live DB (not run in this sandbox — no Supabase credentials)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WryvQ2XYMEtBbGvJpUnCh3)_