### PR TITLE
Add cron-to-workflows migration plan under docs/

### DIFF
--- a/docs/cron-to-workflows/01-direct-jobs.md
+++ b/docs/cron-to-workflows/01-direct-jobs.md
@@ -1,0 +1,145 @@
+# Phase 1: the direct-run jobs → single-step workflows
+
+The five jobs whose cron routes run them **inline** via `runDirectCronJob`
+(`src/utils/cron.ts`): `industry-systems`, `universe-structures`,
+`corp-structures`, `corp-wallet-journal`, `corp-blueprints`.
+
+## Why these are lowest risk — and highest immediate payoff
+
+- Execution semantics barely change: today the whole job runs in one cron
+  invocation; after migration it runs in one workflow step. Same single
+  process, same job code, same heartbeat pair. The only new behavior is
+  Workflows' bounded step retries and the Observability trail.
+- They are also the only jobs still exposed to the **60s function cap**
+  (called out as a real risk in `src/app/api/queue/jobs/route.ts` — "watch
+  these jobs' heartbeat durations"). Migrating them first doesn't remove
+  the cap (a single step still has a duration budget), but it puts them in
+  the one execution model where the fix — splitting into resumable slices
+  like `sde-mirror`'s `ingestSlice` — is a local change instead of a
+  re-architecture.
+- No queue involvement today, so nothing about fan-out or message shapes
+  changes. `vercel.json` is untouched (same paths, same schedules).
+
+## In-phase order (simplest write pattern first)
+
+| # | Job | Runs | Write pattern | Notes |
+|---|---|---|---|---|
+| 1 | `industry-systems` | every 6h `:10` | append-only insert (`industry_system_index`) | Public ESI endpoint, no tokens at all. **First PR: this job alone**, to establish the pattern. |
+| 2 | `universe-structures` | 09:57 daily | upsert cache (`universe_structure`) | Token-authed reads, but a plain refresh of already-known ids. |
+| 3 | `corp-structures` | 09:17 daily | upsert (`corp_structure`) + name resolution | Per-corp token loop via `forEachCorporation` (which records its own per-corp heartbeats — see below). |
+| 4 | `corp-wallet-journal` | every 6h `:37` | paged append (`corp_wallet_journal`) + name resolution | Append-only; re-running a partially-failed pull is naturally idempotent (PK on entry id). |
+| 5 | `corp-blueprints` | 09:07 daily | **SCD-2 reconcile** (`corp_blueprint_over_time`) | The one reconciler in this phase — do it last, after the pattern has survived a few scheduled firings. |
+
+Jobs 2–5 can batch two per PR once #1 has landed and fired on schedule.
+
+## Step 1 — a shared single-step helper
+
+Add `src/workflows/lib.ts` with the workflow-side equivalent of
+`runDirectCronJob` (same start/end heartbeat contract, workflow source):
+
+```ts
+// src/workflows/lib.ts
+// Single-step execution of a whole extract job, with the same start/end
+// heartbeat pair runDirectCronJob records — but source: 'vercel-workflow',
+// and the step gets Workflows' bounded retries. Job modules are imported
+// lazily by the caller-supplied loader: their top-level supabase/esi setup
+// needs env vars absent at build time.
+export async function runJobStep(job: string, load: () => Promise<() => Promise<unknown>>) {
+  'use step'
+  const { randomInt } = await import('node:crypto')
+  const { recordHeartbeat } = await import('@/supabase.js')
+  const run = await load()
+  const runId = randomInt(1, 2 ** 48)
+  await recordHeartbeat(job, 'start', { runId, source: 'vercel-workflow' })
+  try {
+    await run()
+  } finally {
+    await recordHeartbeat(job, 'end', { runId, source: 'vercel-workflow' })
+  }
+}
+```
+
+Notes:
+
+- A `'use step'` function may live in a shared module — but **verify this
+  compiles under the `workflow` package's build in the first PR** (the
+  directive compiler must pick it up outside the workflow's own file). If
+  it doesn't, inline the step into each workflow file; the boilerplate is
+  small and the pilot files already look like that.
+- Retry caveat: if the *end* heartbeat write itself fails after the job
+  succeeded, a step retry re-runs the whole job. Every job in this phase is
+  idempotent (upserts / keyed appends / SCD-2 reconcile that converges), so
+  this is safe — but it's why non-idempotent work must never share a step
+  with its heartbeat bookkeeping.
+
+## Step 2 — one workflow file per job
+
+Thin, named per job so Observability → Workflows shows which is which
+(mirror `src/workflows/characterImplants.ts`):
+
+```ts
+// src/workflows/industrySystems.ts
+import { runJobStep } from './lib'
+
+export async function industrySystemsWorkflow() {
+  'use workflow'
+  await runJobStep('industry-systems', async () => (await import('@/jobs/industrySystems.js')).runIndustrySystems)
+}
+```
+
+Same file shape for `universeStructures.ts`, `corpStructures.ts`,
+`corpWalletJournal.ts`, `corpBlueprints.ts`, each loading its
+`run*()` export.
+
+**Heartbeat subtlety for the corp jobs (#3–#5):** their `run*()` functions
+use `forEachCorporation`, which records its own per-corp heartbeat rows.
+`runDirectCronJob` *additionally* records a whole-job pair today, and
+`runJobStep` preserves exactly that — so the heartbeat picture is
+unchanged. Don't "simplify" the whole-job pair away; `/character/refresh`
+and the daily freshness checks key off it.
+
+## Step 3 — flip each cron route to `start()`
+
+Replace the `runDirectCronJob` body with the `sde-mirror` trigger shape:
+
+```ts
+// src/app/api/cron/industry-systems/route.ts
+export async function GET(request: NextRequest) {
+  const denied = requireCronSecret(request)
+  if (denied) return denied
+
+  const { start } = await import('workflow/api')
+  const { industrySystemsWorkflow } = await import('@/workflows/industrySystems')
+  const run = await start(industrySystemsWorkflow, [])
+  console.log(`[cron/industry-systems] started workflow run=${run.runId}`)
+
+  return NextResponse.json({ ok: true, runId: run.runId })
+}
+```
+
+Fire-and-forget: the route returns immediately; the workflow owns retries.
+Keep `maxDuration = 60` on the route (it's just a trigger now, but there's
+no reason to churn it).
+
+## Step 4 — leave `runDirectCronJob` in place until phase 5
+
+Other routes still use it while this phase is in flight. The contract doc
+(05) deletes it once nothing references it.
+
+## Verification (per PR)
+
+1. `pnpm run lint` && `pnpm run build`.
+2. Curl the route with `$CRON_SECRET`; confirm `{ ok, runId }`, then the
+   run + step green in Observability → Workflows.
+3. Confirm the whole-job heartbeat pair (and, for the corp jobs, the
+   per-corp rows) via `latest_heartbeats()`; confirm the target table's
+   freshness bump (`industry_system_index.recorded_at`,
+   `corp_structure.fuel_expires` refresh, journal max `date`, blueprint
+   `valid_until` bumps).
+4. Watch the next scheduled firing before starting the next PR of the
+   phase; for `corp-blueprints`, also spot-check the `corp_blueprint` view
+   row count against the previous day (a reconcile bug shows up as items
+   vanishing).
+
+Each PR updates the job's row in CLAUDE.md's Extract jobs section (and the
+README table here) to note it runs as a workflow.

--- a/docs/cron-to-workflows/02-account-jobs.md
+++ b/docs/cron-to-workflows/02-account-jobs.md
@@ -1,0 +1,73 @@
+# Phase 2: the account-wide queue jobs → single-step workflows
+
+`universe-names` (every 6h `:58`) and `character-affiliations` (11:41
+daily). Today their cron routes call `dispatchAccountCronJob`
+(`src/utils/cron.ts`), which sends **one** queue message; the consumer
+(`src/app/api/queue/jobs/route.ts`) runs the batch and records the
+whole-job heartbeat itself (`source: 'vercel'`).
+
+## Why second
+
+Same single-batch execution shape as phase 1 — the workflow is the same
+one-step wrapper — but this phase is the first to **take a path off the
+queue**, so it's the first place a behavioral difference could hide:
+
+- Queue retry semantics (`retryAfterSeconds: 60`, message-level) are
+  replaced by Workflows' bounded step retries.
+- The heartbeat writer moves from the queue consumer into the step.
+
+Both jobs are benign to re-run: `universe-names` upserts id→name rows into
+`universe_name` (plus the `resolve*` sweeps, all upserts); `character-
+affiliations` upserts `character_affiliation` and refreshes
+`registration.corporation_id`. No SCD-2, no pagination, no per-character
+tokens (both use public ESI endpoints).
+
+## Steps
+
+1. **Workflow files** — identical shape to phase 1, reusing `runJobStep`
+   from `src/workflows/lib.ts`:
+
+   ```ts
+   // src/workflows/universeNames.ts
+   import { runJobStep } from './lib'
+
+   export async function universeNamesWorkflow() {
+     'use workflow'
+     await runJobStep('universe-names', async () => (await import('@/jobs/universeNames.js')).runUniverseNames)
+   }
+   ```
+
+   Same for `characterAffiliations.ts` → `runCharacterAffiliations`.
+
+2. **Cron routes** — swap `dispatchAccountCronJob(job)` for the
+   `start()` trigger shape (phase 1, step 3).
+
+3. **Queue consumer: leave the `JOBS` entries alone.** The
+   `'character-affiliations'` and `'universe-names'` entries in the
+   consumer's registry stay, because `dispatchRefresh.ts` still enqueues
+   them account-wide when a user adds a character (`ACCOUNT_JOBS`). Only
+   the *scheduled* trigger moves. (The on-demand path is phase 5's
+   decision.) The consumer's whole-job heartbeat block keeps working for
+   those on-demand runs; scheduled runs now get their pair from the step —
+   the `source` column ('vercel' vs 'vercel-workflow') tells them apart.
+
+4. **`dispatchAccountCronJob`**: after both routes flip, nothing calls it —
+   but delete it in phase 5 with the other helpers, not here, to keep
+   these PRs pure job migrations.
+
+## Verification
+
+Per the README gates, plus:
+
+- After the scheduled `universe-names` firing, confirm new/updated rows in
+  `universe_name` and that the heartbeat pair carries
+  `source: 'vercel-workflow'`.
+- After `character-affiliations`, confirm `registration.corporation_id` is
+  still being kept fresh (the corp-table RLS keys off it — a silent
+  failure here would eventually break corp pages for users who change
+  corps).
+- Exercise the on-demand path once (add-character flow or
+  `/character/refresh`) to confirm the queue entries still work untouched.
+
+One PR can cover both jobs — they're the same change twice and share the
+blast radius.

--- a/docs/cron-to-workflows/03-per-character.md
+++ b/docs/cron-to-workflows/03-per-character.md
@@ -1,0 +1,147 @@
+# Phase 3: the per-character jobs → fan-out workflows
+
+The seven scheduled per-character jobs, whose cron routes today fan out one
+queue message per scoped character (`fanOutPerCharacterCronJob`, or the
+any-scope variant for `character-status`). After this phase, each cron
+route `start()`s a workflow that enumerates the characters itself and runs
+**one step per character**.
+
+## Why third
+
+This is the first real orchestration change: the queue leaves the
+scheduled path for jobs with per-character tokens, ESI paging, and (for
+most) SCD-2 reconciles. Everything per-character stays inside the
+untouched job modules — token refresh, per-character heartbeats,
+reconciles all live in `forEachCharacter` and the `run*()` functions — so
+the workflow only replaces the *dispatch* layer. Still, the fan-out
+pattern (lanes, determinism, retry blast radius) needs proving on the
+safest job before the reconcilers follow.
+
+## In-phase order
+
+| # | Job | Write pattern | Why this slot |
+|---|---|---|---|
+| 1 | `character-wallet-transactions` | append-only + ETag skip | Safest possible: single-request snapshot, keyed append, a `304` makes most steps near-no-ops. **First PR: this job alone**, establishing the fan-out pattern. |
+| 2 | `character-orders` | SCD-2 + ETag, single request | Small data, ETag-guarded. |
+| 3 | `character-industry-jobs` | SCD-2 + ETag, single request | Same shape as orders. |
+| 4 | `character-status` | live-row upserts ×5 endpoints | No SCD-2 except clones; internally fault-isolated per endpoint already. Uses the **any-scope** enumeration (see below). |
+| 5 | `character-mercenary-dens` | SCD-2 + append-only status + per-den detail calls | Extra ESI call per den; niche data. |
+| 6 | `character-blueprints` | SCD-2, paginated | First paginated reconciler. |
+| 7 | `character-assets` | SCD-2, paginated + asset names | Biggest volume and the most user-visible table — last. |
+
+## The fan-out workflow shape
+
+```ts
+// src/workflows/lib.ts (additions)
+
+// Step: enumerate the registration uuids carrying the job's scope(s).
+export async function enumerateCharacters(scopes: string[]): Promise<string[]> {
+  'use step'
+  const { selectCharacterIdsWithScopes } = await import('@/supabase.js')
+  return selectCharacterIdsWithScopes(scopes)
+}
+
+// Step: run one job for one character. forEachCharacter (src/jobs/lib.js)
+// still does token refresh + the per-character heartbeat pair, unchanged.
+export async function runCharacterStep(
+  job: string,
+  load: () => Promise<(opts: { characterIds: string[] }) => Promise<unknown>>,
+  characterId: string
+) {
+  'use step'
+  const run = await load()
+  await run({ characterIds: [characterId] })
+}
+```
+
+```ts
+// src/workflows/characterWalletTransactions.ts
+import { enumerateCharacters, runCharacterStep } from './lib'
+
+const load = async () =>
+  (await import('@/jobs/characterWalletTransactions.js')).runCharacterWalletTransactions
+
+export async function characterWalletTransactionsWorkflow() {
+  'use workflow'
+  const ids = await enumerateCharacters(['esi-wallet.read_character_wallet.v1'])
+
+  // Static lane assignment (round-robin over the enumerated order), the
+  // sde-mirror pattern: the id→step-call mapping is identical on every
+  // replay regardless of how in-flight steps resolve. Within a lane,
+  // characters run sequentially; lanes run concurrently.
+  const LANES = 4
+  const lanes: string[][] = Array.from({ length: LANES }, () => [])
+  ids.forEach((id, i) => lanes[i % LANES].push(id))
+  await Promise.all(
+    lanes.map(async (lane) => {
+      for (const id of lane) {
+        await runCharacterStep('character-wallet-transactions', load, id)
+      }
+    })
+  )
+}
+```
+
+Notes:
+
+- **Plain loops in the orchestrator body** are the documented exception to
+  the ramda rule (see `src/workflows/sdeMirror.ts`'s comment): workflow
+  bodies must be simple deterministic control flow, and helpers imported
+  at workflow (non-step) level would execute in workflow context.
+- **Lane count**: start at 4. The queue today runs messages with its own
+  concurrency, so parallel per-character pulls are nothing new for ESI or
+  Supabase; 4 keeps a big account polite to ESI's error-rate limits.
+  It's a per-file constant — tune per job if heartbeat durations say so.
+- **Retry blast radius**: a failed step retries just that character. Under
+  the queue, a whole message (= one character too) retried, so this is
+  parity — but the workflow won't retry forever; a character whose token
+  is dead fails its step, and the run surfaces it in Observability instead
+  of the queue silently re-looping. Decide per the pilot whether a single
+  character's exhausted retries should fail the whole run (probably yes —
+  visible is better than swallowed; the other lanes still complete because
+  `Promise.all` only rejects after in-flight lanes settle their current
+  steps... verify the semantics in the first PR and, if a lane abort
+  cancels sibling steps, wrap `runCharacterStep` in a per-character
+  try/catch that records the failure and continues, then rethrow a summary
+  at the end).
+- **`character-status`** enumerates with the any-of-scopes list
+  (`selectCharacterIdsWithScopes` already unions; this is exactly what
+  `fanOutPerCharacterAnyScopeCronJob` does today) and its handler already
+  runs only the endpoints each token carries.
+
+## Cron routes and the queue consumer
+
+- Each cron route swaps its `fanOutPerCharacter*CronJob(...)` call for the
+  `start()` trigger shape.
+- **Queue consumer `JOBS` entries stay untouched.** The on-demand "Refresh
+  ESI" flow (`PER_CHARACTER_JOBS` in `dispatchRefresh.ts`, the per-cell
+  refresh buttons, `refresh_task` tracking) keeps dispatching these jobs
+  through the queue exactly as today. One job, two triggers, same `run*()`
+  — the phase 5 doc decides whether the on-demand path also moves.
+- The `character-implants` special-case in the consumer (the original
+  pilot) also stays until phase 5.
+
+## Interaction between scheduled and on-demand runs
+
+Today a scheduled queue message and an on-demand one for the same
+character can already run concurrently; per-character reconciles have
+never shown the corp-style race (single writer per `character_id` per
+message, and the overlap window is seconds). The workflow migration
+neither fixes nor worsens this — noting it here so nobody mistakes it for
+a regression when two heartbeat rows land close together.
+
+## Verification (per PR)
+
+README gates, plus:
+
+- `/character/refresh` matrix goes green for the job across **all**
+  characters after the scheduled firing (this is the per-character
+  heartbeat check).
+- For the SCD-2 jobs (#2 onward): compare the current-view row count
+  before/after the first workflow run (`character_order`,
+  `character_industry_job`, `character_blueprint`, `character_asset`) — a
+  reconcile bug shows up as rows vanishing.
+- For the ETag jobs (#1–#3): confirm `esi.conditional_request` metric
+  lines still show `not_modified` hits from workflow-run invocations.
+- Run one on-demand refresh for one character to confirm the queue path
+  still works beside the workflow path.

--- a/docs/cron-to-workflows/04-per-corporation.md
+++ b/docs/cron-to-workflows/04-per-corporation.md
@@ -1,0 +1,132 @@
+# Phase 4: the per-corporation jobs → fan-out workflows
+
+`corp-wallet-transactions`, `corp-industry-jobs`, `corp-assets` — the
+three jobs whose cron routes today group scoped characters by corporation
+and send **one queue message per corp** (`fanOutPerCorporationCronJob`).
+
+## Why last
+
+These carry the project's scar tissue. Two concurrent reconciles of the
+same corp's rows once corrupted the SCD-2 data — the losing invocation
+aborted mid-reconcile on a duplicate-key collision with rows already
+closed (`is_current: false`) but never reopened, so real items vanished
+from the views until a later run reinserted them. The entire
+one-message-per-corp shape, and the fall-back-through-characters logic in
+`forEachCorporation` (a token can carry the OAuth scope without the
+in-game director/accountant role the endpoint separately requires), exist
+because of that incident. Read the long comment on
+`fanOutPerCorporationCronJob` in `src/utils/cron.ts` before touching
+anything.
+
+The migration is actually a *structural improvement* here — "one step per
+corp, never two concurrent for the same corp" becomes control flow instead
+of a queue-shape convention — but it must land after the fan-out pattern
+(phase 3) has run in production for a while, because a mistake reconciles
+corp hangars wrongly, which is the most painful data class in the app.
+
+## In-phase order
+
+| # | Job | Write pattern | Why this slot |
+|---|---|---|---|
+| 1 | `corp-wallet-transactions` | keyed append (`corp_wallet_transaction`, per division) | No reconcile at all — a concurrent or retried run is harmlessly idempotent. Proves the per-corp enumeration + step shape. |
+| 2 | `corp-industry-jobs` | SCD-2 (`corp_industry_job_over_time`) | Reconciler, but modest volume. |
+| 3 | `corp-assets` | SCD-2 (`corp_asset_over_time`) + `corp_structure_rig`, paginated | The original race victim: biggest volume, paginated, most user-visible. Last, deliberately. |
+
+One PR per job. Watch a full scheduled cycle between them.
+
+## The workflow shape
+
+Same lanes as phase 3, but the fan-out unit is a **corp group** — the
+ordered character list `forEachCorporation` falls back through:
+
+```ts
+// src/workflows/lib.ts (addition)
+export async function enumerateCorporations(scope: string): Promise<string[][]> {
+  'use step'
+  const { groupCharacterIdsByCorporation } = await import('@/supabase.js')
+  const { byCorp, unresolved } = await groupCharacterIdsByCorporation([scope])
+  // Same fan-out set fanOutPerCorporationCronJob builds today: one group
+  // per corp, plus singleton groups for characters with no resolved corp.
+  return [...byCorp.values(), ...unresolved.map((id) => [id])]
+}
+
+export async function runCorporationStep(
+  job: string,
+  load: () => Promise<(opts: { characterIds: string[] }) => Promise<unknown>>,
+  characterIds: string[]
+) {
+  'use step'
+  const run = await load()
+  await run({ characterIds })
+}
+```
+
+```ts
+// src/workflows/corpAssets.ts
+import { enumerateCorporations, runCorporationStep } from './lib'
+
+const load = async () => (await import('@/jobs/corpAssets.js')).runCorpAssets
+
+export async function corpAssetsWorkflow() {
+  'use workflow'
+  const groups = await enumerateCorporations('esi-assets.read_corporation_assets.v1')
+
+  const LANES = 2
+  const lanes: string[][][] = Array.from({ length: LANES }, () => [])
+  groups.forEach((group, i) => lanes[i % LANES].push(group))
+  await Promise.all(
+    lanes.map(async (lane) => {
+      for (const group of lane) {
+        await runCorporationStep('corp-assets', load, group)
+      }
+    })
+  )
+}
+```
+
+Invariants to preserve — check each against the code, not from memory:
+
+- **Exactly one step per corp per run.** A corp's characters all ride in
+  one step's `characterIds`; `forEachCorporation` inside the job dedupes
+  to one handler call and falls back through the list on role failures.
+  Never split a corp's characters across steps — that would recreate the
+  race the queue shape was built to kill.
+- **Step retries are serial, and that's why they're safe.** A retried
+  reconcile after a partial failure just converges (the incident was
+  *concurrent* reconciles, not re-runs). Nothing else may write the same
+  corp's rows while the workflow runs — which holds, except for the
+  on-demand path below.
+- **Lanes only parallelize *different* corps** (each corp's rows are
+  disjoint). `LANES = 2` because the corp count is small and corp pulls
+  are the heaviest (paginated hangars); even `LANES = 1` (fully
+  sequential) is acceptable if the daily window allows.
+
+## The on-demand path still exists — same race surface as today
+
+`PER_CORPORATION_JOBS` in `dispatchRefresh.ts` dispatches these same jobs
+through the queue (one message per corp) when a user adds a character or
+clicks refresh. A scheduled *workflow* step and an on-demand *queue*
+message for the same corp could theoretically overlap — but that exact
+overlap already exists today between a cron-enqueued message and an
+on-demand one. Parity, not regression. Phase 5 removes the duality; until
+then, prefer running phase-4 verification at times away from the daily
+09:xx corp schedule.
+
+## Verification (per PR)
+
+README gates, plus — this phase gets the strictest checks:
+
+- Before/after row counts on the current views (`corp_asset`,
+  `corp_industry_job`) and spot-checks of a few known items after the
+  first workflow-run reconcile. The failure mode being hunted: items
+  closed and not reopened.
+- Confirm the per-corp heartbeat rows (attributed
+  `corporation_id`/`character_id`/`user_id`) still land from inside the
+  step, and their durations vs. the old queue runs (`corp-assets` is the
+  one to watch for step-budget pressure; if it trends toward the limit,
+  the escape hatch is the `sde-mirror` cursor-slice pattern inside the
+  job — a later, separate change).
+- Deliberately test the role-fallback: if a corp has a scoped character
+  without the director role ordered first, confirm the step still
+  succeeds via a later character (this is `forEachCorporation` behavior,
+  but the step boundary must not change it).

--- a/docs/cron-to-workflows/05-contract.md
+++ b/docs/cron-to-workflows/05-contract.md
@@ -1,0 +1,90 @@
+# Phase 5: contract — retire the old scheduled plumbing, settle the queue's fate
+
+After phases 1–4, every scheduled extract job `start()`s a workflow. This
+phase deletes what that stranded and makes the one real remaining
+decision: what happens to the on-demand "Refresh ESI" path.
+
+## 1. Delete the dead cron helpers
+
+In `src/utils/cron.ts`, nothing references these anymore — remove them:
+
+- `runDirectCronJob` (phase 1 orphaned it)
+- `dispatchAccountCronJob` (phase 2)
+- `fanOutPerCharacterCronJob` / `fanOutPerCharacterAnyScopeCronJob`
+  (phase 3) — **but check the `character-implants` manual trigger route
+  first**; it still calls `fanOutPerCharacterCronJob` (see §3)
+- `fanOutPerCorporationCronJob` (phase 4)
+
+`requireCronSecret` stays — every cron route still uses it.
+
+## 2. Decide the on-demand path (recommendation: migrate it too)
+
+Today `dispatchRefresh.ts` / `dispatchSingleJob` send queue messages, and
+the consumer at `/api/queue/jobs` runs jobs inline with `refresh_task`
+status tracking. Two coherent end states:
+
+**(a) Keep the queue for on-demand** — zero further work. Cost: every job
+permanently has two execution paths, the consumer's `JOBS` registry and
+its 60s cap live forever, and the [`/workflow` page plan](../workflow-jobs-page.md)'s
+"one home per job" rule never quite lands (a job would be a workflow on
+schedule but a queue job on demand).
+
+**(b) On-demand also starts workflows** — recommended. The dispatch
+functions call `start(<job>Workflow, [{ characterIds, taskId }])` instead
+of `send()`; the per-character/per-corp workflows accept an optional
+pre-enumerated target (skipping their enumerate step when given one, the
+way `characterImplantsWorkflow` already threads `characterIds` through).
+`refresh_task` tracking moves into the step: flip `running` before the
+`run*()`, `done`/`error` after, preserving the consumer's exact
+best-effort semantics (errors recorded and swallowed, terminal state
+always reached). Then:
+
+- The consumer's `JOBS` registry shrinks to nothing; the `jobs` queue
+  topic, `src/app/api/queue/jobs/route.ts`, its `vercel.json`
+  `experimentalTriggers` entry, and `src/utils/queue.ts` can all go
+  **if** nothing else uses the queue by then (check the `innominate`
+  topic — it's separate and stays).
+- `/character/refresh`'s cells and the add-character flow behave
+  identically from the user's side; only the engine underneath changes.
+
+Do (b) as its own small PR stack: thread `characterIds`/`taskId` through
+the workflows first (backward-compatible), then flip `dispatchRefresh.ts`,
+then delete the consumer. Each step is revertable alone.
+
+## 3. Retire the `character-implants` pilot
+
+The pilot did its job. With the fan-out pattern landed:
+
+- Delete the queue-consumer special case for `character-implants`.
+- Delete the manual trigger route `/api/cron/character-implants` (it was
+  explicitly "delete once the pilot is proven out") — or, if a standalone
+  implants schedule is ever wanted, rebuild it as a normal phase-3-style
+  workflow; today `character-status` covers implants on the schedule, so
+  deletion is the default.
+- `src/workflows/characterImplants.ts` goes with it (or is rewritten to
+  the shared `lib.ts` shape if kept for manual/backfill use).
+
+## 4. Documentation contract
+
+- CLAUDE.md: rewrite the Extract jobs section — the four cron dispatch
+  shapes are gone; describe the workflow trigger shape and the
+  `src/workflows/` per-job convention instead. Update the sde-mirror
+  bullet that calls its trigger "a fifth cron dispatch shape" (it's now
+  *the* shape).
+- Mark every row of this plan's README table done; note the end state at
+  the top.
+- If the [`/workflow` page](../workflow-jobs-page.md) has been built, its
+  registry should now list every extract job and `/character/refresh`'s
+  scope per that plan's move rule; if it hasn't, its "initial content"
+  section needs updating to reflect that everything is a workflow now.
+
+## Verification
+
+- `pnpm run lint` && `pnpm run build`, as ever.
+- After (b): run the full add-a-character flow and a single-cell refresh
+  on `/character/refresh`; confirm `refresh_task` rows reach terminal
+  states and the matrix updates live.
+- Grep for `send('jobs'` and `fanOutPer` — both should be gone.
+- Watch one full day of schedules (the 6h cycle plus the 09:xx dailies and
+  12:21 sde-mirror) in Observability → Workflows with everything
+  migrated.

--- a/docs/cron-to-workflows/README.md
+++ b/docs/cron-to-workflows/README.md
@@ -1,0 +1,165 @@
+# Cron → Vercel Workflows: migration plan
+
+Move every scheduled extract job off the current Cron → (inline | queue)
+execution paths and onto **Vercel Workflows**, in risk order: the simplest,
+lowest-blast-radius jobs first, the complex reconcilers last. Each numbered
+doc below is a self-contained implementation spec; do them as **separate
+PRs, in order** (within a phase, jobs are listed in their own risk order).
+
+## Why
+
+Two workflow jobs already exist and prove the chain end to end:
+
+- `character-implants` (`src/workflows/characterImplants.ts`) — the pilot;
+  validated queue → `start()` → `'use step'` → job module unchanged.
+- `sde-mirror` (`src/workflows/sdeMirror.ts`) — real multi-step
+  orchestration: cursor-resumable slices, bounded parallel lanes,
+  deterministic replay, tail steps that start on their actual inputs.
+
+What Workflows buy over the current paths:
+
+- **Own duration budget per step.** The queue consumer and the direct-run
+  cron routes share one 60s invocation cap
+  (`src/app/api/queue/jobs/route.ts` documents this as a live risk for the
+  whole-corp jobs). A workflow step is its own function invocation; a job
+  that outgrows 60s can later split into resumable steps (the `sde-mirror`
+  slice pattern) without changing its schedule or callers.
+- **Bounded retries with visibility.** The queue retries whole messages
+  blindly (`retryAfterSeconds: 60`); a workflow retries the failed *step*,
+  and every run/step's status, timing, and error shows under Vercel's
+  Observability → Workflows.
+- **Structural serialization.** The per-corporation jobs exist in their
+  current one-message-per-corp shape *because* concurrent queue messages
+  once raced the same corp's SCD-2 reconcile and corrupted it (see the long
+  comment on `fanOutPerCorporationCronJob` in `src/utils/cron.ts`). A
+  workflow expresses "one step per corp, never concurrent for the same
+  corp" directly in control flow.
+- **One fewer moving part** on the scheduled path once the queue hop is
+  gone (phase 5; the on-demand "Refresh ESI" queue path is untouched until
+  then).
+
+## Current state (what runs how, today)
+
+18 crons in `vercel.json`, all hitting `/api/cron/<job>` routes guarded by
+`requireCronSecret`. Four dispatch shapes live in `src/utils/cron.ts`, plus
+the workflow shape used by `sde-mirror`:
+
+| Shape | Jobs | Execution today |
+|---|---|---|
+| `runDirectCronJob` (inline) | `industry-systems`, `universe-structures`, `corp-structures`, `corp-wallet-journal`, `corp-blueprints` | Whole job inside the cron route's single 60s invocation |
+| `dispatchAccountCronJob` (1 queue msg) | `universe-names`, `character-affiliations` | Queue consumer runs the batch, records the whole-job heartbeat |
+| `fanOutPerCharacterCronJob` (1 msg/char) | `character-orders`, `character-assets`, `character-blueprints`, `character-mercenary-dens`, `character-wallet-transactions`, `character-industry-jobs` | Queue consumer runs per character |
+| `fanOutPerCharacterAnyScopeCronJob` | `character-status` | Same, any-of-scopes token selection |
+| `fanOutPerCorporationCronJob` (1 msg/corp) | `corp-assets`, `corp-industry-jobs`, `corp-wallet-transactions` | Queue consumer runs per corp |
+| `start()` a workflow | `sde-mirror` | Already a workflow — **done, not in scope** |
+
+Not in scope: `sde-mirror` (already migrated), `esf-data` (unscheduled
+manual bootstrap; the scheduled encode is a tail step of `sde-mirror`),
+`heartbeat` (stays on GitHub Actions on purpose — it's a canary for
+scheduled-trigger health), and the individual `character-wallet`/
+`-location`/`-clones`/`-implants`/`-ship` modules (unscheduled;
+`character-status` covers them — though the `character-implants` pilot gets
+retired in phase 5).
+
+## Target architecture
+
+Every `/api/cron/<job>` route keeps its path and schedule (`vercel.json`
+does not change) but becomes a thin trigger, exactly like
+`src/app/api/cron/sde-mirror/route.ts`:
+`requireCronSecret` → `start(<job>Workflow, […])` → return `runId`.
+
+One workflow file per job under `src/workflows/` (matching the one-file-
+per-job convention in `src/jobs/`), each a thin named export so
+Observability shows distinct workflow names. The heavy lifting stays in the
+untouched `src/jobs/*.js` modules — every step lazy-imports them (their
+top-level supabase/esi setup needs env vars absent at build time; both
+existing workflows document this).
+
+Three workflow shapes cover all 15 jobs:
+
+1. **Single-step** (phases 1–2): one `'use step'` that records the
+   start/end heartbeat (`source: 'vercel-workflow'`) around the job's
+   `run*()`. Execution-equivalent to today, plus retries + observability.
+2. **Per-character fan-out** (phase 3): step 1 enumerates scoped
+   characters; then one step per character, spread across a small number of
+   **statically assigned lanes** (the `sde-mirror` largest-first/
+   round-robin pattern — static assignment keeps replay deterministic).
+   Per-character heartbeats keep coming from `forEachCharacter` inside the
+   step, unchanged.
+3. **Per-corporation fan-out** (phase 4): step 1 groups characters by corp
+   (`groupCharacterIdsByCorporation`); one step per corp, same lane
+   pattern. Same-corp serialization is now structural, not a queue-shape
+   convention.
+
+The on-demand "Refresh ESI" path (`dispatchRefresh.ts` → queue →
+`/api/queue/jobs`) is **deliberately untouched until phase 5** — every job's
+`run*()` stays callable from CLI, queue, and workflow throughout, so each
+migration PR only swaps the scheduled trigger.
+
+## Risk model (what makes a job high-risk here)
+
+- **Write pattern**: append-only insert < live-row upsert < SCD-2
+  reconcile (a botched reconcile closes rows that never reopen — this has
+  happened; see the corp race history).
+- **Fan-out shape**: single batch < per-character < per-corporation (the
+  corp jobs carry the race scar tissue and the in-game-role token
+  fallback).
+- **Volume/pagination**: single-request snapshots < paginated multi-page
+  pulls (`character-assets`, `corp-assets`).
+- **Moving parts changed by the migration**: phase 1 changes almost
+  nothing (same single invocation, new wrapper); phase 3 replaces the
+  queue on the scheduled path; phase 4 does that for the most fragile
+  reconcilers.
+
+## The plan
+
+| Doc | Jobs (in-phase risk order) | Shape change | Status |
+|---|---|---|---|
+| [01-direct-jobs.md](01-direct-jobs.md) | `industry-systems`, `universe-structures`, `corp-structures`, `corp-wallet-journal`, `corp-blueprints` | inline → single-step workflow | — |
+| [02-account-jobs.md](02-account-jobs.md) | `universe-names`, `character-affiliations` | 1 queue msg → single-step workflow | — |
+| [03-per-character.md](03-per-character.md) | `character-wallet-transactions`, `character-orders`, `character-industry-jobs`, `character-status`, `character-mercenary-dens`, `character-blueprints`, `character-assets` | per-char queue fan-out → fan-out workflow | — |
+| [04-per-corporation.md](04-per-corporation.md) | `corp-wallet-transactions`, `corp-industry-jobs`, `corp-assets` | per-corp queue fan-out → fan-out workflow | — |
+| [05-contract.md](05-contract.md) | — | retire dead cron helpers, decide the on-demand queue path, retire the `character-implants` pilot | — |
+
+Phase 1's first PR migrates **one** job (`industry-systems`) to establish
+the single-step pattern; the rest of the phase can then batch 2–3 jobs per
+PR. Phase 3's first PR likewise migrates only `character-wallet-transactions`
+to establish the fan-out pattern. Update the Status column (and CLAUDE.md's
+Extract jobs section) as PRs land.
+
+Related plan: [docs/workflow-jobs-page.md](../workflow-jobs-page.md)
+(a `/workflow` dashboard page that grows as jobs migrate). If that page
+exists by the time a job migrates, the migration PR adds the job to its
+registry per that doc's rules; if not, nothing blocks on it.
+
+## Verification (every PR)
+
+No test runner exists. The gates are:
+
+1. `pnpm run lint` and `pnpm run build` pass.
+2. After deploy, trigger the cron route by hand:
+   `curl -H "Authorization: Bearer $CRON_SECRET" https://<app>/api/cron/<job>`
+   and confirm the run + steps go green under Observability → Workflows.
+3. Confirm the heartbeat pair landed (`latest_heartbeats()` /
+   `/character/refresh` for per-character jobs) and the job's table shows a
+   fresh `valid_until` / `recorded_at` bump.
+4. Watch the next *scheduled* firing before starting the next phase.
+
+Rollback for any single PR is a plain revert: the routes go back to the
+previous dispatch shape, and the job modules were never touched.
+
+## House rules (from CLAUDE.md — these bite)
+
+- **No test runner.** Lint + build + manual exercise, per above.
+- **Ramda over `for`/`while`** in job code — but workflow *orchestrator*
+  bodies are the documented exception (see the comment in
+  `src/workflows/sdeMirror.ts`): plain, deterministic control flow over
+  step calls, no helpers imported at workflow (non-step) level.
+- **Lazy-import job modules inside steps** — their top-level setup needs
+  runtime env vars.
+- **`git fetch origin && git rebase origin/main`** immediately before
+  pushing every PR. No exceptions.
+- Job names double as npm script, queue message name, heartbeat label, and
+  now workflow file name — keep the convention.
+- Pre-commit hooks auto-format; don't fight them.
+- Line numbers cited in these docs will drift — anchor on the quoted code.


### PR DESCRIPTION
Project plan (docs only, no code changes) for migrating every scheduled extract job from the current Cron → inline/queue execution paths onto Vercel Workflows, following the `docs/sde-db-cutover/` format: a README overview plus numbered, self-contained phase specs, done as separate PRs in risk order — lowest-risk (simplest) jobs first, the complex reconcilers last.

**`docs/cron-to-workflows/`**

- **README.md** — motivation (per-step duration budgets, bounded visible retries, structural same-corp serialization), the full inventory of today's 18 crons by dispatch shape, the target architecture (cron routes become thin `start()` triggers like `sde-mirror`'s; one thin workflow file per job under `src/workflows/`; job modules untouched), the risk model, and house rules.
- **01-direct-jobs.md** — the five inline `runDirectCronJob` jobs (`industry-systems` first, alone, to establish the single-step pattern; then `universe-structures`, `corp-structures`, `corp-wallet-journal`, and the SCD-2 `corp-blueprints` last). These are the lowest-risk conversions and also the only jobs still exposed to the 60s cap.
- **02-account-jobs.md** — `universe-names` + `character-affiliations`: same single-step shape, but the first phase to take a path off the queue (heartbeat writer moves from the queue consumer into the step).
- **03-per-character.md** — the seven per-character fan-out jobs, establishing the enumerate-step + one-step-per-character + static-lane pattern on `character-wallet-transactions` (append-only + ETag) before the SCD-2 jobs, ending with `character-assets`. The on-demand "Refresh ESI" queue path is deliberately untouched.
- **04-per-corporation.md** — the three per-corp jobs last (`corp-wallet-transactions` → `corp-industry-jobs` → `corp-assets`), preserving the one-reconcile-per-corp invariant from the race incident as workflow control flow.
- **05-contract.md** — delete the stranded `src/utils/cron.ts` dispatch helpers, decide the on-demand path (recommends migrating `dispatchRefresh` to `start()` workflows with `refresh_task` tracking in-step, then retiring the `jobs` queue topic), retire the `character-implants` pilot, and update CLAUDE.md + the `docs/workflow-jobs-page.md` registry.

Out of scope by design: `sde-mirror` (already a workflow), `esf-data` (tail step of sde-mirror), and `heartbeat` (stays on GitHub Actions as the scheduled-trigger canary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAHQq9ismaRZBswo32fcyE

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAHQq9ismaRZBswo32fcyE)_