### PR TITLE
Mercenary den sightings: form + Discord ping overhaul

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1392,7 +1392,7 @@ create table public.mercenary_den_enemy_intel (
   id bigint generated always as identity primary key,
   system text not null,
   planet text not null,
-  owner text not null,
+  owner text,
   alliance text,
   reinforcement_end timestamptz,
   notes text,

--- a/src/app/mercenary-dens/actions.ts
+++ b/src/app/mercenary-dens/actions.ts
@@ -95,11 +95,21 @@ export const addEnemyDenIntel = async (input: EnemyDenIntelInput): Promise<{ err
     return { error: 'System, planet, owner, and reported by are required' }
   }
 
-  // The <input type="datetime-local"> value ("YYYY-MM-DDTHH:mm") is entered as
-  // EVE/UTC time (that's the clock every pilot is already reading in-game), not
-  // the browser's local timezone — so it's stamped with a literal "Z" rather
-  // than passed through Date parsing, which would apply the browser's offset.
-  const reinforcementEnd = input.reinforcementEnd ? `${input.reinforcementEnd}:00Z` : null
+  // The reinforcement time is entered as EVE/UTC ISO 8601 with seconds
+  // ("YYYY-MM-DDTHH:MM:SS" — the clock every pilot is already reading in-game),
+  // not the browser's local timezone, so it's stamped with a literal "Z"
+  // rather than passed through Date parsing, which would apply the browser's
+  // offset. A space separator is accepted in place of the "T"; seconds are
+  // required.
+  let reinforcementEnd: string | null = null
+  const rawReinforcement = input.reinforcementEnd.trim()
+  if (rawReinforcement) {
+    const iso = rawReinforcement.replace(' ', 'T')
+    if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(iso)) {
+      return { error: 'Reinforcement time must be ISO 8601 with seconds, e.g. 2026-07-20T14:30:45 (UTC)' }
+    }
+    reinforcementEnd = `${iso}Z`
+  }
 
   const { error } = await supabase.from('mercenary_den_enemy_intel').insert({
     system,

--- a/src/app/mercenary-dens/actions.ts
+++ b/src/app/mercenary-dens/actions.ts
@@ -67,10 +67,8 @@ export type EnemyDenIntelInput = {
   system: string
   planet: string
   owner: string
-  alliance: string
   reinforcementEnd: string
   notes: string
-  reportedBy: string
 }
 
 // Post one sighting to the shared enemy-den-intel corkboard (mercenary_den_enemy_intel).
@@ -89,10 +87,23 @@ export const addEnemyDenIntel = async (input: EnemyDenIntelInput): Promise<{ err
 
   const system = input.system.trim()
   const planet = input.planet.trim()
-  const owner = input.owner.trim()
-  const reportedBy = input.reportedBy.trim()
-  if (!system || !planet || !owner || !reportedBy) {
-    return { error: 'System, planet, owner, and reported by are required' }
+  if (!system || !planet) {
+    return { error: 'System and planet are required' }
+  }
+
+  // reported_by is always the caller's main character (falling back to any
+  // registered character) — derived server-side, never client-supplied, so it
+  // can't be spoofed. RLS lets the user read their own registrations.
+  const { data: mainReg } = await supabase
+    .from('registration')
+    .select('name')
+    .eq('user_id', user.id)
+    .order('is_main', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  const reportedBy = mainReg?.name?.trim()
+  if (!reportedBy) {
+    return { error: 'Register a character before reporting sightings' }
   }
 
   // The reinforcement time is entered as EVE/UTC ISO 8601 with seconds
@@ -114,8 +125,7 @@ export const addEnemyDenIntel = async (input: EnemyDenIntelInput): Promise<{ err
   const { error } = await supabase.from('mercenary_den_enemy_intel').insert({
     system,
     planet,
-    owner,
-    alliance: input.alliance.trim() || null,
+    owner: input.owner.trim() || null,
     reinforcement_end: reinforcementEnd,
     notes: input.notes.trim() || null,
     reported_by: reportedBy,

--- a/src/app/mercenary-dens/copyDiscordPing.tsx
+++ b/src/app/mercenary-dens/copyDiscordPing.tsx
@@ -6,24 +6,30 @@ import styles from './mercenaryDens.module.css'
 
 // Small clipboard button next to a reinforced den's timer. Copies a
 // Discord-ready ping, e.g.
-//   Mercenary Den Reinforced - `JVA-FE` planet `II` at <t:1784057275:s> @ <t:1784057275:R>
-// where <t:…:s> renders in Discord as the viewer's local wall-clock time and
-// <t:…:R> as a live relative countdown ("in 26 hours"). Flashes a ✓ on success.
+//   Friendly Den Reinforced - QQGH-G V at <t:1784057275:s> <t:1784057275:R>
+// which renders in Discord as
+//   Friendly Den Reinforced - QQGH-G V at 7/20/26, 02:53 20 minutes ago
+// where <t:…:s> is the viewer's local wall-clock time and <t:…:R> a live
+// relative countdown. "Friendly" for our own dens, "Enemy" for reported
+// sightings. Flashes a ✓ on success.
 const CopyDiscordPing = ({
   system,
   planet,
   reinforcementEnd,
+  enemy,
 }: {
   system: string
   planet: string
   reinforcementEnd: string
+  enemy: boolean
 }) => {
   const [copied, setCopied] = useState(false)
   const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const onClick = async () => {
     const unix = Math.floor(new Date(reinforcementEnd).getTime() / 1000)
-    const text = `Mercenary Den Reinforced - \`${system}\` planet \`${planet}\` at <t:${unix}:s> @ <t:${unix}:R>`
+    const label = enemy ? 'Enemy' : 'Friendly'
+    const text = `${label} Den Reinforced - ${system} ${planet} at <t:${unix}:s> <t:${unix}:R>`
     try {
       await navigator.clipboard.writeText(text)
       setCopied(true)

--- a/src/app/mercenary-dens/duration.ts
+++ b/src/app/mercenary-dens/duration.ts
@@ -28,10 +28,11 @@ export const formatDuration = (ms: number): string => {
   return `${Math.round(t / MINUTE)}m`
 }
 
-// "2026-07-15 14:32 UTC" — EVE time is UTC, so render the wall-clock stamp
-// directly rather than localizing it.
+// "2026-07-15 14:32:07 UTC" — EVE time is UTC, so render the wall-clock stamp
+// directly rather than localizing it. Seconds included: mercenary-den timers
+// are second-precise and the reinforcement time is now entered to the second.
 export const formatUtc = (iso: string): string => {
   const date = new Date(iso)
   if (Number.isNaN(date.getTime())) return iso
-  return `${date.toISOString().slice(0, 16).replace('T', ' ')} UTC`
+  return `${date.toISOString().slice(0, 19).replace('T', ' ')} UTC`
 }

--- a/src/app/mercenary-dens/enemyDenIntel.tsx
+++ b/src/app/mercenary-dens/enemyDenIntel.tsx
@@ -120,6 +120,7 @@ const EnemyDenIntel = ({ rows, defaultReportedBy }: { rows: EnemyDenIntelRow[]; 
                           system={row.system}
                           planet={row.planet}
                           reinforcementEnd={row.reinforcementEnd}
+                          enemy
                         />
                       </>
                     ) : (

--- a/src/app/mercenary-dens/enemyDenIntel.tsx
+++ b/src/app/mercenary-dens/enemyDenIntel.tsx
@@ -70,10 +70,13 @@ const EnemyDenIntel = ({ rows, defaultReportedBy }: { rows: EnemyDenIntelRow[]; 
         <input type="text" placeholder="Owner" value={form.owner} onChange={set('owner')} required />
         <input type="text" placeholder="Alliance (optional)" value={form.alliance} onChange={set('alliance')} />
         <input
-          type="datetime-local"
+          type="text"
+          className={styles.reinforcement}
+          placeholder="Reinforced at (YYYY-MM-DDTHH:MM:SS UTC)"
           value={form.reinforcementEnd}
           onChange={set('reinforcementEnd')}
-          title="Reinforcement ends at (enter in EVE/UTC time)"
+          pattern="\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}"
+          title="Reinforcement ends at, in EVE/UTC time — ISO 8601 with seconds, e.g. 2026-07-20T14:30:45"
         />
         <input type="text" placeholder="Notes (optional)" value={form.notes} onChange={set('notes')} />
         <input type="text" placeholder="Reported by" value={form.reportedBy} onChange={set('reportedBy')} required />

--- a/src/app/mercenary-dens/enemyDenIntel.tsx
+++ b/src/app/mercenary-dens/enemyDenIntel.tsx
@@ -11,8 +11,7 @@ export type EnemyDenIntelRow = {
   id: number
   system: string
   planet: string
-  owner: string
-  alliance: string | null
+  owner: string | null
   reinforcementEnd: string | null
   notes: string | null
   reportedBy: string
@@ -20,14 +19,23 @@ export type EnemyDenIntelRow = {
   mine: boolean
 }
 
-const EMPTY_FORM = { system: '', planet: '', owner: '', alliance: '', reinforcementEnd: '', notes: '', reportedBy: '' }
-
 // User-submitted corkboard of enemy dens seen reinforced — there's no ESI feed
 // for another corp's dens, so this is manually reported. A form to post a new
 // sighting, plus the shared list sorted soonest-reinforcement-first; a
-// submitter can delete their own rows (server-enforced by RLS).
-const EnemyDenIntel = ({ rows, defaultReportedBy }: { rows: EnemyDenIntelRow[]; defaultReportedBy: string }) => {
-  const [form, setForm] = useState({ ...EMPTY_FORM, reportedBy: defaultReportedBy })
+// submitter can delete their own rows (server-enforced by RLS). "Reported by"
+// is fixed to the caller's main character (derived server-side), and the
+// reinforcement time defaults to today at 00:00:00 UTC.
+const EnemyDenIntel = ({
+  rows,
+  defaultReportedBy,
+  defaultReinforcementEnd,
+}: {
+  rows: EnemyDenIntelRow[]
+  defaultReportedBy: string
+  defaultReinforcementEnd: string
+}) => {
+  const emptyForm = { system: '', planet: '', owner: '', reinforcementEnd: defaultReinforcementEnd, notes: '' }
+  const [form, setForm] = useState(emptyForm)
   const [error, setError] = useState('')
   const [pending, startTransition] = useTransition()
   const now = Date.now()
@@ -44,7 +52,7 @@ const EnemyDenIntel = ({ rows, defaultReportedBy }: { rows: EnemyDenIntelRow[]; 
         setError(result.error)
         return
       }
-      setForm({ ...EMPTY_FORM, reportedBy: form.reportedBy })
+      setForm(emptyForm)
     })
   }
 
@@ -67,8 +75,7 @@ const EnemyDenIntel = ({ rows, defaultReportedBy }: { rows: EnemyDenIntelRow[]; 
       <form className={styles.intelForm} onSubmit={onSubmit}>
         <input type="text" placeholder="System" value={form.system} onChange={set('system')} required />
         <input type="text" placeholder="Planet (e.g. III)" value={form.planet} onChange={set('planet')} required />
-        <input type="text" placeholder="Owner" value={form.owner} onChange={set('owner')} required />
-        <input type="text" placeholder="Alliance (optional)" value={form.alliance} onChange={set('alliance')} />
+        <input type="text" placeholder="Owner (optional)" value={form.owner} onChange={set('owner')} />
         <input
           type="text"
           className={styles.reinforcement}
@@ -79,7 +86,7 @@ const EnemyDenIntel = ({ rows, defaultReportedBy }: { rows: EnemyDenIntelRow[]; 
           title="Reinforcement ends at, in EVE/UTC time — ISO 8601 with seconds, e.g. 2026-07-20T14:30:45"
         />
         <input type="text" placeholder="Notes (optional)" value={form.notes} onChange={set('notes')} />
-        <input type="text" placeholder="Reported by" value={form.reportedBy} onChange={set('reportedBy')} required />
+        <span className={styles.reportingAs}>Reporting as {defaultReportedBy || '—'}</span>
         <button type="submit" disabled={pending}>
           Report sighting
         </button>
@@ -104,10 +111,7 @@ const EnemyDenIntel = ({ rows, defaultReportedBy }: { rows: EnemyDenIntelRow[]; 
               <tr key={row.id}>
                 <td className={styles.system}>{row.system}</td>
                 <td className={styles.planet}>{row.planet}</td>
-                <td>
-                  {row.owner}
-                  {row.alliance ? <span className={styles.alliance}> [{row.alliance}]</span> : null}
-                </td>
+                <td>{row.owner || dash}</td>
                 <td>
                   {row.reinforcementEnd ? (
                     new Date(row.reinforcementEnd).getTime() > now ? (

--- a/src/app/mercenary-dens/mercenaryDens.module.css
+++ b/src/app/mercenary-dens/mercenaryDens.module.css
@@ -254,3 +254,8 @@
 .intelForm input[type='text'].reinforcement {
   width: 170pt;
 }
+
+.reportingAs {
+  font-size: 10pt;
+  opacity: 0.75;
+}

--- a/src/app/mercenary-dens/mercenaryDens.module.css
+++ b/src/app/mercenary-dens/mercenaryDens.module.css
@@ -251,6 +251,6 @@
   width: 130pt;
 }
 
-.intelForm input[type='datetime-local'] {
-  width: 150pt;
+.intelForm input[type='text'].reinforcement {
+  width: 170pt;
 }

--- a/src/app/mercenary-dens/page.tsx
+++ b/src/app/mercenary-dens/page.tsx
@@ -241,6 +241,7 @@ const MercenaryDensPage = async () => {
                               system={row.system}
                               planet={row.planet}
                               reinforcementEnd={den.reinforcement_end}
+                              enemy={false}
                             />
                           </>
                         ) : null}

--- a/src/app/mercenary-dens/page.tsx
+++ b/src/app/mercenary-dens/page.tsx
@@ -67,7 +67,10 @@ const MercenaryDensPage = async () => {
   // The caller's characters + corporations (share targets, and to label/scope own
   // dens) and which corps their dens are currently shared with.
   const { corporations } = await fetchOwners(supabase)
-  const { data: myRegs } = await supabase.from('registration').select('id, name, character_id')
+  const { data: myRegs } = await supabase
+    .from('registration')
+    .select('id, name, character_id, is_main')
+    .order('is_main', { ascending: false })
   const ownRegById = new Map(
     (myRegs ?? []).map((r) => [
       r.id as string,
@@ -99,7 +102,6 @@ const MercenaryDensPage = async () => {
     system: row.system,
     planet: row.planet,
     owner: row.owner,
-    alliance: row.alliance,
     reinforcementEnd: row.reinforcement_end,
     notes: row.notes,
     reportedBy: row.reported_by,
@@ -107,6 +109,10 @@ const MercenaryDensPage = async () => {
     mine: row.created_by === data.user.id,
   }))
   const defaultReportedBy = [...ownRegById.values()][0]?.name ?? ''
+  // Reinforcement time input defaults to today at 00:00:00 UTC (EVE time).
+  // Computed on the server so the client's initial state matches (no hydration
+  // mismatch) — the value is a plain ISO date the client edits.
+  const defaultReinforcementEnd = `${new Date().toISOString().slice(0, 10)}T00:00:00`
   const typeNames = await getSdeTypeNames(dens.map((d) => d.type_id).filter((t): t is number => t != null))
 
   // Merge the hand-maintained temperate-planet intel with our real dens, keyed by
@@ -270,7 +276,11 @@ const MercenaryDensPage = async () => {
         </table>
       </div>
 
-      <EnemyDenIntel rows={enemyDenIntel} defaultReportedBy={defaultReportedBy} />
+      <EnemyDenIntel
+        rows={enemyDenIntel}
+        defaultReportedBy={defaultReportedBy}
+        defaultReinforcementEnd={defaultReinforcementEnd}
+      />
     </>
   )
 }

--- a/supabase/migrations/20260720030000_enemy_intel_owner_optional.sql
+++ b/supabase/migrations/20260720030000_enemy_intel_owner_optional.sql
@@ -1,0 +1,4 @@
+-- Owner is now optional on hand-reported enemy-den sightings (the reporter may
+-- not know who owns the den). The alliance column is left in place but no longer
+-- written by the app.
+alter table public.mercenary_den_enemy_intel alter column owner drop not null;


### PR DESCRIPTION
## Summary
A batch of improvements to the enemy-den sighting form and its Discord ping.

### Reinforcement time
- **ISO 8601 with seconds.** The `datetime-local` picker (browser-locale-dependent format, no seconds — the action hard-coded `:00Z`) is replaced with a text input accepting `YYYY-MM-DDTHH:MM:SS` (UTC), validated client-side (`pattern`) and server-side (require seconds, stamp `Z`). `formatUtc` now shows seconds (`2026-07-20 14:30:45 UTC`).
- **Defaults to today at 00:00:00 UTC** — computed on the server so the client's initial state matches (no hydration mismatch).

### Form fields
- **"Reported by" is fixed to the caller's main character**, derived server-side (`registration.is_main`, falling back to any registration). It's no longer an editable field — the form shows a read-only "Reporting as `<name>`" label, and the action ignores any client-supplied value (can't be spoofed).
- **Owner is now optional** — column drops `NOT NULL` (migration `20260720030000_enemy_intel_owner_optional.sql` + `schema.sql`); the input loses `required`; a null owner renders as `—`.
- **Alliance removed** from the form and the sightings table. The DB column stays (nullable, just unwritten); the separate hand-maintained temperate-planet intel's alliance display is untouched.

### Discord ping
The clipboard button now produces e.g.:
> Friendly Den Reinforced - QQGH-G V at 7/20/26, 02:53 20 minutes ago
- **Friendly / Enemy** prefix (own dens vs reported sightings).
- System + roman joined directly (`QQGH-G V`) — no "planet" word or backticks.
- Dropped the ` @ ` between the two Discord timestamps.

## Migration
`alter table public.mercenary_den_enemy_intel alter column owner drop not null;` — non-destructive; auto-applies via the Migrate workflow on merge.

## Test plan
- [x] `tsc --noEmit` + `eslint` clean
- [ ] Preview `/mercenary-dens`: reinforcement field pre-filled with today `T00:00:00`; "Reporting as <main char>" shown, no editable reporter field; submit with owner blank succeeds and shows `—`; alliance field gone
- [ ] Copy-ping: own den → "Friendly Den Reinforced - <SYS> <ROMAN> at …"; enemy sighting → "Enemy …", second-accurate
- [ ] Migrate workflow applies the owner-nullable migration on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnWdT6AvCivWSiRpr4Zb2W