### PR TITLE
Add project plan for nightly SDE-derived industry sheet CSVs

### DIFF
--- a/docs/sheet-csv/01-port-generator.md
+++ b/docs/sheet-csv/01-port-generator.md
@@ -1,0 +1,188 @@
+# PR 1: port the generator to `src/buildSheetCsv.js`
+
+## Goal
+
+A pure encode module, shaped exactly like `src/buildEsfData.js`: reads its SDE
+inputs from the nightly-mirrored `sde_*` tables through the public-read anon
+client (needs `NEXT_PUBLIC_SUPABASE_URL`/`_ANON_KEY`, no service role), applies
+the transform, and returns `{ [fileName]: string }` without touching disk or
+the writable DB. No table, no route, no workflow change yet — those are PRs
+2–4.
+
+```js
+export const SHEET_FILE_NAMES = [
+  'static-inputs-twines.csv',
+  'static-inputs-miros.csv',
+  'static-outputs-twines.csv',
+  'static-outputs-miros.csv',
+  'invention.csv',
+  'types-twines.csv',
+  'types-miros.csv',
+]
+export const encodeSheetCsv = async () => ({ /* name → csv string */ })
+```
+
+## Inputs
+
+Only two mirror tables (the Python also loads `groups.yaml`, but never reads
+it — dead code, dropped in the port):
+
+- `sde_types` — per type: `name.en`, `groupID`, `metaGroupID`, `volume`
+- `sde_blueprints` — per blueprint: `activities.manufacturing`,
+  `activities.reaction`, `activities.invention`, each with `materials`,
+  `products`, `time`
+
+Both are already seeded stems in the mirror
+(`supabase/migrations/20260716010000_sde_mirror.sql` seeds `types` and
+`blueprints`), so **no migration is needed** for this PR. Page them 1000 rows
+at a time exactly like `buildEsfData.js`'s `readMirror(stem)` — lift that
+helper or copy it. Each row's `data` jsonb is the raw SDE JSONL object; the
+`_key` is the type/blueprint id. Verify the field casing against live rows
+before coding (the JSONL uses `typeID`, `metaGroupID`, etc. — same as the
+YAML), and confirm whether `_key` arrives as number or string.
+
+Memory note: `sde_types` is ~50k rows and `sde_blueprints` ~5k — far smaller
+than the `type_dogma` table the ESF encode already pages inside one workflow
+step, so a single-invocation build is comfortably in budget.
+
+## Transform spec
+
+The row *data* below is a faithful port of the Python; the *serialization*
+diverges deliberately (headered RFC 4180 instead of the Python's headerless
+quoted format — see README decision 1), and the `Group` column is a new
+pre-join the Python left to sheet-side lookups.
+
+### Step 0 — name maps
+
+From `sde_types`: `idToName` (id → `name.en`) and `nameToId`, skipping types
+without an English name. Missing names later fall back to `Type <id>`.
+
+### Step 1 — blueprint dedup
+
+When multiple blueprints produce the same output item, keep only the blueprint
+with the **largest blueprint type id** (assumed most recent). "Output" means:
+first product of `manufacturing` if present, else first product of `reaction`,
+else the blueprint has no output and is kept unconditionally (it may still
+carry an invention activity).
+
+### Step 2 — industry rows (StaticInputs, StaticOutputs)
+
+For each surviving blueprint (ascending blueprint-id order, preserving the
+dedup's re-pointing — see "Row ordering" below), for each of its
+`manufacturing` and `reaction` activities: only when the activity has
+**exactly one product** and a `materials` list —
+
+- **StaticInputs**, one row per material:
+  `Group,Type,Material,InputQty` =
+  `<group label of output>, <output name>, <material name>, <material quantity>`
+- **StaticOutputs**, one row:
+  `Group,Type,OutputQty,JobTime` =
+  `<group label of output>, <output name>, <output quantity>, <activity time in seconds>`
+
+`JobTime`/quantities are raw numbers — no thousands separators (the `"6,000"`
+in the sample tab export is Google Sheets display formatting).
+
+Track three id sets along the way: every id seen (`types`), reaction outputs
+(`reactionTypes`), manufacturing outputs (`industryTypes`). These drive the
+group labels (step 4), which means labeling is a **second pass**: `Group` for
+a given output isn't knowable until all blueprints have been scanned
+(membership in `reactionTypes`/`industryTypes` decides `Reaction`/`Input`).
+Collect the row tuples first, resolve labels after, serialize last. The label
+differs per mode only in the `Component` branch, so one collected row set
+serializes into both `-twines` and `-miros` variants.
+
+> Python quirk, do **not** port: `insert_industry_lines` builds per-call dicts
+> keyed by output id (a half-finished dedup, per its own TODO) and its final
+> loop appends `id_to_output_line[output_id]` while iterating `type_id` — a
+> latent bug that's harmless only because the dict never holds more than one
+> entry per call. The port should just append rows directly.
+
+### Step 3 — invention rows (`invention.csv`)
+
+For each surviving blueprint with an `invention` activity having **exactly two
+materials** (the two datacores), one row per product:
+
+`<product name>, <blueprint name>, <base runs = product quantity>,
+<datacore1 name>, <qty>, <datacore2 name>, <qty>,
+<activity time>, <probability>`
+
+Header: `Type,Blueprint,BaseRuns,Datacore1,Datacore1Qty,Datacore2,Datacore2Qty,JobTime,Probability`.
+
+`probability` defaults to `1.0` when absent. Add both datacores, the blueprint
+id, and every product id to `types`. Note the Python indexes `id_to_name[...]`
+directly here (a KeyError if a datacore/blueprint name were missing) — the
+port should use the same `Type <id>` fallback as step 2 rather than throwing.
+
+### Step 4 — group labels and `types.csv` (both mode variants)
+
+Seed `types` with the eight decryptors, resolved by name (a hand-maintained
+constant; if CCP renames one, resolution fails — log and skip rather than
+throw):
+
+> Accelerant / Attainment / Augmentation / Parity / Process / Symmetry /
+> Optimized Attainment / Optimized Augmentation Decryptor
+
+**Group label for a type id** (shared by types.csv and the step-2 pre-join):
+
+- in `reactionTypes` → `Reaction` (checked first, wins over everything)
+- **miros mode only:** `groupID` ∈ {334, 873, 913} → `Component`
+- else by `metaGroupID`: 1 → `Tech I`, 2 → `Tech II`, 3 → `Tech III`;
+  absent → `Input` if the id is not in `industryTypes`, else `Tech I`;
+  any other value (4, 5, 14, …) → `Tech I` (the Python's fall-through
+  default — faction/officer/abyssal items label as Tech I; preserve it)
+
+**types.csv rows:** for every id in `types` (ascending) that exists in
+`sde_types`: `TypeID,Group,Type,Volume`. `Volume` is `''` when absent; hard
+override: `Outrider Blueprint` → `0.01`. (`MIN_TYPE_ID` is 0 in the script —
+the filter is a no-op, dropped.)
+
+### Serialization
+
+Use `toCsv` from `src/utils/csv.ts` (RFC 4180, header from object keys, CRLF)
+— build each file as an array of flat objects whose key order is the column
+order above. No BOM (Sheets `IMPORTDATA` doesn't need the Python's
+`utf-8-sig`; that was for Excel).
+
+### Row ordering
+
+Deterministic and Python-matching, so regenerations diff cleanly and rows
+land where the sheet's adjacent formula columns expect:
+StaticInputs/StaticOutputs/invention follow the dedup result's iteration
+order (sorted blueprint ids, with a duplicate-output blueprint's slot moved
+to the end of the no-output group, exactly as the Python's dict-update does
+— replicate whatever the parity check shows); `types-*` sorted by type id
+ascending.
+
+## Style
+
+House rules apply: ramda over `for`/`while` (`src/jobs/*.js` is the model),
+mutable `.push()` accumulators inside a `reduce` are fine for the big row
+arrays, async pagination recurses or uses `forEachSequential`. Plain `.js` +
+JSDoc like `buildEsfData.js`, not TS.
+
+## Verification (parity check)
+
+Because the serialization deliberately diverges, parity is checked on the
+**data**, not the bytes:
+
+1. Identify the SDE build currently mirrored (`sde_mirror_state`).
+2. Run the Python against the matching YAML export (`--mode twines`, then
+   `--mode miros`) — it's kept in
+   [`reference/full_sheet_gen.py`](reference/full_sheet_gen.py).
+3. Run the port (`node` one-liner calling `encodeSheetCsv()`, writing the
+   seven strings to files).
+4. Normalize both sides (strip BOM/headers/quoting, parse into field tuples;
+   drop the port's `Group` column from StaticInputs/StaticOutputs to compare
+   against `inputs.csv`/`outputs.csv`) and diff:
+   - StaticInputs ↔ `inputs.csv`, StaticOutputs ↔ `outputs.csv`,
+     `invention.csv` ↔ `invention.csv`: identical tuples in identical order.
+   - `types-twines.csv` ↔ twines `types.csv`, `types-miros.csv` ↔ miros
+     `types.csv`: identical.
+   - The pre-joined `Group` column must equal the label the corresponding
+     mode's `types.csv` gives that output's type id, for every row.
+5. Spot-check against the real workbook tab exports: same leading columns,
+   same row order for a sampled region (ignoring the workbook's `#N/A`
+   lookup failures and number formatting).
+
+No lint errors (`pnpm run lint`); no `package.json` script yet (PR 2 adds the
+job CLI).

--- a/docs/sheet-csv/02-table-and-job.md
+++ b/docs/sheet-csv/02-table-and-job.md
@@ -1,0 +1,69 @@
+# PR 2: the `sheet_csv` table and the `sheet-csv` job
+
+## Goal
+
+Persist the five CSVs so the serve route (PR 4) reads rows instead of
+re-encoding. Mirrors the `esf_data` + `src/jobs/esfData.js` pair exactly.
+
+## Table
+
+New table `sheet_csv`, same shape and policies as `esf_data` except the data
+column is plain text (CSV is text; base64 exists in `esf_data` only because
+protobufs are binary):
+
+```sql
+create table public.sheet_csv (
+  name text primary key,          -- e.g. 'types-twines.csv'
+  data text not null,             -- the CSV body, BOM included
+  sde_build bigint not null,      -- the build the row was encoded from
+  updated_at timestamptz not null default now()
+);
+alter table public.sheet_csv enable row level security;
+create policy "sheet_csv is world readable" on public.sheet_csv
+  for select using (true);        -- writes: service role only (no policy)
+```
+
+Two places, per the schema rules in CLAUDE.md:
+
+1. `schema.sql` — add the table (and its drop) so a fresh reset stays correct.
+2. A **new** migration under `supabase/migrations/` with a fresh timestamp
+   (`pnpm run db:new sheet_csv`). Never rename existing migration files.
+
+Grant note: copy whatever `grant select` the `esf_data` migration issued to
+`anon`/`authenticated` so PostgREST exposes it to the anon client.
+
+## Job
+
+`src/jobs/sheetCsv.js`, a line-for-line sibling of `src/jobs/esfData.js`:
+
+- `runSheetCsv({ build, force })`:
+  - `build` defaults to the latest completed `sde_mirror_state` build (same
+    `latestCompletedBuild()` query — consider extracting it to `src/jobs/lib.js`
+    or a shared helper rather than copy-pasting a third time if `esfData.js`
+    wants it too; two copies is the current count, judgement call).
+  - Skip path: unless `force`, no-op when `sheet_csv` already holds every
+    `SHEET_FILE_NAMES` entry stamped with this build (the `alreadyEncoded`
+    check).
+  - Otherwise `encodeSheetCsv()` and upsert the rows (7 files, see README)
+    (`onConflict: 'name'`) via `sudoSupabase`, stamped with `sde_build` and a
+    shared `updated_at`.
+- `cli(import.meta.url, 'sheet-csv', () => runSheetCsv())` at the bottom, and
+  a `"sheet-csv": "node src/jobs/sheetCsv.js"` script in `package.json`, so
+  the job name matches the npm script and heartbeat conventions.
+
+## Bootstrap cron route
+
+`/api/cron/sheet-csv` (`src/app/api/cron/sheet-csv/route.ts`): a copy of the
+existing `/api/cron/esf-data` route — `requireCronSecret`, then
+`runSheetCsv()` with `?force=1` mapped to `force: true`. **Deliberately
+unscheduled** (no `vercel.json` `crons` entry): its jobs are (a) first-time
+bootstrap before the nightly workflow has run, and (b) manual re-encode after
+a code change to the transform, without waiting for tonight's mirror.
+
+## Verification
+
+- `pnpm run db:push` applies the migration cleanly.
+- `pnpm run sheet-csv` populates seven rows; re-running logs the skip path;
+  `--`-less `force` via the route re-encodes.
+- Row content matches PR 1's parity-checked output (spot-check `data` for one
+  file against the CLI artifact).

--- a/docs/sheet-csv/03-workflow-step.md
+++ b/docs/sheet-csv/03-workflow-step.md
@@ -1,0 +1,64 @@
+# PR 3: run it nightly as a tail step of the `sde-mirror` workflow
+
+## Goal
+
+The CSVs regenerate automatically every night, immediately after the SDE
+tables they read have landed — same trigger discipline as the `encodeEsf`
+step. **No new cron entry and no new workflow:** the job rides the existing
+`sde-mirror` run (12:21 UTC).
+
+## Change
+
+All in `src/workflows/sdeMirror.ts`, mirroring `encodeEsf` exactly:
+
+1. A new step function:
+
+   ```ts
+   async function encodeSheets(build: number): Promise<void> {
+     'use step'
+     const { runSheetCsv } = await import('@/jobs/sheetCsv.js')
+     await runSheetCsv({ build, force: true })
+   }
+   ```
+
+   `force: true` for the same reason `encodeEsf` passes it: the nightly
+   workflow always re-ingests the current build, and the derived data
+   re-encodes to match, rather than no-opping on an unchanged build number.
+   (The manual `/api/cron/sheet-csv` route keeps the build-guard by default.)
+
+2. Its input stems:
+
+   ```ts
+   const SHEET_INPUT_STEMS = ['types', 'blueprints']
+   ```
+
+3. In the orchestrator body, alongside the existing tail steps:
+
+   ```ts
+   const sheets = afterStems(SHEET_INPUT_STEMS).then(() => encodeSheets(plan.build))
+   // …
+   await Promise.all([allDrained, stations, esf, sheets])
+   ```
+
+   `afterStems` already degrades to "wait for the full ingest" if CCP ever
+   renames a file away, so no extra guard is needed. The step runs
+   concurrently with `encodeEsf` (which also waits on `types`, among others) —
+   both only read the mirror and write disjoint tables, so ordering between
+   them doesn't matter; `finalize` still runs last.
+
+## Determinism note
+
+The workflow body is replayed — keep the addition to simple, static control
+flow like the existing tail steps (no shared queues, no timers). A fixed
+promise chained off `afterStems` matches the established pattern.
+
+## Verification
+
+- Trigger a run manually (`/api/cron/sde-mirror` with the CRON secret) or wait
+  for the nightly; watch Observability → Workflows for the new `encodeSheets`
+  step succeeding after the `types`/`blueprints` slice chains and before
+  `finalize`.
+- `sheet_csv.sde_build` equals the run's build for all five rows afterward.
+- Confirm the step's duration fits its budget comfortably (expected: a few
+  seconds of paging + string building; the ESF encode is the heavier sibling
+  and already fits).

--- a/docs/sheet-csv/04-serve-route.md
+++ b/docs/sheet-csv/04-serve-route.md
@@ -1,0 +1,68 @@
+# PR 4: serve the CSVs at `/sheets/[file]` and cut the sheet over
+
+## Goal
+
+A public route the Google Sheet can `=IMPORTDATA()`. Structurally a copy of
+`/esf/[file]` (`src/app/esf/[file]/route.ts`) — allowlist, ETag keyed on
+`sde_build`, conditional-request handling, long CDN cache — with the response
+shaped like the Sheets API endpoints (`text/csv`), minus their `api_token`
+auth (this data is public SDE, identical for every caller).
+
+## Route
+
+`src/app/sheets/[file]/route.ts`:
+
+- Allowlist = `SHEET_FILE_NAMES` (import from `src/buildSheetCsv.js` — one
+  source of truth shared by encoder, job, and route; the ESF route's
+  copy-pasted `Set` predates that option). Anything else → 404.
+- Read the row from `sheet_csv` via `sdeSupabase()` (the same lazy anon
+  client the ESF route uses — public-read RLS covers it; the route never
+  needs the service role).
+- Empty table (workflow hasn't run yet) → 404, same as ESF.
+- `ETag: "<sde_build>-<file>"`, `Last-Modified` truncated to second
+  precision, and the same `If-None-Match`/`If-Modified-Since` → 304 logic —
+  lift it verbatim; if a third route ever needs it, extract a shared helper.
+- `Cache-Control`: same policy as ESF
+  (`public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800`) —
+  the data changes at most nightly and only when CCP ships a build, browsers
+  revalidate cheaply via 304, Vercel's CDN serves stale while revalidating.
+  Note Google's IMPORTDATA fetcher caches on its own schedule (up to ~1h)
+  regardless of headers; that's fine at this change cadence.
+- Response headers: `Content-Type: text/csv; charset=utf-8` plus the caching
+  set. `Content-Length` from the UTF-8 byte length (not `data.length` —
+  type names contain non-ASCII).
+
+No `dynamic`/`maxDuration` exports needed (single-row read; the per-user CSV
+endpoints force-dynamic only because their content is per-token).
+
+## Sheet cutover
+
+Not a code change, but the point of the project — do it as this PR's rollout:
+
+1. In the workbook, replace the pasted `StaticInputs` data with
+   `=IMPORTDATA("https://<host>/sheets/static-inputs-twines.csv")` in `A1`
+   (header row included — the current tabs have headers), and likewise
+   `StaticOutputs` from `static-outputs-twines.csv`.
+2. Verify the adjacent formula columns still compute (row ordering matches
+   the old pastes; see README open question 4 on row shift across SDE
+   builds).
+3. If tabs exist for invention/types, point them at `invention.csv` /
+   `types-twines.csv` the same way.
+
+## Docs & bookkeeping (same PR)
+
+- `CLAUDE.md`: add the `sheet-csv` npm script to Commands, `sheet_csv` to the
+  table reference, `/sheets/[file]` to the routes table, and a line in the
+  sde-mirror workflow bullet mentioning the `encodeSheets` tail step.
+- `README.md` (repo): mention the endpoints if it lists public URLs.
+- Update this directory's docs to Status: DONE as phases land (house style —
+  see `docs/sde-db-cutover/`).
+
+## Verification
+
+- `curl -i` each of the seven filenames: 200, `text/csv`, sane body; unknown
+  name → 404; repeat with `If-None-Match` → 304.
+- `=IMPORTDATA(...)` from a scratch Google Sheet renders the header + rows
+  with numbers parsed as numbers (raw, unformatted).
+- After the next nightly `sde-mirror` run, the ETag flips only if the build
+  changed content (`sde_build` stamp), and the CDN revalidates.

--- a/docs/sheet-csv/README.md
+++ b/docs/sheet-csv/README.md
@@ -1,0 +1,166 @@
+# Static industry CSVs: nightly build from the SDE mirror, served as CSV
+
+## What this is
+
+A colleague's Python script (`full_sheet_gen.py`, kept for reference as
+[`reference/full_sheet_gen.py`](reference/full_sheet_gen.py)) reads SDE YAML
+files and writes CSVs that feed an industry-planning Google Sheet (the
+"Cuddles" workbook). Today someone has to download the SDE, run the script by
+hand, and paste the output into the sheet's static tabs.
+
+This project makes it a nightly pipeline: port the transform to JavaScript,
+run it as a tail step of the existing `sde-mirror` Vercel Workflow (so it
+regenerates whenever CCP ships an SDE build), store the CSVs in a Supabase
+table, and serve them from public routes that the sheet can `=IMPORTDATA()`
+directly — replacing the manual paste entirely.
+
+## Endpoints (the deliverable)
+
+The sheet's two static tabs define the target shape. Sample exports of those
+tabs show the generated payload is their **leading columns**; everything to
+the right is sheet-side formulas we don't produce:
+
+- **StaticInputs** — `Group,Type,Material,InputQty`: one row per material of
+  every buildable item. This is the Python's `inputs.csv` **plus a `Group`
+  column** (the tech-level label the Python only emitted into `types.csv`,
+  which the sheet then joined in with lookups — we pre-join it, so the
+  `#N/A` rows visible in the sheet export can't happen).
+- **StaticOutputs** — `Group,Type,OutputQty,JobTime`: one row per buildable
+  item. The Python's `outputs.csv`, same pre-joined `Group` column.
+
+Plus two secondary files the script also derives (same transform pass, nearly
+free to keep):
+
+- **invention.csv** — invention outcomes (datacores, base runs, probability)
+- **types.csv** — every referenced type id with group label and volume (the
+  sheet may keep using it for volume lookups; the Group join above makes it
+  optional for grouping)
+
+The Python's `--mode twines|miros` flag changes only the group labeling
+(`miros` labels groupIDs 334/873/913 as `Component`). The sample workbook is
+`twines`-mode (no `Component` rows). Mode now affects three of the four files
+(everything carrying a `Group` column or labels), so files are precomputed
+per mode rather than parameterized:
+
+| Row `name` (PK) / URL file | Contents |
+|---|---|
+| `static-inputs-twines.csv`, `static-inputs-miros.csv` | StaticInputs |
+| `static-outputs-twines.csv`, `static-outputs-miros.csv` | StaticOutputs |
+| `types-twines.csv`, `types-miros.csv` | types.csv |
+| `invention.csv` | invention (mode-independent) |
+
+(Open question 3: if `miros` mode is no longer used, drop its variants and
+the suffixes — 4 files instead of 7.)
+
+## Architecture: a hybrid of two existing patterns
+
+| | ESF protobufs (`esf-data`) | Sheets API endpoints (`/api/character/*`) | **This project (`sheet-csv`)** |
+|---|---|---|---|
+| Built | nightly, tail step of `sde-mirror` workflow | per-request | **nightly, tail step of `sde-mirror` workflow** |
+| Source | `sde_*` mirror tables | extract DB (per-user) | **`sde_*` mirror tables** |
+| Stored | `esf_data` table (base64) | not stored | **`sheet_csv` table (plain text)** |
+| Served | `/esf/[file]`, binary, CDN-cached, ETag on `sde_build` | CSV, `api_token`-authenticated, uncached | **`/sheets/[file]`, CSV, CDN-cached, ETag on `sde_build`, no auth** |
+
+The build side is a straight copy of the `esf-data` shape (`src/buildEsfData.js`
++ `src/jobs/esfData.js` + the `encodeEsf` workflow step): a pure encode module
+that pages the mirror tables through the public-read anon client and returns
+`{ [fileName]: string }`, wrapped by a job that upserts into a table, kicked by
+the workflow once its input tables have landed.
+
+The serve side is a copy of `/esf/[file]` (allowlisted filename, ETag keyed on
+`sde_build`, long CDN cache with stale-while-revalidate) — but returning
+`text/csv` like the Sheets API endpoints do. Unlike those endpoints there is
+**no `api_token`**: the CSVs are derived purely from CCP's public SDE, contain
+no player data, and are identical for every caller, so they can be public and
+aggressively CDN-cached (which per-user endpoints never can be).
+
+## Data flow
+
+```
+CCP SDE zip ──(sde-mirror workflow, 12:21 UTC nightly)──▶ sde_types, sde_blueprints
+                                                              │
+                              tail step (after those 2 stems drain)
+                                                              ▼
+                                    runSheetCsv() ──▶ sheet_csv table (7 rows)
+                                                              │
+                                                              ▼
+        Google Sheets =IMPORTDATA("https://…/sheets/static-inputs-twines.csv")
+                                                              ▲
+                                              /sheets/[file] route (CDN-cached)
+```
+
+## Transform spec (ported from the Python)
+
+Full field-by-field spec, including the script's quirks and one latent bug,
+in [01-port-generator.md](01-port-generator.md). Highlights that shape the
+port:
+
+- **Blueprint dedup:** when several blueprints produce the same item, only the
+  one with the **largest blueprint type id** (assumed newest) is kept.
+- **`groups.yaml` is dead code** — the script loads it and never reads it. The
+  port needs only `sde_types` and `sde_blueprints`, both already seeded stems
+  in the mirror (`supabase/migrations/20260716010000_sde_mirror.sql`).
+- **Hand-maintained constants:** the eight decryptor names force-included in
+  `types.csv`, and the `Outrider Blueprint` volume override (`0.01`). These
+  become named constants in the encoder module.
+- **Output format:** headered RFC 4180 CSV via the existing `toCsv`
+  (`src/utils/csv.ts`), matching the sample tab exports — **not** the
+  Python's odd headerless `", "`-joined format (decision 1 below). Row
+  *ordering* still matches the Python so rows land in the same positions the
+  sheet's adjacent formula columns expect.
+
+## Phases
+
+Each phase is an independently-shippable PR, smallest-first, matching the
+`docs/cron-to-workflows/` playbook:
+
+1. **[01-port-generator.md](01-port-generator.md)** — `src/buildSheetCsv.js`:
+   the pure transform, mirror-fed, CLI-verifiable, parity-checked against the
+   Python's output on the same SDE build.
+2. **[02-table-and-job.md](02-table-and-job.md)** — `sheet_csv` table
+   (migration + `schema.sql`), `src/jobs/sheetCsv.js` (`runSheetCsv()`,
+   `pnpm run sheet-csv`), and the unscheduled bootstrap route
+   `/api/cron/sheet-csv`.
+3. **[03-workflow-step.md](03-workflow-step.md)** — the `encodeSheets` tail
+   step in `src/workflows/sdeMirror.ts`, gated on the `types` + `blueprints`
+   stems draining.
+4. **[04-serve-route.md](04-serve-route.md)** — the public `/sheets/[file]`
+   route with ESF-style caching, plus docs/CLAUDE.md updates and the sheet
+   cutover checklist.
+
+## Decisions taken (revisit if wrong)
+
+1. **Headered RFC 4180 output** (via `src/utils/csv.ts`), not byte-compatible
+   with the Python: the sheet consumes tab-shaped data (`Group,Type,…` with a
+   header), numbers are emitted raw (the `"6,000"` in the tab export is
+   display formatting, not data), and no UTF-8 BOM (`IMPORTDATA` doesn't need
+   the Python's `utf-8-sig`; the BOM was for Excel).
+2. **`Group` pre-joined** into StaticInputs/StaticOutputs server-side instead
+   of making the sheet look it up against types.csv — removes the `#N/A`
+   failure mode seen in the current workbook.
+3. **Both modes precomputed** as separate files instead of a `?mode=` param
+   (cache- and allowlist-friendly).
+4. **No authentication** on the serve route — SDE-derived, no player data,
+   same bytes for everyone.
+5. **Plain-text `data` column**, not base64 — CSV is text; base64 in
+   `esf_data` exists only because protobufs are binary.
+6. **`MIN_TYPE_ID` is dropped** — it's `0` in the script, so the filter never
+   excludes anything (it was a dev-time knob for partial runs).
+
+## Open questions for the repo owner
+
+1. Route path: `/sheets/[file]` is proposed; `/csv/[file]` would work equally.
+2. In the StaticOutputs sample, some rows carry Group `Input` — under the
+   Python's rules a manufacturing output can't be labeled `Input`, so those
+   are presumably rows whose sheet lookup hit a type the old types.csv
+   labeled before it became buildable (or lookup drift). Pre-joining makes
+   the label consistent; confirm the sheet's formulas don't *depend* on the
+   stale labels.
+3. Is `miros` mode still used? If not, drop its file variants (7 files → 4,
+   no suffixes).
+4. Row-position stability: sheet columns to the right of the imported range
+   reference row numbers. IMPORTDATA rewrites rows on every refresh — the
+   adjacent-formula pattern survives only if ordering is deterministic (it
+   is: blueprint-id order) but *inserted/removed blueprints between SDE
+   builds still shift rows*, exactly as they did with manual pastes. Worth
+   confirming with the sheet owner that this is understood/acceptable.

--- a/docs/sheet-csv/reference/full_sheet_gen.py
+++ b/docs/sheet-csv/reference/full_sheet_gen.py
@@ -1,0 +1,199 @@
+from typing import Dict, List, Optional, Set
+import argparse
+import yaml
+import os
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--mode", choices=["twines", "miros"], required=True)
+args = parser.parse_args()
+
+SDE_PATH = "sde"
+
+MIN_TYPE_ID = 0
+
+type_filename = (
+    os.path.join(SDE_PATH, "types.yaml")
+)
+blueprint_filename = (
+    os.path.join(SDE_PATH, "blueprints.yaml")
+)
+group_filename = (
+    os.path.join(SDE_PATH, "groups.yaml")
+)
+
+inputs_csv_filename = "inputs.csv"
+outputs_csv_filename = "outputs.csv"
+invention_csv_filename = "invention.csv"
+types_csv_filename = "types.csv"
+
+with open(blueprint_filename, "r") as f:
+    blueprint_data = yaml.load(f, Loader=yaml.CLoader)
+
+def get_output(blueprint_data: dict) -> Optional[int]:
+    activities = blueprint_data["activities"]
+    if "manufacturing" in activities and "products" in activities["manufacturing"]:
+        output = activities["manufacturing"]["products"][0]["typeID"]
+    elif "reaction" in activities:
+        output = activities["reaction"]["products"][0]["typeID"]
+    else:
+        output = None
+    return output
+
+def remove_duplicate_blueprints(blueprint_data: dict) -> dict:
+    """
+    When multiple blueprints output the same item, keeps only the blueprint
+    with the largest type ID (the most recent one).
+    """
+    blueprint_ids = sorted(list(blueprint_data.keys()))
+    output_blueprints = {}
+    return_blueprints = {}
+    for id in blueprint_ids:
+        output = get_output(blueprint_data[id])
+        if output is None:
+            return_blueprints[id] = blueprint_data[id]
+        else:
+            output_blueprints[output] = (id, blueprint_data[id])
+    return_blueprints.update(dict(output_blueprints.values()))
+    return return_blueprints
+
+blueprint_data = remove_duplicate_blueprints(blueprint_data)
+
+with open(group_filename, "r") as f:
+    group_data = yaml.load(f, Loader=yaml.CLoader)
+
+with open(type_filename, "r") as f:
+    type_data = yaml.load(f, Loader=yaml.CLoader)
+
+decryptor_types = """Accelerant Decryptor
+Attainment Decryptor
+Augmentation Decryptor
+Parity Decryptor
+Process Decryptor
+Symmetry Decryptor
+Optimized Attainment Decryptor
+Optimized Augmentation Decryptor""".split("\n")
+
+name_to_id = {}
+id_to_name = {}
+for type_id, data in type_data.items():
+    if "name" in data and "en" in data["name"]:
+        name_to_id[data["name"]["en"]] = type_id
+        id_to_name[type_id] = data["name"]["en"]
+
+
+def insert_industry_lines(entry, input_lines: List[str], output_lines: List[str], types: Set[int], industry_types=None):
+    id_to_input_lines: Dict[str, List[str]] = {}
+    id_to_output_line: Dict[str, str] = {}
+    if "products" in entry and len(entry["products"]) == 1 and "materials" in entry:
+        output_id = entry["products"][0]["typeID"]
+        output_quantity = entry["products"][0]["quantity"]
+        output_name = id_to_name.get(output_id, f"Type {output_id}")
+        types.add(output_id)
+        if industry_types is not None:
+            industry_types.add(output_id)
+        type_input_lines = []
+        for material_data in entry["materials"]:
+            input_id = material_data["typeID"]
+            input_name = id_to_name.get(input_id, f"Type {input_id}")
+            types.add(input_id)
+            input_quantity = material_data["quantity"]
+            type_input_lines.append(f'"{output_name}", "{input_name}", "{input_quantity}"')
+        id_to_input_lines[output_id] = type_input_lines
+        job_time = entry["time"]
+        id_to_output_line[output_id] = f'"{output_name}", "{output_quantity}", "{job_time}"'
+    # TODO: these dictionary shenanegans currently do nothing, if we really want to dedupe
+    # by output ID we need to manipulate a dict with this function
+    # and then create input/output lines at the end of the for loop
+    for type_id in sorted(list(id_to_output_line.keys())):
+        input_lines.extend(id_to_input_lines[type_id])
+        output_lines.append(id_to_output_line[output_id])
+
+
+def insert_invention_lines(entry, blueprint_type_id, invention_lines: List[str], types: Set[int]):
+    if len(entry.get("materials", [])) == 2:
+        input_1_id = entry["materials"][0]['typeID']
+        input_1_quantity = entry["materials"][0]["quantity"]
+        input_2_id = entry["materials"][1]['typeID']
+        input_2_quantity = entry["materials"][1]["quantity"]
+        job_time = entry["time"]
+        input_1_name = id_to_name[input_1_id]
+        input_2_name = id_to_name[input_2_id]
+        types.add(input_1_id)
+        types.add(input_2_id)
+        types.add(blueprint_type_id)
+        blueprint_name = id_to_name[blueprint_type_id]
+        for output_data in entry.get("products", []):
+            types.add(output_data["typeID"])
+            output_name = id_to_name[output_data["typeID"]]
+            probability = output_data.get("probability", 1.)
+            base_runs = output_data["quantity"]
+            invention_lines.append(
+                f'"{output_name}", "{blueprint_name}", "{base_runs}", "{input_1_name}", "{input_1_quantity}", '
+                f'"{input_2_name}", "{input_2_quantity}", "{job_time}", "{probability}"'
+            )
+
+
+input_lines: List[str] = []
+output_lines: List[str] = []
+invention_lines: List[str] = []
+types: Set[int] = set([name_to_id[n] for n in decryptor_types])
+reaction_types: Set[int] = set()
+industry_types: Set[int] = set()
+# assume blueprints are sorted with newer ones later
+for type_id, entry in blueprint_data.items():
+    if type_id > MIN_TYPE_ID:
+        print(f"processing type {type_id}")
+        if "manufacturing" in entry["activities"]:
+            insert_industry_lines(entry["activities"]["manufacturing"], input_lines, output_lines, types, industry_types=industry_types)
+        if "reaction" in entry["activities"]:
+            insert_industry_lines(entry["activities"]["reaction"], input_lines, output_lines, types, industry_types=reaction_types)
+        if "invention" in entry["activities"]:
+            insert_invention_lines(entry["activities"]["invention"], type_id, invention_lines, types)
+    else:
+        print(f"skipping type {type_id}")
+
+
+with open(inputs_csv_filename, "w", encoding="utf-8-sig") as f:
+    f.write("\n".join(input_lines))
+
+with open(outputs_csv_filename, "w", encoding="utf-8-sig") as f:
+    f.write("\n".join(output_lines))
+
+with open(invention_csv_filename, "w", encoding="utf-8-sig") as f:
+    f.write("\n".join(invention_lines))
+
+
+type_lines = []
+for type_id in sorted(list(types)):
+    if type_id in type_data:
+        data = type_data[type_id]
+        type_name = data["name"]["en"]
+        volume = data.get("volume", "")
+        if type_name == "Outrider Blueprint":
+            volume = "0.01"
+        if type_id in reaction_types:
+            group_name = "Reaction"
+        else:
+            meta_level = data.get("metaGroupID", None)
+            group_id = data.get("groupID", None)
+            group_name = "Tech I"
+            if args.mode == "miros" and (group_id == 334 or group_id == 873 or group_id == 913):
+                group_name = "Component"
+            else:
+                if meta_level == 1:
+                    group_name = "Tech I"
+                elif meta_level == 2:
+                    group_name = "Tech II"
+                elif meta_level == 3:
+                    group_name = "Tech III"
+                elif meta_level is None:
+                    if type_id not in industry_types:
+                        group_name = "Input"
+                    else:
+                        group_name = "Tech I"
+        type_lines.append(f'"{type_id}", "{group_name}", "{type_name}", "{volume}"')
+
+with open(types_csv_filename, "w", encoding="utf-8-sig") as f:
+    f.write("\n".join(type_lines))
+
+


### PR DESCRIPTION
## Summary

Docs-only: a phased project plan (`docs/sheet-csv/`) for turning an inherited Python script (`full_sheet_gen.py`, committed under `docs/sheet-csv/reference/`) into a nightly pipeline that regenerates the industry-planning Google Sheet's static CSVs from the SDE mirror and serves them over HTTP — replacing the current download-SDE-run-script-paste-into-sheet ritual.

The design is an explicit hybrid of two existing patterns:

- **Build like `esf-data`:** a pure encoder (`src/buildSheetCsv.js`) paging `sde_types`/`sde_blueprints` via the anon client, a job (`src/jobs/sheetCsv.js`) upserting into a new public-read `sheet_csv` table, run as an `encodeSheets` tail step of the `sde-mirror` workflow once the `types`+`blueprints` stems drain (plus an unscheduled `/api/cron/sheet-csv` bootstrap route).
- **Serve like the Sheets API endpoints:** `text/csv` for `=IMPORTDATA()` — but with no `api_token` (pure public SDE data, same bytes for everyone) and `/esf/[file]`-style caching (ETag on `sde_build`, CDN `s-maxage` + stale-while-revalidate).

## Endpoints planned

- `static-inputs-{twines,miros}.csv` — `Group,Type,Material,InputQty` (the sheet's StaticInputs tab shape, with the Group label pre-joined server-side so the tab's `#N/A` lookup failures can't happen)
- `static-outputs-{twines,miros}.csv` — `Group,Type,OutputQty,JobTime`
- `invention.csv`, `types-{twines,miros}.csv`

## Plan structure

- `README.md` — architecture, file set, decisions taken, open questions
- `01-port-generator.md` — full transform spec ported from the Python (blueprint dedup, group-label rules, quirks/latent bug not to port), with a data-level parity check
- `02-table-and-job.md` — `sheet_csv` table (migration + `schema.sql`), job + CLI + bootstrap route
- `03-workflow-step.md` — the `sde-mirror` workflow tail step
- `04-serve-route.md` — the `/sheets/[file]` route, caching, and the sheet cutover checklist

No code changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdB1hhUFwKKP2KYVGjsodc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdB1hhUFwKKP2KYVGjsodc)_