### PR TITLE
Split corp_structure_status off corp_structure; open corp_structure to alliance-mates

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -63,6 +63,7 @@ drop table if exists public.character_affiliation         cascade;
 drop table if exists public.industry_system_index cascade;
 drop table if exists public.corporation          cascade;
 drop table if exists public.alliance             cascade;
+drop table if exists public.corp_structure_status cascade;
 drop table if exists public.corp_structure_rig   cascade;
 drop table if exists public.corp_structure       cascade;
 drop table if exists public.corp_wallet_journal  cascade;
@@ -1555,7 +1556,6 @@ create table public.corp_structure (
   profile_id bigint,
   name text,
   state text,
-  fuel_expires timestamptz,
   unanchors_at timestamptz,
   reinforce_hour int,
   next_reinforce_hour int,
@@ -1579,8 +1579,60 @@ create policy "Users read structures for own corps"
     )
   );
 
+-- Open corp_structure viewing to alliance-mates: a structure whose owning
+-- corporation's alliance is one of the alliances the caller's own characters'
+-- corporations belong to. Additive/permissive — OR'd with the own-corps policy
+-- above. Fuel stays private: it lives in corp_structure_status (below), which
+-- keeps the own-corps-only policy.
+create policy "Alliance members read corp structures"
+  on public.corp_structure
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.corporation owner_corp
+      where owner_corp.corporation_id = corp_structure.corporation_id
+        and owner_corp.alliance_id is not null
+        and owner_corp.alliance_id in (
+          select member_corp.alliance_id
+          from public.registration r
+          join public.corporation member_corp on member_corp.corporation_id = r.corporation_id
+          where r.user_id = (select auth.uid())
+            and member_corp.alliance_id is not null
+        )
+    )
+  );
+
 grant select on public.corp_structure to authenticated;
 grant all    on public.corp_structure to service_role;
+
+-- ── corp_structure_status ──────────────────────────────────────────────────
+-- The volatile fuel timer, split off corp_structure so it can stay own-corp
+-- only while corp_structure opens up to alliance-mates. One row per structure,
+-- pointing back to it.
+create table public.corp_structure_status (
+  structure_id bigint primary key references public.corp_structure (structure_id) on delete cascade,
+  corporation_id bigint not null,
+  fuel_expires timestamptz,
+  updated_at timestamptz not null default now()
+);
+create index corp_structure_status_corporation_id_idx on public.corp_structure_status (corporation_id);
+
+alter table public.corp_structure_status enable row level security;
+create policy "Users read structure status for own corps"
+  on public.corp_structure_status
+  for select
+  to authenticated
+  using (
+    corporation_id in (
+      select corporation_id from public.registration
+      where user_id = (select auth.uid()) and corporation_id is not null
+    )
+  );
+
+grant select on public.corp_structure_status to authenticated;
+grant all    on public.corp_structure_status to service_role;
 
 -- ── corp_structure_rig ────────────────────────────────────────────────────
 -- Rigs (and other fitted modules) in Upwell structures. ESI has no dedicated

--- a/src/app/structure/[structureId]/page.tsx
+++ b/src/app/structure/[structureId]/page.tsx
@@ -78,7 +78,7 @@ const StructurePage = async ({ params }: StructureParams) => {
     ? await supabase
         .from('corp_structure')
         .select(
-          'structure_id, corporation_id, type_id, system_id, profile_id, name, state, fuel_expires, unanchors_at, reinforce_hour, next_reinforce_hour, next_reinforce_apply, next_reinforce_weekday, services, last_seen_at, updated_at'
+          'structure_id, corporation_id, type_id, system_id, profile_id, name, state, unanchors_at, reinforce_hour, next_reinforce_hour, next_reinforce_apply, next_reinforce_weekday, services, last_seen_at, updated_at'
         )
         .eq('structure_id', structureId)
         .maybeSingle()
@@ -97,6 +97,16 @@ const StructurePage = async ({ params }: StructureParams) => {
   }
 
   const s = structure as Structure
+
+  // Fuel timer lives in corp_structure_status now (own-corp only). RLS returns a
+  // row only if the caller's corp owns this structure — an alliance-mate viewing
+  // it via corp_structure sees no fuel.
+  const { data: statusRow } = await supabase
+    .from('corp_structure_status')
+    .select('fuel_expires')
+    .eq('structure_id', structureId)
+    .maybeSingle<{ fuel_expires: string | null }>()
+  s.fuel_expires = statusRow?.fuel_expires ?? null
 
   const { data: jobsData } = await supabase
     .from('character_industry_job')

--- a/src/app/structure/page.tsx
+++ b/src/app/structure/page.tsx
@@ -60,7 +60,7 @@ const StructuresPage = async () => {
   const { data: structures } = await supabase
     .from('corp_structure')
     .select(
-      'structure_id, corporation_id, type_id, system_id, name, state, fuel_expires, unanchors_at, services, last_seen_at'
+      'structure_id, corporation_id, type_id, system_id, name, state, unanchors_at, services, last_seen_at'
     )
     .order('corporation_id', { ascending: true })
     .order('structure_id', { ascending: true })
@@ -90,6 +90,20 @@ const StructuresPage = async () => {
     const structureId = j.station_id ?? j.facility_id
     if (structureId != null) structureByJob.set(String(j.job_id), String(structureId))
   }
+
+  // Fuel timers live in corp_structure_status now (own-corp only). RLS returns a
+  // row only for structures the caller's corp owns, so an alliance-mate's
+  // structure that's visible via corp_structure simply has no fuel here.
+  const { data: statusRows } = structureIds.length
+    ? await supabase.from('corp_structure_status').select('structure_id, fuel_expires').in('structure_id', structureIds)
+    : { data: [] }
+  const fuelByStructure = new Map<string, string | null>(
+    ((statusRows ?? []) as Array<{ structure_id: number | string; fuel_expires: string | null }>).map((r) => [
+      String(r.structure_id),
+      r.fuel_expires,
+    ])
+  )
+  for (const s of list) s.fuel_expires = fuelByStructure.get(String(s.structure_id)) ?? null
 
   // Rigs fitted to each structure (pulled from corp assets by the corp-assets job).
   const { data: rigRows } = structureIds.length

--- a/src/jobs/corpStructures.js
+++ b/src/jobs/corpStructures.js
@@ -21,7 +21,6 @@ export const runCorpStructures = ({ characterIds } = {}) =>
       profile_id: s.profile_id ?? null,
       name: s.name ?? null,
       state: s.state ?? null,
-      fuel_expires: s.fuel_expires ?? null,
       unanchors_at: s.unanchors_at ?? null,
       reinforce_hour: s.reinforce_hour ?? null,
       next_reinforce_hour: s.next_reinforce_hour ?? null,
@@ -32,9 +31,23 @@ export const runCorpStructures = ({ characterIds } = {}) =>
       updated_at: now,
     }))
 
+    // fuel_expires lives in corp_structure_status now (own-corp-only, while
+    // corp_structure opens to alliance-mates). Upsert the structures first — the
+    // status table's FK points back at them.
+    const statusRows = all.map((s) => ({
+      structure_id: s.structure_id,
+      corporation_id: s.corporation_id,
+      fuel_expires: s.fuel_expires ?? null,
+      updated_at: now,
+    }))
+
     if (rows.length > 0) {
       const { error } = await sudoSupabase.from('corp_structure').upsert(rows, { onConflict: 'structure_id' })
       if (error) throw error
+      const { error: statusError } = await sudoSupabase
+        .from('corp_structure_status')
+        .upsert(statusRows, { onConflict: 'structure_id' })
+      if (statusError) throw statusError
     }
     console.log(`[${TAG}] ${ctx}: corp ${corporation_id} ${rows.length} structure(s) in ${Date.now() - t0}ms`)
   })

--- a/supabase/migrations/20260720050000_split_corp_structure_status.sql
+++ b/supabase/migrations/20260720050000_split_corp_structure_status.sql
@@ -1,0 +1,61 @@
+-- Split the volatile fuel timer off corp_structure into its own table so it can
+-- keep a strict own-corp-only RLS policy while corp_structure itself opens up to
+-- alliance-mates (policy added at the bottom). corp_structure_status points back
+-- to the corp_structure row it describes.
+create table if not exists public.corp_structure_status (
+  structure_id bigint primary key references public.corp_structure (structure_id) on delete cascade,
+  corporation_id bigint not null,
+  fuel_expires timestamptz,
+  updated_at timestamptz not null default now()
+);
+create index if not exists corp_structure_status_corporation_id_idx
+  on public.corp_structure_status (corporation_id);
+
+-- Move existing fuel data across before dropping the column.
+insert into public.corp_structure_status (structure_id, corporation_id, fuel_expires, updated_at)
+  select structure_id, corporation_id, fuel_expires, updated_at from public.corp_structure
+  on conflict (structure_id) do nothing;
+
+alter table public.corp_structure drop column if exists fuel_expires;
+
+alter table public.corp_structure_status enable row level security;
+-- Same scoping as corp_structure's own-corp policy: the player only sees fuel
+-- for structures owned by a corporation one of their characters belongs to.
+drop policy if exists "Users read structure status for own corps" on public.corp_structure_status;
+create policy "Users read structure status for own corps"
+  on public.corp_structure_status
+  for select
+  to authenticated
+  using (
+    corporation_id in (
+      select corporation_id from public.registration
+      where user_id = (select auth.uid()) and corporation_id is not null
+    )
+  );
+grant select on public.corp_structure_status to authenticated;
+grant all    on public.corp_structure_status to service_role;
+
+-- Open corp_structure viewing to alliance-mates: a structure whose owning
+-- corporation's alliance is one of the alliances the caller's own characters'
+-- corporations belong to. Additive/permissive — OR'd with the existing own-corps
+-- policy. Fuel stays private (corp_structure_status keeps the own-corps policy).
+drop policy if exists "Alliance members read corp structures" on public.corp_structure;
+create policy "Alliance members read corp structures"
+  on public.corp_structure
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.corporation owner_corp
+      where owner_corp.corporation_id = corp_structure.corporation_id
+        and owner_corp.alliance_id is not null
+        and owner_corp.alliance_id in (
+          select member_corp.alliance_id
+          from public.registration r
+          join public.corporation member_corp on member_corp.corporation_id = r.corporation_id
+          where r.user_id = (select auth.uid())
+            and member_corp.alliance_id is not null
+        )
+    )
+  );


### PR DESCRIPTION
## Summary
Splits the volatile fuel timer off `corp_structure` into a new `corp_structure_status` table so it can keep a **strict own-corp-only** RLS policy, while `corp_structure` itself **opens up to alliance-mates**.

### New table `corp_structure_status`
- `structure_id` (PK) → `corp_structure(structure_id)` `on delete cascade`, plus `corporation_id`, `fuel_expires`, `updated_at`.
- `fuel_expires` is **dropped from `corp_structure`** (the migration backfills the new table from the old column first).
- RLS: the same own-corp SELECT policy `corp_structure` previously had (a user sees fuel only for structures owned by a corp one of their characters belongs to).

### New alliance-view policy on `corp_structure`
A permissive SELECT policy OR'd with the existing own-corps one: a user can view a structure whose owning corporation's **alliance** is one of the alliances **their own characters' corporations** belong to (derived through the `corporation` table's `alliance_id`). Because fuel now lives in the own-corp-only status table, **alliance-mates see the structure but not its fuel timer**.

### Write path
The `corp-structures` job upserts `corp_structure` first (the FK parent), then `corp_structure_status` with the fuel timer.

### Read paths
`/structure` (list) and `/structure/[structureId]` (detail) now read `fuel_expires` from `corp_structure_status` via a separate scoped fetch. For a structure visible only via the alliance policy, the status RLS returns no row, so it simply renders no fuel.

## Notes
- No other reader referenced `fuel_expires` (verified — every other `corp_structure` select lists explicit columns).
- The alliance policy's subqueries hit `corporation` (public-read) and `registration` (own-rows) — no reference back to `corp_structure`, so no policy recursion. It only grants when the `corporation` table actually carries the relevant corp→alliance rows.

## Test plan
- [x] `tsc --noEmit`, `eslint`, `node --check` clean
- [ ] Migrate workflow applies `20260720050000_split_corp_structure_status` on merge (uses `--include-all`)
- [ ] After the next `corp-structures` run: own structures show fuel on `/structure` + `/structure/[id]` as before; a structure owned by an alliance-mate's corp (not your own corp) is visible but shows no fuel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnWdT6AvCivWSiRpr4Zb2W

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnWdT6AvCivWSiRpr4Zb2W)_