### PR TITLE
Draw mercenary-dens systems as circles with per-planet globe rows

### DIFF
--- a/src/app/mercenary-dens/data.ts
+++ b/src/app/mercenary-dens/data.ts
@@ -99,11 +99,12 @@ export const TEMPERATE_PLANETS: TemperatePlanet[] = [
 ]
 
 // Fixed 2-D layout for the topology graph, in the SVG's own coordinate space
-// (see topology.tsx's viewBox). Positions are hand-placed so the staging system
-// sits at the top and links fan out without crossing.
+// (see topology.tsx's viewBox). Positions are hand-placed so links fan out
+// without crossing; the staging system anchors the bottom-left corner, its
+// lone link running up the empty left edge to RXA-W1.
 export const NODE_POSITIONS: Record<string, { x: number; y: number }> = {
-  'X1-IZ0': { x: 300, y: 40 },
-  'RXA-W1': { x: 300, y: 120 },
+  'X1-IZ0': { x: 80, y: 700 },
+  'RXA-W1': { x: 80, y: 200 },
   'JVA-FE': { x: 300, y: 200 },
   'QFU-4S': { x: 140, y: 290 },
   '8P-LKL': { x: 300, y: 300 },
@@ -117,7 +118,7 @@ export const NODE_POSITIONS: Record<string, { x: number; y: number }> = {
   // the middle, while Y4OK-W starts the long loop down the right edge and along
   // the bottom (6U-1RX → FO1U-K → VX1-HV) back to QQGH-G.
   'E4-E8W': { x: 650, y: 290 },
-  '5LAJ-8': { x: 740, y: 330 },
+  '5LAJ-8': { x: 750, y: 315 },
   'E-BFLT': { x: 600, y: 390 },
   'B9EA-G': { x: 720, y: 390 },
   'GF-GR7': { x: 720, y: 460 },

--- a/src/app/mercenary-dens/mercenaryDens.module.css
+++ b/src/app/mercenary-dens/mercenaryDens.module.css
@@ -84,11 +84,12 @@
   font-size: 11px;
 }
 
-/* Second line inside a node's pill: 🌍 + how many temperate planets it has. */
+/* Second line inside a node's circle: one globe per temperate planet. Sized so
+ * even a four-planet row (XR-ZL7) fits the circle's lower chord. */
 .nodeCount {
   fill: var(--ink-soft);
   font-family: var(--mono);
-  font-size: 10px;
+  font-size: 9px;
 }
 
 /* The staging system stands apart with the indigo accent. */

--- a/src/app/mercenary-dens/topology.tsx
+++ b/src/app/mercenary-dens/topology.tsx
@@ -3,11 +3,18 @@ import styles from './mercenaryDens.module.css'
 
 export type NodeColor = 'red' | 'yellow' | 'green'
 
-// Pill dimensions for each system node, in SVG user units. A system with
-// temperate planets gets the taller pill to fit its 🌍 count on a second line.
-const NODE_W = 66
-const NODE_H = 24
-const NODE_H_BADGE = 40
+// Circle radius for each system node, in SVG user units. A system with
+// temperate planets gets the larger circle to fit its row of globes on a
+// second line.
+const NODE_R = 24
+const NODE_R_BADGE = 30
+
+// One globe per temperate planet, all showing the same face of the earth for a
+// given system — which face is a hash of the system name, so it's stable
+// across renders but varies across the map.
+const GLOBES = ['🌍', '🌎', '🌏']
+const globeFor = (system: string) =>
+  GLOBES[[...system].reduce((h, c) => (h * 31 + c.charCodeAt(0)) & 0x7fffffff, 0) % GLOBES.length]
 
 const COLOR_CLASS: Record<NodeColor, string> = {
   red: styles.nodeRed,
@@ -52,10 +59,10 @@ export const Topology = ({
       // Enemy-den intel overlays a dashed red outline regardless of the tint.
       const className = [groupClass, enemyIntel?.has(system) ? styles.nodeEnemyIntel : null].filter(Boolean).join(' ')
       const temperate = TEMPERATE_COUNTS[system] ?? 0
-      const h = temperate > 0 ? NODE_H_BADGE : NODE_H
+      const r = temperate > 0 ? NODE_R_BADGE : NODE_R
       return (
         <g key={system} className={className}>
-          <rect x={x - NODE_W / 2} y={y - h / 2} width={NODE_W} height={h} rx={6} className={styles.nodeBox} />
+          <circle cx={x} cy={y} r={r} className={styles.nodeBox} />
           <text
             x={x}
             y={temperate > 0 ? y - 8 : y}
@@ -67,7 +74,7 @@ export const Topology = ({
           </text>
           {temperate > 0 ? (
             <text x={x} y={y + 10} className={styles.nodeCount} textAnchor="middle" dominantBaseline="central">
-              🌍 {temperate}
+              {globeFor(system).repeat(temperate)}
             </text>
           ) : null}
         </g>


### PR DESCRIPTION
## What

Follow-up to #671, reworking how the `/mercenary-dens` topology draws its nodes:

- **Circles instead of pills** — each system is now a circle (`r=24`, or `r=30` when it has temperate planets to leave room for the globe row).
- **One globe per temperate planet** — the count line now shows repeated globe emojis instead of `🌍 N` (XR-ZL7 shows four, 6U-1RX three). Which of the three earth faces (🌍🌎🌏) a system uses is picked by a deterministic hash of the system name, so it's stable across renders but varies across the map.
- **X1-IZ0 moved to the bottom-left corner** — its lone link to RXA-W1 now runs up the empty left edge, with RXA-W1 relocated to the top-left so that edge doesn't cross the QFU-4S/QQGH-G web. 5LAJ-8 nudged slightly apart from B9EA-G to keep the larger circles clear.

## Testing

- `pnpm run lint` and `pnpm run build` pass (re-verified after rebasing onto latest `main`).
- Rendered the layout headlessly and audited it programmatically — no circle overlaps and no edge passes through a non-endpoint node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEx5kQLCTaoNXwdgGj7LW3

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEx5kQLCTaoNXwdgGj7LW3)_