### PR TITLE
Merc dens: dashed red node outline for systems with enemy-den intel

### DIFF
--- a/src/app/mercenary-dens/mercenaryDens.module.css
+++ b/src/app/mercenary-dens/mercenaryDens.module.css
@@ -206,6 +206,14 @@
   fill: color-mix(in srgb, var(--merc-green) 22%, var(--paper-raised));
   stroke: var(--merc-green);
 }
+/* Reported enemy-den intel: a dashed red outline over the node's existing fill.
+ * Same specificity as the status-stroke rules above, so being later in source
+ * order lets it override their stroke while keeping their fill. */
+.nodeEnemyIntel .nodeBox {
+  stroke: var(--merc-red);
+  stroke-width: 2;
+  stroke-dasharray: 4 2;
+}
 .nodeRed .nodeLabel,
 .nodeYellow .nodeLabel,
 .nodeGreen .nodeLabel {

--- a/src/app/mercenary-dens/page.tsx
+++ b/src/app/mercenary-dens/page.tsx
@@ -192,6 +192,13 @@ const MercenaryDensPage = async () => {
     if (!cur || severity[c] > severity[cur]) nodeColors[row.system] = c
   }
 
+  // Systems with a reported enemy-den sighting get a dashed red outline on the
+  // topology, on top of whatever den-status tint they already have. Matched by
+  // name against the node keys, upper-cased since sightings are free text.
+  const enemyIntelSystems = new Set(
+    enemyDenIntel.map((r) => r.system?.trim().toUpperCase()).filter((s): s is string => !!s)
+  )
+
   const dash = <span className={styles.empty}>—</span>
   const evolution = (level: string | null, amount: number | null) =>
     level != null ? `${level}${amount != null ? ` (${amount})` : ''}` : dash
@@ -210,7 +217,7 @@ const MercenaryDensPage = async () => {
         Systems immediately accessible from our staging system, <span className={styles.system}>{STAGING}</span>.
       </p>
 
-      <Topology nodeColors={nodeColors} />
+      <Topology nodeColors={nodeColors} enemyIntel={enemyIntelSystems} />
 
       <h2>Temperate planets</h2>
       <div className={styles.tableScroll}>

--- a/src/app/mercenary-dens/topology.tsx
+++ b/src/app/mercenary-dens/topology.tsx
@@ -17,13 +17,21 @@ const COLOR_CLASS: Record<NodeColor, string> = {
 // fixed hand-placed layout (see NODE_POSITIONS) — no interactivity — so it
 // renders on the server and scales to the container width. Each system node is
 // tinted by the most severe den status among its temperate planets (red
-// reinforced > yellow external > green ours), matching the table below.
-export const Topology = ({ nodeColors = {} }: { nodeColors?: Record<string, NodeColor> }) => (
+// reinforced > yellow external > green ours), matching the table below; a
+// system with reported enemy-den intel also gets a dashed red outline
+// (`enemyIntel`, upper-cased system names) on top of that tint.
+export const Topology = ({
+  nodeColors = {},
+  enemyIntel,
+}: {
+  nodeColors?: Record<string, NodeColor>
+  enemyIntel?: Set<string>
+}) => (
   <svg
     className={styles.topology}
     viewBox="0 0 760 450"
     role="img"
-    aria-label="Network topology of systems accessible from the staging system, coloured by mercenary den status"
+    aria-label="Network topology of systems accessible from the staging system, coloured by mercenary den status; a dashed red outline marks a system with reported enemy-den intel"
   >
     {EDGES.map(([from, to]) => {
       const a = NODE_POSITIONS[from]
@@ -36,9 +44,13 @@ export const Topology = ({ nodeColors = {} }: { nodeColors?: Record<string, Node
       const isStaging = system === STAGING
       const color = nodeColors[system]
       // A den-status colour wins; otherwise the staging system keeps its accent.
+      // (styles.node is undefined — a plain node just gets the base .nodeBox —
+      // so compose with a filter to avoid a stray "undefined" class.)
       const groupClass = color ? COLOR_CLASS[color] : isStaging ? styles.nodeStaging : styles.node
+      // Enemy-den intel overlays a dashed red outline regardless of the tint.
+      const className = [groupClass, enemyIntel?.has(system) ? styles.nodeEnemyIntel : null].filter(Boolean).join(' ')
       return (
-        <g key={system} className={groupClass}>
+        <g key={system} className={className}>
           <rect
             x={x - NODE_W / 2}
             y={y - NODE_H / 2}


### PR DESCRIPTION
## What

On the mercenary-dens topology SVG, outline a system's node with a **dashed red border** when it has reported enemy-den intel — on top of whatever den-status tint it already carries (red reinforced > yellow external > green ours). Previously enemy-den sightings only appeared in the table below the map.

## How

- `page.tsx` builds a `Set` of the systems named in the current (non-deleted, active-timer) enemy-den-intel rows, upper-cased since sightings are free text, and passes it to `Topology` as `enemyIntel`.
- `topology.tsx` adds `styles.nodeEnemyIntel` to a node's group when its system is in that set (composed via a filter so a plain, untinted node — the common "enemy den where we hold none" case — doesn't get a stray class).
- The CSS rule `.nodeEnemyIntel .nodeBox` sets `stroke: var(--merc-red)` + `stroke-dasharray`. It shares specificity with the status-stroke rules and is placed later in source order, so it overrides their stroke while keeping their fill — the node keeps its status tint and gains the dashed red outline. Also extended the SVG `aria-label` to describe the outline.

## Verification

`pnpm run lint`, `tsc --noEmit`, and `prettier --check` all clean. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8z4BUDPm9JnBcxHrbnZx4

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8z4BUDPm9JnBcxHrbnZx4)_