### PR TITLE
Show the fitting ship in asset search results

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -363,7 +363,10 @@ returns table (
   contents bigint,
   type_name text,
   root_location_name text,
-  system_id bigint
+  system_id bigint,
+  parent_id bigint,
+  parent_type_id bigint,
+  parent_name text
 )
 language sql
 stable
@@ -421,12 +424,16 @@ as $$
     coalesce(ct.contents, 0) as contents,
     t.name as type_name,
     st.name as root_location_name,
-    st.system_id
+    st.system_id,
+    m.location_id as parent_id,
+    p.type_id as parent_type_id,
+    p.name as parent_name
   from matched m
   join roots r on r.start_item = m.item_id
   left join contents ct on ct.ancestor = m.item_id
   left join public.sde_published_type t on t.type_id = m.type_id
-  left join public.sde_station st on st.station_id = r.root_location_id;
+  left join public.sde_station st on st.station_id = r.root_location_id
+  left join public.character_asset p on p.item_id = m.location_id;
 $$;
 
 grant execute on function public.character_asset_location_summary()        to authenticated;
@@ -2017,7 +2024,9 @@ returns table (
   contents bigint,
   type_name text,
   root_location_name text,
-  system_id bigint
+  system_id bigint,
+  parent_id bigint,
+  parent_type_id bigint
 )
 language sql
 stable
@@ -2074,12 +2083,15 @@ as $$
     coalesce(ct.contents, 0) as contents,
     t.name as type_name,
     st.name as root_location_name,
-    st.system_id
+    st.system_id,
+    m.location_id as parent_id,
+    p.type_id as parent_type_id
   from matched m
   join roots r on r.start_item = m.item_id
   left join contents ct on ct.ancestor = m.item_id
   left join public.sde_published_type t on t.type_id = m.type_id
-  left join public.sde_station st on st.station_id = r.root_location_id;
+  left join public.sde_station st on st.station_id = r.root_location_id
+  left join public.corp_asset p on p.item_id = m.location_id;
 $$;
 
 grant execute on function public.corp_asset_location_summary()        to authenticated;

--- a/src/app/asset/search/page.tsx
+++ b/src/app/asset/search/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { prop, uniqBy } from 'ramda'
 
-import { searchSdeTypesAll } from '@/sdeTypes'
+import { getSdeTypes, searchSdeTypesAll } from '@/sdeTypes'
 import { createClient } from '@/utils/supabase/server'
 
 import { fetchOwners } from '../../owners'
@@ -30,6 +30,10 @@ const SHUFFLE_SEED = 20260704
 // blueprints" checkbox opts back in.
 const BLUEPRINT_CATEGORY_ID = 9
 
+// invGroups.categoryID for the Ship category in CCP's SDE. A match whose
+// immediate parent is a ship (fitted module, drone, cargo) shows that ship.
+const SHIP_CATEGORY_ID = 6
+
 type CharacterSearchRow = {
   item_id: number | string
   character_id: string
@@ -41,10 +45,18 @@ type CharacterSearchRow = {
   root_location_id: number | string | null
   root_location_type: string | null
   contents: number | string
+  // The matched item's immediate parent — null when it sits directly in a
+  // station (the parent isn't one of the caller's items). parent_name is the
+  // parent's player-assigned name (a ship's custom name), if any.
+  parent_id: number | string | null
+  parent_type_id: number | string | null
+  parent_name: string | null
 }
 
 // Corp assets carry no player-assigned name column; owner is the corporation.
-type CorpSearchRow = Omit<CharacterSearchRow, 'character_id' | 'name'> & { corporation_id: number | string }
+type CorpSearchRow = Omit<CharacterSearchRow, 'character_id' | 'name' | 'parent_name'> & {
+  corporation_id: number | string
+}
 
 type SearchRow = {
   itemId: string
@@ -56,6 +68,9 @@ type SearchRow = {
   flag: string | null
   root: LocationRef | null
   contents: number
+  parentId: string | null
+  parentTypeId: number | null
+  parentName: string | null
 }
 
 const AssetSearchPage = async ({ searchParams }: { searchParams: Promise<{ q?: string; blueprints?: string }> }) => {
@@ -151,6 +166,9 @@ const AssetSearchPage = async ({ searchParams }: { searchParams: Promise<{ q?: s
       flag: r.location_flag,
       root: r.root_location_id != null ? { id: String(r.root_location_id), type: r.root_location_type } : null,
       contents: Number(r.contents),
+      parentId: r.parent_id != null ? String(r.parent_id) : null,
+      parentTypeId: r.parent_type_id != null ? Number(r.parent_type_id) : null,
+      parentName: r.parent_name,
     })),
     ...((corpRows ?? []) as CorpSearchRow[]).map((r): SearchRow => ({
       itemId: String(r.item_id),
@@ -162,6 +180,9 @@ const AssetSearchPage = async ({ searchParams }: { searchParams: Promise<{ q?: s
       flag: r.location_flag,
       root: r.root_location_id != null ? { id: String(r.root_location_id), type: r.root_location_type } : null,
       contents: Number(r.contents),
+      parentId: r.parent_id != null ? String(r.parent_id) : null,
+      parentTypeId: r.parent_type_id != null ? Number(r.parent_type_id) : null,
+      parentName: null,
     })),
   ]
 
@@ -171,6 +192,26 @@ const AssetSearchPage = async ({ searchParams }: { searchParams: Promise<{ q?: s
   )
   const { nameFor, systemFor } = await resolveLocations(rootRefs)
   const ownerMap = new Map([...owners.characters, ...owners.corporations].map((o) => [o.id, o.name]))
+
+  // A match whose immediate parent is a ship (fitted module, drone, cargo) is
+  // far more useful shown as "which ship" than as a bare slot flag. One bulk SDE
+  // lookup over every distinct parent type → the Ship-category set plus each
+  // ship's type name, so the per-row test stays a sync map/Set lookup.
+  const parentTypeIds = [...new Set(rows.map((r) => r.parentTypeId).filter((t): t is number => t != null))]
+  const parentTypes = parentTypeIds.length > 0 ? await getSdeTypes(parentTypeIds) : {}
+  const shipTypeNameById = new Map(
+    Object.values(parentTypes)
+      .filter((t) => t.categoryID === SHIP_CATEGORY_ID)
+      .map((t) => [t.typeID, t.name])
+  )
+  // The ship label mirrors the /ship page heading: "<custom name> (<type>)" when
+  // the ship was renamed, otherwise just the type name.
+  const shipLabelFor = (row: SearchRow): string | null => {
+    if (row.parentId == null || row.parentTypeId == null) return null
+    const typeName = shipTypeNameById.get(row.parentTypeId)
+    if (typeName == null) return null
+    return row.parentName && row.parentName !== typeName ? `${row.parentName} (${typeName})` : typeName
+  }
 
   const displayRows = rows
     .map((row) => {
@@ -234,7 +275,22 @@ const AssetSearchPage = async ({ searchParams }: { searchParams: Promise<{ q?: s
                   )}
                 </td>
                 <td className={retro.num}>{row.isSingleton ? '—' : <Quantity value={row.quantity} />}</td>
-                <td>{row.flag ?? '—'}</td>
+                <td>
+                  {(() => {
+                    const shipLabel = shipLabelFor(row)
+                    if (shipLabel && row.parentId) {
+                      return (
+                        <>
+                          <Link className="serif" href={`/ship/${row.parentId}`}>
+                            {shipLabel}
+                          </Link>
+                          {row.flag ? <span className={retro.muted}> · {row.flag}</span> : null}
+                        </>
+                      )
+                    }
+                    return row.flag ?? '—'
+                  })()}
+                </td>
                 <td className={retro.num}>{row.contents > 0 ? row.contents : '—'}</td>
               </tr>
             ))}

--- a/src/app/retro.module.css
+++ b/src/app/retro.module.css
@@ -33,6 +33,11 @@
   background: var(--paper-raised);
 }
 
+/* Secondary in-cell text — e.g. the fitting slot next to a ship name. */
+.muted {
+  color: var(--ink-soft);
+}
+
 /* Numeric cells: the only place we use the fixed-width face. */
 .num {
   font-family: var(--mono);

--- a/supabase/migrations/20260721020000_asset_search_parent_ship.sql
+++ b/supabase/migrations/20260721020000_asset_search_parent_ship.sql
@@ -1,0 +1,187 @@
+-- /asset/search shows each match's immediate "hangar" (its location_flag, e.g.
+-- HiSlot4 / MedSlot1 for a fitted module). A slot flag means the item is on a
+-- ship, but the search never surfaced *which* ship. Extend both search RPCs to
+-- also return the matched item's immediate parent — its item id, type, and
+-- (character only) player-assigned name — so the page can resolve a fitted
+-- item's ship and link to it. parent_* is null when the immediate parent isn't
+-- one of the caller's items (e.g. the item sits directly in a station).
+--
+-- This builds on 20260721010000_sde_name_joins.sql, which added the
+-- type_name / root_location_name / system_id columns to these same functions;
+-- both column sets are preserved here. Adding columns changes the RETURNS TABLE
+-- signature, which create-or-replace can't do — drop first (which discards
+-- grants), recreate with the wider result, then re-grant.
+
+drop function if exists public.character_asset_search(bigint[]) cascade;
+create function public.character_asset_search(type_ids bigint[])
+returns table (
+  item_id bigint,
+  character_id uuid,
+  type_id bigint,
+  quantity bigint,
+  is_singleton boolean,
+  name text,
+  location_flag text,
+  root_location_id bigint,
+  root_location_type text,
+  contents bigint,
+  type_name text,
+  root_location_name text,
+  system_id bigint,
+  parent_id bigint,
+  parent_type_id bigint,
+  parent_name text
+)
+language sql
+stable
+as $$
+  with recursive parent_of as (
+    select distinct on (item_id) item_id, location_id, location_type
+    from public.character_asset_over_time
+    order by item_id, is_current desc, valid_until desc
+  ),
+  matched as (
+    select a.item_id, a.character_id, a.type_id, a.quantity, a.is_singleton, a.name,
+           a.location_flag, a.location_id, a.location_type
+    from public.character_asset a
+    where a.type_id = any(type_ids)
+  ),
+  climb as (
+    select m.item_id as start_item, m.location_id, m.location_type, 1 as depth
+    from matched m
+    union all
+    select c.start_item, p.location_id, p.location_type, c.depth + 1
+    from climb c
+    join parent_of p on p.item_id = c.location_id
+    where c.depth < 64
+  ),
+  roots as (
+    select w.start_item, w.location_id as root_location_id, w.location_type as root_location_type
+    from climb w
+    where w.location_id is not null
+      and not exists (select 1 from parent_of o where o.item_id = w.location_id)
+  ),
+  descend as (
+    select m.item_id as ancestor, m.item_id as node, 1 as depth
+    from matched m
+    union all
+    select d.ancestor, c.item_id, d.depth + 1
+    from descend d
+    join public.character_asset c on c.location_id = d.node
+    where d.depth < 64
+  ),
+  contents as (
+    select ancestor, count(*) - 1 as contents
+    from descend
+    group by ancestor
+  )
+  select
+    m.item_id,
+    m.character_id,
+    m.type_id,
+    m.quantity,
+    m.is_singleton,
+    m.name,
+    m.location_flag,
+    r.root_location_id,
+    r.root_location_type,
+    coalesce(ct.contents, 0) as contents,
+    t.name as type_name,
+    st.name as root_location_name,
+    st.system_id,
+    m.location_id as parent_id,
+    p.type_id as parent_type_id,
+    p.name as parent_name
+  from matched m
+  join roots r on r.start_item = m.item_id
+  left join contents ct on ct.ancestor = m.item_id
+  left join public.sde_published_type t on t.type_id = m.type_id
+  left join public.sde_station st on st.station_id = r.root_location_id
+  left join public.character_asset p on p.item_id = m.location_id;
+$$;
+grant execute on function public.character_asset_search(bigint[]) to authenticated;
+
+drop function if exists public.corp_asset_search(bigint[]) cascade;
+create function public.corp_asset_search(type_ids bigint[])
+returns table (
+  item_id bigint,
+  corporation_id bigint,
+  type_id bigint,
+  quantity bigint,
+  is_singleton boolean,
+  location_flag text,
+  root_location_id bigint,
+  root_location_type text,
+  contents bigint,
+  type_name text,
+  root_location_name text,
+  system_id bigint,
+  parent_id bigint,
+  parent_type_id bigint
+)
+language sql
+stable
+as $$
+  with recursive parent_of as (
+    select distinct on (item_id) item_id, location_id, location_type
+    from public.corp_asset_over_time
+    order by item_id, is_current desc, valid_until desc
+  ),
+  matched as (
+    select a.item_id, a.corporation_id, a.type_id, a.quantity, a.is_singleton,
+           a.location_flag, a.location_id, a.location_type
+    from public.corp_asset a
+    where a.type_id = any(type_ids)
+  ),
+  climb as (
+    select m.item_id as start_item, m.location_id, m.location_type, 1 as depth
+    from matched m
+    union all
+    select c.start_item, p.location_id, p.location_type, c.depth + 1
+    from climb c
+    join parent_of p on p.item_id = c.location_id
+    where c.depth < 64
+  ),
+  roots as (
+    select w.start_item, w.location_id as root_location_id, w.location_type as root_location_type
+    from climb w
+    where w.location_id is not null
+      and not exists (select 1 from parent_of o where o.item_id = w.location_id)
+  ),
+  descend as (
+    select m.item_id as ancestor, m.item_id as node, 1 as depth
+    from matched m
+    union all
+    select d.ancestor, c.item_id, d.depth + 1
+    from descend d
+    join public.corp_asset c on c.location_id = d.node
+    where d.depth < 64
+  ),
+  contents as (
+    select ancestor, count(*) - 1 as contents
+    from descend
+    group by ancestor
+  )
+  select
+    m.item_id,
+    m.corporation_id,
+    m.type_id,
+    m.quantity,
+    m.is_singleton,
+    m.location_flag,
+    r.root_location_id,
+    r.root_location_type,
+    coalesce(ct.contents, 0) as contents,
+    t.name as type_name,
+    st.name as root_location_name,
+    st.system_id,
+    m.location_id as parent_id,
+    p.type_id as parent_type_id
+  from matched m
+  join roots r on r.start_item = m.item_id
+  left join contents ct on ct.ancestor = m.item_id
+  left join public.sde_published_type t on t.type_id = m.type_id
+  left join public.sde_station st on st.station_id = r.root_location_id
+  left join public.corp_asset p on p.item_id = m.location_id;
+$$;
+grant execute on function public.corp_asset_search(bigint[]) to authenticated;


### PR DESCRIPTION
## What

On `/asset/search`, when a match sits in a ship slot (`HiSlot4`, `MedSlot1`, …) the **Hangar** column only showed the raw slot flag — never *which* ship the item was fitted to. This resolves the ship and links to it.

Searching "Ship Scanner" now shows, in the Hangar column, the actual ship (e.g. **My Heron (Heron)**, linked to `/ship/[id]`) with the slot flag kept as muted context (` · HiSlot4`), instead of a bare `HiSlot4`.

## How

- **`character_asset_search` / `corp_asset_search`** now also return the matched item's **immediate parent**: `parent_id`, `parent_type_id`, and — character only — `parent_name` (the parent's player-assigned name). `parent_*` is `null` when the immediate parent isn't one of the caller's items (e.g. the item sits directly in a station). Implemented with a `left join` on the asset view keyed on the matched row's `location_id`.
- **`/asset/search` page** does one bulk `getSdeTypes` over the distinct parent type ids → the Ship-category (`6`) set plus each ship's type name. Any match whose parent is a ship renders a linked ship label mirroring the `/ship` page heading (`<custom name> (<type>)`, or just the type when unnamed), with the slot flag alongside as muted context. Non-ship parents fall back to the flag as before.
- Added a `.muted` class (existing `--ink-soft` token) to `retro.module.css` for the in-cell slot context.

## Migration

- `supabase/migrations/20260721020000_asset_search_parent_ship.sql` — builds on `20260721010000_sde_name_joins.sql` (which added `type_name`/`root_location_name`/`system_id` to these same functions); both column sets are preserved. **Drops** each function before recreating, since widening a `RETURNS TABLE` changes the signature and `create or replace` can't, then re-grants. `schema.sql` (full-reset source of truth) updated to match.
- Purely additive columns; the existing MCP `search_assets` caller selects specific columns and is unaffected.

Rebased onto latest `main`. Lint and `tsc --noEmit` pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)