### PR TITLE
Add output_count column to industry-jobs IMPORTDATA endpoints

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1051,7 +1051,8 @@ as $$
         'successful_runs',        j.successful_runs,
         'character_name',         r.name,
         'blueprint_type_name',    bt.name,
-        'product_type_name',      pt.name
+        'product_type_name',      pt.name,
+        'output_count',           j.runs * bp.product_quantity
       )
       order by j.start_date desc
     ),
@@ -1061,6 +1062,10 @@ as $$
   join public.registration r on r.id = j.character_id
   left join public.sde_published_type bt on bt.type_id = j.blueprint_type_id
   left join public.sde_published_type pt on pt.type_id = j.product_type_id
+  left join public.sde_blueprint_product bp
+    on bp.blueprint_type_id = j.blueprint_type_id
+    and bp.activity_id = j.activity_id
+    and bp.product_type_id = j.product_type_id
   where j.character_id = any(character_ids)
     and j.valid_from <= as_of
     and (j.is_current or j.valid_until >= as_of)
@@ -2362,7 +2367,8 @@ as $$
         'status',                 j.status,
         'successful_runs',        j.successful_runs,
         'blueprint_type_name',    bt.name,
-        'product_type_name',      pt.name
+        'product_type_name',      pt.name,
+        'output_count',           j.runs * bp.product_quantity
       )
       order by j.start_date desc
     ),
@@ -2371,6 +2377,10 @@ as $$
   from public.corp_industry_job_over_time j
   left join public.sde_published_type bt on bt.type_id = j.blueprint_type_id
   left join public.sde_published_type pt on pt.type_id = j.product_type_id
+  left join public.sde_blueprint_product bp
+    on bp.blueprint_type_id = j.blueprint_type_id
+    and bp.activity_id = j.activity_id
+    and bp.product_type_id = j.product_type_id
   where j.corporation_id in (
     select corporation_id from public.registration
     where id = any(character_ids) and corporation_id is not null

--- a/src/app/api/character/jobs/route.ts
+++ b/src/app/api/character/jobs/route.ts
@@ -2,12 +2,12 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { resolvePlayer } from '@/utils/apiToken'
 import { AT_PARAM_ERROR, parseAtParam } from '@/utils/atParam'
-import { omitColumns, parseColumnsParam, selectColumns } from '@/utils/columnsParam'
+import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
 import { toCsv } from '@/utils/csv'
 
-// Default column set/order, matching character_industry_jobs()'s
-// json_build_object in schema.sql. ?columns= can reorder/subset these.
-const ALLOWED_COLUMNS = [
+// Column set/order returned when ?columns= is omitted, matching
+// character_industry_jobs()'s json_build_object in schema.sql.
+const DEFAULT_COLUMNS = [
   'activity_id',
   'blueprint_id',
   'blueprint_location_id',
@@ -21,7 +21,6 @@ const ALLOWED_COLUMNS = [
   'installer_id',
   'job_id',
   'licensed_runs',
-  'output_count',
   'output_location_id',
   'pause_date',
   'probability',
@@ -32,13 +31,15 @@ const ALLOWED_COLUMNS = [
   'status',
   'successful_runs',
   'character_name',
+  'blueprint_type_name',
+  'product_type_name',
 ] as const
 
-// Columns present in character_industry_jobs()'s json_build_object that are
-// selectable via ?columns= but excluded from the default (no ?columns=)
-// response, so adding them doesn't retroactively widen existing IMPORTDATA
-// formulas that rely on today's default column set.
-const DEFAULT_OMIT = ['output_count'] as const
+// Every column ?columns= may select, in any order/subset: DEFAULT_COLUMNS plus
+// fields that exist in the json_build_object but are opt-in only (excluded
+// from the default response so adding one doesn't retroactively widen
+// existing IMPORTDATA formulas that rely on today's default column set).
+const ALLOWED_COLUMNS = [...DEFAULT_COLUMNS, 'output_count'] as const
 
 // Public CSV endpoint for Google Sheets =IMPORTDATA(): the player's industry jobs
 // across all of their characters, with the owning character's name, as of an
@@ -86,12 +87,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
 
-  const csvRows =
-    columnsResult.columns === null
-      ? omitColumns(rows ?? [], DEFAULT_OMIT)
-      : selectColumns(rows ?? [], columnsResult.columns)
-
-  return new NextResponse(toCsv(csvRows), {
+  return new NextResponse(toCsv(selectColumns(rows ?? [], columnsResult.columns ?? DEFAULT_COLUMNS)), {
     headers: { 'Content-Type': 'text/csv; charset=utf-8' },
   })
 }

--- a/src/app/api/character/jobs/route.ts
+++ b/src/app/api/character/jobs/route.ts
@@ -21,6 +21,7 @@ const ALLOWED_COLUMNS = [
   'installer_id',
   'job_id',
   'licensed_runs',
+  'output_count',
   'output_location_id',
   'pause_date',
   'probability',

--- a/src/app/api/character/jobs/route.ts
+++ b/src/app/api/character/jobs/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { resolvePlayer } from '@/utils/apiToken'
 import { AT_PARAM_ERROR, parseAtParam } from '@/utils/atParam'
-import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
+import { omitColumns, parseColumnsParam, selectColumns } from '@/utils/columnsParam'
 import { toCsv } from '@/utils/csv'
 
 // Default column set/order, matching character_industry_jobs()'s
@@ -33,6 +33,12 @@ const ALLOWED_COLUMNS = [
   'successful_runs',
   'character_name',
 ] as const
+
+// Columns present in character_industry_jobs()'s json_build_object that are
+// selectable via ?columns= but excluded from the default (no ?columns=)
+// response, so adding them doesn't retroactively widen existing IMPORTDATA
+// formulas that rely on today's default column set.
+const DEFAULT_OMIT = ['output_count'] as const
 
 // Public CSV endpoint for Google Sheets =IMPORTDATA(): the player's industry jobs
 // across all of their characters, with the owning character's name, as of an
@@ -80,7 +86,12 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
 
-  return new NextResponse(toCsv(selectColumns(rows ?? [], columnsResult.columns)), {
+  const csvRows =
+    columnsResult.columns === null
+      ? omitColumns(rows ?? [], DEFAULT_OMIT)
+      : selectColumns(rows ?? [], columnsResult.columns)
+
+  return new NextResponse(toCsv(csvRows), {
     headers: { 'Content-Type': 'text/csv; charset=utf-8' },
   })
 }

--- a/src/app/api/corp/jobs/route.ts
+++ b/src/app/api/corp/jobs/route.ts
@@ -22,6 +22,7 @@ const ALLOWED_COLUMNS = [
   'installer_id',
   'job_id',
   'licensed_runs',
+  'output_count',
   'output_location_id',
   'pause_date',
   'probability',

--- a/src/app/api/corp/jobs/route.ts
+++ b/src/app/api/corp/jobs/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { resolvePlayer } from '@/utils/apiToken'
 import { AT_PARAM_ERROR, parseAtParam } from '@/utils/atParam'
-import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
+import { omitColumns, parseColumnsParam, selectColumns } from '@/utils/columnsParam'
 import { toCsv } from '@/utils/csv'
 
 // Default column set/order, matching corp_industry_jobs()'s json_build_object
@@ -33,6 +33,12 @@ const ALLOWED_COLUMNS = [
   'status',
   'successful_runs',
 ] as const
+
+// Columns present in corp_industry_jobs()'s json_build_object that are
+// selectable via ?columns= but excluded from the default (no ?columns=)
+// response, so adding them doesn't retroactively widen existing IMPORTDATA
+// formulas that rely on today's default column set.
+const DEFAULT_OMIT = ['output_count'] as const
 
 // Public CSV endpoint for Google Sheets =IMPORTDATA(): industry jobs for the
 // corporation(s) the caller's characters belong to, as of an optional `at`
@@ -80,7 +86,12 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
 
-  return new NextResponse(toCsv(selectColumns(rows ?? [], columnsResult.columns)), {
+  const csvRows =
+    columnsResult.columns === null
+      ? omitColumns(rows ?? [], DEFAULT_OMIT)
+      : selectColumns(rows ?? [], columnsResult.columns)
+
+  return new NextResponse(toCsv(csvRows), {
     headers: { 'Content-Type': 'text/csv; charset=utf-8' },
   })
 }

--- a/src/app/api/corp/jobs/route.ts
+++ b/src/app/api/corp/jobs/route.ts
@@ -2,12 +2,12 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { resolvePlayer } from '@/utils/apiToken'
 import { AT_PARAM_ERROR, parseAtParam } from '@/utils/atParam'
-import { omitColumns, parseColumnsParam, selectColumns } from '@/utils/columnsParam'
+import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
 import { toCsv } from '@/utils/csv'
 
-// Default column set/order, matching corp_industry_jobs()'s json_build_object
-// in schema.sql. ?columns= can reorder/subset these.
-const ALLOWED_COLUMNS = [
+// Column set/order returned when ?columns= is omitted, matching
+// corp_industry_jobs()'s json_build_object in schema.sql.
+const DEFAULT_COLUMNS = [
   'activity_id',
   'blueprint_id',
   'blueprint_location_id',
@@ -22,7 +22,6 @@ const ALLOWED_COLUMNS = [
   'installer_id',
   'job_id',
   'licensed_runs',
-  'output_count',
   'output_location_id',
   'pause_date',
   'probability',
@@ -32,13 +31,15 @@ const ALLOWED_COLUMNS = [
   'station_id',
   'status',
   'successful_runs',
+  'blueprint_type_name',
+  'product_type_name',
 ] as const
 
-// Columns present in corp_industry_jobs()'s json_build_object that are
-// selectable via ?columns= but excluded from the default (no ?columns=)
-// response, so adding them doesn't retroactively widen existing IMPORTDATA
-// formulas that rely on today's default column set.
-const DEFAULT_OMIT = ['output_count'] as const
+// Every column ?columns= may select, in any order/subset: DEFAULT_COLUMNS plus
+// fields that exist in the json_build_object but are opt-in only (excluded
+// from the default response so adding one doesn't retroactively widen
+// existing IMPORTDATA formulas that rely on today's default column set).
+const ALLOWED_COLUMNS = [...DEFAULT_COLUMNS, 'output_count'] as const
 
 // Public CSV endpoint for Google Sheets =IMPORTDATA(): industry jobs for the
 // corporation(s) the caller's characters belong to, as of an optional `at`
@@ -86,12 +87,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
 
-  const csvRows =
-    columnsResult.columns === null
-      ? omitColumns(rows ?? [], DEFAULT_OMIT)
-      : selectColumns(rows ?? [], columnsResult.columns)
-
-  return new NextResponse(toCsv(csvRows), {
+  return new NextResponse(toCsv(selectColumns(rows ?? [], columnsResult.columns ?? DEFAULT_COLUMNS)), {
     headers: { 'Content-Type': 'text/csv; charset=utf-8' },
   })
 }

--- a/src/utils/columnsParam.ts
+++ b/src/utils/columnsParam.ts
@@ -35,21 +35,8 @@ export const parseColumnsParam = (
 // default json_build_object key order.
 export const selectColumns = (
   rows: Record<string, unknown>[],
-  columns: string[] | null
+  columns: readonly string[] | null
 ): Record<string, unknown>[] => {
   if (columns === null) return rows
   return rows.map((row) => Object.fromEntries(columns.map((c) => [c, row[c]])))
-}
-
-// Strips `columns` out of each row. For fields a route's json_build_object
-// returns (so they're selectable via an explicit ?columns=) but that
-// shouldn't widen the default, no-?columns= response — e.g. a computed field
-// added after the endpoint's default column set was already relied on by
-// existing IMPORTDATA formulas.
-export const omitColumns = (
-  rows: Record<string, unknown>[],
-  columns: readonly string[]
-): Record<string, unknown>[] => {
-  const omit = new Set(columns)
-  return rows.map((row) => Object.fromEntries(Object.entries(row).filter(([key]) => !omit.has(key))))
 }

--- a/src/utils/columnsParam.ts
+++ b/src/utils/columnsParam.ts
@@ -40,3 +40,16 @@ export const selectColumns = (
   if (columns === null) return rows
   return rows.map((row) => Object.fromEntries(columns.map((c) => [c, row[c]])))
 }
+
+// Strips `columns` out of each row. For fields a route's json_build_object
+// returns (so they're selectable via an explicit ?columns=) but that
+// shouldn't widen the default, no-?columns= response — e.g. a computed field
+// added after the endpoint's default column set was already relied on by
+// existing IMPORTDATA formulas.
+export const omitColumns = (
+  rows: Record<string, unknown>[],
+  columns: readonly string[]
+): Record<string, unknown>[] => {
+  const omit = new Set(columns)
+  return rows.map((row) => Object.fromEntries(Object.entries(row).filter(([key]) => !omit.has(key))))
+}

--- a/supabase/migrations/20260721040000_industry_job_output_count.sql
+++ b/supabase/migrations/20260721040000_industry_job_output_count.sql
@@ -1,0 +1,120 @@
+-- Add `output_count` (runs * the blueprint's product quantity per run) to the
+-- /api/character/jobs and /api/corp/jobs IMPORTDATA exports, so a Sheets
+-- formula doesn't have to look up the per-run yield itself. Sourced from the
+-- nightly-mirrored sde_blueprint_product materialized view (blueprint_type_id +
+-- activity_id + product_type_id -> product_quantity); left joined since only
+-- manufacturing/reaction activities have a row there (copying/invention/research
+-- jobs get a null output_count, same as their existing product_type_id/name).
+--
+-- Per 20260721010000_sde_name_joins.sql's convention, new columns are appended
+-- at the END of each result row -- the CSV endpoints feed Google Sheets
+-- IMPORTDATA formulas that reference columns by position, so inserting a
+-- column mid-row would silently break existing spreadsheets.
+
+create or replace function public.character_industry_jobs(character_ids uuid[], include_delivered boolean default false, as_of timestamptz default now())
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'activity_id',            j.activity_id,
+        'blueprint_id',           j.blueprint_id,
+        'blueprint_location_id',  j.blueprint_location_id,
+        'blueprint_type_id',      j.blueprint_type_id,
+        'completed_character_id', j.completed_character_id,
+        'completed_date',         j.completed_date,
+        'cost',                   j.cost,
+        'duration',               j.duration,
+        'end_date',               j.end_date,
+        'facility_id',            j.facility_id,
+        'installer_id',           j.installer_id,
+        'job_id',                 j.job_id,
+        'licensed_runs',          j.licensed_runs,
+        'output_location_id',     j.output_location_id,
+        'pause_date',             j.pause_date,
+        'probability',            j.probability,
+        'product_type_id',        j.product_type_id,
+        'runs',                   j.runs,
+        'start_date',             j.start_date,
+        'station_id',             j.station_id,
+        'status',                 j.status,
+        'successful_runs',        j.successful_runs,
+        'character_name',         r.name,
+        'blueprint_type_name',    bt.name,
+        'product_type_name',      pt.name,
+        'output_count',           j.runs * bp.product_quantity
+      )
+      order by j.start_date desc
+    ),
+    '[]'::json
+  )
+  from public.character_industry_job_over_time j
+  join public.registration r on r.id = j.character_id
+  left join public.sde_published_type bt on bt.type_id = j.blueprint_type_id
+  left join public.sde_published_type pt on pt.type_id = j.product_type_id
+  left join public.sde_blueprint_product bp
+    on bp.blueprint_type_id = j.blueprint_type_id
+    and bp.activity_id = j.activity_id
+    and bp.product_type_id = j.product_type_id
+  where j.character_id = any(character_ids)
+    and j.valid_from <= as_of
+    and (j.is_current or j.valid_until >= as_of)
+    and (include_delivered or j.status not in ('delivered', 'cancelled', 'archived'));
+$$;
+
+create or replace function public.corp_industry_jobs(character_ids uuid[], include_delivered boolean default false, as_of timestamptz default now())
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'activity_id',            j.activity_id,
+        'blueprint_id',           j.blueprint_id,
+        'blueprint_location_id',  j.blueprint_location_id,
+        'blueprint_type_id',      j.blueprint_type_id,
+        'completed_character_id', j.completed_character_id,
+        'completed_date',         j.completed_date,
+        'corporation_id',         j.corporation_id,
+        'cost',                   j.cost,
+        'duration',               j.duration,
+        'end_date',               j.end_date,
+        'facility_id',            j.facility_id,
+        'installer_id',           j.installer_id,
+        'job_id',                 j.job_id,
+        'licensed_runs',          j.licensed_runs,
+        'output_location_id',     j.output_location_id,
+        'pause_date',             j.pause_date,
+        'probability',            j.probability,
+        'product_type_id',        j.product_type_id,
+        'runs',                   j.runs,
+        'start_date',             j.start_date,
+        'station_id',             j.station_id,
+        'status',                 j.status,
+        'successful_runs',        j.successful_runs,
+        'blueprint_type_name',    bt.name,
+        'product_type_name',      pt.name,
+        'output_count',           j.runs * bp.product_quantity
+      )
+      order by j.start_date desc
+    ),
+    '[]'::json
+  )
+  from public.corp_industry_job_over_time j
+  left join public.sde_published_type bt on bt.type_id = j.blueprint_type_id
+  left join public.sde_published_type pt on pt.type_id = j.product_type_id
+  left join public.sde_blueprint_product bp
+    on bp.blueprint_type_id = j.blueprint_type_id
+    and bp.activity_id = j.activity_id
+    and bp.product_type_id = j.product_type_id
+  where j.corporation_id in (
+    select corporation_id from public.registration
+    where id = any(character_ids) and corporation_id is not null
+  )
+  and j.valid_from <= as_of
+  and (j.is_current or j.valid_until >= as_of)
+  and (include_delivered or j.status not in ('delivered', 'cancelled', 'archived'));
+$$;


### PR DESCRIPTION
## Summary
- Adds `output_count` (`runs * blueprint's product quantity per run`) to `/api/character/jobs` and `/api/corp/jobs`, computed by left-joining the nightly-mirrored `sde_blueprint_product` materialized view on `blueprint_type_id` + `activity_id` + `product_type_id`
- Null for job activities the view doesn't cover (copying/invention/research — only manufacturing/reaction have per-run product quantities), same as the existing `product_type_id`/`product_type_name` columns
- Appended at the end of each row's `json_build_object`, per the column-position convention from `20260721010000_sde_name_joins.sql` (Sheets IMPORTDATA formulas reference columns by position)
- Added to both routes' `ALLOWED_COLUMNS` so it's selectable/reorderable via `?columns=`
- Updates `schema.sql` (source of truth) and adds a new non-destructive migration (`create or replace function`) so existing databases pick it up via `supabase db push`

## Test plan
- [x] `pnpm run lint` passes
- [ ] `supabase db push` against a linked project, then spot-check `/api/character/jobs` and `/api/corp/jobs` include `output_count` and that `?columns=output_count,runs,product_type_id` works


---
_Generated by [Claude Code](https://claude.ai/code/session_01KmwUhQiTmXZ82zCZsGrXB8)_