### PR TITLE
Reveal shared merc-den owner identity + fix enemy-intel sharing

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1377,6 +1377,73 @@ create policy "Corpmates read shared mercenary dens"
     )
   );
 
+-- ── Shared-den owner visibility helpers ──────────────────────────────────────
+-- registration RLS only exposes a user's own rows, so a corpmate viewing a
+-- shared den (or shared enemy-den intel) can't resolve the owner/reporter's
+-- identity. These SECURITY DEFINER helpers bypass that for exactly the data the
+-- caller may already see, exposing only public EVE identity (name,
+-- character_id) or a boolean — never user_id / which characters share an
+-- account.
+
+-- Own + shared-to-caller registrations, resolved to name + character_id only.
+-- "Shared to caller" mirrors "Corpmates read shared mercenary dens" above, so a
+-- registration is returned exactly when the caller can already see its dens.
+-- Backs the /mercenary-dens owner column (a shared den would otherwise show
+-- "Corpmate").
+create or replace function public.mercenary_den_owner_names(reg_ids uuid[])
+returns table (id uuid, name text, character_id bigint)
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select r.id, r.name, r.character_id
+  from public.registration r
+  where r.id = any(reg_ids)
+    and (
+      r.user_id = auth.uid()
+      or exists (
+        select 1
+        from public.character_mercenary_den_share sh
+        where sh.character_id = r.id
+          and sh.corporation_id in (
+            select c.corporation_id
+            from public.registration c
+            where c.user_id = auth.uid() and c.corporation_id is not null
+          )
+      )
+    );
+$$;
+
+grant execute on function public.mercenary_den_owner_names(uuid[]) to authenticated;
+
+-- True when target_user shares their Mercenary Den data with a corporation the
+-- caller owns a character in. Computed under definer rights so it can read the
+-- reporter's registrations (hidden from the caller by registration RLS); backs
+-- the enemy-intel corp-sharing policy below (whose earlier direct join on
+-- registration silently matched nothing for the corpmate).
+create or replace function public.user_shares_dens_with_caller(target_user uuid)
+returns boolean
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select exists (
+    select 1
+    from public.registration r
+    join public.character_mercenary_den_share sh on sh.character_id = r.id
+    where r.user_id = target_user
+      and sh.corporation_id in (
+        select c.corporation_id
+        from public.registration c
+        where c.user_id = auth.uid() and c.corporation_id is not null
+      )
+  );
+$$;
+
+grant execute on function public.user_shares_dens_with_caller(uuid) to authenticated;
+
 -- ── mercenary_den_enemy_intel ────────────────────────────────────────────────────
 -- Hand-submitted intel on enemy-owned Mercenary Dens seen reinforced. ESI has no
 -- feed for another corp's dens, so this is a shared corkboard: any authenticated
@@ -1415,24 +1482,15 @@ create policy "Users read own enemy den intel"
 
 -- Corpmates read another user's reports exactly when that user shares their
 -- Mercenary Den data with a corporation the caller owns a character in — the
--- same character_mercenary_den_share preference that gates real dens.
--- Additive/permissive: OR'd with "Users read own enemy den intel" above.
+-- same character_mercenary_den_share preference that gates real dens. Goes
+-- through the definer helper because a direct join on registration runs as the
+-- querying corpmate, whose RLS hides the reporter's rows (so the branch never
+-- matched). Additive/permissive: OR'd with "Users read own enemy den intel".
 create policy "Corpmates read shared enemy den intel"
   on public.mercenary_den_enemy_intel
   for select
   to authenticated
-  using (
-    exists (
-      select 1
-      from public.registration r
-      join public.character_mercenary_den_share sh on sh.character_id = r.id
-      where r.user_id = mercenary_den_enemy_intel.created_by
-        and sh.corporation_id in (
-          select c.corporation_id from public.registration c
-          where c.user_id = (select auth.uid()) and c.corporation_id is not null
-        )
-    )
-  );
+  using (public.user_shares_dens_with_caller(created_by));
 
 -- A user can only post (and later remove) intel attributed to themselves.
 create policy "Authenticated insert own enemy den intel"

--- a/src/app/mercenary-dens/enemyDenIntel.tsx
+++ b/src/app/mercenary-dens/enemyDenIntel.tsx
@@ -24,7 +24,8 @@ export type EnemyDenIntelRow = {
 // sighting, plus the shared list sorted soonest-reinforcement-first; a
 // submitter can delete their own rows (server-enforced by RLS). "Reported by"
 // is fixed to the caller's main character (derived server-side), and the
-// reinforcement time defaults to today at 00:00:00 UTC.
+// reinforcement time defaults to 24h out (date only, so the reporter fills in
+// just the time).
 const EnemyDenIntel = ({
   rows,
   defaultReportedBy,

--- a/src/app/mercenary-dens/page.tsx
+++ b/src/app/mercenary-dens/page.tsx
@@ -88,6 +88,19 @@ const MercenaryDensPage = async () => {
   const { data: denData } = await supabase.from('character_mercenary_den').select('*')
   const dens = (denData ?? []) as DenRow[]
 
+  // Resolve owner identity for dens we can see but don't own (shared to one of
+  // our corps). Their registration is hidden from us by RLS, so a
+  // security-definer RPC returns just the public EVE name + id for own +
+  // shared-to-us registrations — without it a shared den shows only "Corpmate".
+  const denOwnerById = new Map(ownRegById)
+  const foreignOwnerIds = [...new Set(dens.map((d) => d.character_id))].filter((id) => !denOwnerById.has(id))
+  if (foreignOwnerIds.length) {
+    const { data: owners } = await supabase.rpc('mercenary_den_owner_names', { reg_ids: foreignOwnerIds })
+    for (const o of (owners ?? []) as { id: string; name: string; character_id: number | null }[]) {
+      denOwnerById.set(o.id, { name: o.name, characterId: o.character_id != null ? String(o.character_id) : null })
+    }
+  }
+
   // Hand-submitted enemy-den sightings — a submitter always sees their own, and
   // sees others' reports exactly when that submitter shares their Mercenary Den
   // data with one of the caller's corps (mercenary_den_enemy_intel's RLS
@@ -114,10 +127,11 @@ const MercenaryDensPage = async () => {
     mine: row.created_by === data.user.id,
   }))
   const defaultReportedBy = [...ownRegById.values()][0]?.name ?? ''
-  // Reinforcement time input defaults to today at 00:00:00 UTC (EVE time).
+  // Reinforcement time input defaults to 24h out (a den reinforces for roughly a
+  // day), date only — "YYYY-MM-DDT" — so the reporter just fills in the hh:mm:ss.
   // Computed on the server so the client's initial state matches (no hydration
-  // mismatch) — the value is a plain ISO date the client edits.
-  const defaultReinforcementEnd = `${new Date().toISOString().slice(0, 10)}T00:00:00`
+  // mismatch) — the value is a plain string the client edits.
+  const defaultReinforcementEnd = `${new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 10)}T`
   const typeNames = await getSdeTypeNames(dens.map((d) => d.type_id).filter((t): t is number => t != null))
 
   // Merge the hand-maintained temperate-planet intel with our real dens, keyed by
@@ -137,13 +151,14 @@ const MercenaryDensPage = async () => {
     const planet = planetsById[den.planet_id] ?? null
     const system = planet?.systemName ?? ''
     const roman = planet?.roman ?? ''
-    const ownReg = ownRegById.get(den.character_id)
+    const ownReg = denOwnerById.get(den.character_id)
     const enriched = {
       ...den,
       ownerLabel: ownReg?.name ?? 'Corpmate',
-      // The EVE character id, shown in parens after the owner. Only resolvable
-      // for the caller's own characters — a corpmate's registration is hidden
-      // by RLS, so their id (and name) stay unknown.
+      // The EVE character id, shown in parens after the owner. Resolvable for
+      // the caller's own characters and for shared dens' owners (via the
+      // security-definer RPC above); "Corpmate" only survives if resolution
+      // somehow fails.
       ownerCharacterId: ownReg?.characterId ?? null,
       typeName: den.type_id != null ? (typeNames[den.type_id] ?? null) : null,
     }

--- a/supabase/migrations/20260720050000_mercenary_den_owner_visibility.sql
+++ b/supabase/migrations/20260720050000_mercenary_den_owner_visibility.sql
@@ -1,0 +1,88 @@
+-- Make the owner identity of *shared* Mercenary Den data visible to the
+-- corpmates it's shared with. Both fixes below have the same root cause:
+-- registration RLS only ever exposes a user's OWN rows, so anything that has to
+-- read another user's registration on behalf of a corpmate silently finds
+-- nothing.
+--
+--   1. The /mercenary-dens table labelled a shared den's owner "Corpmate"
+--      instead of the character's name, because the page can only resolve
+--      registration ids it owns.
+--   2. The "Corpmates read shared enemy den intel" policy joined
+--      public.registration inside a USING clause that runs as the querying
+--      corpmate; registration RLS hid the reporter's rows, so the corp-sharing
+--      branch never matched and enemy-den intel was effectively private.
+--      (The friendly-den policy avoided this by reading only the
+--      corpmate-readable character_mercenary_den_share table.)
+--
+-- Both are fixed with SECURITY DEFINER helpers that bypass registration RLS but
+-- expose only the minimum: public EVE identity (name, character_id) for dens the
+-- caller can already see, and a boolean for intel visibility. Neither leaks
+-- user_id / which characters share an account.
+
+-- Own + shared-to-caller registrations, resolved to their public EVE identity
+-- only (name + character_id — never user_id). "Shared to caller" mirrors the
+-- corp-sharing policy on character_mercenary_den_over_time, so a registration is
+-- returned exactly when the caller can already see that owner's dens.
+create or replace function public.mercenary_den_owner_names(reg_ids uuid[])
+returns table (id uuid, name text, character_id bigint)
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select r.id, r.name, r.character_id
+  from public.registration r
+  where r.id = any(reg_ids)
+    and (
+      r.user_id = auth.uid()
+      or exists (
+        select 1
+        from public.character_mercenary_den_share sh
+        where sh.character_id = r.id
+          and sh.corporation_id in (
+            select c.corporation_id
+            from public.registration c
+            where c.user_id = auth.uid() and c.corporation_id is not null
+          )
+      )
+    );
+$$;
+
+grant execute on function public.mercenary_den_owner_names(uuid[]) to authenticated;
+
+-- True when target_user shares their Mercenary Den data with a corporation the
+-- caller owns a character in — the same character_mercenary_den_share preference
+-- that gates real dens, but computed under definer rights so it can read the
+-- reporter's registrations (which registration RLS would otherwise hide from the
+-- caller). Returns only a boolean, so it can't be used to enumerate a user's
+-- characters or corps.
+create or replace function public.user_shares_dens_with_caller(target_user uuid)
+returns boolean
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select exists (
+    select 1
+    from public.registration r
+    join public.character_mercenary_den_share sh on sh.character_id = r.id
+    where r.user_id = target_user
+      and sh.corporation_id in (
+        select c.corporation_id
+        from public.registration c
+        where c.user_id = auth.uid() and c.corporation_id is not null
+      )
+  );
+$$;
+
+grant execute on function public.user_shares_dens_with_caller(uuid) to authenticated;
+
+-- Rewrite the enemy-intel corp-sharing policy to go through the definer helper
+-- instead of joining registration directly (which RLS blocked).
+drop policy if exists "Corpmates read shared enemy den intel" on public.mercenary_den_enemy_intel;
+create policy "Corpmates read shared enemy den intel"
+  on public.mercenary_den_enemy_intel
+  for select
+  to authenticated
+  using (public.user_shares_dens_with_caller(created_by));


### PR DESCRIPTION
Two mercenary-den visibility bugs plus a small UX tweak.

## Root cause (both bugs)

`registration` RLS only ever exposes a user's **own** rows. So a corpmate who can see *shared* den data can't resolve the owner's identity behind it — anything that reads another user's `registration` on their behalf silently finds nothing.

## Fixes

- **Shared den owner shows "Corpmate" instead of the character name.** The page could only resolve registration ids it owns. Added a `SECURITY DEFINER` RPC `mercenary_den_owner_names(reg_ids)` returning only public EVE identity (`name`, `character_id`) for **own + shared-to-caller** registrations (the "shared" test mirrors the existing corp-sharing policy on `character_mercenary_den_over_time`). `/mercenary-dens` now resolves owners of shared dens through it.
- **Enemy-den intel was never actually shared.** The `Corpmates read shared enemy den intel` policy joined `public.registration` inside a `USING` clause that runs as the querying corpmate — whose RLS hid the reporter's rows, so the corp-sharing branch never matched. (The friendly-den policy avoided this by reading only the corpmate-readable `character_mercenary_den_share`.) Rewrote it to go through a `SECURITY DEFINER` boolean helper `user_shares_dens_with_caller(created_by)`.
- Neither helper exposes `user_id` or which characters share an account — only a public name/id, or a boolean.
- **Default reinforcement time on the report-a-sighting form** now starts 24h out, date only (`YYYY-MM-DDT`), so the reporter just fills in the time.

## Schema

Adds migration `20260720050000_mercenary_den_owner_visibility.sql` (two functions + policy rewrite) and mirrors it in `schema.sql`.

## Verification

`pnpm run lint` and `tsc --noEmit` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8z4BUDPm9JnBcxHrbnZx4

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8z4BUDPm9JnBcxHrbnZx4)_