### PR TITLE
sde-mirror: force the nightly ESF re-encode

### DIFF
--- a/src/workflows/sdeMirror.ts
+++ b/src/workflows/sdeMirror.ts
@@ -59,14 +59,15 @@ async function finalize(build: number, runId: number): Promise<void> {
 
 // Re-encode the eveship.fit protobuf data into the esf_data table from the
 // freshly-mirrored SDE. Its own step (own duration budget + retries), run on
-// EVERY mirror pass — including the build-unchanged skip path — so the table
-// is (re)populated whenever the SDE extract runs, not only on a fresh ingest.
-// runEsfData no-ops cheaply when esf_data is already at this build, so the
-// steady-state cost is one query; it only pays the ~30s encode when stale.
+// every mirror pass. force: true re-encodes unconditionally — the nightly run
+// always re-does the full ingest (planRun no longer skips), and the ESF encode
+// matches that: it re-writes esf_data every night rather than no-opping when
+// the build is unchanged. (The manual /api/cron/esf-data route keeps the
+// build-guard by default; pass ?force=1 there to match.)
 async function encodeEsf(build: number): Promise<void> {
   'use step'
   const { runEsfData } = await import('@/jobs/esfData.js')
-  await runEsfData({ build })
+  await runEsfData({ build, force: true })
 }
 
 // Plain loops rather than the jobs' usual ramda/forEachSequential: the
@@ -86,7 +87,7 @@ export async function sdeMirrorWorkflow() {
   }
   await stationNames()
   await finalize(plan.build, plan.runId)
-  // Re-encode the esf_data table from the freshly-mirrored build (runEsfData
-  // still no-ops cheaply when esf_data already matches this build).
+  // Re-encode the esf_data table from the freshly-mirrored build (forced, so it
+  // re-writes every night alongside the full re-ingest above).
   await encodeEsf(plan.build)
 }


### PR DESCRIPTION
## Summary
The `sde-mirror` workflow's `encodeEsf` step now calls `runEsfData({ force: true })`, so the nightly run **re-writes `esf_data` every time** instead of no-opping when the SDE build is unchanged.

This matches #647, which changed `planRun` to always re-ingest the full SDE — the ESF encode now follows suit rather than short-circuiting on the build guard. Requested directly.

- **`src/workflows/sdeMirror.ts`** — `encodeEsf` passes `force: true`; comments updated.
- The manual `/api/cron/esf-data` route is unchanged: it keeps the build-guard by default (`?force=1` to override). Only the scheduled workflow forces.

## Note
Re-encoding an unchanged build produces identical `.pb2` bytes, so the `sde_build`-keyed **ETag stays the same** (304s still cheap) — only `updated_at`/`Last-Modified` bumps nightly. So this costs the ~30s encode each night but doesn't churn the CDN via ETag.

## Test plan
- [x] `tsc --noEmit` + `eslint` clean
- [ ] Preview build green
- [ ] After merge: the next 12:21 UTC `sde-mirror` run logs an actual esf-data upsert (6 files) rather than "already encoded … skipping", even with the build unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnWdT6AvCivWSiRpr4Zb2W

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnWdT6AvCivWSiRpr4Zb2W)_