### PR TITLE
Reverse clone path to system-first, drop its bullet, unwrap implants

### DIFF
--- a/src/app/character/character.module.css
+++ b/src/app/character/character.module.css
@@ -79,14 +79,15 @@
   padding-left: 16pt;
 }
 
-/* Clone systems: keep each region/constellation/system path on one line and
-   pull the bullet in closer to the label. */
-.cloneList {
-  padding-left: 11pt;
+/* Neither the clone-system paths nor the implant names should wrap. */
+.bulletList li {
+  white-space: nowrap;
 }
 
-.cloneList li {
-  white-space: nowrap;
+/* Clone systems: no bullet, aligned flush under the label. */
+.cloneList {
+  list-style: none;
+  padding-left: 0;
 }
 
 .actions {

--- a/src/sdeSystems.ts
+++ b/src/sdeSystems.ts
@@ -59,11 +59,11 @@ export const getSdeSystemNames = async (systemIDs: Iterable<number>): Promise<Re
   return Object.fromEntries(Object.entries(systems).map(([id, s]) => [id, s.name]))
 }
 
-// "[region]/[constellation]/[system]" — falls back to just the system name
+// "[system] / [constellation] / [region]" — falls back to just the system name
 // for systems the mirror can't place in a constellation/region (shouldn't
 // happen for known-space systems, but the join is a left join).
 export const formatSystemPath = (system: SdeSystem): string =>
-  [system.regionName, system.constellationName, system.name].filter((part): part is string => Boolean(part)).join('/')
+  [system.name, system.constellationName, system.regionName].filter((part): part is string => Boolean(part)).join(' / ')
 
 export const getSdeSystemPaths = async (systemIDs: Iterable<number>): Promise<Record<number, string>> => {
   const systems = await getSdeSystems(systemIDs)


### PR DESCRIPTION
## Summary
- **Clone-system format** flips from `Region / Constellation / System` to **`System / Constellation / Region`** (spaced slashes), in `formatSystemPath`. The list now sorts and reads by the system name first.
- **Clone list** drops its bullet (`list-style: none`) and aligns flush under the "Clone systems:" label.
- **Implant names** no longer wrap either — `white-space: nowrap` now applies to every `.bulletList` item, not just the clone paths (the clone-specific nowrap rule folded into the shared one).

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec prettier --check`
- [x] Rendered the tile with the real `globals` + `character.module` CSS to confirm the new "System / Constellation / Region" format, the bullet-less flush clone list, and non-wrapping implants
- [] Manual check on `/character` against a live DB (not run in this sandbox — no Supabase credentials)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WryvQ2XYMEtBbGvJpUnCh3)_