### PR TITLE
Hug the character-tile avatar to the corner; keep clone paths on one line

### DIFF
--- a/src/app/character/character.module.css
+++ b/src/app/character/character.module.css
@@ -14,6 +14,8 @@
   border-radius: var(--radius);
   background: var(--paper-raised);
   transition: border-color 0.12s ease;
+  /* Clip the corner-hugging avatar to the tile's rounded rectangle. */
+  overflow: hidden;
 }
 
 .tile:hover {
@@ -22,12 +24,16 @@
 
 .avatar {
   position: absolute;
-  top: 12px;
-  right: 12px;
+  /* Hug the tile's top-right corner, overlapping the 1px border so the
+     avatar's rounded corner lines up with the tile's outer corner. The tile's
+     overflow: hidden clips the square top/right edges to the tile radius. */
+  top: -1px;
+  right: -1px;
   width: 64px;
   height: 64px;
   flex-shrink: 0;
-  border-radius: 50%;
+  /* Square top-left & bottom-right; top-right & bottom-left match the tile. */
+  border-radius: 0 var(--radius) 0 var(--radius);
   background: var(--line-soft);
   border: 1px solid var(--line);
 }
@@ -71,6 +77,16 @@
 .bulletList {
   margin: 2pt 0 0;
   padding-left: 16pt;
+}
+
+/* Clone systems: keep each region/constellation/system path on one line and
+   pull the bullet in closer to the label. */
+.cloneList {
+  padding-left: 11pt;
+}
+
+.cloneList li {
+  white-space: nowrap;
 }
 
 .actions {

--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -141,7 +141,7 @@ const CharacterPage = async () => {
               {(cloneSystems.get(c.id)?.length ?? 0) > 0 && (
                 <div className={styles.metaBlock}>
                   <span className={styles.metaLabel}>Clone systems:</span>
-                  <ul className={styles.bulletList}>
+                  <ul className={`${styles.bulletList} ${styles.cloneList}`}>
                     {cloneSystems.get(c.id)!.map((system) => (
                       <li key={system}>{system}</li>
                     ))}


### PR DESCRIPTION
## Summary
- **Avatar** now sits flush in the character tile's top-right corner instead of floating inset: square top-left & bottom-right corners, top-right & bottom-left rounded to the tile radius (`var(--radius)`, 10px). It overlaps the 1px border (`top/right: -1px`) so its rounded corner lines up with the tile's outer corner, and the tile gains `overflow: hidden` to clip the square edges to the tile's rounded rectangle.
- **Clone-system bullets** no longer wrap — each `region/constellation/system` path stays on one line — and the bullet is pulled in slightly (smaller left indent). Scoped to the clone list via a `cloneList` modifier class, so the implants list keeps its existing wrapping behavior.

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm exec prettier --check`
- [x] Rendered the tile with the real `globals` + `character.module` CSS to confirm the corner-hugging avatar and the clone-list one-line/bullet placement (and that implants are unaffected)
- [] Manual check on `/character` against a live DB (not run in this sandbox — no Supabase credentials)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WryvQ2XYMEtBbGvJpUnCh3)_