### PR TITLE
Add privacy policy and terms of service pages

### DIFF
--- a/src/app/layout/footer.module.css
+++ b/src/app/layout/footer.module.css
@@ -7,3 +7,13 @@
 .footer a {
   font-family: var(--mono);
 }
+
+/* Privacy/Terms are UI chrome, not code — keep them in the sans face and set
+ * them off from the build metadata. */
+.links {
+  margin-left: 8px;
+}
+
+.footer .links a {
+  font-family: var(--sans);
+}

--- a/src/app/layout/footer.tsx
+++ b/src/app/layout/footer.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link'
+
 import { DateTime } from '../DateTime'
 import styles from './footer.module.css'
 
@@ -24,6 +26,11 @@ const Footer = () => {
             <a href={`${REPO}/commit/${sha}`}>{sha.slice(0, 7)}</a>
           </>
         ) : null}
+        <span className={styles.links}>
+          <Link href="/privacy">Privacy</Link>
+          {' · '}
+          <Link href="/terms">Terms</Link>
+        </span>
       </footer>
     </>
   )

--- a/src/app/legal.module.css
+++ b/src/app/legal.module.css
@@ -1,0 +1,11 @@
+/* Shared layout for the static legal pages (/privacy, /terms): a readable
+ * measure and slightly muted meta line. */
+.wrap {
+  max-width: 42rem;
+}
+
+.updated {
+  color: var(--ink-faint);
+  font-size: 12px;
+  margin-top: -8px;
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,101 @@
+import type { Metadata } from 'next'
+
+import styles from '../legal.module.css'
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy — Edencom Link',
+}
+
+const REPO = 'https://github.com/philihp/edencom-link'
+
+const PrivacyPage = () => (
+  <main className={styles.wrap}>
+    <h1>Privacy Policy</h1>
+    <p className={styles.updated}>Last updated: 19 July 2026</p>
+
+    <p>
+      Edencom Link (&ldquo;the site&rdquo;) is a hobby tool for tracking your own EVE Online characters&rsquo; assets,
+      wallet, industry, and structures. This page explains what it stores and why, in plain terms. If anything is
+      unclear, ask via the <a href={REPO}>GitHub repository</a>.
+    </p>
+
+    <h2>What we collect</h2>
+    <ul>
+      <li>
+        <strong>Account credentials.</strong> When you register, Supabase Auth stores your email address and a hashed
+        password.
+      </li>
+      <li>
+        <strong>EVE character links.</strong> When you add an EVE Online character, we store its character ID and name
+        and the OAuth tokens EVE SSO issues us (an access token and a refresh token), so we can read the data you
+        authorized on your behalf.
+      </li>
+      <li>
+        <strong>Game data from ESI.</strong> Using those tokens, scheduled jobs pull the data you granted access to —
+        assets, wallet balance and transactions, market orders, industry jobs, blueprints, clones and implants, current
+        location and ship, mercenary dens, and corporation structures, assets, and wallet where you hold the in-game
+        roles. We keep a history of this data over time, so older versions are retained rather than only the latest
+        snapshot.
+      </li>
+      <li>
+        <strong>Preferences.</strong> Settings such as the systems you choose to watch and an optional API token you can
+        generate for spreadsheet exports.
+      </li>
+      <li>
+        <strong>Discord (if you enable notifications).</strong> If you link a Discord channel to receive alerts, we
+        store the Discord server (guild) and channel IDs, their display names, and the Discord user ID of whoever ran
+        the link command.
+      </li>
+    </ul>
+
+    <h2>What we do with it</h2>
+    <ul>
+      <li>We show your data back to you, on your account&rsquo;s pages.</li>
+      <li>
+        We share data only where you opt in: with a corporation you belong to (corp assets and industry, mercenary-den
+        sharing), through public share links you generate yourself (a ship&rsquo;s fit, or the corpses page, which stays
+        off unless you enable it), or to a Discord channel you link.
+      </li>
+      <li>We do not sell your data or share it with advertisers.</li>
+    </ul>
+
+    <h2>Where your data lives, and who else sees it</h2>
+    <ul>
+      <li>
+        <strong>Supabase</strong> stores the database and handles authentication.
+      </li>
+      <li>
+        <strong>Vercel</strong> hosts the site and provides its analytics and performance monitoring (Vercel Analytics
+        and Speed Insights), which collect anonymous usage and page-performance data.
+      </li>
+      <li>
+        <strong>CCP / EVE Online ESI</strong> is the source of the game data and where your EVE authorization is
+        managed.
+      </li>
+      <li>
+        <strong>Discord</strong> receives any notifications you configure. Messages posted to a Discord channel are
+        visible to that channel&rsquo;s members and governed by Discord&rsquo;s own terms and privacy policy.
+      </li>
+    </ul>
+
+    <h2>Keeping and removing your data</h2>
+    <ul>
+      <li>
+        You can revoke this site&rsquo;s access to an EVE character at any time from your EVE Online account&rsquo;s
+        third-party application settings on CCP&rsquo;s side. Once revoked, we can no longer refresh tokens or pull new
+        data for that character.
+      </li>
+      <li>
+        To have your account and its stored data deleted, contact us (below) and we will remove it.
+      </li>
+      <li>Unlinking a Discord channel stops notifications to it and removes the stored channel link.</li>
+    </ul>
+
+    <h2>Contact</h2>
+    <p>
+      For questions or deletion requests, open an issue on the project&rsquo;s <a href={REPO}>GitHub repository</a>.
+    </p>
+  </main>
+)
+
+export default PrivacyPage

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from 'next'
+
+import styles from '../legal.module.css'
+
+export const metadata: Metadata = {
+  title: 'Terms of Service — Edencom Link',
+}
+
+const TermsPage = () => (
+  <main className={styles.wrap}>
+    <h1>Terms of Service</h1>
+    <p className={styles.updated}>Last updated: 19 July 2026</p>
+
+    <p>
+      Edencom Link is a personal, non-commercial hobby project, provided free of charge and &ldquo;as is.&rdquo;
+    </p>
+
+    <ul>
+      <li>
+        <strong>No warranty.</strong> The site is provided without warranty of any kind. It may be unavailable, lose
+        data, or show incorrect information at any time. Do not rely on it for anything critical.
+      </li>
+      <li>
+        <strong>Your responsibility.</strong> You are responsible for the EVE characters and accounts you link and for
+        keeping your credentials and share links private. Only link characters you control.
+      </li>
+      <li>
+        <strong>Acceptable use.</strong> Do not attempt to access data belonging to accounts other than your own,
+        disrupt the service, or use it to violate CCP&rsquo;s or Discord&rsquo;s terms.
+      </li>
+      <li>
+        <strong>Changes.</strong> These terms and the service itself may change or be discontinued at any time.
+      </li>
+    </ul>
+
+    <h2>EVE Online</h2>
+    <p>
+      EVE Online and the EVE logo are the registered trademarks of CCP hf. All rights are reserved worldwide. All other
+      trademarks are the property of their respective owners. EVE Online, the EVE logo, EVE and all associated logos and
+      designs are the intellectual property of CCP hf. All artwork, screenshots, characters, vehicles, storylines, world
+      facts, or other recognizable features of the intellectual property relating to these trademarks are likewise the
+      intellectual property of CCP hf. This site is not affiliated with or endorsed by CCP hf.
+    </p>
+
+    <h2>Discord</h2>
+    <p>Discord is a trademark of Discord Inc. This site is not affiliated with or endorsed by Discord Inc.</p>
+  </main>
+)
+
+export default TermsPage


### PR DESCRIPTION
Stage 1 of the Discord bot project ([`docs/discord-bot/01-legal-pages.md`](https://github.com/philihp/edencom-link/blob/main/docs/discord-bot/01-legal-pages.md)). The Discord developer-portal app registration (stage 2) requires Privacy Policy and Terms of Service URLs, so these come first — and the site stores account credentials, EVE tokens, and game data, so it should have these pages regardless.

## Changes

- **`/privacy`** (`src/app/privacy/page.tsx`) — static server component describing what the app actually stores today: Supabase Auth credentials, EVE character links + OAuth tokens, the ESI-pulled game data and its retained history, watch/API-token preferences, and (conditionally) Discord channel links once notifications ship. Covers opt-in corp/public sharing, the third parties data transits (Supabase, Vercel, CCP/ESI, Discord), and data removal.
- **`/terms`** (`src/app/terms/page.tsx`) — static server component: personal hobby project, no warranty, acceptable use, plus the standard CCP hf. intellectual-property notice and a Discord non-affiliation note.
- **Footer** now links to both (`src/app/layout/footer.tsx` + `.module.css`), keeping the labels in the sans face rather than the footer's mono link styling.
- **`src/app/legal.module.css`** — shared readable measure + muted "last updated" line for both pages.

## Notes on accuracy

I deviated from the scoping doc in two places to keep the pages truthful:

- The doc sketched "no third-party analytics," but the app uses **Vercel Analytics and Speed Insights** (in `layout.tsx`), so the privacy page states that.
- There is **no self-serve character-unlink or account-delete flow** in the codebase, so data removal is described honestly: revoke the EVE SSO grant on CCP's side (stops token refresh), and contact via GitHub issues for account deletion.

The Discord section is written conditionally ("if you link a Discord channel…") so it's accurate now (the feature doesn't exist yet) and won't need revising when stage 3 lands.

The wording is honest and readable rather than boilerplate-maximal; a human review of the legal text is worth doing but is outside this PR's scope.

## Verification

- `pnpm run lint` — passes.
- `pnpm run build` — passes; `/privacy` and `/terms` both appear in the route manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRxxVyXXBDc1hv4nupxsQ1

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRxxVyXXBDc1hv4nupxsQ1)_