### PR TITLE
Add Innominate appraisal client + appraise_items MCP tool, throttled globally via a Vercel queue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ SUPABASE_USERNAME=
 SUPABASE_PASSWORD=
 FLAGS_SECRET=base64-encoded-32-byte-secret
 CRON_SECRET=random-secret-shared-with-vercel-cron
+# ISK price appraisals via https://innomin.at/api/docs/ (key issued via their Discord)
+INNOMINATE_API_KEY=
 
 # this is so NextJS will make these things available in client components
 NEXT_PUBLIC_SUPABASE_URL=https://ifqywgxsdjxbonsytqya.supabase.co

--- a/docs/appraisals/README.md
+++ b/docs/appraisals/README.md
@@ -99,6 +99,19 @@ whole deployment.** Consequences baked into the designs:
    responses, and turn a `429` into a friendly "try again in Ns" using
    `x-ratelimit-reset-after` — never retry automatically.
 
+**Global throttle (added post-Milestone-1).** The in-process cache can't stop
+several lambda instances from bursting past 200/hour together, so on Vercel
+every `appraise()` call is funnelled through a Vercel queue (topic
+`innominate`, consumer at `/api/queue/innominate`) that drains at most **one
+request every 18 seconds** (= 200/hour) via an atomic Postgres leaky bucket
+(`innominate_try_acquire()`). `appraise()` keeps its synchronous contract: it
+upserts a `pending` row in `innominate_appraisal`, enqueues one message, and
+blocks polling that row (up to ~50s, under the MCP function's 60s limit) until
+the consumer fills in the result — which also serves as a shared 5-minute price
+cache across instances. Local dev (no `VERCEL`) skips the queue and calls
+directly. See `src/innominate.ts` and
+`supabase/migrations/20260719000000_innominate_appraisal_throttle.sql`.
+
 ### Privacy note
 
 Requests to innomin.at carry **only type names and quantities** — never

--- a/schema.sql
+++ b/schema.sql
@@ -100,6 +100,8 @@ drop table if exists public.refresh_task         cascade;
 drop table if exists public.shared_asset_token   cascade;
 drop table if exists public.heartbeat            cascade;
 drop table if exists public.esi_etag             cascade;
+drop table if exists public.innominate_throttle  cascade;
+drop table if exists public.innominate_appraisal cascade;
 drop table if exists public.esf_data             cascade;
 drop table if exists public.impersonation_log    cascade;
 drop table if exists public.token                cascade;
@@ -626,6 +628,79 @@ create table public.esi_etag (
 
 alter table public.esi_etag enable row level security;
 grant all on public.esi_etag to service_role;
+
+-- ── innominate_throttle / innominate_appraisal ──────────────────────────────
+-- Global throttle for the innomin.at appraisal API (see src/innominate.ts). The
+-- provider allows 200 requests/hour for the whole deployment, so appraisals are
+-- funnelled through a Vercel queue (topic "innominate", consumer at
+-- /api/queue/innominate) draining at most one request every 18 seconds across
+-- ALL lambda instances. Separate instances don't share memory, so the throttle
+-- timestamp and the pending/finished results live here. Internal service-role
+-- bookkeeping only: RLS on with no policy, so only the service role (the queue
+-- consumer and the MCP tool) reaches them.
+create table public.innominate_throttle (
+  id               boolean primary key default true check (id),
+  last_request_at  timestamptz not null default 'epoch'
+);
+insert into public.innominate_throttle (id) values (true) on conflict (id) do nothing;
+
+alter table public.innominate_throttle enable row level security;
+grant all on public.innominate_throttle to service_role;
+
+-- One row per distinct (market + sorted item list) request, keyed by request_key
+-- (the same hash the in-process cache uses). The producer upserts a 'pending'
+-- row and blocks polling it; the consumer flips it to 'done' (mapped Appraisal
+-- in `result`) or 'error' ({ kind, message, retryAfterSeconds } in `error`). A
+-- fresh 'done' row (< 5 min) doubles as the global price cache.
+create table public.innominate_appraisal (
+  request_key  text primary key,
+  market       text not null,
+  items        jsonb not null,
+  status       text not null default 'pending' check (status in ('pending', 'done', 'error')),
+  result       jsonb,
+  error        jsonb,
+  created_at   timestamptz not null default now(),
+  updated_at   timestamptz not null default now()
+);
+create index innominate_appraisal_updated_at_idx on public.innominate_appraisal (updated_at);
+
+alter table public.innominate_appraisal enable row level security;
+grant all on public.innominate_appraisal to service_role;
+
+-- Atomic leaky bucket: advance last_request_at to now() only if at least
+-- min_interval_seconds have elapsed, returning acquired=true; otherwise return
+-- acquired=false with wait_seconds until the next slot. The guarded UPDATE is a
+-- single atomic statement, so concurrent consumers can't both take the same slot.
+create or replace function public.innominate_try_acquire(min_interval_seconds integer default 18)
+returns table (acquired boolean, wait_seconds double precision)
+language plpgsql
+as $$
+declare
+  v_now timestamptz := now();
+begin
+  insert into public.innominate_throttle (id) values (true) on conflict (id) do nothing;
+
+  update public.innominate_throttle
+     set last_request_at = v_now
+   where id = true
+     and v_now - last_request_at >= make_interval(secs => min_interval_seconds);
+
+  if found then
+    return query select true, 0::double precision;
+  else
+    return query
+      select false,
+             greatest(
+               extract(epoch from (make_interval(secs => min_interval_seconds) - (v_now - last_request_at))),
+               0
+             )::double precision
+        from public.innominate_throttle
+       where id = true;
+  end if;
+end;
+$$;
+
+grant execute on function public.innominate_try_acquire(integer) to service_role;
 
 -- ── impersonation_log ──────────────────────────────────────────────────────
 -- Chancellor-impersonation audit trail: one row per magic-link impersonation

--- a/src/app/api/mcp/tools.ts
+++ b/src/app/api/mcp/tools.ts
@@ -19,6 +19,7 @@ import { prop, uniqBy } from 'ramda'
 import { z } from 'zod'
 
 import { ACTIVITY_NAMES } from '@/app/industry/jobFields'
+import { appraise, MARKETS, type AppraisalItemInput, type Market } from '@/innominate'
 import { resolveLocations, type LocationRef } from '@/app/resolveLocations'
 import { fetchSystemNames } from '@/app/systemNames'
 import {
@@ -965,7 +966,11 @@ export const registerTools = (server: McpServer): void => {
       const mods = await resolveModifiers(modifiers, bp.activityID, extra)
       if (!mods.ok) return textResult(mods.message)
 
-      const names = await getSdeTypeNames([bp.blueprintTypeID, bp.productTypeID, ...bp.materials.map((mat) => mat.typeID)])
+      const names = await getSdeTypeNames([
+        bp.blueprintTypeID,
+        bp.productTypeID,
+        ...bp.materials.map((mat) => mat.typeID),
+      ])
       const runs = modifiers.runs ?? 1
       return textResult({
         product: names[bp.productTypeID] ?? resolved.name,
@@ -1046,6 +1051,105 @@ export const registerTools = (server: McpServer): void => {
         ...(capNote(blueprints.length, shown.length, 'blueprints') && {
           cap_note: capNote(blueprints.length, shown.length, 'blueprints'),
         }),
+      })
+    }
+  )
+
+  server.registerTool(
+    'appraise_items',
+    {
+      title: 'Appraise items',
+      description:
+        'Estimate the ISK market value of a batch of items via the innomin.at appraisal service (Jita by default). Answers "what\'s 3 Rifters and 100k Tritanium worth" or follows up a search_assets result with prices. Item names are matched fuzzily against EVE types. Prices are live market data, not the user\'s own orders.',
+      inputSchema: {
+        items: z
+          .array(
+            z.object({
+              item: z
+                .string()
+                .min(1)
+                .describe('Item name, e.g. "Tritanium", "Rifter" (matched fuzzily against EVE types)'),
+              quantity: z.number().int().min(1).optional().describe('How many (default 1)'),
+            })
+          )
+          .min(1)
+          .max(100)
+          .describe('The items to appraise (1–100 distinct entries)'),
+        market: z
+          .enum(MARKETS)
+          .optional()
+          .describe(
+            'Market hub to price against (default jita). Others: amarr, rens, dodi, hek, plus player markets ualx, cj6mt.'
+          ),
+      },
+    },
+    // No Supabase client and no bearer token: this tool reads nothing from the
+    // DB. It still only runs for authenticated MCP callers (the whole server is
+    // behind withMcpAuth), which is what gates the shared 200/hour budget.
+    async ({ items, market }) => {
+      // Canonicalize each fuzzy input against the SDE the way the blueprint
+      // tools do. A match sends the canonical name (noting when it differs from
+      // what was typed); a miss sends the raw name anyway so the API's own fuzzy
+      // handling can return possible_matches — better than failing locally.
+      const resolved = await Promise.all(
+        items.map(async ({ item, quantity }) => {
+          const match = await resolveOneType(item)
+          const name = match.ok ? match.name : item.trim()
+          return { input: item.trim(), name, quantity: quantity ?? 1 }
+        })
+      )
+
+      const notes = resolved
+        .filter((r) => r.name.toLowerCase() !== r.input.toLowerCase())
+        .map((r) => `Interpreted "${r.input}" as ${r.name}.`)
+
+      // Merge duplicate resolved names before sending — the API prices distinct
+      // lines separately, which would double-count and inflate the batch.
+      const merged = new Map<string, AppraisalItemInput>()
+      resolved.forEach((r) => {
+        const existing = merged.get(r.name)
+        merged.set(r.name, { name: r.name, quantity: (existing?.quantity ?? 0) + r.quantity })
+      })
+
+      const result = await appraise([...merged.values()], (market ?? 'jita') as Market)
+      if (!result.ok) {
+        if (result.kind === 'unconfigured')
+          return textResult("Appraisals aren't configured on this deployment (missing INNOMINATE_API_KEY).")
+        if (result.kind === 'rate_limited')
+          return textResult(
+            `The appraisal service is rate limited.${
+              result.retryAfterSeconds != null ? ` Try again in ${result.retryAfterSeconds}s.` : ''
+            }`
+          )
+        return textResult(result.message)
+      }
+
+      const { appraisal } = result
+      const priced = appraisal.items.filter((i) => i.error == null)
+      const unpriced = appraisal.items.filter((i) => i.error != null)
+
+      return textResult({
+        market: appraisal.market,
+        total_sell_value: appraisal.totalSellValue,
+        total_buy_value: appraisal.totalBuyValue,
+        price_split: appraisal.priceSplit,
+        total_volume_m3: appraisal.totalVol,
+        items: priced.map((i) => ({
+          item: i.name,
+          quantity: i.quantity,
+          sell_price: i.sellPrice,
+          buy_price: i.buyPrice,
+          total_sell: i.totalSellPrice,
+          total_buy: i.totalBuyPrice,
+          volume_m3: i.totalItemVol,
+        })),
+        ...(unpriced.length && {
+          unpriced: unpriced.map((i) => ({ item: i.name, possible_matches: i.possibleMatches })),
+        }),
+        ...(notes.length && { notes }),
+        ...(appraisal.cached && { cached: true }),
+        ...(appraisal.rateLimitRemaining != null && { rate_limit_remaining: appraisal.rateLimitRemaining }),
+        source: 'innomin.at',
       })
     }
   )

--- a/src/app/api/queue/innominate/route.ts
+++ b/src/app/api/queue/innominate/route.ts
@@ -1,0 +1,24 @@
+// Queue consumer for the innomin.at appraisal throttle (topic "innominate", wired
+// up in vercel.json via experimentalTriggers). Every appraisal request is
+// enqueued here so the whole deployment sends at most one request every 18
+// seconds (the provider's 200/hour budget) — see the throttle explanation in
+// src/innominate.ts. This route is the ONLY thing that drains the topic; the
+// producer (appraise()) enqueues and blocks polling the shared DB row this
+// consumer fills in.
+import { handleCallback } from '@/utils/queue'
+import { InnominateThrottleRetry, runInnominateQueueMessage, type InnominateQueueMessage } from '@/innominate'
+
+export const runtime = 'nodejs'
+
+// When it isn't this message's turn under the global throttle, runInnominateQueueMessage
+// throws InnominateThrottleRetry(afterSeconds); the retry handler reschedules the
+// message for that many seconds later instead of failing it. Any other throw
+// falls through to the queue's default retry (retryAfterSeconds in vercel.json).
+export const POST = handleCallback(
+  async (message: InnominateQueueMessage) => {
+    await runInnominateQueueMessage(message)
+  },
+  {
+    retry: (error) => (error instanceof InnominateThrottleRetry ? { afterSeconds: error.afterSeconds } : undefined),
+  }
+)

--- a/src/innominate.ts
+++ b/src/innominate.ts
@@ -7,7 +7,21 @@
 // prices aren't in our DB at all, so we call innomin.at server-side at request
 // time. Nothing is persisted, and we still never call ESI. See
 // docs/appraisals/README.md for the API reference and the 200 req/hour budget.
+//
+// Global throttle: the provider's 200 requests/hour is a budget for the WHOLE
+// deployment, not per user or per lambda. In-process state can't enforce that —
+// separate serverless instances don't share memory — so on Vercel every call is
+// funnelled through a Vercel queue (topic "innominate", consumer at
+// /api/queue/innominate) that drains at most one request every 18 seconds
+// (= 200/hour) via an atomic Postgres leaky bucket. The MCP tool stays
+// synchronous: appraise() enqueues the request and BLOCKS polling a shared
+// Supabase row until the consumer fills it in (or a ~50s budget elapses). Local
+// dev (no VERCEL) skips the queue and calls directly — a single developer isn't
+// a threat to the shared budget, and it keeps `pnpm run dev` working.
 import { sortBy } from 'ramda'
+
+import { send } from '@/utils/queue'
+import { createServiceClient } from '@/utils/supabase/service'
 
 export type AppraisalItemInput = { name: string; quantity: number }
 
@@ -52,6 +66,13 @@ const ENDPOINT = 'https://innomin.at/api/v1/appraise/'
 const USER_AGENT = 'edencom-link (philihp@gmail.com)'
 const TIMEOUT_MS = 10_000
 
+// The global rate: one request per 18 seconds = 200/hour, the provider's budget.
+const THROTTLE_SECONDS = 18
+// How long appraise() blocks polling the shared row before giving up — kept
+// under the MCP route's 60s function limit (src/app/api/mcp/route.ts).
+const POLL_BUDGET_MS = 50_000
+const POLL_INTERVAL_MS = 1_000
+
 // The raw response shapes (snake_case) we map to the camelCase exports above.
 type RawAppraisedItem = {
   name?: string
@@ -94,18 +115,17 @@ const mapItem = (r: RawAppraisedItem): AppraisedItem => ({
 
 // ---- In-process TTL cache -------------------------------------------------
 //
-// Both consumers re-request identical batches (double-clicks, an LLM re-asking
-// the same question); the 200 req/hour budget makes that expensive, so we
-// absorb bursts here. On Vercel this Map is per-lambda-instance and evaporates
-// on cold starts — that's fine. It exists to smooth repeats, NOT to be a
-// durable price store; market prices don't move fast enough for a 5-minute TTL
-// to matter. Only successful results are cached; errors never are.
+// A per-lambda-instance fast path over the shared DB cache below: identical
+// batches re-requested on the SAME instance (double-clicks, an LLM re-asking)
+// skip the DB round-trip and the queue entirely. It evaporates on cold starts —
+// that's fine; the shared innominate_appraisal row is the durable/global cache.
+// Only successful results are cached; errors never are.
 const CACHE_TTL_MS = 5 * 60 * 1000
 const CACHE_MAX_ENTRIES = 200
 const cache = new Map<string, { at: number; appraisal: Appraisal }>()
 
 // Key on market + the item list sorted by name, so batches that differ only in
-// input order hit the same entry.
+// input order hit the same entry. Doubles as the shared row's request_key.
 const cacheKey = (items: AppraisalItemInput[], market: Market): string =>
   JSON.stringify({ market, items: sortBy((i) => i.name, items).map((i) => [i.name, i.quantity]) })
 
@@ -129,19 +149,15 @@ const cacheSet = (key: string, appraisal: Appraisal): void => {
   }
 }
 
-// ---- The one call ---------------------------------------------------------
-
-export const appraise = async (items: AppraisalItemInput[], market: Market = 'jita'): Promise<AppraisalResult> => {
+// ---- The raw call ---------------------------------------------------------
+//
+// Actually hits innomin.at. Only ever called by the queue consumer (one call at
+// a time, throttled) — or directly by appraise() in local dev. Never throws.
+const callInnominate = async (items: AppraisalItemInput[], market: Market): Promise<AppraisalResult> => {
   const apiKey = process.env.INNOMINATE_API_KEY
   if (!apiKey) {
-    // No key locally → answer without hitting the network, so dev without the
-    // key still works.
     return { ok: false, kind: 'unconfigured', message: 'INNOMINATE_API_KEY is not set on this deployment.' }
   }
-
-  const key = cacheKey(items, market)
-  const cached = cacheGet(key)
-  if (cached) return { ok: true, appraisal: { ...cached, cached: true } }
 
   let response: Response
   try {
@@ -164,8 +180,8 @@ export const appraise = async (items: AppraisalItemInput[], market: Market = 'ji
   }
 
   if (response.status === 429) {
-    // 200/hour is a hard budget; a retry loop is how it dies. Surface the
-    // wait instead of retrying automatically.
+    // 200/hour is a hard budget; the throttle should keep us under it, but if
+    // the provider still 429s, surface the wait — never retry automatically.
     const resetAfter = response.headers.get('x-ratelimit-reset-after')
     const retryAfterSeconds = resetAfter != null && resetAfter !== '' ? Number(resetAfter) : null
     return {
@@ -200,6 +216,167 @@ export const appraise = async (items: AppraisalItemInput[], market: Market = 'ji
     rateLimitRemaining,
     cached: false,
   }
-  cacheSet(key, appraisal)
   return { ok: true, appraisal }
+}
+
+// ---- Shared DB row (throttle coordination + global cache) -----------------
+
+type ServiceClient = ReturnType<typeof createServiceClient>
+type AppraisalRow = {
+  request_key: string
+  market: string
+  items: AppraisalItemInput[]
+  status: 'pending' | 'done' | 'error'
+  result: Appraisal | null
+  error: AppraisalError | null
+  updated_at: string
+}
+
+const readAppraisalRow = async (supabase: ServiceClient, requestKey: string): Promise<AppraisalRow | null> => {
+  const { data } = await supabase
+    .from('innominate_appraisal')
+    .select('request_key, market, items, status, result, error, updated_at')
+    .eq('request_key', requestKey)
+    .maybeSingle()
+  return (data as AppraisalRow | null) ?? null
+}
+
+const isFresh = (updatedAt: string): boolean => Date.now() - new Date(updatedAt).getTime() < CACHE_TTL_MS
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+// Block until the consumer fills in the shared row, or the poll budget elapses.
+// Recursion rather than a while loop (ramda house style — sequential async).
+const pollForResult = async (supabase: ServiceClient, key: string, deadline: number): Promise<AppraisalResult> => {
+  const row = await readAppraisalRow(supabase, key)
+  if (row?.status === 'done' && row.result) {
+    const appraisal: Appraisal = { ...row.result, cached: false }
+    cacheSet(key, appraisal)
+    return { ok: true, appraisal }
+  }
+  if (row?.status === 'error' && row.error) return row.error
+  if (Date.now() >= deadline) {
+    // Still queued behind the global throttle backlog after our budget. Report
+    // it as rate-limited so the caller retries rather than treating it as a hard
+    // failure — the identical retry will find the by-then-cached result.
+    return {
+      ok: false,
+      kind: 'rate_limited',
+      message: 'The appraisal is queued behind the global rate limit; try again in a moment.',
+      retryAfterSeconds: THROTTLE_SECONDS,
+    }
+  }
+  await delay(POLL_INTERVAL_MS)
+  return pollForResult(supabase, key, deadline)
+}
+
+const appraiseViaQueue = async (items: AppraisalItemInput[], market: Market, key: string): Promise<AppraisalResult> => {
+  // appraise() must never throw (the MCP tool relies on that), so a DB or queue
+  // outage becomes a clean upstream error rather than a rejection.
+  try {
+    const supabase = createServiceClient()
+
+    // Global cache: a fresh 'done' row (< TTL) is reusable across every instance.
+    const existing = await readAppraisalRow(supabase, key)
+    if (existing?.status === 'done' && existing.result && isFresh(existing.updated_at)) {
+      const appraisal: Appraisal = { ...existing.result, cached: true }
+      cacheSet(key, appraisal)
+      return { ok: true, appraisal }
+    }
+
+    // Upsert a pending row and enqueue one message for the consumer to drain. The
+    // idempotency key is bucketed to the TTL so a hot key doesn't pile up
+    // duplicate messages within a window, while a later request can re-drive a
+    // stale row. Concurrent producers for the same key share this one row and both
+    // poll it. (A rare race can reset a just-finished 'done' row back to pending,
+    // costing one extra throttled call — harmless given the low request volume.)
+    await supabase.from('innominate_appraisal').upsert(
+      {
+        request_key: key,
+        market,
+        items,
+        status: 'pending',
+        result: null,
+        error: null,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'request_key' }
+    )
+
+    const bucket = Math.floor(Date.now() / CACHE_TTL_MS)
+    await send('innominate', { requestKey: key }, { idempotencyKey: `${key}:${bucket}` })
+
+    return pollForResult(supabase, key, Date.now() + POLL_BUDGET_MS)
+  } catch {
+    return { ok: false, kind: 'upstream', message: 'Could not queue the appraisal request (queue or database error).' }
+  }
+}
+
+// ---- Public entry point ---------------------------------------------------
+
+export const appraise = async (items: AppraisalItemInput[], market: Market = 'jita'): Promise<AppraisalResult> => {
+  if (!process.env.INNOMINATE_API_KEY) {
+    // No key → answer without any network/queue work, so local dev without the
+    // key still works and the tool degrades gracefully in prod if it's unset.
+    return { ok: false, kind: 'unconfigured', message: 'INNOMINATE_API_KEY is not set on this deployment.' }
+  }
+
+  const key = cacheKey(items, market)
+  const hit = cacheGet(key)
+  if (hit) return { ok: true, appraisal: { ...hit, cached: true } }
+
+  // Local dev has no Vercel queue infrastructure and is a single developer, so
+  // it calls directly (bypassing the shared-budget throttle); production routes
+  // every call through the throttled queue.
+  if (process.env.VERCEL !== '1') {
+    const result = await callInnominate(items, market)
+    if (result.ok) cacheSet(key, result.appraisal)
+    return result
+  }
+
+  return appraiseViaQueue(items, market, key)
+}
+
+// ---- Queue consumer entry point -------------------------------------------
+
+// Thrown by the consumer when it isn't this message's turn under the global
+// throttle; the queue route's retry handler turns it into a reschedule.
+export class InnominateThrottleRetry extends Error {
+  constructor(public readonly afterSeconds: number) {
+    super('innominate request throttled')
+    this.name = 'InnominateThrottleRetry'
+  }
+}
+
+export type InnominateQueueMessage = { requestKey: string }
+
+// Runs one queued appraisal request: reads its shared row, takes the global
+// throttle slot (or throws InnominateThrottleRetry to reschedule), calls
+// innomin.at, and writes the result/error back onto the row for the blocked
+// producer to pick up. Called only by /api/queue/innominate.
+export const runInnominateQueueMessage = async ({ requestKey }: InnominateQueueMessage): Promise<void> => {
+  const supabase = createServiceClient()
+
+  const row = await readAppraisalRow(supabase, requestKey)
+  // Row expired/swept, or another delivery already satisfied it — nothing to do.
+  if (!row) return
+  if (row.status === 'done' && row.result && isFresh(row.updated_at)) return
+
+  // Global throttle: at most one innomin.at request per THROTTLE_SECONDS across
+  // every lambda instance and deployment (they share this Supabase project).
+  const { data } = await supabase.rpc('innominate_try_acquire', { min_interval_seconds: THROTTLE_SECONDS })
+  const gate = (Array.isArray(data) ? data[0] : data) as { acquired: boolean; wait_seconds: number } | null
+  if (!gate?.acquired) {
+    throw new InnominateThrottleRetry(Math.max(1, Math.ceil(gate?.wait_seconds ?? THROTTLE_SECONDS)))
+  }
+
+  const result = await callInnominate(row.items, row.market as Market)
+  await supabase
+    .from('innominate_appraisal')
+    .update(
+      result.ok
+        ? { status: 'done', result: result.appraisal, error: null, updated_at: new Date().toISOString() }
+        : { status: 'error', result: null, error: result, updated_at: new Date().toISOString() }
+    )
+    .eq('request_key', requestKey)
 }

--- a/src/innominate.ts
+++ b/src/innominate.ts
@@ -1,0 +1,205 @@
+// The single module in the repo that talks to the Innominate Appraisal API
+// (https://innomin.at/api/docs/) — an Evepraisal-style ISK price service. Both
+// consumers (the appraise_items MCP tool now, the asset viewer in doc 03) go
+// through here so the save:false invariant, auth header, in-process cache, and
+// rate-limit handling live in exactly one place. This is a deliberate, narrow
+// exception to the "UI/MCP read the DB, never call a third-party" rule: market
+// prices aren't in our DB at all, so we call innomin.at server-side at request
+// time. Nothing is persisted, and we still never call ESI. See
+// docs/appraisals/README.md for the API reference and the 200 req/hour budget.
+import { sortBy } from 'ramda'
+
+export type AppraisalItemInput = { name: string; quantity: number }
+
+export type AppraisedItem = {
+  name: string
+  itemId: number | null
+  quantity: number
+  itemVol: number | null
+  totalItemVol: number | null
+  sellPrice: number | null
+  buyPrice: number | null
+  totalSellPrice: number | null
+  totalBuyPrice: number | null
+  error: string | null // "Item not found" etc.
+  possibleMatches: string[] // suggestions when error is set
+}
+
+export type Appraisal = {
+  items: AppraisedItem[] // in request order
+  totalVol: number
+  totalSellValue: number
+  totalBuyValue: number
+  priceSplit: number
+  market: string
+  marketStatus: string
+  rateLimitRemaining: number | null // from x-ratelimit-remaining
+  cached: boolean // true when served from the TTL cache
+}
+
+export type AppraisalError =
+  | { ok: false; kind: 'unconfigured'; message: string } // no INNOMINATE_API_KEY
+  | { ok: false; kind: 'rate_limited'; message: string; retryAfterSeconds: number | null }
+  | { ok: false; kind: 'upstream'; message: string } // 4xx/5xx/network/timeout
+
+export type AppraisalResult = { ok: true; appraisal: Appraisal } | AppraisalError
+
+export const MARKETS = ['jita', 'amarr', 'rens', 'dodi', 'hek', 'ualx', 'cj6mt'] as const
+export type Market = (typeof MARKETS)[number]
+
+const ENDPOINT = 'https://innomin.at/api/v1/appraise/'
+// Matches the etiquette src/esi.js follows (identify us + a contact).
+const USER_AGENT = 'edencom-link (philihp@gmail.com)'
+const TIMEOUT_MS = 10_000
+
+// The raw response shapes (snake_case) we map to the camelCase exports above.
+type RawAppraisedItem = {
+  name?: string
+  item_id?: number | null
+  quantity?: number
+  item_vol?: number | null
+  total_item_vol?: number | null
+  sell_price?: number | null
+  buy_price?: number | null
+  total_sell_price?: number | null
+  total_buy_price?: number | null
+  error?: string | null
+  possible_matches?: string[] | null
+}
+type RawAppraisal = {
+  appraisals?: RawAppraisedItem[]
+  total_vol?: number
+  total_sell_value?: number
+  total_buy_value?: number
+  price_split?: number
+  market?: string
+  market_status?: string
+}
+
+const num = (v: number | null | undefined): number | null => (typeof v === 'number' ? v : null)
+
+const mapItem = (r: RawAppraisedItem): AppraisedItem => ({
+  name: r.name ?? '',
+  itemId: num(r.item_id),
+  quantity: r.quantity ?? 0,
+  itemVol: num(r.item_vol),
+  totalItemVol: num(r.total_item_vol),
+  sellPrice: num(r.sell_price),
+  buyPrice: num(r.buy_price),
+  totalSellPrice: num(r.total_sell_price),
+  totalBuyPrice: num(r.total_buy_price),
+  error: r.error ?? null,
+  possibleMatches: r.possible_matches ?? [],
+})
+
+// ---- In-process TTL cache -------------------------------------------------
+//
+// Both consumers re-request identical batches (double-clicks, an LLM re-asking
+// the same question); the 200 req/hour budget makes that expensive, so we
+// absorb bursts here. On Vercel this Map is per-lambda-instance and evaporates
+// on cold starts — that's fine. It exists to smooth repeats, NOT to be a
+// durable price store; market prices don't move fast enough for a 5-minute TTL
+// to matter. Only successful results are cached; errors never are.
+const CACHE_TTL_MS = 5 * 60 * 1000
+const CACHE_MAX_ENTRIES = 200
+const cache = new Map<string, { at: number; appraisal: Appraisal }>()
+
+// Key on market + the item list sorted by name, so batches that differ only in
+// input order hit the same entry.
+const cacheKey = (items: AppraisalItemInput[], market: Market): string =>
+  JSON.stringify({ market, items: sortBy((i) => i.name, items).map((i) => [i.name, i.quantity]) })
+
+const cacheGet = (key: string): Appraisal | null => {
+  const hit = cache.get(key)
+  if (!hit) return null
+  if (Date.now() - hit.at > CACHE_TTL_MS) {
+    cache.delete(key)
+    return null
+  }
+  return hit.appraisal
+}
+
+const cacheSet = (key: string, appraisal: Appraisal): void => {
+  cache.set(key, { at: Date.now(), appraisal })
+  // Insertion-order sweep — evict the oldest entries once over the cap.
+  while (cache.size > CACHE_MAX_ENTRIES) {
+    const oldest = cache.keys().next().value
+    if (oldest === undefined) break
+    cache.delete(oldest)
+  }
+}
+
+// ---- The one call ---------------------------------------------------------
+
+export const appraise = async (items: AppraisalItemInput[], market: Market = 'jita'): Promise<AppraisalResult> => {
+  const apiKey = process.env.INNOMINATE_API_KEY
+  if (!apiKey) {
+    // No key locally → answer without hitting the network, so dev without the
+    // key still works.
+    return { ok: false, kind: 'unconfigured', message: 'INNOMINATE_API_KEY is not set on this deployment.' }
+  }
+
+  const key = cacheKey(items, market)
+  const cached = cacheGet(key)
+  if (cached) return { ok: true, appraisal: { ...cached, cached: true } }
+
+  let response: Response
+  try {
+    response = await fetch(ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'X-API-Key': apiKey,
+        'Content-Type': 'application/json',
+        'User-Agent': USER_AGENT,
+      },
+      // save: false is HARD-CODED (never a parameter, never configurable):
+      // it keeps the call side-effect-free on the provider's server — nothing
+      // stored, no appraisal id minted — per the API-key agreement.
+      body: JSON.stringify({ items, market, save: false }),
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    })
+  } catch {
+    // Network error or the 10s timeout aborting — never throw.
+    return { ok: false, kind: 'upstream', message: 'Could not reach the appraisal service (network error or timeout).' }
+  }
+
+  if (response.status === 429) {
+    // 200/hour is a hard budget; a retry loop is how it dies. Surface the
+    // wait instead of retrying automatically.
+    const resetAfter = response.headers.get('x-ratelimit-reset-after')
+    const retryAfterSeconds = resetAfter != null && resetAfter !== '' ? Number(resetAfter) : null
+    return {
+      ok: false,
+      kind: 'rate_limited',
+      message: 'The appraisal service is rate limited (200 requests/hour, shared).',
+      retryAfterSeconds: Number.isFinite(retryAfterSeconds) ? retryAfterSeconds : null,
+    }
+  }
+
+  if (!response.ok) {
+    const message = await response
+      .json()
+      .then((body: { error?: string }) => body?.error ?? `Appraisal service returned ${response.status}.`)
+      .catch(() => `Appraisal service returned ${response.status}.`)
+    return { ok: false, kind: 'upstream', message }
+  }
+
+  const raw: RawAppraisal = await response.json().catch(() => ({}))
+  const remaining = response.headers.get('x-ratelimit-remaining')
+  const rateLimitRemaining =
+    remaining != null && remaining !== '' && Number.isFinite(Number(remaining)) ? Number(remaining) : null
+
+  const appraisal: Appraisal = {
+    items: (raw.appraisals ?? []).map(mapItem),
+    totalVol: raw.total_vol ?? 0,
+    totalSellValue: raw.total_sell_value ?? 0,
+    totalBuyValue: raw.total_buy_value ?? 0,
+    priceSplit: raw.price_split ?? 0,
+    market: raw.market ?? market,
+    marketStatus: raw.market_status ?? '',
+    rateLimitRemaining,
+    cached: false,
+  }
+  cacheSet(key, appraisal)
+  return { ok: true, appraisal }
+}

--- a/supabase/migrations/20260719000000_innominate_appraisal_throttle.sql
+++ b/supabase/migrations/20260719000000_innominate_appraisal_throttle.sql
@@ -1,0 +1,80 @@
+-- Global throttle for the innomin.at appraisal API (see src/innominate.ts).
+-- The provider allows 200 requests/hour for the whole deployment, so every
+-- appraisal call is funnelled through a Vercel queue (topic "innominate",
+-- consumer at /api/queue/innominate) that drains at most one request every 18
+-- seconds (200/hour) across ALL lambda instances and deployments. In-process
+-- state can't coordinate that — separate serverless instances don't share
+-- memory — so the throttle timestamp and the pending/finished results live in
+-- these two service-role-only tables (RLS on, no policy: only the service role,
+-- which the queue consumer and the MCP tool use, can reach them).
+
+-- ── innominate_throttle ──────────────────────────────────────────────────────
+-- Singleton leaky-bucket row: the timestamp of the last request the consumer was
+-- allowed to send. `innominate_try_acquire()` advances it atomically.
+create table if not exists public.innominate_throttle (
+  id               boolean primary key default true check (id),
+  last_request_at  timestamptz not null default 'epoch'
+);
+insert into public.innominate_throttle (id) values (true) on conflict (id) do nothing;
+
+alter table public.innominate_throttle enable row level security;
+grant all on public.innominate_throttle to service_role;
+
+-- ── innominate_appraisal ─────────────────────────────────────────────────────
+-- One row per distinct (market + sorted item list) request, keyed by request_key
+-- (the same hash the in-process cache uses). The producer upserts a 'pending'
+-- row and blocks polling it; the consumer flips it to 'done' (with the mapped
+-- Appraisal in `result`) or 'error' (with { kind, message, retryAfterSeconds } in
+-- `error`). A fresh 'done' row (< 5 min) doubles as the global price cache.
+create table if not exists public.innominate_appraisal (
+  request_key  text primary key,
+  market       text not null,
+  items        jsonb not null,
+  status       text not null default 'pending' check (status in ('pending', 'done', 'error')),
+  result       jsonb,
+  error        jsonb,
+  created_at   timestamptz not null default now(),
+  updated_at   timestamptz not null default now()
+);
+create index if not exists innominate_appraisal_updated_at_idx on public.innominate_appraisal (updated_at);
+
+alter table public.innominate_appraisal enable row level security;
+grant all on public.innominate_appraisal to service_role;
+
+-- ── innominate_try_acquire(min_interval_seconds) ─────────────────────────────
+-- Atomic leaky bucket. Advances last_request_at to now() only if at least
+-- min_interval_seconds have elapsed since the previous request, returning
+-- acquired=true. Otherwise returns acquired=false with wait_seconds until the
+-- next slot, so the consumer can reschedule its queue message. The guarded
+-- UPDATE is a single atomic statement, so concurrent consumers can't both
+-- acquire the same slot.
+create or replace function public.innominate_try_acquire(min_interval_seconds integer default 18)
+returns table (acquired boolean, wait_seconds double precision)
+language plpgsql
+as $$
+declare
+  v_now timestamptz := now();
+begin
+  insert into public.innominate_throttle (id) values (true) on conflict (id) do nothing;
+
+  update public.innominate_throttle
+     set last_request_at = v_now
+   where id = true
+     and v_now - last_request_at >= make_interval(secs => min_interval_seconds);
+
+  if found then
+    return query select true, 0::double precision;
+  else
+    return query
+      select false,
+             greatest(
+               extract(epoch from (make_interval(secs => min_interval_seconds) - (v_now - last_request_at))),
+               0
+             )::double precision
+        from public.innominate_throttle
+       where id = true;
+  end if;
+end;
+$$;
+
+grant execute on function public.innominate_try_acquire(integer) to service_role;

--- a/vercel.json
+++ b/vercel.json
@@ -86,6 +86,18 @@
           "initialDelaySeconds": 0
         }
       ]
+    },
+    "src/app/api/queue/innominate/route.ts": {
+      "maxDuration": 30,
+      "memory": 256,
+      "experimentalTriggers": [
+        {
+          "type": "queue/v2beta",
+          "topic": "innominate",
+          "retryAfterSeconds": 18,
+          "initialDelaySeconds": 0
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Milestone 1 of the appraisals project ([docs/appraisals/01-mcp-appraise-tool.md](../blob/main/docs/appraisals/01-mcp-appraise-tool.md)), plus a follow-on global throttle.

## Milestone 1 — client + tool

- **`src/innominate.ts`** — the single module in the repo that talks to the [innomin.at appraisal API](https://innomin.at/api/docs/). `POST /api/v1/appraise/` with `X-API-Key` auth and a **hard-coded** `save: false` (side-effect-free on the provider's server, per the API-key agreement). Maps snake_case → camelCase, 10s `AbortSignal.timeout`, **never auto-retries on `429`**, reads `x-ratelimit-remaining`. In-process 5-minute TTL cache (keyed on market + name-sorted items).
- **`appraise_items` MCP tool** — appraises 1–100 items by name (market enum, default `jita`). Canonicalizes fuzzy names via the SDE (`resolveOneType`), merges duplicate resolved names, splits into priced `items` / `unpriced`, echoes `cached` / `rate_limit_remaining`. Reads nothing from the DB but runs behind `withMcpAuth`.
- **`.env.example`** — documents `INNOMINATE_API_KEY`; the tool degrades to an "unconfigured" message when unset.

## Global throttle — 1 request / 18 s via a Vercel queue

The 200 req/hour budget is shared by the **whole deployment**, which the per-lambda in-process cache can't enforce (several instances can burst past it together). So on Vercel every `appraise()` call is now funnelled through a Vercel queue that drains at most one request every 18 s (= 200/hour):

- **`/api/queue/innominate`** consumer — the only caller of innomin.at. Before each call it takes an atomic Postgres leaky-bucket slot (`innominate_try_acquire(18)`); when it isn't a message's turn it reschedules via the queue's `retry` directive. Registered as a new `innominate` topic trigger in `vercel.json`.
- **`appraise()` keeps its synchronous contract** (block-until-ready): it upserts a `pending` row in `innominate_appraisal`, enqueues one message, and blocks polling that row (up to ~50 s, under the MCP route's 60 s limit) until the consumer fills in the result — which also serves as a shared 5-minute price cache across instances. A backlog past the budget returns a `rate_limited` "try again shortly" the caller can retry into the cached result.
- **Local dev** (no `VERCEL`) skips the queue and calls innomin.at directly, so `pnpm run dev` still works and the shared budget stays a production-only concern.
- **Schema** (dual-write `schema.sql` + new migration `20260719000000_innominate_appraisal_throttle.sql`): `innominate_throttle` (singleton leaky-bucket row), `innominate_appraisal` (pending/result store + global cache), and the `innominate_try_acquire()` function — all service-role-only (RLS on, no policy), mirroring `esi_etag`.

## Architecture note

A deliberate, narrow exception to the CLAUDE.md "UI/MCP read the DB, never call a third party" rule: market prices aren't in our DB, so the appraisal path calls innomin.at server-side. It still never calls ESI. All calls funnel through `src/innominate.ts` so the `save: false` invariant, auth, caching, and the throttle live in one place.

## Testing

No test runner — gates are `pnpm run lint` + `pnpm run build`, both green. The migration applies via the `Migrate` workflow on merge to `main`. Manual verification of the live-API paths (normal batch, garbage name → `unpriced`, fuzzy name → note, repeat within 5 min → `cached`, alternate market, unset key → unconfigured) and the throttle drain rate should be exercised on a deploy with `INNOMINATE_API_KEY` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CD6ePt8KsVQFoouMCzzc4r