### PR TITLE
Move Structures window dropdown to top-right; scope sparklines to it

### DIFF
--- a/src/app/structure/page.tsx
+++ b/src/app/structure/page.tsx
@@ -82,9 +82,10 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
     redirect('/')
   }
 
-  // The tax-revenue window: the footer (per-structure Revenue, unaccounted tax,
-  // clone revenue) sums only entries newer than this. Driven by the ?days=N
-  // dropdown, clamped to an offered option.
+  // The time window: the footer (per-structure Revenue, unaccounted tax, clone
+  // revenue) sums only entries newer than this, and the industry-index
+  // sparklines cover the same span. Driven by the ?days=N dropdown (top-right),
+  // clamped to an offered option.
   const { days: daysParam } = await searchParams
   const windowDays = structureWindowDays(daysParam)
   const windowStart = new Date(Date.now() - windowDays * 86_400_000).toISOString()
@@ -166,11 +167,14 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
     supabase,
     list.map((s) => Number(s.system_id))
   )
+  // The same window that drives the revenue footer also scopes the index
+  // sparklines. Widen the bucket for longer windows so the point count stays
+  // sane on a 100px sparkline (~180 points max: 24h/day ÷ bucketHours).
   const indexHistoryBySystem = await fetchSystemIndexHistory(
     supabase,
-    list.map((s) => Number(s.system_id))
+    list.map((s) => Number(s.system_id)),
+    { days: windowDays, bucketHours: Math.max(1, Math.ceil((windowDays * 24) / 180)) }
   )
-  console.log({ indexHistoryBySystem })
 
   const journal = await fetchAllRows<JournalRow>((from, to) =>
     supabase
@@ -278,7 +282,13 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
 
   return (
     <>
-      <h1>Structures</h1>
+      <div className={styles.header}>
+        <h1>Structures</h1>
+        <span className={styles.headerControl}>
+          <span className={styles.headerControlLabel}>Window</span>
+          <WindowSelect days={windowDays} />
+        </span>
+      </div>
       {list.length > 0 ? (
         <>
           <ul className={styles.grid}>
@@ -386,10 +396,6 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
           </ul>
 
           <div className={styles.footer}>
-            <span className={styles.footerControlLabel}>Revenue window</span>
-            <span className={styles.footerControl}>
-              <WindowSelect days={windowDays} />
-            </span>
             {unaccountedParties.length > 0 && (
               <>
                 <span>Unaccounted tax revenue:</span>

--- a/src/app/structure/structures.module.css
+++ b/src/app/structure/structures.module.css
@@ -245,6 +245,27 @@
   }
 }
 
+/* Page header: title on the left, the time-window dropdown pinned top-right. The
+ * window drives both the revenue footer and the industry-index sparklines. */
+.header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.headerControl {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.headerControlLabel {
+  color: var(--ink-faint);
+}
+
 .footer {
   display: grid;
   grid-template-columns: auto auto;
@@ -259,14 +280,6 @@
   font-family: var(--mono);
   font-variant-numeric: tabular-nums;
   text-align: right;
-}
-
-.footerControlLabel {
-  color: var(--ink-faint);
-}
-
-.footerControl {
-  justify-self: start;
 }
 
 .windowSelect {

--- a/src/app/structure/windowSelect.tsx
+++ b/src/app/structure/windowSelect.tsx
@@ -6,17 +6,18 @@ import { useTransition } from 'react'
 import { STRUCTURE_WINDOW_OPTIONS } from './windows'
 import styles from './structures.module.css'
 
-// The tax-revenue time-window dropdown shown in the Structures footer, next to
-// the unaccounted-revenue figure — the same control as the Market/Indexes
-// pages. The window lives in the URL (?days=N) so the server component refetches
-// exactly the span it needs.
+// The time-window dropdown pinned to the top-right of the Structures page — the
+// same control as the Market/Indexes pages. It scopes both the revenue footer
+// (per-structure Revenue, unaccounted tax, clone revenue) and the industry-index
+// sparklines. The window lives in the URL (?days=N) so the server component
+// refetches exactly the span it needs.
 export const WindowSelect = ({ days }: { days: number }) => {
   const router = useRouter()
   const [pending, startTransition] = useTransition()
 
   return (
     <label className={styles.windowSelect} data-pending={pending || undefined}>
-      <span className={styles.srOnly}>Revenue window</span>
+      <span className={styles.srOnly}>Time window</span>
       <select
         value={days}
         onChange={(e) => {


### PR DESCRIPTION
## Summary

- Moves the revenue time-window dropdown out of the footer and into a header row pinned to the **top-right** of the Structures page, next to the "Structures" title.
- The selected window now **also scopes the industry-index sparklines**. Previously the sparklines were fixed at a 7-day history regardless of the dropdown; they now cover the same span as the revenue figures.
- The sparkline bucket width scales with the window (≈180 points max) so longer windows (e.g. 90 days) don't cram thousands of hourly points into a 100px sparkline.
- Removes a leftover `console.log({ indexHistoryBySystem })` debug statement.

## Changes

- `src/app/structure/page.tsx` — render a `.header` flex row with the title and `WindowSelect`; pass `{ days: windowDays, bucketHours }` to `fetchSystemIndexHistory`; drop the footer window control and the debug log.
- `src/app/structure/structures.module.css` — add `.header` / `.headerControl` / `.headerControlLabel`; remove the now-unused `.footerControl*` styles.
- `src/app/structure/windowSelect.tsx` — update the accessible label ("Time window") and comment to reflect that it now governs both revenue and sparklines.

## Testing

- `pnpm run lint` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183v67SLeCyRLPB2bmVBbF7

---
_Generated by [Claude Code](https://claude.ai/code/session_0183v67SLeCyRLPB2bmVBbF7)_