### PR TITLE
Populate registration.corporation_id for all linked characters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,7 +243,7 @@ One job per ESI endpoint. The npm script, queue job name, and heartbeat job labe
 | `character-industry-jobs` | `/characters/{id}/industry/jobs/` | `character_industry_job_over_time` | every 6h `:48` |
 | `character-mercenary-dens` | `/characters/{id}/structures/mercenary-dens/` (+ per-den detail) | `character_mercenary_den_over_time` (SCD identity), `character_mercenary_den_status` (append-only observations) | every 6h `:30` |
 | `character-status` | `/characters/{id}/wallet/` + `/location/` + `/implants/` + `/clones/` + `/ship/` | `character_wallet`, `character_location`, `character_implant`, `character_clone_over_time`, `character_clone_state`, `character_ship` | every 6h `:14` |
-| `character-affiliations` | `/characters/affiliation/` | `character_affiliation` | 11:41 daily |
+| `character-affiliations` | `/characters/affiliation/` | `character_affiliation`, `registration` (corporation_id) | 11:41 daily |
 | `corp-structures` | `/corporations/{id}/structures/` | `corp_structure` | 09:17 daily |
 | `corp-assets` | `/corporations/{id}/assets/` | `corp_asset_over_time`, `corp_structure_rig` | 09:27 daily |
 | `corp-blueprints` | `/corporations/{id}/blueprints/` | `corp_blueprint_over_time` | 09:07 daily |

--- a/src/app/character/callback/route.ts
+++ b/src/app/character/callback/route.ts
@@ -3,6 +3,7 @@
 import { SupabaseClient } from '@supabase/supabase-js'
 import { NextRequest, NextResponse } from 'next/server'
 
+import { character } from '@/esi'
 import { createClient } from '@/utils/supabase/server'
 
 import { dispatchRefresh } from '../dispatchRefresh'
@@ -10,7 +11,13 @@ import { sso } from '../sso'
 
 const upsertCharacter =
   (supabase: SupabaseClient) =>
-  async (columns: { user_id: string; owner: string; name: string; character_id: number }) => {
+  async (columns: {
+    user_id: string
+    owner: string
+    name: string
+    character_id: number
+    corporation_id?: number
+  }) => {
     const response = await supabase.from('registration').upsert(columns, { onConflict: 'user_id, owner' }).select()
     if (response.error) throw new Error(`upsert character failed: ${JSON.stringify(response.error)}`)
     if (!response.data?.[0]?.id) throw new Error(`upsert character returned no row: ${JSON.stringify(response)}`)
@@ -78,7 +85,27 @@ export const GET = async (request: NextRequest) => {
   const expires_at = new Date(exp * 1000).toISOString()
   const eve_character_id = Number(sub.split(':')[2])
   await sso.getAccessToken(refresh_token, true)
-  const character_id = await upsertCharacter(supabase)({ user_id, owner, name, character_id: eve_character_id })
+
+  // Resolve the character's corporation up front so registration.corporation_id
+  // is populated immediately, instead of only after the first
+  // character-affiliations run. Best-effort: a transient ESI failure just leaves
+  // it unset (that job backfills it), so it never blocks registration. Only
+  // written when resolved, so a failed re-auth can't null out a known corp.
+  let corporation_id: number | undefined
+  try {
+    const sheet = await character(access_token, eve_character_id)
+    if (sheet?.corporation_id != null) corporation_id = Number(sheet.corporation_id)
+  } catch (e) {
+    console.warn(`/character/callback: corp lookup failed for ${eve_character_id}: ${(e as Error)?.message}`)
+  }
+
+  const character_id = await upsertCharacter(supabase)({
+    user_id,
+    owner,
+    name,
+    character_id: eve_character_id,
+    ...(corporation_id != null ? { corporation_id } : {}),
+  })
   await ensureMainCharacter(supabase)(user_id)
   await upsertToken(supabase)({
     user_id,

--- a/src/jobs/characterAffiliations.js
+++ b/src/jobs/characterAffiliations.js
@@ -2,7 +2,7 @@ import { filter, map, pipe, prop, reduce, splitEvery } from 'ramda'
 
 import { characterAffiliations } from '../esi.js'
 import { sudoSupabase } from '../supabase.js'
-import { cli } from './lib.js'
+import { cli, forEachSequential } from './lib.js'
 
 const TAG = 'character-affiliations'
 const BATCH_SIZE = 1000
@@ -10,11 +10,17 @@ const BATCH_SIZE = 1000
 const isPositiveId = (n) => Number.isFinite(n) && n > 0
 const idToNumber = pipe(prop('id'), Number)
 
-// POST /characters/affiliation/ → character_affiliation. Maps each known
+// POST /characters/affiliation/ → character_affiliation, and push each linked
+// character's corporation back into registration.corporation_id. Maps each known
 // character to the corporation they currently belong to, so the UI can show who
 // paid industry tax and which corp they fly for. Affiliations are public (no
-// token) and resolved in batches over every character id cached in
-// universe_name; account-wide batch work, so it takes no character scope. Names
+// token) and resolved in batches over every character id cached in universe_name
+// UNION every linked registration's character. Including the registrations
+// matters: registration.corporation_id is otherwise written only by
+// forEachCorporation (src/jobs/lib.js), which runs only for corp-scoped jobs, so
+// a character whose token carries no corp scope never got its corp populated —
+// leaving it out of the corp-table RLS scope and the owner/share pickers
+// (fetchOwners). This makes that population scope-independent and daily. Names
 // for any newly seen corporations are picked up by the universe-names job.
 export const runCharacterAffiliations = async () => {
   const { data: chars, error: charsErr } = await sudoSupabase
@@ -23,7 +29,20 @@ export const runCharacterAffiliations = async () => {
     .eq('category', 'character')
   if (charsErr) throw charsErr
 
-  const ids = filter(isPositiveId, map(idToNumber, chars ?? []))
+  // Linked characters, resolved regardless of the ESI scopes their token holds,
+  // so their corp lands in registration even without a corp-scoped job.
+  const { data: regs, error: regsErr } = await sudoSupabase
+    .from('registration')
+    .select('id, character_id, corporation_id')
+    .not('character_id', 'is', null)
+  if (regsErr) throw regsErr
+
+  const ids = [
+    ...new Set([
+      ...filter(isPositiveId, map(idToNumber, chars ?? [])),
+      ...filter(isPositiveId, map((r) => Number(r.character_id), regs ?? [])),
+    ]),
+  ]
   console.log(`[${TAG}] resolving affiliations for ${ids.length} character(s)`)
   if (ids.length === 0) return
 
@@ -53,6 +72,36 @@ export const runCharacterAffiliations = async () => {
   const { error: upErr } = await sudoSupabase.from('character_affiliation').upsert(rows, { onConflict: 'character_id' })
   if (upErr) throw upErr
   console.log(`[${TAG}] upserted ${rows.length} character affiliation(s)`)
+
+  // Propagate each linked character's current corporation into its registration
+  // row. Only registrations whose corp actually changed are touched, grouped
+  // into one update per target corporation (the accumulator is mutated in place,
+  // the accepted exception for building a collection in a reduce).
+  const corpByCharacter = new Map(rows.map((r) => [Number(r.character_id), Number(r.corporation_id)]))
+  const idsByCorp = reduce(
+    (acc, reg) => {
+      const current = reg.corporation_id == null ? null : Number(reg.corporation_id)
+      const corp = corpByCharacter.get(Number(reg.character_id))
+      if (corp != null && corp !== current) {
+        if (!acc[corp]) acc[corp] = []
+        acc[corp].push(reg.id)
+      }
+      return acc
+    },
+    {},
+    regs ?? []
+  )
+  await forEachSequential(Object.entries(idsByCorp), async ([corp, regIds]) => {
+    const { error } = await sudoSupabase
+      .from('registration')
+      .update({ corporation_id: Number(corp) })
+      .in('id', regIds)
+    if (error) {
+      console.warn(`[${TAG}] registration.corporation_id update failed for corp ${corp}: ${error.message}`)
+    } else {
+      console.log(`[${TAG}] set corporation_id=${corp} on ${regIds.length} registration(s)`)
+    }
+  })
 }
 
 cli(import.meta.url, TAG, runCharacterAffiliations)


### PR DESCRIPTION
## Problem

A linked character's corporation was missing from its `registration` row (e.g. a character in GoonWaffe showed no corp), so that corp never appeared as a share target / owner.

## Root cause

`registration.corporation_id` was written in exactly **one** place — `forEachCorporation` (`src/jobs/lib.js`), which runs *only* for corp-scoped extract jobs (corp-assets/industry-jobs/wallet-transactions/structures/blueprints/wallet-journal). A character whose token carries no corp ESI scope never goes through that path, so its `corporation_id` stayed `null` — even though `character-affiliations` already knew the corp (it writes the separate `character_affiliation` table and never propagated it back).

That column drives corp-table RLS and `fetchOwners` (the owner filter + the `/mercenary-dens` corp share-target picker), so an unpopulated corp is invisible for sharing.

## Fix

Two complementary changes, so the corp is populated both **immediately on registration** and **kept fresh for every existing character**:

1. **At registration** (`src/app/character/callback/route.ts`) — the OAuth callback now fetches the character sheet and sets `registration.corporation_id` up front, instead of leaving it null until a job runs. Best-effort: a transient ESI failure just leaves it unset (the affiliations job backfills it), so it never blocks registration, and it's only written when resolved so a failed re-auth can't null out a known corp.

2. **Ongoing / backfill** (`src/jobs/characterAffiliations.js`) — make `character-affiliations` the scope-independent populator of `registration.corporation_id`: union every linked registration's EVE character into the resolve set (`universe_name`, what the job iterated, doesn't necessarily cache a user's own characters) and push each resolved corp back into its `registration` row, batched into one update per changed corporation. This runs daily and is dispatched on-demand (`ACCOUNT_JOBS`), so already-registered characters like the reported one get backfilled on the next run / refresh — no scope grant needed.

`forEachCorporation` still updates the column during corp pulls (all three sources agree — same ESI corp); these just add a universal baseline.

## Verification

`pnpm run lint` and `tsc --noEmit` clean. No schema change (uses the existing `registration` / `character_affiliation` tables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8z4BUDPm9JnBcxHrbnZx4