### PR TITLE
Add Discord interactions endpoint (signed PING handler)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,14 @@ CRON_SECRET=random-secret-shared-with-vercel-cron
 # ISK price appraisals via https://innomin.at/api/docs/ (key issued via their Discord)
 INNOMINATE_API_KEY=
 
+# Discord application (developer portal → your app). APP_ID and PUBLIC_KEY are
+# public identifiers; BOT_TOKEN is secret. PUBLIC_KEY verifies the signature on
+# inbound interactions (/api/discord/interactions); BOT_TOKEN authenticates
+# outbound REST calls (used from a later stage).
+DISCORD_APP_ID=
+DISCORD_PUBLIC_KEY=
+DISCORD_BOT_TOKEN=
+
 # this is so NextJS will make these things available in client components
 NEXT_PUBLIC_SUPABASE_URL=https://ifqywgxsdjxbonsytqya.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJh...JIM

--- a/src/app/api/discord/interactions/route.ts
+++ b/src/app/api/discord/interactions/route.ts
@@ -1,0 +1,64 @@
+// The one route Discord calls into us. Discord signs every interaction with
+// Ed25519; we verify the signature (over the raw body, before parsing) and
+// answer by interaction type. Stage 2 only handles PING (what the developer
+// portal's endpoint validation exercises) — application commands get a
+// placeholder ephemeral reply until the command router lands in a later stage.
+//
+// Node runtime: node:crypto Ed25519 verification (and, later, the service-role
+// Supabase client) aren't available on the edge runtime.
+import { NextResponse } from 'next/server'
+
+import { recordDiscordInteraction } from '@/observability'
+
+import { EPHEMERAL, InteractionResponseType, InteractionType, verifyDiscordSignature } from '../lib'
+
+export const runtime = 'nodejs'
+
+export async function POST(request: Request) {
+  // Verification needs the exact bytes Discord signed, so read the raw text and
+  // parse it ourselves — never let the framework consume the body as JSON first.
+  const rawBody = await request.text()
+
+  const verified = verifyDiscordSignature({
+    rawBody,
+    signature: request.headers.get('x-signature-ed25519'),
+    timestamp: request.headers.get('x-signature-timestamp'),
+    publicKey: process.env.DISCORD_PUBLIC_KEY,
+  })
+  if (!verified) {
+    recordDiscordInteraction({ type: null, outcome: 'bad_signature' })
+    return new NextResponse('invalid request signature', { status: 401 })
+  }
+
+  // A verified body came from Discord and is always valid JSON; guard anyway so
+  // a malformed one is a clean 400 rather than a logged 500.
+  let interaction: { type?: number }
+  try {
+    interaction = JSON.parse(rawBody)
+  } catch {
+    return new NextResponse('invalid request body', { status: 400 })
+  }
+
+  switch (interaction.type) {
+    case InteractionType.PING:
+      recordDiscordInteraction({ type: interaction.type, outcome: 'pong' })
+      return NextResponse.json({ type: InteractionResponseType.PONG })
+
+    case InteractionType.APPLICATION_COMMAND:
+      recordDiscordInteraction({ type: interaction.type, outcome: 'unimplemented' })
+      return NextResponse.json({
+        type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+        data: {
+          flags: EPHEMERAL,
+          content: 'Edencom Link is still setting up — commands are not available yet.',
+        },
+      })
+
+    default:
+      recordDiscordInteraction({ type: interaction.type ?? null, outcome: 'unhandled' })
+      return NextResponse.json({
+        type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+        data: { flags: EPHEMERAL, content: 'Unsupported interaction.' },
+      })
+  }
+}

--- a/src/app/api/discord/lib.ts
+++ b/src/app/api/discord/lib.ts
@@ -1,0 +1,62 @@
+// Shared helpers for the Discord HTTP-interactions endpoint
+// (src/app/api/discord/interactions/route.ts). Kept dependency-free — Node's
+// built-in crypto verifies Ed25519 natively — so no `discord-interactions`
+// package is needed. Later stages (the /edencom command router) reuse the
+// constants and the verifier here.
+import { createPublicKey, verify } from 'node:crypto'
+
+// Interaction `type` on the inbound payload.
+// https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-type
+export const InteractionType = {
+  PING: 1,
+  APPLICATION_COMMAND: 2,
+  MESSAGE_COMPONENT: 3,
+  APPLICATION_COMMAND_AUTOCOMPLETE: 4,
+  MODAL_SUBMIT: 5,
+} as const
+
+// Callback `type` on our response.
+// https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-type
+export const InteractionResponseType = {
+  PONG: 1,
+  CHANNEL_MESSAGE_WITH_SOURCE: 4,
+  DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE: 5,
+} as const
+
+// Message flag EPHEMERAL (1 << 6): only the invoking user sees the reply.
+export const EPHEMERAL = 1 << 6
+
+const hexToBytes = (hex: string): Buffer => Buffer.from(hex, 'hex')
+
+// Discord publishes its application public key in the developer portal as a
+// 32-byte hex string. Import it as a raw OKP JWK (no SPKI/DER wrapping) so
+// node:crypto can build a verifying KeyObject with zero dependencies.
+const publicKeyFrom = (hexKey: string) =>
+  createPublicKey({
+    key: { kty: 'OKP', crv: 'Ed25519', x: hexToBytes(hexKey).toString('base64url') },
+    format: 'jwk',
+  })
+
+// Verify the X-Signature-Ed25519 header over (timestamp + rawBody), the exact
+// message Discord signs. Returns false on any missing/malformed input rather
+// than throwing, so the caller answers a clean 401. Discord's endpoint
+// validation deliberately sends bad signatures and requires a 401 to pass.
+export const verifyDiscordSignature = ({
+  rawBody,
+  signature,
+  timestamp,
+  publicKey,
+}: {
+  rawBody: string
+  signature: string | null
+  timestamp: string | null
+  publicKey: string | undefined
+}): boolean => {
+  if (!signature || !timestamp || !publicKey) return false
+  try {
+    const message = Buffer.from(timestamp + rawBody)
+    return verify(null, message, publicKeyFrom(publicKey), hexToBytes(signature))
+  } catch {
+    return false
+  }
+}

--- a/src/observability.js
+++ b/src/observability.js
@@ -39,3 +39,11 @@ export const recordEsiConditional = ({
     rows,
     duration_ms: durationMs,
   })
+
+// One Discord interaction outcome — see src/app/api/discord/interactions/route.ts.
+// Group by (type, outcome) to watch signature rejections (portal validation and
+// spoof attempts) and, later, command traffic.
+//   type: the Discord interaction type (1=PING, 2=APPLICATION_COMMAND, ...), or null
+//   outcome: 'pong' | 'unimplemented' | 'unhandled' | 'bad_signature'
+export const recordDiscordInteraction = ({ type, outcome }) =>
+  recordMetric('discord.interaction', { type, outcome })


### PR DESCRIPTION
Stage 2 of the Discord bot project ([`docs/discord-bot/02-interactions-endpoint.md`](https://github.com/philihp/edencom-link/blob/main/docs/discord-bot/02-interactions-endpoint.md)). Stands up the one route Discord calls into us — `POST /api/discord/interactions` — so the developer-portal endpoint validation can pass. No behavior behind it yet beyond PING.

## Changes

- **`src/app/api/discord/lib.ts`** — zero-dependency Ed25519 signature verification via `node:crypto` (imports Discord's hex public key as a raw OKP JWK, no SPKI/DER wrapping, no `discord-interactions` package), plus the interaction-type / response-type constants and the `EPHEMERAL` flag. The command router in stage 3 reuses these.
- **`src/app/api/discord/interactions/route.ts`** (Node runtime) — verifies `X-Signature-Ed25519` over `(timestamp + raw body)` **before** parsing the body, then dispatches:
  - PING → PONG (what portal validation exercises)
  - application command → placeholder ephemeral reply (stage 3 replaces this)
  - bad/missing signature → `401`; malformed verified body → `400` (not a logged 500)
- **`discord.interaction` metric** in `src/observability.js`, grouped by `type` + `outcome`, matching the `esi.conditional_request` precedent.
- **`.env.example`** — `DISCORD_APP_ID`, `DISCORD_PUBLIC_KEY`, `DISCORD_BOT_TOKEN`.

## Verification

Beyond `pnpm run lint` and `pnpm run build` (both pass; the route appears in the manifest), I exercised it end-to-end against a running dev server with a generated Ed25519 key:

| Case | Result |
|---|---|
| Correctly signed PING | `200 {"type":1}` ✅ |
| Unsigned request | `401` ✅ |
| Bad signature | `401` ✅ |
| Tampered body (valid sig for original) | `401` ✅ |

The emitted `discord.interaction` metric lines confirmed the dispatch path (`pong` on the signed PINGs, `bad_signature` on the rejects). A standalone harness also checked the verifier against tampered-timestamp, wrong-key, and garbage-hex inputs.

## Follow-up (manual, only the maintainer can do it)

Once this is deployed to production, the Discord app has to be registered in the developer portal: create the application (fill in the stage-1 `/privacy` + `/terms` URLs), create the bot user, set the **Interactions Endpoint URL** to `https://edencom.link/api/discord/interactions`, and set `DISCORD_APP_ID` / `DISCORD_PUBLIC_KEY` / `DISCORD_BOT_TOKEN` in Vercel. Discord validates the endpoint at save time — which is exactly the signed-PING / bad-signature behavior verified above. **The endpoint must be live in production before that URL will save**, hence code-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRxxVyXXBDc1hv4nupxsQ1

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRxxVyXXBDc1hv4nupxsQ1)_