### PR TITLE
Hide empty rows and rename the mercenary-dens table to Friendly dens

### DIFF
--- a/src/app/mercenary-dens/page.tsx
+++ b/src/app/mercenary-dens/page.tsx
@@ -180,7 +180,8 @@ const MercenaryDensPage = async () => {
     .filter(([k]) => !staticKeys.has(k))
     .map(([, row]) => row)
     .sort((a, b) => a.system.localeCompare(b.system) || a.planet.localeCompare(b.planet))
-  const rows = [...staticRows, ...extraRows]
+  // Drop planets with neither a den nor intel — an empty row has nothing to show.
+  const rows = [...staticRows, ...extraRows].filter((row) => row.den || row.intel)
 
   // Node colour per system: the most severe colour among that system's rows
   // (red > yellow > green).
@@ -220,7 +221,7 @@ const MercenaryDensPage = async () => {
 
       <Topology nodeColors={nodeColors} enemyIntel={enemyIntelSystems} />
 
-      <h2>Temperate planets</h2>
+      <h2>Friendly dens</h2>
       <div className={styles.tableScroll}>
         <table className={styles.table}>
           <thead>


### PR DESCRIPTION
## What

Two small changes to the `/mercenary-dens` table below the topology map:

- **Hide empty rows.** A temperate planet with neither a den nor hand-kept intel had nothing to show but dashes across every column. Those rows are now dropped — only planets with a den or intel appear.
- **Rename the heading** from "Temperate planets" to "Friendly dens".

## Testing

- `pnpm run lint` and `pnpm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEx5kQLCTaoNXwdgGj7LW3

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEx5kQLCTaoNXwdgGj7LW3)_