### PR TITLE
Fix Migrate: use `supabase db push --include-all` (unblocks out-of-order migrations)

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -29,4 +29,12 @@ jobs:
         env:
           SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF }}
       - name: Push migrations
-        run: supabase db push
+        # --include-all applies pending migrations even when one has a timestamp
+        # earlier than the last migration already on remote. That happens
+        # routinely when PRs merge in a different order than their migration
+        # timestamps (e.g. a migration dated 07-19 merging after one dated
+        # 07-19T12:00 that already landed) — without this flag `db push` aborts
+        # the whole batch with "found local migration files to be inserted
+        # before the last migration on remote". The migrations here are
+        # independent and additive, so applying them in filename order is safe.
+        run: supabase db push --include-all


### PR DESCRIPTION
## Problem
The Migrate workflow is **failing on `main`** and has been since the Innominate appraisal PR merged. The error is an out-of-order migration, not a bad migration:

```
Found local migration files to be inserted before the last migration on remote database.
Rerun the command with --include-all flag to apply these migrations:
supabase/migrations/20260719000000_innominate_appraisal_throttle.sql
```

`20260719000000_innominate_appraisal_throttle` (from the Innominate PR) is dated **earlier** than `20260719120000_sde_kspace_system_region_path` (from #641), which merged first and already landed on remote. `supabase db push` refuses to insert a migration "before" the last one on remote and aborts the **entire** pending batch — which also blocked #648's `20260720030000_enemy_intel_owner_optional`.

### Production impact
#648 merged with code that inserts `owner: null` for enemy-den sightings, but its `owner DROP NOT NULL` migration couldn't apply — so **blank-owner sightings currently error in prod**. This unblocks that migration.

## Fix
Change the workflow's push to `supabase db push --include-all`. That flag applies pending migrations in filename order even when one predates the last remote migration — the documented remedy for this exact case. Out-of-order timestamps are routine when PRs merge in a different order than their migration dates, so this is a permanent robustness improvement, not a one-off.

**No migration files are renamed or edited** — per the repo rule, that stays forbidden. Only the push command changes.

## After merge
The `migrate.yml` change itself triggers the Migrate workflow (it's in the trigger `paths`), which will apply both pending migrations (`…_innominate_appraisal_throttle` and `…_enemy_intel_owner_optional`) with `--include-all`. I'll confirm the run goes green and that the `owner` column is nullable in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnWdT6AvCivWSiRpr4Zb2W

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnWdT6AvCivWSiRpr4Zb2W)_