### PR TITLE
Add L-WG68, HIK-MC, and GZM-KB to mercenary-dens map

### DIFF
--- a/src/app/mercenary-dens/data.ts
+++ b/src/app/mercenary-dens/data.ts
@@ -19,7 +19,8 @@ export const LINKS: Record<string, string[]> = {
   'JVA-FE': ['RXA-W1', 'QFU-4S', '8P-LKL', 'VK6-EZ'],
   'QFU-4S': ['8P-LKL', 'QQGH-G'],
   '8P-LKL': ['JVA-FE', 'QFU-4S', 'QQGH-G'],
-  'VK6-EZ': ['JVA-FE', 'Q-UVY6', 'QQGH-G'],
+  'VK6-EZ': ['JVA-FE', 'Q-UVY6', 'QQGH-G', 'L-WG68'],
+  'L-WG68': ['VK6-EZ', 'HIK-MC', 'GZM-KB'],
 }
 
 // The current owner of a mercenary den on a temperate planet. `null` den means
@@ -41,9 +42,9 @@ export type TemperatePlanet = {
   den: Den | null
 }
 
-// One row per temperate planet in the area. JVA-FE and 8P-LKL each have two
-// temperate planets, so they appear twice. Ordered to follow the topology
-// outward from staging.
+// One row per temperate planet in the area. JVA-FE, 8P-LKL, and GZM-KB each
+// have two temperate planets, so they appear twice. Ordered to follow the
+// topology outward from staging.
 export const TEMPERATE_PLANETS: TemperatePlanet[] = [
   { system: 'RXA-W1', planet: 'III', den: null },
   { system: 'JVA-FE', planet: 'II', den: null },
@@ -54,6 +55,8 @@ export const TEMPERATE_PLANETS: TemperatePlanet[] = [
   { system: 'VK6-EZ', planet: 'IV', den: null },
   { system: 'QQGH-G', planet: 'V', den: null },
   { system: 'Q-UVY6', planet: 'II', den: null },
+  { system: 'GZM-KB', planet: 'IV', den: null },
+  { system: 'GZM-KB', planet: 'V', den: null },
 ]
 
 // Fixed 2-D layout for the topology graph, in the SVG's own coordinate space
@@ -68,6 +71,9 @@ export const NODE_POSITIONS: Record<string, { x: number; y: number }> = {
   'VK6-EZ': { x: 470, y: 285 },
   'QQGH-G': { x: 285, y: 400 },
   'Q-UVY6': { x: 520, y: 385 },
+  'L-WG68': { x: 600, y: 245 },
+  'HIK-MC': { x: 700, y: 185 },
+  'GZM-KB': { x: 700, y: 310 },
 }
 
 // Distinct undirected edges derived from LINKS (each pair once), for drawing.

--- a/src/app/mercenary-dens/topology.tsx
+++ b/src/app/mercenary-dens/topology.tsx
@@ -21,7 +21,7 @@ const COLOR_CLASS: Record<NodeColor, string> = {
 export const Topology = ({ nodeColors = {} }: { nodeColors?: Record<string, NodeColor> }) => (
   <svg
     className={styles.topology}
-    viewBox="0 0 600 450"
+    viewBox="0 0 760 450"
     role="img"
     aria-label="Network topology of systems accessible from the staging system, coloured by mercenary den status"
   >


### PR DESCRIPTION
Extends the hand-maintained mercenary-dens intel (`src/app/mercenary-dens/data.ts`) with three more systems reachable out from staging.

## Changes

- **`L-WG68`** — links off `VK6-EZ`, and branches out to `HIK-MC` and `GZM-KB`. No temperate planets (renders as an uncolored topology node, no table rows), same as the staging system.
- **`HIK-MC`** — reachable from `L-WG68`. No temperate planets (uncolored node).
- **`GZM-KB`** — reachable from `L-WG68`, with temperate planets at **IV** and **V** (two table rows, dens `null` until intel arrives).
- Added `NODE_POSITIONS` for all three (fanning right off `VK6-EZ`) and widened the `topology.tsx` viewBox from `0 0 600 450` to `0 0 760 450` so the new right-side nodes aren't clipped.

## Notes

Consistent with existing behavior: the topology renders every system in `NODE_POSITIONS`, while the table lists only temperate planets, so systems without temperate planets show as nodes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8z4BUDPm9JnBcxHrbnZx4

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8z4BUDPm9JnBcxHrbnZx4)_