### PR TITLE
Fix output_count returning null for reaction industry jobs

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1064,7 +1064,10 @@ as $$
   left join public.sde_published_type pt on pt.type_id = j.product_type_id
   left join public.sde_blueprint_product bp
     on bp.blueprint_type_id = j.blueprint_type_id
-    and bp.activity_id = j.activity_id
+    -- ESI's job activity_id (9 = Reactions) doesn't match the SDE-internal
+    -- dogma activity id sde_blueprint_product carries for the same activity
+    -- (11); everything else (manufacturing = 1 in both) lines up already.
+    and bp.activity_id = case j.activity_id when 9 then 11 else j.activity_id end
     and bp.product_type_id = j.product_type_id
   where j.character_id = any(character_ids)
     and j.valid_from <= as_of
@@ -2379,7 +2382,10 @@ as $$
   left join public.sde_published_type pt on pt.type_id = j.product_type_id
   left join public.sde_blueprint_product bp
     on bp.blueprint_type_id = j.blueprint_type_id
-    and bp.activity_id = j.activity_id
+    -- ESI's job activity_id (9 = Reactions) doesn't match the SDE-internal
+    -- dogma activity id sde_blueprint_product carries for the same activity
+    -- (11); everything else (manufacturing = 1 in both) lines up already.
+    and bp.activity_id = case j.activity_id when 9 then 11 else j.activity_id end
     and bp.product_type_id = j.product_type_id
   where j.corporation_id in (
     select corporation_id from public.registration

--- a/supabase/migrations/20260722000000_industry_job_output_count_reaction_fix.sql
+++ b/supabase/migrations/20260722000000_industry_job_output_count_reaction_fix.sql
@@ -1,0 +1,115 @@
+-- Fix output_count (20260721040000_industry_job_output_count.sql) coming back
+-- null for reaction jobs: ESI's industry-job activity_id for reactions is 9
+-- (see src/app/industry/jobFields.ts's ACTIVITY_NAMES), but sde_blueprint_product
+-- carries the SDE-internal dogma activity id for the same activity, 11 (see
+-- src/sdeBlueprints.ts's REACTION constant) — the two numbering schemes only
+-- happen to agree on manufacturing (1 in both). Map 9 -> 11 in the join so
+-- reaction jobs' output_count resolves same as manufacturing jobs'.
+
+create or replace function public.character_industry_jobs(character_ids uuid[], include_delivered boolean default false, as_of timestamptz default now())
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'activity_id',            j.activity_id,
+        'blueprint_id',           j.blueprint_id,
+        'blueprint_location_id',  j.blueprint_location_id,
+        'blueprint_type_id',      j.blueprint_type_id,
+        'completed_character_id', j.completed_character_id,
+        'completed_date',         j.completed_date,
+        'cost',                   j.cost,
+        'duration',               j.duration,
+        'end_date',               j.end_date,
+        'facility_id',            j.facility_id,
+        'installer_id',           j.installer_id,
+        'job_id',                 j.job_id,
+        'licensed_runs',          j.licensed_runs,
+        'output_location_id',     j.output_location_id,
+        'pause_date',             j.pause_date,
+        'probability',            j.probability,
+        'product_type_id',        j.product_type_id,
+        'runs',                   j.runs,
+        'start_date',             j.start_date,
+        'station_id',             j.station_id,
+        'status',                 j.status,
+        'successful_runs',        j.successful_runs,
+        'character_name',         r.name,
+        'blueprint_type_name',    bt.name,
+        'product_type_name',      pt.name,
+        'output_count',           j.runs * bp.product_quantity
+      )
+      order by j.start_date desc
+    ),
+    '[]'::json
+  )
+  from public.character_industry_job_over_time j
+  join public.registration r on r.id = j.character_id
+  left join public.sde_published_type bt on bt.type_id = j.blueprint_type_id
+  left join public.sde_published_type pt on pt.type_id = j.product_type_id
+  left join public.sde_blueprint_product bp
+    on bp.blueprint_type_id = j.blueprint_type_id
+    and bp.activity_id = case j.activity_id when 9 then 11 else j.activity_id end
+    and bp.product_type_id = j.product_type_id
+  where j.character_id = any(character_ids)
+    and j.valid_from <= as_of
+    and (j.is_current or j.valid_until >= as_of)
+    and (include_delivered or j.status not in ('delivered', 'cancelled', 'archived'));
+$$;
+
+create or replace function public.corp_industry_jobs(character_ids uuid[], include_delivered boolean default false, as_of timestamptz default now())
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'activity_id',            j.activity_id,
+        'blueprint_id',           j.blueprint_id,
+        'blueprint_location_id',  j.blueprint_location_id,
+        'blueprint_type_id',      j.blueprint_type_id,
+        'completed_character_id', j.completed_character_id,
+        'completed_date',         j.completed_date,
+        'corporation_id',         j.corporation_id,
+        'cost',                   j.cost,
+        'duration',               j.duration,
+        'end_date',               j.end_date,
+        'facility_id',            j.facility_id,
+        'installer_id',           j.installer_id,
+        'job_id',                 j.job_id,
+        'licensed_runs',          j.licensed_runs,
+        'output_location_id',     j.output_location_id,
+        'pause_date',             j.pause_date,
+        'probability',            j.probability,
+        'product_type_id',        j.product_type_id,
+        'runs',                   j.runs,
+        'start_date',             j.start_date,
+        'station_id',             j.station_id,
+        'status',                 j.status,
+        'successful_runs',        j.successful_runs,
+        'blueprint_type_name',    bt.name,
+        'product_type_name',      pt.name,
+        'output_count',           j.runs * bp.product_quantity
+      )
+      order by j.start_date desc
+    ),
+    '[]'::json
+  )
+  from public.corp_industry_job_over_time j
+  left join public.sde_published_type bt on bt.type_id = j.blueprint_type_id
+  left join public.sde_published_type pt on pt.type_id = j.product_type_id
+  left join public.sde_blueprint_product bp
+    on bp.blueprint_type_id = j.blueprint_type_id
+    and bp.activity_id = case j.activity_id when 9 then 11 else j.activity_id end
+    and bp.product_type_id = j.product_type_id
+  where j.corporation_id in (
+    select corporation_id from public.registration
+    where id = any(character_ids) and corporation_id is not null
+  )
+  and j.valid_from <= as_of
+  and (j.is_current or j.valid_until >= as_of)
+  and (include_delivered or j.status not in ('delivered', 'cancelled', 'archived'));
+$$;


### PR DESCRIPTION
## Summary
- Follow-up to #688: `output_count` was coming back null for reaction industry jobs
- ESI's job `activity_id` for reactions is `9` (`ACTIVITY_NAMES` in `src/app/industry/jobFields.ts`), but the `sde_blueprint_product` mirror view carries the SDE-internal dogma activity id for the same activity, `11` (`REACTION` in `src/sdeBlueprints.ts`) — the two numbering schemes only happen to agree on manufacturing (`1` in both)
- Maps `9 -> 11` in the `character_industry_jobs()`/`corp_industry_jobs()` join against `sde_blueprint_product`, so reaction jobs' `output_count` resolves the same way manufacturing jobs' already did
- Updates `schema.sql` (source of truth) and adds a new non-destructive migration (`create or replace function`) so existing databases pick it up via `supabase db push`

## Test plan
- [x] `pnpm run lint` passes
- [ ] `supabase db push` against a linked project, then spot-check `/api/character/jobs?columns=activity_id,runs,output_count` (or `/api/corp/jobs`) shows a non-null `output_count` for a reaction job (`activity_id=9`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KmwUhQiTmXZ82zCZsGrXB8)_