### PR TITLE
Double the mercenary-dens map node size for legibility

### DIFF
--- a/src/app/mercenary-dens/mercenaryDens.module.css
+++ b/src/app/mercenary-dens/mercenaryDens.module.css
@@ -81,7 +81,7 @@
 .nodeLabel {
   fill: var(--ink);
   font-family: var(--mono);
-  font-size: 11px;
+  font-size: 22px;
 }
 
 /* Second line inside a node's circle: one globe per temperate planet. Sized so
@@ -89,7 +89,7 @@
 .nodeCount {
   fill: var(--ink-soft);
   font-family: var(--mono);
-  font-size: 9px;
+  font-size: 18px;
 }
 
 /* The staging system stands apart with the indigo accent. */

--- a/src/app/mercenary-dens/topology.tsx
+++ b/src/app/mercenary-dens/topology.tsx
@@ -5,9 +5,10 @@ export type NodeColor = 'red' | 'yellow' | 'green'
 
 // Circle radius for each system node, in SVG user units. A system with
 // temperate planets gets the larger circle to fit its row of globes on a
-// second line.
-const NODE_R = 24
-const NODE_R_BADGE = 30
+// second line. Sized relative to the NODE_POSITIONS coordinate space (see
+// NODE_VIEWBOX) so the labels stay legible when the SVG scales to fit.
+const NODE_R = 48
+const NODE_R_BADGE = 60
 
 // One globe per temperate planet, all showing the same face of the earth for a
 // given system — which face is a hash of the system name, so it's stable
@@ -66,7 +67,7 @@ export const Topology = ({
           <circle cx={x} cy={y} r={r} className={styles.nodeBox} />
           <text
             x={x}
-            y={temperate > 0 ? y - 8 : y}
+            y={temperate > 0 ? y - 16 : y}
             className={styles.nodeLabel}
             textAnchor="middle"
             dominantBaseline="central"
@@ -74,7 +75,7 @@ export const Topology = ({
             {system}
           </text>
           {temperate > 0 ? (
-            <text x={x} y={y + 10} className={styles.nodeCount} textAnchor="middle" dominantBaseline="central">
+            <text x={x} y={y + 20} className={styles.nodeCount} textAnchor="middle" dominantBaseline="central">
               {globeFor(system).repeat(temperate)}
             </text>
           ) : null}


### PR DESCRIPTION
## What

Follow-up to #682. The crossing-free layout renders in a larger coordinate space (viewBox ~2093 wide), so the fixed-radius node circles and their labels ended up too small to read once the SVG scales down to fit the page. This doubles the node size so the labels are legible again.

## How

- `src/app/mercenary-dens/topology.tsx` — node radii `NODE_R` 24 → 48 and `NODE_R_BADGE` 30 → 60; the two-line (badge) label offsets doubled to match (`y-8`/`y+10` → `y-16`/`y+20`).
- `src/app/mercenary-dens/mercenaryDens.module.css` — in-circle `.nodeLabel` font-size 11 → 22px and `.nodeCount` (globe row) 9 → 18px.

The node positions and viewBox are unchanged, so the layout stays crossing-free. Circles don't overlap (minimum gap between circle edges ≈ 37 units), and the globe rows still fit inside the larger badge circles.

## Verification

- Rendered the map from the baked positions at the new sizes to confirm labels are readable and no circles overlap or collide.
- `pnpm run lint` passes; `tsc --noEmit` reports no errors in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GMK6SLbmNMBjMNa7q3X7a

---
_Generated by [Claude Code](https://claude.ai/code/session_014GMK6SLbmNMBjMNa7q3X7a)_