### PR TITLE
Extend mercenary-dens map beyond HIK-MC with temperate-planet counts

### DIFF
--- a/src/app/mercenary-dens/data.ts
+++ b/src/app/mercenary-dens/data.ts
@@ -21,6 +21,21 @@ export const LINKS: Record<string, string[]> = {
   '8P-LKL': ['JVA-FE', 'QFU-4S', 'QQGH-G'],
   'VK6-EZ': ['JVA-FE', 'Q-UVY6', 'QQGH-G', 'L-WG68'],
   'L-WG68': ['VK6-EZ', 'HIK-MC', 'GZM-KB'],
+  'HIK-MC': ['Y4OK-W', '5LAJ-8', 'E4-E8W'],
+  'Y4OK-W': ['6U-1RX'],
+  '6U-1RX': ['FO1U-K'],
+  'FO1U-K': ['VX1-HV'],
+  'VX1-HV': ['QQGH-G', 'K-XJJT', 'JNG7-K'],
+  'K-XJJT': ['P-NI4K'],
+  'QQGH-G': ['G-VFVB'],
+  'Q-UVY6': ['KPI-OW'],
+  'JNG7-K': ['8-SPNN'],
+  '5LAJ-8': ['B9EA-G'],
+  'E4-E8W': ['E-BFLT', 'B9EA-G'],
+  'B9EA-G': ['GF-GR7'],
+  'GF-GR7': ['HPMN-V', 'Z19-B8', 'DVN6-0'],
+  'DVN6-0': ['U1-VHY', '8OYE-Z'],
+  'XR-ZL7': ['HPMN-V', 'Z19-B8', 'XUPK-Z'],
 }
 
 // The current owner of a mercenary den on a temperate planet. `null` den means
@@ -42,9 +57,11 @@ export type TemperatePlanet = {
   den: Den | null
 }
 
-// One row per temperate planet in the area. JVA-FE, 8P-LKL, and GZM-KB each
-// have two temperate planets, so they appear twice. Ordered to follow the
-// topology outward from staging.
+// One row per temperate planet in the area. A system with several temperate
+// planets appears once per planet (6U-1RX has three, XR-ZL7 four). Ordered to
+// follow the topology outward from staging. HIK-MC, E4-E8W, FO1U-K, P-NI4K,
+// G-VFVB, KPI-OW, E-BFLT, GF-GR7, Z19-B8, and 8OYE-Z have no temperate planet,
+// so they appear on the map but not here.
 export const TEMPERATE_PLANETS: TemperatePlanet[] = [
   { system: 'RXA-W1', planet: 'III', den: null },
   { system: 'JVA-FE', planet: 'II', den: null },
@@ -57,6 +74,28 @@ export const TEMPERATE_PLANETS: TemperatePlanet[] = [
   { system: 'Q-UVY6', planet: 'II', den: null },
   { system: 'GZM-KB', planet: 'IV', den: null },
   { system: 'GZM-KB', planet: 'V', den: null },
+  { system: 'VX1-HV', planet: 'II', den: null },
+  { system: 'VX1-HV', planet: 'III', den: null },
+  { system: 'K-XJJT', planet: 'III', den: null },
+  { system: 'JNG7-K', planet: 'V', den: null },
+  { system: '8-SPNN', planet: 'VI', den: null },
+  { system: '6U-1RX', planet: 'IV', den: null },
+  { system: '6U-1RX', planet: 'IX', den: null },
+  { system: '6U-1RX', planet: 'X', den: null },
+  { system: 'Y4OK-W', planet: 'II', den: null },
+  { system: '5LAJ-8', planet: 'VI', den: null },
+  { system: 'B9EA-G', planet: 'VIII', den: null },
+  { system: 'HPMN-V', planet: 'III', den: null },
+  { system: 'HPMN-V', planet: 'V', den: null },
+  { system: 'DVN6-0', planet: 'II', den: null },
+  { system: 'DVN6-0', planet: 'III', den: null },
+  { system: 'U1-VHY', planet: 'III', den: null },
+  { system: 'U1-VHY', planet: 'V', den: null },
+  { system: 'XR-ZL7', planet: 'III', den: null },
+  { system: 'XR-ZL7', planet: 'V', den: null },
+  { system: 'XR-ZL7', planet: 'VII', den: null },
+  { system: 'XR-ZL7', planet: 'VIII', den: null },
+  { system: 'XUPK-Z', planet: 'VII', den: null },
 ]
 
 // Fixed 2-D layout for the topology graph, in the SVG's own coordinate space
@@ -73,8 +112,44 @@ export const NODE_POSITIONS: Record<string, { x: number; y: number }> = {
   'Q-UVY6': { x: 520, y: 385 },
   'L-WG68': { x: 600, y: 245 },
   'HIK-MC': { x: 700, y: 185 },
-  'GZM-KB': { x: 700, y: 310 },
+  'GZM-KB': { x: 560, y: 330 },
+  // HIK-MC's fan: the E4-E8W/5LAJ-8 pair feeds the B9EA-G→GF-GR7 cluster in
+  // the middle, while Y4OK-W starts the long loop down the right edge and along
+  // the bottom (6U-1RX → FO1U-K → VX1-HV) back to QQGH-G.
+  'E4-E8W': { x: 650, y: 290 },
+  '5LAJ-8': { x: 740, y: 330 },
+  'E-BFLT': { x: 600, y: 390 },
+  'B9EA-G': { x: 720, y: 390 },
+  'GF-GR7': { x: 720, y: 460 },
+  'HPMN-V': { x: 620, y: 510 },
+  'Z19-B8': { x: 720, y: 530 },
+  'DVN6-0': { x: 850, y: 490 },
+  'U1-VHY': { x: 840, y: 560 },
+  '8OYE-Z': { x: 930, y: 590 },
+  'XR-ZL7': { x: 660, y: 580 },
+  'XUPK-Z': { x: 760, y: 610 },
+  'Y4OK-W': { x: 1020, y: 120 },
+  '6U-1RX': { x: 1020, y: 680 },
+  'FO1U-K': { x: 560, y: 640 },
+  'VX1-HV': { x: 350, y: 520 },
+  'K-XJJT': { x: 200, y: 580 },
+  'P-NI4K': { x: 140, y: 660 },
+  'JNG7-K': { x: 390, y: 620 },
+  '8-SPNN': { x: 420, y: 700 },
+  'G-VFVB': { x: 180, y: 450 },
+  'KPI-OW': { x: 560, y: 460 },
 }
+
+// Temperate-planet count per system, shown as the 🌍 badge under each node's
+// name on the topology. Derived from TEMPERATE_PLANETS so the badge can never
+// drift from the table.
+export const TEMPERATE_COUNTS: Record<string, number> = (() => {
+  const counts: Record<string, number> = {}
+  TEMPERATE_PLANETS.forEach(({ system }) => {
+    counts[system] = (counts[system] ?? 0) + 1
+  })
+  return counts
+})()
 
 // Distinct undirected edges derived from LINKS (each pair once), for drawing.
 export const EDGES: [string, string][] = (() => {

--- a/src/app/mercenary-dens/mercenaryDens.module.css
+++ b/src/app/mercenary-dens/mercenaryDens.module.css
@@ -62,7 +62,7 @@
 .topology {
   display: block;
   width: 100%;
-  max-width: 640px;
+  max-width: 960px;
   height: auto;
   margin: 8pt 0 4pt;
 }
@@ -82,6 +82,13 @@
   fill: var(--ink);
   font-family: var(--mono);
   font-size: 11px;
+}
+
+/* Second line inside a node's pill: 🌍 + how many temperate planets it has. */
+.nodeCount {
+  fill: var(--ink-soft);
+  font-family: var(--mono);
+  font-size: 10px;
 }
 
 /* The staging system stands apart with the indigo accent. */

--- a/src/app/mercenary-dens/topology.tsx
+++ b/src/app/mercenary-dens/topology.tsx
@@ -1,11 +1,13 @@
-import { EDGES, NODE_POSITIONS, STAGING } from './data'
+import { EDGES, NODE_POSITIONS, STAGING, TEMPERATE_COUNTS } from './data'
 import styles from './mercenaryDens.module.css'
 
 export type NodeColor = 'red' | 'yellow' | 'green'
 
-// Pill dimensions for each system node, in SVG user units.
+// Pill dimensions for each system node, in SVG user units. A system with
+// temperate planets gets the taller pill to fit its 🌍 count on a second line.
 const NODE_W = 66
 const NODE_H = 24
+const NODE_H_BADGE = 40
 
 const COLOR_CLASS: Record<NodeColor, string> = {
   red: styles.nodeRed,
@@ -29,7 +31,7 @@ export const Topology = ({
 }) => (
   <svg
     className={styles.topology}
-    viewBox="0 0 760 450"
+    viewBox="0 0 1100 750"
     role="img"
     aria-label="Network topology of systems accessible from the staging system, coloured by mercenary den status; a dashed red outline marks a system with reported enemy-den intel"
   >
@@ -49,19 +51,25 @@ export const Topology = ({
       const groupClass = color ? COLOR_CLASS[color] : isStaging ? styles.nodeStaging : styles.node
       // Enemy-den intel overlays a dashed red outline regardless of the tint.
       const className = [groupClass, enemyIntel?.has(system) ? styles.nodeEnemyIntel : null].filter(Boolean).join(' ')
+      const temperate = TEMPERATE_COUNTS[system] ?? 0
+      const h = temperate > 0 ? NODE_H_BADGE : NODE_H
       return (
         <g key={system} className={className}>
-          <rect
-            x={x - NODE_W / 2}
-            y={y - NODE_H / 2}
-            width={NODE_W}
-            height={NODE_H}
-            rx={6}
-            className={styles.nodeBox}
-          />
-          <text x={x} y={y} className={styles.nodeLabel} textAnchor="middle" dominantBaseline="central">
+          <rect x={x - NODE_W / 2} y={y - h / 2} width={NODE_W} height={h} rx={6} className={styles.nodeBox} />
+          <text
+            x={x}
+            y={temperate > 0 ? y - 8 : y}
+            className={styles.nodeLabel}
+            textAnchor="middle"
+            dominantBaseline="central"
+          >
             {system}
           </text>
+          {temperate > 0 ? (
+            <text x={x} y={y + 10} className={styles.nodeCount} textAnchor="middle" dominantBaseline="central">
+              🌍 {temperate}
+            </text>
+          ) : null}
         </g>
       )
     })}


### PR DESCRIPTION
## What

Extends the `/mercenary-dens` topology with the 22 systems reachable past L-WG68/HIK-MC, and adds a temperate-planet count badge (🌍 N) under each system name on the map.

### New map area

- HIK-MC fans out to Y4OK-W, 5LAJ-8, and E4-E8W.
- The long loop Y4OK-W → 6U-1RX → FO1U-K → VX1-HV closes back to QQGH-G, with spurs VX1-HV → K-XJJT → P-NI4K and VX1-HV → JNG7-K → 8-SPNN.
- The B9EA-G → GF-GR7 cluster hangs off 5LAJ-8/E4-E8W, reaching HPMN-V, Z19-B8, DVN6-0 (→ U1-VHY, 8OYE-Z) and XR-ZL7 (→ XUPK-Z), plus leaves E-BFLT, G-VFVB, and KPI-OW (off Q-UVY6).

### Temperate planets

Every new system's temperate planets (planet `type_id` 11) were verified against ESI's public `/universe/ids`, `/universe/systems`, and `/universe/planets` endpoints and added to `TEMPERATE_PLANETS` with their roman positions. That verification also surfaced two temperate planets beyond the requested list: **8-SPNN VI** and **XUPK-Z VII**, included here.

### Count badge

- Systems with temperate planets get a taller pill with a second line: 🌍 + count (e.g. 6U-1RX shows 3, XR-ZL7 shows 4). Systems without one keep the short pill.
- Counts are a derived export (`TEMPERATE_COUNTS`) computed from `TEMPERATE_PLANETS`, so the badge can never drift from the table below the map.
- The SVG viewBox grows to 1100×750 for the larger graph (positions hand-placed, verified render with no pill/edge collisions), and the diagram's max-width is raised to 960px. GZM-KB moved slightly to make room for the E4-E8W/5LAJ-8 fan.

## Testing

- `pnpm run lint` and `pnpm run build` pass (re-run after rebasing onto latest `main`).
- Rendered the layout headlessly and inspected the output — all 33 nodes and 38 edges draw without overlaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEx5kQLCTaoNXwdgGj7LW3

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEx5kQLCTaoNXwdgGj7LW3)_