### PR TITLE
Merc dens: tick reinforcement countdowns in real time

### DIFF
--- a/src/app/mercenary-dens/countdown.tsx
+++ b/src/app/mercenary-dens/countdown.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { formatDuration } from './duration'
+
+// Live "time remaining" for a reinforcement timer. The first render uses the
+// server-supplied `now` (a plain serialized number, identical on the server and
+// on hydration, so no mismatch), then a 1s interval takes over and the value
+// ticks down in the browser without a round trip. formatDuration clamps at 0,
+// so a lapsed timer settles on "0m 0s" until the next page load re-evaluates it
+// as expired.
+export const Countdown = ({ end, now }: { end: string; now: number }) => {
+  const endMs = new Date(end).getTime()
+  const [current, setCurrent] = useState(now)
+
+  useEffect(() => {
+    const tick = () => setCurrent(Date.now())
+    tick()
+    const id = setInterval(tick, 1000)
+    return () => clearInterval(id)
+  }, [])
+
+  return <>{formatDuration(endMs - current)}</>
+}

--- a/src/app/mercenary-dens/enemyDenIntel.tsx
+++ b/src/app/mercenary-dens/enemyDenIntel.tsx
@@ -3,8 +3,9 @@
 import { useState, useTransition } from 'react'
 
 import { addEnemyDenIntel, deleteEnemyDenIntel } from './actions'
+import { Countdown } from './countdown'
 import CopyDiscordPing from './copyDiscordPing'
-import { formatDuration, formatUtc } from './duration'
+import { formatUtc } from './duration'
 import styles from './mercenaryDens.module.css'
 
 export type EnemyDenIntelRow = {
@@ -30,16 +31,19 @@ const EnemyDenIntel = ({
   rows,
   defaultReportedBy,
   defaultReinforcementEnd,
+  now,
 }: {
   rows: EnemyDenIntelRow[]
   defaultReportedBy: string
   defaultReinforcementEnd: string
+  // Server render time — used for the reinforced/expired split and as the
+  // Countdown's hydration-safe starting point (its display then ticks live).
+  now: number
 }) => {
   const emptyForm = { system: '', planet: '', owner: '', reinforcementEnd: defaultReinforcementEnd, notes: '' }
   const [form, setForm] = useState(emptyForm)
   const [error, setError] = useState('')
   const [pending, startTransition] = useTransition()
-  const now = Date.now()
 
   const set = (field: keyof typeof form) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
     setForm((f) => ({ ...f, [field]: e.target.value }))
@@ -118,7 +122,7 @@ const EnemyDenIntel = ({
                     new Date(row.reinforcementEnd).getTime() > now ? (
                       <>
                         <span className={styles.reinforced}>
-                          reinforced {formatDuration(new Date(row.reinforcementEnd).getTime() - now)}
+                          reinforced <Countdown end={row.reinforcementEnd} now={now} />
                         </span>
                         <span className={styles.timestamp}> {formatUtc(row.reinforcementEnd)}</span>
                         <CopyDiscordPing

--- a/src/app/mercenary-dens/page.tsx
+++ b/src/app/mercenary-dens/page.tsx
@@ -5,6 +5,7 @@ import { getSdeTypeNames } from '@/sdeTypes'
 import { createClient } from '@/utils/supabase/server'
 
 import { fetchOwners } from '../owners'
+import { Countdown } from './countdown'
 import CopyDiscordPing from './copyDiscordPing'
 import { STAGING, TEMPERATE_PLANETS } from './data'
 import { formatDuration, formatUtc } from './duration'
@@ -263,9 +264,12 @@ const MercenaryDensPage = async () => {
                       <>
                         <span className={styles.reinforced}>
                           reinforced
-                          {den?.reinforcement_end
-                            ? ` ${formatDuration(new Date(den.reinforcement_end).getTime() - now)}`
-                            : ''}
+                          {den?.reinforcement_end ? (
+                            <>
+                              {' '}
+                              <Countdown end={den.reinforcement_end} now={now} />
+                            </>
+                          ) : null}
                         </span>
                         {den?.reinforcement_end ? (
                           <>
@@ -307,6 +311,7 @@ const MercenaryDensPage = async () => {
         rows={enemyDenIntel}
         defaultReportedBy={defaultReportedBy}
         defaultReinforcementEnd={defaultReinforcementEnd}
+        now={now}
       />
     </>
   )


### PR DESCRIPTION
## What

The reinforcement countdowns ("reinforced 5h 23m") on `/mercenary-dens` were static strings computed at server render, only updating on reload. Make them tick down live in the browser — in both the temperate-planet table and the enemy-den-intel table.

## How

- New `Countdown` client component (`countdown.tsx`): seeds its first render from a server-supplied `now` (a serialized number, identical on the server and on hydration → no mismatch), then a 1s `setInterval` re-renders `formatDuration(end - now)` live. `formatDuration` already clamps at 0, so a lapsed timer settles on "0m 0s" until the next load re-evaluates it as expired.
- `page.tsx` renders `<Countdown end={…} now={now} />` in the reinforced cell (reusing the `now` it already computes).
- `enemyDenIntel.tsx` now takes `now` as a prop and uses it for both the reinforced/expired split and the `Countdown` — which also removes its previous in-render `Date.now()`, a latent hydration mismatch.

## Verification

`pnpm run lint`, `tsc --noEmit`, and `prettier --check` all clean. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8z4BUDPm9JnBcxHrbnZx4

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8z4BUDPm9JnBcxHrbnZx4)_