### PR TITLE
Float character tile avatar top-right, keep text left-aligned

### DIFF
--- a/src/app/character/character.module.css
+++ b/src/app/character/character.module.css
@@ -8,8 +8,7 @@
 }
 
 .tile {
-  display: flex;
-  gap: 10pt;
+  position: relative;
   padding: 12px;
   border: 1px solid var(--line);
   border-radius: var(--radius);
@@ -22,6 +21,9 @@
 }
 
 .avatar {
+  position: absolute;
+  top: 12px;
+  right: 12px;
   width: 64px;
   height: 64px;
   flex-shrink: 0;
@@ -35,7 +37,8 @@
   flex-direction: column;
   gap: 2pt;
   min-width: 0;
-  flex: 1;
+  padding-right: 74px;
+  text-align: left;
 }
 
 .name {


### PR DESCRIPTION
## Summary
- The character-list tile's avatar was a flex sibling of the text body, pushing the text into a second column.
- Avatar is now absolutely positioned in the tile's top-right corner; the text body reserves space under it via `padding-right` and stays left-aligned (`text-align: left`).

## Test plan
- [x] `pnpm run lint`
- [ ] Manual check on `/character` against a live DB (not run in this sandbox — no Supabase credentials; verified the CSS logic by hand instead of a live/browser render)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WryvQ2XYMEtBbGvJpUnCh3)_