### PR TITLE
Enemy den intel: soft-delete + hide stale/deleted sightings

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1398,7 +1398,8 @@ create table public.mercenary_den_enemy_intel (
   notes text,
   reported_by text not null,
   created_by uuid not null references auth.users(id) on delete cascade default auth.uid(),
-  created_at timestamptz not null default now()
+  created_at timestamptz not null default now(),
+  deleted_at timestamptz
 );
 create index mercenary_den_enemy_intel_reinforcement_end_idx
   on public.mercenary_den_enemy_intel (reinforcement_end);
@@ -1446,7 +1447,16 @@ create policy "Authenticated delete own enemy den intel"
   to authenticated
   using (created_by = (select auth.uid()));
 
-grant select, insert, delete on public.mercenary_den_enemy_intel to authenticated;
+-- Removal is a soft delete (stamping deleted_at), so the submitter needs update
+-- on their own rows.
+create policy "Authenticated soft-delete own enemy den intel"
+  on public.mercenary_den_enemy_intel
+  for update
+  to authenticated
+  using (created_by = (select auth.uid()))
+  with check (created_by = (select auth.uid()));
+
+grant select, insert, update, delete on public.mercenary_den_enemy_intel to authenticated;
 grant all                    on public.mercenary_den_enemy_intel to service_role;
 
 -- ── character_clone_state ──────────────────────────────────────────────────

--- a/src/app/mercenary-dens/actions.ts
+++ b/src/app/mercenary-dens/actions.ts
@@ -139,12 +139,17 @@ export const addEnemyDenIntel = async (input: EnemyDenIntelInput): Promise<{ err
   return {}
 }
 
-// Remove one sighting. RLS restricts deletion to the row's own submitter, so an
-// attempt on someone else's row is simply a no-op rather than an error.
+// Soft-delete one sighting: stamp deleted_at rather than removing the row, so
+// the record is retained (the /mercenary-dens query hides deleted_at rows).
+// RLS restricts the update to the row's own submitter, so an attempt on someone
+// else's row simply matches nothing.
 export const deleteEnemyDenIntel = async (id: number): Promise<{ error?: string }> => {
   const supabase = await createClient()
 
-  const { error } = await supabase.from('mercenary_den_enemy_intel').delete().eq('id', id)
+  const { error } = await supabase
+    .from('mercenary_den_enemy_intel')
+    .update({ deleted_at: new Date().toISOString() })
+    .eq('id', id)
   if (error) {
     return { error: error.message }
   }

--- a/src/app/mercenary-dens/page.tsx
+++ b/src/app/mercenary-dens/page.tsx
@@ -92,11 +92,16 @@ const MercenaryDensPage = async () => {
   // sees others' reports exactly when that submitter shares their Mercenary Den
   // data with one of the caller's corps (mercenary_den_enemy_intel's RLS
   // piggybacks on character_mercenary_den_share). Soonest reinforcement timer
-  // first.
+  // first. Only rows whose reinforcement timer is still in the future or expired
+  // less than an hour ago are shown (long-stale and undated rows drop off), and
+  // soft-deleted rows (deleted_at set) are hidden.
+  const reinforcementCutoff = new Date(Date.now() - 60 * 60 * 1000).toISOString()
   const { data: intelData } = await supabase
     .from('mercenary_den_enemy_intel')
     .select('*')
-    .order('reinforcement_end', { ascending: true, nullsFirst: false })
+    .is('deleted_at', null)
+    .gt('reinforcement_end', reinforcementCutoff)
+    .order('reinforcement_end', { ascending: true })
   const enemyDenIntel: EnemyDenIntelRow[] = (intelData ?? []).map((row) => ({
     id: row.id,
     system: row.system,

--- a/supabase/migrations/20260720040000_enemy_intel_soft_delete.sql
+++ b/supabase/migrations/20260720040000_enemy_intel_soft_delete.sql
@@ -1,0 +1,16 @@
+-- Soft-delete for enemy-den sightings: deleting a row now stamps deleted_at
+-- instead of removing it, so the record is retained. The /mercenary-dens query
+-- filters out rows where deleted_at is set.
+alter table public.mercenary_den_enemy_intel add column if not exists deleted_at timestamptz;
+
+-- The submitter soft-deletes by updating their own row's deleted_at, so they
+-- need update (scoped the same way as the existing delete policy).
+drop policy if exists "Authenticated soft-delete own enemy den intel" on public.mercenary_den_enemy_intel;
+create policy "Authenticated soft-delete own enemy den intel"
+  on public.mercenary_den_enemy_intel
+  for update
+  to authenticated
+  using (created_by = (select auth.uid()))
+  with check (created_by = (select auth.uid()));
+
+grant update on public.mercenary_den_enemy_intel to authenticated;


### PR DESCRIPTION
## Summary
Two changes to the enemy-den sighting corkboard.

### Soft-delete
Deleting a sighting no longer removes the row — it stamps a new `deleted_at` column, so the record is retained.
- Migration `20260720040000_enemy_intel_soft_delete.sql` + `schema.sql`: add `deleted_at timestamptz` and an RLS **update** policy (a submitter can set `deleted_at` on their own rows, scoped like the existing delete policy), plus `grant update`.
- `deleteEnemyDenIntel` now does `.update({ deleted_at: now })` instead of `.delete()`.

### Visibility filter
The `/mercenary-dens` list only shows sightings whose reinforcement timer is **in the future or expired less than an hour ago** (`reinforcement_end > now − 1h`), and hides soft-deleted rows (`deleted_at is null`). Long-stale timers and undated rows drop off the board.

**Interpretation note:** I read "in the future, or at least 1 hour in the past" as *keep it visible until the timer is at least an hour past* → `reinforcement_end > now − 1h`. Since the filter is a `>` comparison, rows with a **null** reinforcement time are also excluded (they don't have a qualifying timer). If you'd rather keep null-timer sightings visible, tell me and I'll `OR` them back in.

### Ordering
Unchanged and already matches "latest one last": ascending by `reinforcement_end` (soonest first).

## Test plan
- [x] `tsc --noEmit` + `eslint` clean
- [ ] Migrate workflow applies `…_enemy_intel_soft_delete` on merge (now uses `--include-all` from #649)
- [ ] Preview: a sighting reinforcing in the future or within the last hour shows; one expired >1h ago is hidden; deleting a row removes it from the list but the row remains in the table with `deleted_at` set; ordering soonest→latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnWdT6AvCivWSiRpr4Zb2W

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnWdT6AvCivWSiRpr4Zb2W)_