### PR TITLE
Move structure profile_id into own-corp-only corp_structure_status

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1584,7 +1584,6 @@ create table public.corp_structure (
   corporation_id bigint not null,
   type_id bigint not null,
   system_id bigint not null,
-  profile_id bigint,
   name text,
   state text,
   unanchors_at timestamptz,
@@ -1613,8 +1612,8 @@ create policy "Users read structures for own corps"
 -- Open corp_structure viewing to alliance-mates: a structure whose owning
 -- corporation's alliance is one of the alliances the caller's own characters'
 -- corporations belong to. Additive/permissive — OR'd with the own-corps policy
--- above. Fuel stays private: it lives in corp_structure_status (below), which
--- keeps the own-corps-only policy.
+-- above. Fuel and the reinforcement profile stay private: they live in
+-- corp_structure_status (below), which keeps the own-corps-only policy.
 create policy "Alliance members read corp structures"
   on public.corp_structure
   for select
@@ -1639,13 +1638,14 @@ grant select on public.corp_structure to authenticated;
 grant all    on public.corp_structure to service_role;
 
 -- ── corp_structure_status ──────────────────────────────────────────────────
--- The volatile fuel timer, split off corp_structure so it can stay own-corp
--- only while corp_structure opens up to alliance-mates. One row per structure,
--- pointing back to it.
+-- The private per-structure state — fuel timer and reinforcement profile — split
+-- off corp_structure so it can stay own-corp only while corp_structure opens up
+-- to alliance-mates. One row per structure, pointing back to it.
 create table public.corp_structure_status (
   structure_id bigint primary key references public.corp_structure (structure_id) on delete cascade,
   corporation_id bigint not null,
   fuel_expires timestamptz,
+  profile_id bigint,
   updated_at timestamptz not null default now()
 );
 create index corp_structure_status_corporation_id_idx on public.corp_structure_status (corporation_id);

--- a/src/app/structure/[structureId]/page.tsx
+++ b/src/app/structure/[structureId]/page.tsx
@@ -78,7 +78,7 @@ const StructurePage = async ({ params }: StructureParams) => {
     ? await supabase
         .from('corp_structure')
         .select(
-          'structure_id, corporation_id, type_id, system_id, profile_id, name, state, unanchors_at, reinforce_hour, next_reinforce_hour, next_reinforce_apply, next_reinforce_weekday, services, last_seen_at, updated_at'
+          'structure_id, corporation_id, type_id, system_id, name, state, unanchors_at, reinforce_hour, next_reinforce_hour, next_reinforce_apply, next_reinforce_weekday, services, last_seen_at, updated_at'
         )
         .eq('structure_id', structureId)
         .maybeSingle()
@@ -98,15 +98,16 @@ const StructurePage = async ({ params }: StructureParams) => {
 
   const s = structure as Structure
 
-  // Fuel timer lives in corp_structure_status now (own-corp only). RLS returns a
-  // row only if the caller's corp owns this structure — an alliance-mate viewing
-  // it via corp_structure sees no fuel.
+  // Fuel timer and reinforcement profile live in corp_structure_status now
+  // (own-corp only). RLS returns a row only if the caller's corp owns this
+  // structure — an alliance-mate viewing it via corp_structure sees neither.
   const { data: statusRow } = await supabase
     .from('corp_structure_status')
-    .select('fuel_expires')
+    .select('fuel_expires, profile_id')
     .eq('structure_id', structureId)
-    .maybeSingle<{ fuel_expires: string | null }>()
+    .maybeSingle<{ fuel_expires: string | null; profile_id: number | null }>()
   s.fuel_expires = statusRow?.fuel_expires ?? null
+  s.profile_id = statusRow?.profile_id ?? null
 
   const { data: jobsData } = await supabase
     .from('character_industry_job')

--- a/src/jobs/corpStructures.js
+++ b/src/jobs/corpStructures.js
@@ -18,7 +18,6 @@ export const runCorpStructures = ({ characterIds } = {}) =>
       corporation_id: s.corporation_id,
       type_id: s.type_id,
       system_id: s.system_id,
-      profile_id: s.profile_id ?? null,
       name: s.name ?? null,
       state: s.state ?? null,
       unanchors_at: s.unanchors_at ?? null,
@@ -31,13 +30,14 @@ export const runCorpStructures = ({ characterIds } = {}) =>
       updated_at: now,
     }))
 
-    // fuel_expires lives in corp_structure_status now (own-corp-only, while
-    // corp_structure opens to alliance-mates). Upsert the structures first — the
-    // status table's FK points back at them.
+    // fuel_expires and profile_id live in corp_structure_status now (own-corp-only,
+    // while corp_structure opens to alliance-mates). Upsert the structures first —
+    // the status table's FK points back at them.
     const statusRows = all.map((s) => ({
       structure_id: s.structure_id,
       corporation_id: s.corporation_id,
       fuel_expires: s.fuel_expires ?? null,
+      profile_id: s.profile_id ?? null,
       updated_at: now,
     }))
 

--- a/supabase/migrations/20260721030000_move_profile_id_to_status.sql
+++ b/supabase/migrations/20260721030000_move_profile_id_to_status.sql
@@ -1,0 +1,14 @@
+-- Move profile_id off corp_structure into the own-corp-only corp_structure_status
+-- table, exactly like fuel_expires was split out (20260720060000). corp_structure
+-- itself is readable by alliance-mates, but a structure's reinforcement profile is
+-- private intel that shouldn't leak past the owning corp — parking it in
+-- corp_structure_status keeps it behind that table's own-corps-only RLS policy.
+alter table public.corp_structure_status add column if not exists profile_id bigint;
+
+-- Backfill from corp_structure before dropping the column there.
+update public.corp_structure_status s
+  set profile_id = c.profile_id
+  from public.corp_structure c
+  where c.structure_id = s.structure_id;
+
+alter table public.corp_structure drop column if exists profile_id;


### PR DESCRIPTION
## What & why

`corp_structure` is now readable by alliance-mates, but a structure's reinforcement **profile** is private intel that shouldn't leak past the owning corp. This moves `profile_id` off `corp_structure` and into `corp_structure_status` — the same own-corp-only table `fuel_expires` was split into (#20260720060000) for exactly this reason — so it stays behind that table's own-corps-only RLS policy.

In short: the profile moves to where fuel lives, and stays hidden from anyone outside the owning corp.

## Changes

- **Migration** `20260721030000_move_profile_id_to_status.sql` — adds `profile_id` to `corp_structure_status`, backfills it from `corp_structure`, then drops the column there. `schema.sql` (full-reset source of truth) updated to match.
- **Extract job** (`corpStructures.js`) — `profile_id` now written in the `corp_structure_status` upsert instead of the `corp_structure` upsert.
- **Structure detail page** — reads `profile_id` from `corp_structure_status` alongside `fuel_expires`. The owner still sees the value; an alliance-mate viewing a structure they don't own sees `—` for both (RLS returns no status row), consistent with how fuel already behaves.

No consumer other than the detail page referenced `profile_id` (the structures list page never selected it).

## Verification

- `pnpm run lint` ✅ and `pnpm run build` ✅.
- The migration mirrors the fuel split: add column → backfill → drop old column, all idempotent (`if not exists` / `if exists`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQ7tHq1sTBaynBFrerxo1K)_