### PR TITLE
Remove memory settings from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -77,7 +77,6 @@
   "functions": {
     "src/app/api/queue/jobs/route.ts": {
       "maxDuration": 60,
-      "memory": 512,
       "experimentalTriggers": [
         {
           "type": "queue/v2beta",
@@ -89,7 +88,6 @@
     },
     "src/app/api/queue/innominate/route.ts": {
       "maxDuration": 30,
-      "memory": 256,
       "experimentalTriggers": [
         {
           "type": "queue/v2beta",


### PR DESCRIPTION
## Summary

Removed memory allocation settings from vercel.json for the queue job handlers. With active CPU billing, Vercel automatically manages memory based on actual usage, making these settings unnecessary.

## Changes

- Removed `memory: 512` from `src/app/api/queue/jobs/route.ts`
- Removed `memory: 256` from `src/app/api/queue/innominate/route.ts`

---
_Generated by [Claude Code](https://claude.ai/code/session_01QsS1kk9LmzzVxqibtotUDo)_