### PR TITLE
Breadcrumb: show region › system › station in the location path

### DIFF
--- a/src/app/asset/[locationId]/page.tsx
+++ b/src/app/asset/[locationId]/page.tsx
@@ -3,7 +3,7 @@ import { notFound, redirect } from 'next/navigation'
 import { getSdeTypes } from '@/sdeTypes'
 import { createClient } from '@/utils/supabase/server'
 import { createServiceClient } from '@/utils/supabase/service'
-import { AssetPath, fetchAssetPath, type Crumb } from '../../assetPath'
+import { AssetPath, fetchAssetPath, regionSystemCrumbs, type Crumb } from '../../assetPath'
 import { fetchOwners } from '../../owners'
 import { resolveShareToken } from '../../ship/access'
 import { fetchStationNames, fetchStationSystems } from '../../stationNames'
@@ -226,6 +226,18 @@ const AssetLocationPage = async ({
         : (stationNames[numericId] ?? (locationType === 'solar_system' ? systemNames[numericId] : undefined))) ??
       `Location #${locationId}`
     systemName = systemId != null ? (systemNames[systemId] ?? `#${systemId}`) : undefined
+
+    // Breadcrumb: region › system for this place (the place itself is the
+    // heading). For a bare solar system the system is the heading, so only the
+    // region shows. Falls back to the Assets root when it can't be placed.
+    const prefix = await regionSystemCrumbs(systemId, systemName, locationType === 'solar_system')
+    if (prefix.length > 0) {
+      crumbs = prefix
+      // The system now lives in the breadcrumb (region › system), so drop the
+      // redundant "System:" line below the heading. Kept only in the Assets
+      // fallback, where the breadcrumb can't show the system.
+      systemName = undefined
+    }
   }
 
   // Owner names for the filter dropdown: the caller's own owners, or — in the

--- a/src/app/assetPath.tsx
+++ b/src/app/assetPath.tsx
@@ -7,12 +7,33 @@
 import Link from 'next/link'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { map, reverse } from 'ramda'
+import { getSdeSystem } from '@/sdeSystems'
 import { createClient } from '@/utils/supabase/server'
 import { resolveLocations } from './resolveLocations'
 import { fetchTypeNames } from './typeNames'
 import styles from './assetPath.module.css'
 
 export type Crumb = { href: string | null; label: string }
+
+// The leading location crumbs for a solar system: its region (a plain label —
+// there's no region page) followed by the system (linked to its /asset view).
+// Region is omitted for systems the SDE mirror can't place (wormhole/abyssal).
+// The system crumb is omitted when the location *is* that system (isBareSystem),
+// since the caller renders the system itself elsewhere (as the place crumb or
+// the page heading) — this avoids a duplicate. Shared by the breadcrumb here
+// and the bare-place branch of /asset/[locationId].
+export const regionSystemCrumbs = async (
+  systemId: number | undefined,
+  systemName: string | undefined,
+  isBareSystem: boolean
+): Promise<Crumb[]> => {
+  if (systemId == null) return []
+  const system = await getSdeSystem(systemId)
+  const crumbs: Crumb[] = []
+  if (system?.regionName) crumbs.push({ href: null, label: system.regionName })
+  if (!isBareSystem) crumbs.push({ href: `/asset/${systemId}`, label: systemName ?? system?.name ?? `#${systemId}` })
+  return crumbs
+}
 
 type AncestorRow = {
   item_id: number | string
@@ -46,9 +67,17 @@ export const fetchAssetPath = async (itemId: string, client?: SupabaseClient): P
     fetchTypeNames(map((a: AncestorRow) => Number(a.type_id), ancestors)),
   ])
 
+  // Lead with region › system (splitting the system out of the root place), then
+  // the root place itself (a station/structure; for a bare system it's already
+  // the system crumb). Falls back to the Assets root only when the system can't
+  // be placed in a region (non-known-space), so there's always a nav root.
+  const isBareSystem = root.type === 'solar_system'
+  const prefix = await regionSystemCrumbs(resolved.systemIdFor(root), resolved.systemFor(root), isBareSystem)
+  const placeCrumb = { href: `/asset/${root.id}`, label: resolved.nameFor(root) }
+  const head = prefix.length > 0 ? [...prefix, placeCrumb] : [ASSETS_CRUMB, placeCrumb]
+
   return [
-    ASSETS_CRUMB,
-    { href: `/asset/${root.id}`, label: resolved.nameFor(root) },
+    ...head,
     ...map(
       (a: AncestorRow) => ({
         href: `/asset/${a.item_id}`,

--- a/src/app/resolveLocations.ts
+++ b/src/app/resolveLocations.ts
@@ -16,6 +16,7 @@ type Structure = { structure_id: number | string; name: string | null; system_id
 export type ResolvedLocations = {
   nameFor: (loc: LocationRef) => string
   systemFor: (loc: LocationRef) => string | undefined
+  systemIdFor: (loc: LocationRef) => number | undefined
 }
 
 export const resolveLocations = async (
@@ -75,16 +76,19 @@ export const resolveLocations = async (
     return `Location #${loc.id}`
   }
 
-  const systemFor = (loc: LocationRef): string | undefined => {
+  const systemIdFor = (loc: LocationRef): number | undefined => {
     const structure = structureById.get(loc.id)
-    if (structure?.system_id != null) return systemNames[Number(structure.system_id)] ?? `#${structure.system_id}`
-    if (loc.type === 'solar_system') return systemNames[Number(loc.id)]
-    if (loc.type === 'station') {
-      const systemId = stationSystems[Number(loc.id)]
-      if (systemId != null) return systemNames[systemId] ?? `#${systemId}`
-    }
+    if (structure?.system_id != null) return Number(structure.system_id)
+    if (loc.type === 'solar_system') return Number(loc.id)
+    if (loc.type === 'station') return stationSystems[Number(loc.id)] ?? undefined
     return undefined
   }
 
-  return { nameFor, systemFor }
+  const systemFor = (loc: LocationRef): string | undefined => {
+    const systemId = systemIdFor(loc)
+    if (systemId == null) return undefined
+    return systemNames[systemId] ?? `#${systemId}`
+  }
+
+  return { nameFor, systemFor, systemIdFor }
 }


### PR DESCRIPTION
## Summary
The location breadcrumb on `/ship/[itemId]` and `/asset/[locationId]` collapsed the whole root place into a single crumb (e.g. `Assets › Jita IV-4 CNAP`), hiding the system and region. It now leads with the solar system's **region** and **system**, split out from the station/structure:

> Region › System › Station › `<containers>` › `<subject>`

Addresses both requests:
- **Ship view** — station is split out from the system (region › system › station), and the region replaces the leading "Assets".
- **Assets page** — the system is broken into region › system.

## Changes
- **`resolveLocations.ts`** — new `systemIdFor(loc)` so a root place (station / structure / solar system) resolves to its solar-system id; `systemFor` now derives from it. This lets the breadcrumb look up the region via `getSdeSystem` (regionName came from the `sde_kspace_system` mirror view).
- **`assetPath.tsx`** — new `regionSystemCrumbs()` helper: the **region** is a plain label (there's no region page), the **system** links to its `/asset` view, and the system crumb is omitted when the place *is* that system (bare solar system) to avoid a duplicate. `fetchAssetPath` leads with it and drops the "Assets" crumb — falling back to "Assets" only when the system can't be placed in a region (wormhole/abyssal space).
- **`/asset/[locationId]`** — the bare-place branch uses the same helper for its breadcrumb, and drops the now-redundant "System:" line below the heading when the system is already shown in the breadcrumb (kept in the Assets fallback).

Region and system labels resolve from the nightly SDE mirror; no new queries to ESI. No migration.

## Test plan
- [x] `tsc --noEmit` + `eslint` clean
- [ ] Preview:
  - `/ship/[itemId]` of a docked ship → breadcrumb reads `Region › System › Station › … › Ship`
  - `/asset/[stationId]` → `Region › System › Station`, no duplicate "System:" line
  - `/asset/[systemId]` (loose-in-space) → `Region › System`
  - Drill into a container → region/system/station/container chain intact
  - A wormhole/abyssal location (no region) → falls back to `Assets › place`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnWdT6AvCivWSiRpr4Zb2W

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnWdT6AvCivWSiRpr4Zb2W)_