### PR TITLE
Make the mercenary-dens map layout crossing-free

### DIFF
--- a/scripts/mercenaryDenLayout.mjs
+++ b/scripts/mercenaryDenLayout.mjs
@@ -1,20 +1,26 @@
 // Generator for the Mercenary Dens topology layout (src/app/mercenary-dens/data.ts's
 // NODE_POSITIONS). The map is a fixed, hand-maintained set of systems, so rather
-// than hand-place each node we derive the layout from CCP's real universe geometry:
+// than hand-place each node we derive the layout from CCP's real universe geometry
+// and then untangle it into a clean, crossing-free drawing:
 //
-//   1. Start from each system's true 3-D position in the SDE (position.x/y/z, in
+//   1. Seed from each system's true 3-D position in the SDE (position.x/y/z, in
 //      metres), projected onto the EVE galaxy-map plane (x, z) — the same top-down
-//      plane the in-game star map uses (y is galactic "up" and is dropped).
-//   2. Relax with a force-directed pass — pairwise repulsion so crowded systems
-//      stop overlapping, edge springs so linked systems stay a readable distance
-//      apart, and a weak anchor back to the true projected position so the map
-//      keeps its real geography instead of drifting into a generic graph blob.
+//      plane the in-game star map uses (y is galactic "up" and is dropped). This
+//      gives the untangler a starting point that already resembles real geography.
+//   2. Simulated annealing to a planar (zero edge-crossing) embedding — crossings
+//      are penalised far more heavily than spacing, and the anneal is restarted
+//      from the seed with fresh randomness until it finds a layout with no
+//      crossings (the graph is planar, so one exists).
+//   3. Planarity-preserving force relaxation — spring + repulsion forces even out
+//      spacing and shorten long edges, but any node move that would re-introduce a
+//      crossing is rejected, so the result stays crossing-free while looking tidy.
 //
-// The raw SDE coordinates are embedded below (build 3439610, mapSolarSystems.jsonl)
-// so this script reproduces the layout deterministically with no network. When the
-// system list changes, add the new system's coordinates here (from the SDE mirror)
-// and re-run: `node scripts/mercenaryDenLayout.mjs` prints the NODE_POSITIONS block
-// to paste into data.ts.
+// A seeded PRNG makes the whole thing deterministic. The raw SDE coordinates are
+// embedded below (build 3439610, mapSolarSystems.jsonl) so this reproduces the
+// layout with no network. When the system list changes, add the new system's
+// coordinates here (from the SDE mirror) and re-run:
+// `node scripts/mercenaryDenLayout.mjs` prints the NODE_POSITIONS block and the
+// viewBox to paste into data.ts.
 
 // system -> true SDE position (metres). x/z are the map plane; y is dropped.
 const SDE = {
@@ -83,15 +89,27 @@ const STAGING = 'X1-IZ0'
 
 // ── Layout parameters ────────────────────────────────────────────────────────
 const NODE_NAMES = Object.keys(SDE)
-const REST_LEN = 120 // ideal drawn distance along a link
+const IDX = Object.fromEntries(NODE_NAMES.map((n, i) => [n, i]))
+const REST_LEN = 150 // ideal drawn distance along a link
 const MIN_SEP = 92 // desired minimum centre-to-centre spacing (node badge Ø ≈ 60)
-const K_REP = 44000 // pairwise repulsion strength
-const K_SPRING = 0.06 // edge spring stiffness
-const K_ANCHOR = 0.015 // pull back toward the true SDE position (keeps geography)
-const ITERATIONS = 4000
-const T0 = 40 // initial max step (cools linearly to 0)
+const SA_ITERS = 300000 // annealing steps per restart
+const SA_RESTARTS = 30 // re-seeded attempts to find a crossing-free embedding
+const FDL_PASSES = 900 // planarity-preserving relaxation passes
 
-// Distinct undirected edges.
+// Deterministic PRNG (mulberry32) so the layout is reproducible run-to-run.
+let seed = 0
+const setSeed = (s) => {
+  seed = s | 0
+}
+const rnd = () => {
+  seed |= 0
+  seed = (seed + 0x6d2b79f5) | 0
+  let t = Math.imul(seed ^ (seed >>> 15), 1 | seed)
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+}
+
+// Distinct undirected edges as index pairs.
 const edges = (() => {
   const seen = new Set()
   const out = []
@@ -100,97 +118,154 @@ const edges = (() => {
       const k = [from, to].sort().join('|')
       if (seen.has(k)) continue
       seen.add(k)
-      out.push([from, to])
+      out.push([IDX[from], IDX[to]])
     }
   }
   return out
 })()
+const incident = NODE_NAMES.map(() => [])
+edges.forEach(([a, b], ei) => {
+  incident[a].push(ei)
+  incident[b].push(ei)
+})
 
-// Project true 3-D position onto the map plane (x, z), then normalise to a
-// working box so the force constants above are in "screen" units.
-const projected = (() => {
+// Seed positions: true 3-D position projected onto the map plane (x, z),
+// normalised to a ~900px working box.
+const seedProjection = (() => {
   const px = NODE_NAMES.map((n) => SDE[n].x)
   const pz = NODE_NAMES.map((n) => SDE[n].z)
-  const minX = Math.min(...px)
-  const maxX = Math.max(...px)
-  const minZ = Math.min(...pz)
-  const maxZ = Math.max(...pz)
-  const span = Math.max(maxX - minX, maxZ - minZ)
+  const lo = Math.min(...px)
+  const loZ = Math.min(...pz)
+  const span = Math.max(Math.max(...px) - lo, Math.max(...pz) - loZ)
   const scale = 900 / span
-  const out = {}
-  for (const n of NODE_NAMES) {
-    out[n] = {
-      // screen y = z (flipped later if needed so staging sits at the bottom)
-      x: (SDE[n].x - minX) * scale,
-      y: (SDE[n].z - minZ) * scale,
-    }
+  return {
+    x: NODE_NAMES.map((n) => (SDE[n].x - lo) * scale),
+    y: NODE_NAMES.map((n) => (SDE[n].z - loZ) * scale),
   }
-  return out
 })()
 
-// Simulate.
-const pos = {}
-for (const n of NODE_NAMES) pos[n] = { x: projected[n].x, y: projected[n].y }
+const X = seedProjection.x.slice()
+const Y = seedProjection.y.slice()
 
-for (let iter = 0; iter < ITERATIONS; iter++) {
-  const temp = T0 * (1 - iter / ITERATIONS)
-  const disp = {}
-  for (const n of NODE_NAMES) disp[n] = { x: 0, y: 0 }
-
-  // Repulsion between every pair.
-  for (let i = 0; i < NODE_NAMES.length; i++) {
+// Do two edges (given as index pairs) properly cross? Segments sharing an
+// endpoint don't count.
+const ccw = (ax, ay, bx, by, cx, cy) => (cy - ay) * (bx - ax) - (by - ay) * (cx - ax)
+const segCross = (i1, j1, i2, j2) => {
+  if (i1 === i2 || i1 === j2 || j1 === i2 || j1 === j2) return false
+  const d1 = ccw(X[i1], Y[i1], X[j1], Y[j1], X[i2], Y[i2])
+  const d2 = ccw(X[i1], Y[i1], X[j1], Y[j1], X[j2], Y[j2])
+  const d3 = ccw(X[i2], Y[i2], X[j2], Y[j2], X[i1], Y[i1])
+  const d4 = ccw(X[i2], Y[i2], X[j2], Y[j2], X[j1], Y[j1])
+  return d1 > 0 !== d2 > 0 && d3 > 0 !== d4 > 0
+}
+const crossings = () => {
+  let c = 0
+  for (let a = 0; a < edges.length; a++)
+    for (let b = a + 1; b < edges.length; b++) if (segCross(edges[a][0], edges[a][1], edges[b][0], edges[b][1])) c++
+  return c
+}
+// Penalty for nodes closer than MIN_SEP (spacing) and for edges longer/shorter
+// than REST_LEN (compactness) — the tie-breakers once crossings are handled.
+const spacingPenalty = () => {
+  let p = 0
+  for (let i = 0; i < NODE_NAMES.length; i++)
     for (let j = i + 1; j < NODE_NAMES.length; j++) {
-      const a = NODE_NAMES[i]
-      const b = NODE_NAMES[j]
-      let dx = pos[a].x - pos[b].x
-      let dy = pos[a].y - pos[b].y
-      let d2 = dx * dx + dy * dy
-      if (d2 < 1) {
-        // Coincident: nudge deterministically so they separate.
-        dx = (i - j) * 0.01 + 0.1
-        dy = 0.1
-        d2 = dx * dx + dy * dy
-      }
-      const d = Math.sqrt(d2)
-      const f = K_REP / d2
-      const ux = dx / d
-      const uy = dy / d
-      disp[a].x += ux * f
-      disp[a].y += uy * f
-      disp[b].x -= ux * f
-      disp[b].y -= uy * f
+      const d = Math.hypot(X[i] - X[j], Y[i] - Y[j])
+      if (d < MIN_SEP) p += MIN_SEP - d
+    }
+  let e = 0
+  for (const [a, b] of edges) {
+    const diff = Math.hypot(X[a] - X[b], Y[a] - Y[b]) - REST_LEN
+    e += diff > 0 ? diff * diff * 0.02 : -diff * 0.4
+  }
+  return p * 14 + e
+}
+const cost = () => crossings() * 200000 + spacingPenalty()
+
+// Phase 1 — simulated annealing to a crossing-free embedding, restarted from the
+// seed with fresh randomness until it finds one (crossings dominate the cost).
+let best = null
+for (let restart = 0; restart < SA_RESTARTS; restart++) {
+  setSeed(1000 + restart * 7919)
+  for (let i = 0; i < NODE_NAMES.length; i++) {
+    X[i] = seedProjection.x[i]
+    Y[i] = seedProjection.y[i]
+  }
+  for (let it = 0; it < SA_ITERS; it++) {
+    const T = 90 * Math.pow(0.0002 / 90, it / SA_ITERS) // exp cool 90 → ~0
+    const k = (rnd() * NODE_NAMES.length) | 0
+    const ox = X[k]
+    const oy = Y[k]
+    const before = cost()
+    X[k] += (rnd() - 0.5) * T * 2
+    Y[k] += (rnd() - 0.5) * T * 2
+    const after = cost()
+    if (!(after <= before || rnd() < Math.exp((before - after) / (T + 1)))) {
+      X[k] = ox
+      Y[k] = oy
     }
   }
+  const cr = crossings()
+  const c = cost()
+  if (!best || cr < best.cr || (cr === best.cr && c < best.c)) best = { cr, c, X: X.slice(), Y: Y.slice() }
+  if (best.cr === 0) break
+}
+for (let i = 0; i < NODE_NAMES.length; i++) {
+  X[i] = best.X[i]
+  Y[i] = best.Y[i]
+}
 
-  // Spring attraction along links.
-  for (const [a, b] of edges) {
-    const dx = pos[b].x - pos[a].x
-    const dy = pos[b].y - pos[a].y
-    const d = Math.hypot(dx, dy) || 0.001
-    const f = K_SPRING * (d - REST_LEN)
-    const ux = dx / d
-    const uy = dy / d
-    disp[a].x += ux * f
-    disp[a].y += uy * f
-    disp[b].x -= ux * f
-    disp[b].y -= uy * f
-  }
+// Would moving node k leave any of its incident edges crossing another edge?
+const moveBreaksPlanarity = (k) => {
+  for (const ei of incident[k])
+    for (let ej = 0; ej < edges.length; ej++)
+      if (ej !== ei && segCross(edges[ei][0], edges[ei][1], edges[ej][0], edges[ej][1])) return true
+  return false
+}
 
-  // Weak anchor back to the true projected position — this is what keeps the
-  // layout faithful to the real star geography rather than a generic blob.
-  for (const n of NODE_NAMES) {
-    disp[n].x += (projected[n].x - pos[n].x) * K_ANCHOR
-    disp[n].y += (projected[n].y - pos[n].y) * K_ANCHOR
-  }
-
-  // Apply, capped by the cooling temperature.
-  for (const n of NODE_NAMES) {
-    const d = Math.hypot(disp[n].x, disp[n].y) || 0.001
-    const step = Math.min(d, temp)
-    pos[n].x += (disp[n].x / d) * step
-    pos[n].y += (disp[n].y / d) * step
+// Phase 2 — planarity-preserving force relaxation. Apply spring + repulsion
+// forces to even out spacing and shorten long edges, but reject any move that
+// would re-introduce a crossing.
+for (let pass = 0; pass < FDL_PASSES; pass++) {
+  const damp = 0.9 * (1 - pass / FDL_PASSES) + 0.1
+  for (let k = 0; k < NODE_NAMES.length; k++) {
+    let fx = 0
+    let fy = 0
+    for (let j = 0; j < NODE_NAMES.length; j++) {
+      if (j === k) continue
+      const dx = X[k] - X[j]
+      const dy = Y[k] - Y[j]
+      const d2 = dx * dx + dy * dy || 0.01
+      const d = Math.sqrt(d2)
+      const f = 42000 / d2
+      fx += (dx / d) * f
+      fy += (dy / d) * f
+    }
+    for (const ei of incident[k]) {
+      const other = edges[ei][0] === k ? edges[ei][1] : edges[ei][0]
+      const dx = X[other] - X[k]
+      const dy = Y[other] - Y[k]
+      const d = Math.hypot(dx, dy) || 0.01
+      const f = 0.05 * (d - REST_LEN)
+      fx += (dx / d) * f
+      fy += (dy / d) * f
+    }
+    const mag = Math.hypot(fx, fy) || 0.01
+    const step = Math.min(mag, 30) * damp
+    const ox = X[k]
+    const oy = Y[k]
+    X[k] += (fx / mag) * step
+    Y[k] += (fy / mag) * step
+    if (moveBreaksPlanarity(k)) {
+      X[k] = ox
+      Y[k] = oy
+    }
   }
 }
+
+// Assemble into a name→position map for the finishing steps below.
+const pos = {}
+for (let i = 0; i < NODE_NAMES.length; i++) pos[NODE_NAMES[i]] = { x: X[i], y: Y[i] }
 
 // Orient so the staging system sits at the bottom (largest screen y), matching
 // the page's "staging anchors the bottom" convention.
@@ -202,10 +277,8 @@ if (pos[STAGING].y < midY) {
 
 // Fit to a padded integer viewBox and round positions.
 const PAD = 100
-const xs = NODE_NAMES.map((n) => pos[n].x)
-const yy = NODE_NAMES.map((n) => pos[n].y)
-const minX = Math.min(...xs)
-const minY = Math.min(...yy)
+const minX = Math.min(...NODE_NAMES.map((n) => pos[n].x))
+const minY = Math.min(...NODE_NAMES.map((n) => pos[n].y))
 for (const n of NODE_NAMES) {
   pos[n].x = Math.round(pos[n].x - minX + PAD)
   pos[n].y = Math.round(pos[n].y - minY + PAD)
@@ -213,7 +286,7 @@ for (const n of NODE_NAMES) {
 const w = Math.round(Math.max(...NODE_NAMES.map((n) => pos[n].x)) + PAD)
 const h = Math.round(Math.max(...NODE_NAMES.map((n) => pos[n].y)) + PAD)
 
-// Report closest pair (sanity check on overlaps).
+// Report crossing count + closest pair (sanity check).
 let closest = Infinity
 let closestPair = ''
 for (let i = 0; i < NODE_NAMES.length; i++) {
@@ -225,6 +298,7 @@ for (let i = 0; i < NODE_NAMES.length; i++) {
     }
   }
 }
+console.error(`crossings: ${crossings()}`)
 
 // Emit the NODE_POSITIONS block, ordered to match the current file's ordering.
 const ORDER = [

--- a/src/app/mercenary-dens/data.ts
+++ b/src/app/mercenary-dens/data.ts
@@ -101,60 +101,61 @@ export const TEMPERATE_PLANETS: TemperatePlanet[] = [
 // Fixed 2-D layout for the topology graph, in the SVG's own coordinate space
 // (see topology.tsx's viewBox — kept in sync with NODE_VIEWBOX below). Rather
 // than hand-place each node, this is derived from CCP's real universe geometry
-// and then relaxed for legibility:
+// and then untangled into a clean, crossing-free drawing:
 //
-//   1. Start from each system's true 3-D position in the SDE (position.x/y/z),
+//   1. Seed from each system's true 3-D position in the SDE (position.x/y/z),
 //      projected onto the EVE galaxy-map plane (x, z) — the same top-down plane
 //      the in-game star map uses (y is galactic "up" and is dropped).
-//   2. Relax with a force-directed pass — pairwise repulsion so crowded systems
-//      stop overlapping, edge springs so linked systems stay a readable distance
-//      apart, and a weak anchor back to the true projected position so the map
-//      keeps its real geography instead of drifting into a generic graph blob.
+//   2. Simulated annealing to a planar (zero edge-crossing) embedding, then a
+//      planarity-preserving force relaxation to even out spacing and shorten
+//      long edges without ever re-introducing a crossing.
 //
-// Because the system list is a fixed, hand-maintained set, the positions are
-// baked here rather than recomputed at request time. The generator lives at
-// scripts/mercenaryDenLayout.mjs (raw SDE coordinates embedded, deterministic,
-// no network) — when a system is added to/removed from LINKS, add its SDE
-// coordinates there and re-run it to regenerate this block and NODE_VIEWBOX.
+// So no two links cross, while the layout still broadly follows real geography
+// (the annealer starts from the SDE projection). Because the system list is a
+// fixed, hand-maintained set, the positions are baked here rather than recomputed
+// at request time. The generator lives at scripts/mercenaryDenLayout.mjs (raw SDE
+// coordinates embedded, seeded PRNG, deterministic, no network) — when a system
+// is added to/removed from LINKS, add its SDE coordinates there and re-run it to
+// regenerate this block and NODE_VIEWBOX.
 export const NODE_POSITIONS: Record<string, { x: number; y: number }> = {
-  'JVA-FE': { x: 221, y: 501 },
-  'RXA-W1': { x: 145, y: 738 },
-  'X1-IZ0': { x: 100, y: 974 },
-  '8P-LKL': { x: 354, y: 329 },
-  'QFU-4S': { x: 383, y: 455 },
-  'VK6-EZ': { x: 278, y: 393 },
-  'QQGH-G': { x: 495, y: 374 },
-  'L-WG68': { x: 278, y: 605 },
-  'Q-UVY6': { x: 244, y: 218 },
-  'G-VFVB': { x: 561, y: 206 },
-  'VX1-HV': { x: 640, y: 552 },
-  'HIK-MC': { x: 431, y: 727 },
-  'GZM-KB': { x: 108, y: 589 },
-  'KPI-OW': { x: 347, y: 100 },
-  'K-XJJT': { x: 708, y: 388 },
-  'JNG7-K': { x: 758, y: 768 },
-  'FO1U-K': { x: 566, y: 775 },
-  'Y4OK-W': { x: 391, y: 885 },
-  '5LAJ-8': { x: 647, y: 715 },
-  'E4-E8W': { x: 566, y: 629 },
-  'P-NI4K': { x: 760, y: 245 },
-  '8-SPNN': { x: 787, y: 969 },
-  '6U-1RX': { x: 530, y: 930 },
-  'B9EA-G': { x: 765, y: 612 },
-  'E-BFLT': { x: 436, y: 597 },
-  'GF-GR7': { x: 936, y: 567 },
-  'HPMN-V': { x: 1062, y: 485 },
-  'Z19-B8': { x: 952, y: 398 },
-  'DVN6-0': { x: 1033, y: 712 },
-  'XR-ZL7': { x: 1093, y: 345 },
-  'U1-VHY': { x: 1167, y: 645 },
-  '8OYE-Z': { x: 1108, y: 870 },
-  'XUPK-Z': { x: 1238, y: 282 },
+  'JVA-FE': { x: 372, y: 1262 },
+  'RXA-W1': { x: 209, y: 1421 },
+  'X1-IZ0': { x: 100, y: 1586 },
+  '8P-LKL': { x: 519, y: 1395 },
+  'QFU-4S': { x: 540, y: 1239 },
+  'VK6-EZ': { x: 521, y: 1055 },
+  'QQGH-G': { x: 705, y: 1293 },
+  'L-WG68': { x: 630, y: 777 },
+  'Q-UVY6': { x: 307, y: 958 },
+  'G-VFVB': { x: 727, y: 1498 },
+  'VX1-HV': { x: 980, y: 1381 },
+  'HIK-MC': { x: 852, y: 597 },
+  'GZM-KB': { x: 493, y: 623 },
+  'KPI-OW': { x: 118, y: 883 },
+  'K-XJJT': { x: 1069, y: 1595 },
+  'JNG7-K': { x: 1212, y: 1405 },
+  'FO1U-K': { x: 1030, y: 1177 },
+  'Y4OK-W': { x: 922, y: 787 },
+  '5LAJ-8': { x: 982, y: 392 },
+  'E4-E8W': { x: 1064, y: 518 },
+  'P-NI4K': { x: 1174, y: 1767 },
+  '8-SPNN': { x: 1412, y: 1436 },
+  '6U-1RX': { x: 1003, y: 975 },
+  'B9EA-G': { x: 1220, y: 372 },
+  'E-BFLT': { x: 1214, y: 625 },
+  'GF-GR7': { x: 1494, y: 357 },
+  'HPMN-V': { x: 1597, y: 164 },
+  'Z19-B8': { x: 1694, y: 300 },
+  'DVN6-0': { x: 1635, y: 553 },
+  'XR-ZL7': { x: 1800, y: 142 },
+  'U1-VHY': { x: 1639, y: 751 },
+  '8OYE-Z': { x: 1823, y: 634 },
+  'XUPK-Z': { x: 1993, y: 100 },
 }
 
 // SVG viewBox that frames NODE_POSITIONS with padding — regenerated alongside
 // the positions above by scripts/mercenaryDenLayout.mjs.
-export const NODE_VIEWBOX = '0 0 1338 1074'
+export const NODE_VIEWBOX = '0 0 2093 1867'
 
 // Temperate-planet count per system, shown as the 🌍 badge under each node's
 // name on the topology. Derived from TEMPERATE_PLANETS so the badge can never

--- a/src/app/mercenary-dens/topology.tsx
+++ b/src/app/mercenary-dens/topology.tsx
@@ -23,7 +23,7 @@ const COLOR_CLASS: Record<NodeColor, string> = {
 }
 
 // A network diagram of the systems reachable out from staging. Pure SVG with a
-// fixed layout derived from real SDE geometry then force-relaxed (see
+// fixed, crossing-free layout derived from real SDE geometry then untangled (see
 // NODE_POSITIONS) — no interactivity — so it renders on the server and scales to
 // the container width. Each system node is
 // tinted by the most severe den status among its temperate planets (red


### PR DESCRIPTION
## What

Follow-up to #681. That layout derived node positions from real SDE geometry and relaxed them with a force-directed pass, but the relaxation still left some links crossing. This makes the map **crossing-free**: no two edges intersect.

## How

The generator (`scripts/mercenaryDenLayout.mjs`) now untangles the graph in two phases instead of a single force pass:

1. **Seed** from each system's true SDE position (`position.x`/`z`) projected onto the EVE galaxy-map plane — same as before, so the layout still broadly follows real geography.
2. **Simulated annealing to a planar embedding** — edge crossings are penalised far above spacing/edge-length, and the anneal is restarted from the seed with fresh randomness until it finds a layout with zero crossings (the graph is planar, so one exists).
3. **Planarity-preserving force relaxation** — spring + repulsion forces even out spacing and shorten long edges, but any node move that would re-introduce a crossing is rejected, so the tidy-up never re-tangles the graph.

A seeded PRNG (mulberry32) keeps the whole thing deterministic and reproducible.

## Changes

- `scripts/mercenaryDenLayout.mjs` — replaced the single force pass with the annealing + planarity-preserving relaxation described above.
- `src/app/mercenary-dens/data.ts` — regenerated `NODE_POSITIONS` and `NODE_VIEWBOX`.
- `src/app/mercenary-dens/topology.tsx` — updated the layout comment.

## Verification

- Generator reports `crossings: 0`; closest node pair ≈ 150px (no overlaps).
- Rendered the baked positions to confirm no two links cross.
- `pnpm run lint` passes; `tsc --noEmit` reports no errors in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GMK6SLbmNMBjMNa7q3X7a

---
_Generated by [Claude Code](https://claude.ai/code/session_014GMK6SLbmNMBjMNa7q3X7a)_