### PR TITLE
Add tax-revenue time-window dropdown to the structures page

### DIFF
--- a/src/app/structure/page.tsx
+++ b/src/app/structure/page.tsx
@@ -15,7 +15,27 @@ import {
 } from './industryIndex'
 import { StructureSilhouette } from './silhouette'
 import { Sparkline } from './sparkline'
+import { WindowSelect } from './windowSelect'
+import { structureWindowDays } from './windows'
 import styles from './structures.module.css'
+
+const PAGE_SIZE = 1000
+
+// Page through a select past PostgREST's max_rows (1000) cap until a short page
+// signals the end (cf. src/app/structure/revenue/page.tsx). The revenue footer
+// sums every tax entry in the window, so a busy corp can exceed one page.
+const fetchAllRows = async <T,>(
+  build: (from: number, to: number) => PromiseLike<{ data: T[] | null; error: unknown }>
+): Promise<T[]> => {
+  const rows: T[] = []
+  for (let from = 0; ; from += PAGE_SIZE) {
+    const { data, error } = await build(from, from + PAGE_SIZE - 1)
+    if (error || !data || data.length === 0) break
+    rows.push(...data)
+    if (data.length < PAGE_SIZE) break
+  }
+  return rows
+}
 
 type Structure = {
   structure_id: number
@@ -49,13 +69,24 @@ type RigRow = {
   type_id: number | string
 }
 
-const StructuresPage = async () => {
+type StructuresParams = {
+  searchParams: Promise<{ days?: string }>
+}
+
+const StructuresPage = async ({ searchParams }: StructuresParams) => {
   const supabase = await createClient()
 
   const { data: auth, error: authError } = await supabase.auth.getUser()
   if (authError || !auth?.user) {
     redirect('/')
   }
+
+  // The tax-revenue window: the footer (per-structure Revenue, unaccounted tax,
+  // clone revenue) sums only entries newer than this. Driven by the ?days=N
+  // dropdown, clamped to an offered option.
+  const { days: daysParam } = await searchParams
+  const windowDays = structureWindowDays(daysParam)
+  const windowStart = new Date(Date.now() - windowDays * 86_400_000).toISOString()
 
   const { data: structures } = await supabase
     .from('corp_structure')
@@ -140,10 +171,15 @@ const StructuresPage = async () => {
   )
   console.log({ indexHistoryBySystem })
 
-  const { data: journal } = await supabase
-    .from('corp_wallet_journal')
-    .select('amount, context_id, description, first_party_id')
-    .eq('ref_type', 'industry_job_tax')
+  const journal = await fetchAllRows<JournalRow>((from, to) =>
+    supabase
+      .from('corp_wallet_journal')
+      .select('amount, context_id, description, first_party_id')
+      .eq('ref_type', 'industry_job_tax')
+      .gte('date', windowStart)
+      .order('date', { ascending: false })
+      .range(from, to)
+  )
 
   const totalByStructure = new Map<string, number>()
   // Unaccounted tax broken down by the party that paid it (the character/corp that ran the job).
@@ -213,16 +249,19 @@ const StructuresPage = async () => {
     }
   }
 
-  // Revenue from structure clone bays (jump clone installation and activation fees).
-  const { data: cloneJournal } = await supabase
-    .from('corp_wallet_journal')
-    .select('amount')
-    .in('ref_type', ['jump_clone_installation_fee', 'jump_clone_activation_fee'])
-
-  const cloneRevenue = ((cloneJournal ?? []) as Array<{ amount: number | string | null }>).reduce(
-    (sum, entry) => sum + Number(entry.amount ?? 0),
-    0
+  // Revenue from structure clone bays (jump clone installation and activation
+  // fees), over the same window as the tax revenue above.
+  const cloneJournal = await fetchAllRows<{ amount: number | string | null }>((from, to) =>
+    supabase
+      .from('corp_wallet_journal')
+      .select('amount')
+      .in('ref_type', ['jump_clone_installation_fee', 'jump_clone_activation_fee'])
+      .gte('date', windowStart)
+      .order('date', { ascending: false })
+      .range(from, to)
   )
+
+  const cloneRevenue = cloneJournal.reduce((sum, entry) => sum + Number(entry.amount ?? 0), 0)
 
   // When the Structures background job last finished. Each scheduled run writes a
   // public.heartbeat row stamped with ended_at and a link to the workflow run; we
@@ -346,17 +385,27 @@ const StructuresPage = async () => {
           </ul>
 
           <div className={styles.footer}>
-            <span>Unaccounted tax revenue:</span>
-            <span className={styles.footerValue}>{formatIsk(unaccounted)}</span>
+            <span className={styles.footerControlLabel}>Revenue window</span>
+            <span className={styles.footerControl}>
+              <WindowSelect days={windowDays} />
+            </span>
+            {unaccountedParties.length > 0 && (
+              <>
+                <span>Unaccounted tax revenue:</span>
+                <span className={styles.footerValue}>{formatIsk(unaccounted)}</span>
+              </>
+            )}
             <span>Clone revenue:</span>
             <span className={styles.footerValue}>{formatKisk(cloneRevenue)}</span>
           </div>
-          <p className={styles.unaccountedNote}>
-            <em>
-              Unaccounted revenue comes from industry jobs started by players we can&rsquo;t see, so we can&rsquo;t tie
-              the tax back to one of our structures.
-            </em>
-          </p>
+          {unaccountedParties.length > 0 && (
+            <p className={styles.unaccountedNote}>
+              <em>
+                Unaccounted revenue comes from industry jobs started by players we can&rsquo;t see, so we can&rsquo;t tie
+                the tax back to one of our structures.
+              </em>
+            </p>
+          )}
           {unaccountedParties.length > 0 && (
             <details className={styles.breakdown}>
               <summary>Breakdown by payer ({unaccountedParties.length})</summary>

--- a/src/app/structure/page.tsx
+++ b/src/app/structure/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from 'next/navigation'
+import { concat } from 'ramda'
 
 import { createClient } from '@/utils/supabase/server'
 import { DateTime } from '../DateTime'
@@ -21,20 +22,20 @@ import styles from './structures.module.css'
 
 const PAGE_SIZE = 1000
 
-// Page through a select past PostgREST's max_rows (1000) cap until a short page
-// signals the end (cf. src/app/structure/revenue/page.tsx). The revenue footer
-// sums every tax entry in the window, so a busy corp can exceed one page.
+// Drain a PostgREST select past its max_rows (1000) cap by recursing to the
+// next page until a short (or empty/errored) page signals the end — an
+// unbounded pull written as tail recursion rather than a mutable loop, per the
+// house style (cf. src/app/structure/revenue/page.tsx). The revenue footer sums
+// every tax entry in the window, so a busy corp can exceed one page.
 const fetchAllRows = async <T,>(
-  build: (from: number, to: number) => PromiseLike<{ data: T[] | null; error: unknown }>
+  build: (from: number, to: number) => PromiseLike<{ data: T[] | null; error: unknown }>,
+  from = 0,
+  acc: readonly T[] = []
 ): Promise<T[]> => {
-  const rows: T[] = []
-  for (let from = 0; ; from += PAGE_SIZE) {
-    const { data, error } = await build(from, from + PAGE_SIZE - 1)
-    if (error || !data || data.length === 0) break
-    rows.push(...data)
-    if (data.length < PAGE_SIZE) break
-  }
-  return rows
+  const { data, error } = await build(from, from + PAGE_SIZE - 1)
+  if (error || !data || data.length === 0) return [...acc]
+  const rows = concat(acc, data)
+  return data.length < PAGE_SIZE ? rows : fetchAllRows(build, from + PAGE_SIZE, rows)
 }
 
 type Structure = {

--- a/src/app/structure/structures.module.css
+++ b/src/app/structure/structures.module.css
@@ -250,6 +250,7 @@
   grid-template-columns: auto auto;
   gap: 4px 12px;
   justify-content: start;
+  align-items: baseline;
   margin: 16px 0;
   font-size: 13px;
 }
@@ -258,6 +259,35 @@
   font-family: var(--mono);
   font-variant-numeric: tabular-nums;
   text-align: right;
+}
+
+.footerControlLabel {
+  color: var(--ink-faint);
+}
+
+.footerControl {
+  justify-self: start;
+}
+
+.windowSelect {
+  font-size: 10pt;
+  color: var(--ink-soft);
+}
+
+.windowSelect[data-pending] {
+  opacity: 0.6;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .unaccountedNote {

--- a/src/app/structure/windowSelect.tsx
+++ b/src/app/structure/windowSelect.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useTransition } from 'react'
+
+import { STRUCTURE_WINDOW_OPTIONS } from './windows'
+import styles from './structures.module.css'
+
+// The tax-revenue time-window dropdown shown in the Structures footer, next to
+// the unaccounted-revenue figure — the same control as the Market/Indexes
+// pages. The window lives in the URL (?days=N) so the server component refetches
+// exactly the span it needs.
+export const WindowSelect = ({ days }: { days: number }) => {
+  const router = useRouter()
+  const [pending, startTransition] = useTransition()
+
+  return (
+    <label className={styles.windowSelect} data-pending={pending || undefined}>
+      <span className={styles.srOnly}>Revenue window</span>
+      <select
+        value={days}
+        onChange={(e) => {
+          const next = Number(e.target.value)
+          startTransition(() => router.replace(`/structure?days=${next}`, { scroll: false }))
+        }}
+      >
+        {STRUCTURE_WINDOW_OPTIONS.map((o) => (
+          <option key={o.days} value={o.days}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+}

--- a/src/app/structure/windows.ts
+++ b/src/app/structure/windows.ts
@@ -1,0 +1,31 @@
+// The Structures page's tax-revenue time window, mirroring the Market/Indexes
+// page dropdowns. A single control (see WindowSelect) drives the revenue
+// footer: per-structure Revenue tiles, the unaccounted-tax figure, and the
+// clone revenue are all summed over the selected trailing window. The window
+// lives in the URL (?days=N) so the server component refetches exactly the span
+// it needs.
+export type StructureWindowOption = {
+  label: string
+  days: number
+}
+
+export const STRUCTURE_WINDOW_OPTIONS: StructureWindowOption[] = [
+  { label: '1 day', days: 1 },
+  { label: '3 days', days: 3 },
+  { label: '7 days', days: 7 },
+  { label: '14 days', days: 14 },
+  { label: '30 days', days: 30 },
+  { label: '90 days', days: 90 },
+]
+
+export const DEFAULT_STRUCTURE_WINDOW_DAYS = 30
+
+const fallback =
+  STRUCTURE_WINDOW_OPTIONS.find((o) => o.days === DEFAULT_STRUCTURE_WINDOW_DAYS) ?? STRUCTURE_WINDOW_OPTIONS[0]
+
+// Clamp an arbitrary ?days value to one of the offered options (defends the
+// server query against hand-edited URLs), returning the default otherwise.
+export const structureWindowDays = (raw: string | undefined): number => {
+  const n = Number(raw)
+  return STRUCTURE_WINDOW_OPTIONS.some((o) => o.days === n) ? n : fallback.days
+}


### PR DESCRIPTION
Adds a time-window dropdown to the `/structure` page, matching the Market/Indexes page controls, and gates the unaccounted-revenue section on there being anything to allocate.

## What changes

- **Window dropdown** (`1 / 3 / 7 / 14 / 30 / 90 days`, default 30) in the revenue footer, next to the unaccounted-revenue figure. URL-driven (`?days=N`) so the server component refetches exactly the span it needs — same pattern as `src/app/indexes/windowSelect.tsx`.
- The window drives the **whole revenue footer**: per-structure "Revenue" tile values, the unaccounted-tax figure + breakdown, and clone revenue are now all summed over the selected trailing window.
- The unaccounted tax journal and the clone-fee journal are now **paged past PostgREST's 1000-row cap** within the window (mirroring `/structure/revenue`'s `fetchAllRows`), so the totals stay correct on busy corps instead of silently truncating to an arbitrary 1000 rows. This is why the breakdown was previously missing recent payers.
- The **unaccounted-tax section** — the figure, the explanatory note, and the "Breakdown by payer" list — now renders **only when there are unaccounted transactions to allocate** in the window. The dropdown and clone revenue stay visible regardless, so the window is always adjustable.

## Design choices worth confirming

- **Scope of the window:** I made it govern the entire revenue footer (per-structure Revenue + unaccounted + clone), since per-structure Revenue and unaccounted come from the same journal scan and a mixed lifetime/windowed footer reads incoherently. If you'd rather per-structure Revenue and/or clone revenue stay all-time, that's a one-line change.
- **Default window:** 30 days. Market/Indexes default to 7, but revenue reads better over a longer horizon — easy to change.

## Note

Separate from the cron→workflows migration (different branch, `main`-based). This also resolves, within the window, the truncation bug behind the earlier "Breakdown by payer is missing Bricktop72" report — a payer whose jobs run in your own visible structures is still "accounted" and correctly rolls into the per-structure totals rather than the unaccounted list.

## Verification

- `pnpm run lint` — clean.
- `pnpm run build` — compiles; `/structure` still builds as a dynamic route.
- Manual check to do post-deploy: toggle the dropdown and confirm the footer figures + breakdown recompute for the window, and that the unaccounted block disappears on a window with nothing to allocate while the dropdown stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAHQq9ismaRZBswo32fcyE

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAHQq9ismaRZBswo32fcyE)_