### PR TITLE
Reduce extract-job peak memory: stream the SDE ingest, compact reconciles

### DIFF
--- a/src/app/api/queue/jobs/route.ts
+++ b/src/app/api/queue/jobs/route.ts
@@ -129,25 +129,14 @@ type Msg = {
   taskId?: string
 }
 
-// A thrown error fails the callback, so the Vercel queue retries the message
-// (per retryAfterSeconds in vercel.json).
-// Log this invocation's memory footprint to the console. Called from a `finally`
-// so it prints on every exit path (success, throw, tracked, untracked) — the
-// point is to see what the job actually needs so the function's `memory` limit
-// (vercel.json) can be sized against real usage rather than guessed. `maxRSS`
-// (process.resourceUsage) is the peak resident set size in KB on Linux; under
-// Vercel Fluid Compute the instance is reused across messages, so it's the
-// high-water mark for the whole worker, which is exactly the number to compare
-// against the configured limit.
-const mb = (bytes: number) => Math.round((bytes / 1024 / 1024) * 10) / 10
-const logMemoryUsage = (job: string) => {
-  const mem = process.memoryUsage()
-  const peakRssMb = Math.round((process.resourceUsage().maxRSS / 1024) * 10) / 10
-  console.log(
-    `[queue/jobs] mem job=${job} rss=${mb(mem.rss)}MB heapUsed=${mb(mem.heapUsed)}MB external=${mb(
-      mem.external
-    )}MB peakRss=${peakRssMb}MB`
-  )
+// Emit this invocation's memory footprint as a `job.peak_rss` metric line
+// (src/observability.js). Called from a `finally` so it fires on every exit
+// path (success, throw, tracked, untracked) — the point is to see what the job
+// actually needs so the function's `memory` limit (vercel.json) can be sized
+// against real usage rather than guessed.
+const logMemoryUsage = async (job: string) => {
+  const { recordPeakRss } = await import('@/observability.js')
+  recordPeakRss({ job })
 }
 
 // A thrown error fails the callback, so the Vercel queue retries the message
@@ -228,6 +217,6 @@ export const POST = handleCallback(async (message: Msg) => {
         .eq('id', taskId)
     }
   } finally {
-    logMemoryUsage(job)
+    await logMemoryUsage(job)
   }
 })

--- a/src/buildEsfData.js
+++ b/src/buildEsfData.js
@@ -354,13 +354,17 @@ const encodeMessage = (root, messageName, entries) => {
 }
 
 // The six .pb2 files, in the (message, output filename) order they encode.
+// Largest-first (typeDogma dwarfs the rest): each map is released right after
+// its encode, so the biggest map's fromObject() copy never coexists with the
+// other maps plus the finished buffers. Output order doesn't matter — buffers
+// is keyed by fileName, and ESF_FILE_NAMES consumers treat it as a set.
 const FILES = [
-  { messageName: 'Types', key: 'types', fileName: 'types.pb2' },
-  { messageName: 'Groups', key: 'groups', fileName: 'groups.pb2' },
-  { messageName: 'MarketGroups', key: 'marketGroups', fileName: 'marketGroups.pb2' },
-  { messageName: 'DogmaAttributes', key: 'dogmaAttributes', fileName: 'dogmaAttributes.pb2' },
-  { messageName: 'DogmaEffects', key: 'dogmaEffects', fileName: 'dogmaEffects.pb2' },
   { messageName: 'TypeDogma', key: 'typeDogma', fileName: 'typeDogma.pb2' },
+  { messageName: 'Types', key: 'types', fileName: 'types.pb2' },
+  { messageName: 'DogmaEffects', key: 'dogmaEffects', fileName: 'dogmaEffects.pb2' },
+  { messageName: 'DogmaAttributes', key: 'dogmaAttributes', fileName: 'dogmaAttributes.pb2' },
+  { messageName: 'MarketGroups', key: 'marketGroups', fileName: 'marketGroups.pb2' },
+  { messageName: 'Groups', key: 'groups', fileName: 'groups.pb2' },
 ]
 
 // The six output filenames, for consumers that need the set before encoding
@@ -373,26 +377,32 @@ export const ESF_FILE_NAMES = FILES.map(({ fileName }) => fileName)
 // upserts the buffers into the esf_data table for /esf/[file] to serve.
 export const encodeEsfData = async () => {
   console.log('esf: reading source tables from the sde_* mirror…')
-  const groups = await buildGroups()
-  const [types, categories, marketGroups, dogmaAttributes, dogmaEffects, typeDogma] = await Promise.all([
-    buildTypes(groups),
-    buildCategories(),
-    buildMarketGroups(),
-    buildDogmaAttributes(),
-    buildDogmaEffects(),
-    buildTypeDogma(),
-  ])
+  // Built sequentially, and held in one `maps` object rather than individual
+  // bindings, so each map can be dropped the moment its last consumer is done —
+  // applyPatches needs every map alive at once (that floor is inherent), but
+  // categories dies right after patching and each encoded map dies after its
+  // encode instead of the whole set surviving to the end of the function.
+  const maps = {}
+  maps.groups = await buildGroups()
+  maps.types = await buildTypes(maps.groups)
+  maps.categories = await buildCategories()
+  maps.marketGroups = await buildMarketGroups()
+  maps.dogmaAttributes = await buildDogmaAttributes()
+  maps.dogmaEffects = await buildDogmaEffects()
+  maps.typeDogma = await buildTypeDogma()
 
   const patchGroups = JSON.parse(await readFile(PATCHES_PATH, 'utf8'))
-  applyPatches(patchGroups, { types, groups, categories, dogmaAttributes, dogmaEffects, typeDogma })
+  applyPatches(patchGroups, maps)
   console.log(`esf: applied ${patchGroups.length} eveship.fit patch groups`)
+  delete maps.categories
 
-  const entriesByKey = { types, groups, marketGroups, dogmaAttributes, dogmaEffects, typeDogma }
   const root = await protobuf.load(PROTO_PATH)
   const buffers = {}
   for (const { messageName, key, fileName } of FILES) {
-    buffers[fileName] = encodeMessage(root, messageName, entriesByKey[key])
-    console.log(`esf: encoded ${fileName} (${buffers[fileName].length} bytes, ${Object.keys(entriesByKey[key]).length} entries)`)
+    const entryCount = Object.keys(maps[key]).length
+    buffers[fileName] = encodeMessage(root, messageName, maps[key])
+    delete maps[key]
+    console.log(`esf: encoded ${fileName} (${buffers[fileName].length} bytes, ${entryCount} entries)`)
   }
   return buffers
 }

--- a/src/jobs/characterAssets.js
+++ b/src/jobs/characterAssets.js
@@ -13,7 +13,9 @@ const SCOPE = 'esi-assets.read_assets.v1'
 
 // The tracked attributes that define a version of an item. Two sightings with
 // the same signature are the "same" row; any difference opens a new SCD row.
-const signature = (a) =>
+// `name` is an explicit arg for fetched ESI rows, whose player-assigned name
+// lives in a separate lookup Map rather than on the row.
+const signature = (a, name = a.name ?? null) =>
   JSON.stringify([
     Number(a.type_id),
     a.location_id == null ? null : Number(a.location_id),
@@ -22,7 +24,7 @@ const signature = (a) =>
     a.quantity == null ? null : Number(a.quantity),
     a.is_singleton ?? null,
     !!a.is_blueprint_copy,
-    a.name ?? null,
+    name,
   ])
 
 // ESI only names singleton items (assembled ships, containers). Resolve them in
@@ -49,36 +51,43 @@ const fetchNames = async (access_token, characterID, fetched) => {
 // hangar doesn't silently truncate the "current" set. Reading a truncated set
 // makes the un-read items look new, so they'd be re-inserted and collide with
 // their existing current row on character_asset_over_time_current_item_idx.
+// Each page is folded into a compact item_id → { id, sig } map as it arrives
+// and then discarded — the classify step only ever compares signatures, so
+// holding every current row's full 10 columns just multiplied peak memory.
 const PAGE = 1000
 
-const fetchCurrentRows = async (character_id, cols, from = 0) => {
-  const { data, error } = await sudoSupabase
-    .from('character_asset_over_time')
-    .select(cols)
-    .eq('character_id', character_id)
-    .eq('is_current', true)
-    .order('id', { ascending: true })
-    .range(from, from + PAGE - 1)
-  if (error) throw error
-  const page = data ?? []
-  if (page.length < PAGE) return page
-  return [...page, ...(await fetchCurrentRows(character_id, cols, from + PAGE))]
+const fetchCurrentByItem = async (character_id) => {
+  const cols =
+    'id, item_id, type_id, location_id, location_flag, location_type, quantity, is_singleton, is_blueprint_copy, name'
+  const byItem = new Map()
+  const fetchPage = async (from) => {
+    const { data, error } = await sudoSupabase
+      .from('character_asset_over_time')
+      .select(cols)
+      .eq('character_id', character_id)
+      .eq('is_current', true)
+      .order('id', { ascending: true })
+      .range(from, from + PAGE - 1)
+    if (error) throw error
+    const page = data ?? []
+    forEach((c) => byItem.set(Number(c.item_id), { id: c.id, sig: signature(c) }), page)
+    if (page.length === PAGE) await fetchPage(from + PAGE)
+  }
+  await fetchPage(0)
+  return byItem
 }
 
 // Reconcile the freshly fetched assets against the character's current (open)
 // rows: unchanged items get their valid_until extended, changed items have
 // their old row closed and a new one inserted, and vanished items are closed.
-const reconcile = async (character_id, fetched) => {
-  const cols =
-    'id, item_id, type_id, location_id, location_flag, location_type, quantity, is_singleton, is_blueprint_copy, name'
-  const current = await fetchCurrentRows(character_id, cols)
-
-  const byItemId = map(juxt([pipe(prop('item_id'), Number), identity]))
-  const currentByItem = new Map(byItemId(current))
+// `names` is the player-assigned-name Map from fetchNames, applied here per
+// item instead of pre-merged onto a full copy of the fetched array.
+const reconcile = async (character_id, fetched, names) => {
+  const currentByItem = await fetchCurrentByItem(character_id)
 
   // ESI can return the same item twice across pages if assets shift mid-fetch;
   // collapse to one entry per item so we never queue two inserts for it.
-  const fetchedByItem = new Map(byItemId(fetched))
+  const fetchedByItem = new Map(map(juxt([pipe(prop('item_id'), Number), identity]), fetched))
 
   const now = new Date().toISOString()
 
@@ -89,8 +98,10 @@ const reconcile = async (character_id, fetched) => {
   // an O(n) pass into O(n²).
   const { touchIds, closeIds, inserts } = reduce(
     (acc, a) => {
-      const cur = currentByItem.get(Number(a.item_id))
-      if (cur && signature(cur) === signature(a)) {
+      const itemId = Number(a.item_id)
+      const name = names.get(itemId) ?? null
+      const cur = currentByItem.get(itemId)
+      if (cur && cur.sig === signature(a, name)) {
         acc.touchIds.push(cur.id)
       } else {
         if (cur) acc.closeIds.push(cur.id)
@@ -106,7 +117,7 @@ const reconcile = async (character_id, fetched) => {
           is_singleton: a.is_singleton ?? null,
           is_blueprint_copy: !!a.is_blueprint_copy,
           valid_until: now,
-          name: a.name ?? null,
+          name,
         })
       }
       return acc
@@ -116,11 +127,10 @@ const reconcile = async (character_id, fetched) => {
   )
 
   // Anything still open but not seen this run has left the character's assets.
-  const fetchedIds = new Set(fetchedByItem.keys())
-  const vanishedIds = pipe(
-    filter((cur) => !fetchedIds.has(Number(cur.item_id))),
-    map(prop('id'))
-  )([...currentByItem.values()])
+  const vanishedIds = []
+  currentByItem.forEach(({ id }, itemId) => {
+    if (!fetchedByItem.has(itemId)) vanishedIds.push(id)
+  })
   const allCloseIds = [...closeIds, ...vanishedIds]
 
   await forEachSequential(splitEvery(200, touchIds), async (ids) => {
@@ -151,12 +161,11 @@ export const runCharacterAssets = ({ characterIds } = {}) =>
     const t0 = Date.now()
     const fetched = await fetchAllPages((page) => assets(access_token, characterID, page))
     const names = await fetchNames(access_token, characterID, fetched)
-    const all = map((a) => ({ ...a, name: names.get(Number(a.item_id)) ?? null }), fetched)
-    const { touched, opened, closed } = await reconcile(character_id, all)
+    const { touched, opened, closed } = await reconcile(character_id, fetched, names)
 
     const dt = Date.now() - t0
     console.log(
-      `[${TAG}] ${ctx}: ${all.length} asset(s); ${touched} unchanged, ${opened} opened, ${closed} closed in ${dt}ms`
+      `[${TAG}] ${ctx}: ${fetched.length} asset(s); ${touched} unchanged, ${opened} opened, ${closed} closed in ${dt}ms`
     )
   })
 

--- a/src/jobs/corpAssets.js
+++ b/src/jobs/corpAssets.js
@@ -1,4 +1,4 @@
-import { filter, map, pipe, prop, reduce, splitEvery } from 'ramda'
+import { forEach, reduce, splitEvery } from 'ramda'
 
 import { corpAssets } from '../esi.js'
 import { sudoSupabase } from '../supabase.js'
@@ -32,21 +32,31 @@ const signature = (a) =>
   ])
 
 // PostgREST caps a single select; page through every open row so a large corp
-// hangar doesn't silently truncate the "current" set.
+// hangar doesn't silently truncate the "current" set. Each page is folded into
+// a compact item_id → { id, sig } map as it arrives and then discarded — the
+// classify step only ever compares signatures, so holding every current row's
+// full columns just multiplied peak memory (see the character-assets twin).
 const PAGE = 1000
 
-const fetchCurrentRows = async (corporation_id, cols, from = 0) => {
-  const { data, error } = await sudoSupabase
-    .from('corp_asset_over_time')
-    .select(cols)
-    .eq('corporation_id', corporation_id)
-    .eq('is_current', true)
-    .order('id', { ascending: true })
-    .range(from, from + PAGE - 1)
-  if (error) throw error
-  const page = data ?? []
-  if (page.length < PAGE) return page
-  return [...page, ...(await fetchCurrentRows(corporation_id, cols, from + PAGE))]
+const fetchCurrentByItem = async (corporation_id) => {
+  const cols =
+    'id, item_id, type_id, location_id, location_flag, location_type, quantity, is_singleton, is_blueprint_copy'
+  const byItem = new Map()
+  const fetchPage = async (from) => {
+    const { data, error } = await sudoSupabase
+      .from('corp_asset_over_time')
+      .select(cols)
+      .eq('corporation_id', corporation_id)
+      .eq('is_current', true)
+      .order('id', { ascending: true })
+      .range(from, from + PAGE - 1)
+    if (error) throw error
+    const page = data ?? []
+    forEach((c) => byItem.set(Number(c.item_id), { id: c.id, sig: signature(c) }), page)
+    if (page.length === PAGE) await fetchPage(from + PAGE)
+  }
+  await fetchPage(0)
+  return byItem
 }
 
 // Reconcile freshly fetched corp assets against the corp's current (open) rows
@@ -54,11 +64,7 @@ const fetchCurrentRows = async (corporation_id, cols, from = 0) => {
 // for per-character assets: unchanged items get valid_until extended, changed
 // items close their old row and open a new one, and vanished items are closed.
 const reconcile = async (corporation_id, fetched) => {
-  const cols =
-    'id, item_id, type_id, location_id, location_flag, location_type, quantity, is_singleton, is_blueprint_copy'
-  const current = await fetchCurrentRows(corporation_id, cols)
-
-  const currentByItem = new Map(current.map((c) => [Number(c.item_id), c]))
+  const currentByItem = await fetchCurrentByItem(corporation_id)
   // ESI can return the same item twice across pages if assets shift mid-fetch;
   // collapse to one entry per item so we never queue two inserts for it.
   const fetchedByItem = new Map(fetched.map((a) => [Number(a.item_id), a]))
@@ -73,7 +79,7 @@ const reconcile = async (corporation_id, fetched) => {
   const { touchIds, closeIds, inserts } = reduce(
     (acc, a) => {
       const cur = currentByItem.get(Number(a.item_id))
-      if (cur && signature(cur) === signature(a)) {
+      if (cur && cur.sig === signature(a)) {
         acc.touchIds.push(cur.id)
       } else {
         if (cur) acc.closeIds.push(cur.id)
@@ -97,11 +103,10 @@ const reconcile = async (corporation_id, fetched) => {
   )
 
   // Anything still open but not seen this run has left the corp's assets.
-  const fetchedIds = new Set(fetchedByItem.keys())
-  const vanishedIds = pipe(
-    filter((cur) => !fetchedIds.has(Number(cur.item_id))),
-    map(prop('id'))
-  )([...currentByItem.values()])
+  const vanishedIds = []
+  currentByItem.forEach(({ id }, itemId) => {
+    if (!fetchedByItem.has(itemId)) vanishedIds.push(id)
+  })
   const allCloseIds = [...closeIds, ...vanishedIds]
 
   await forEachSequential(splitEvery(200, touchIds), async (ids) => {

--- a/src/jobs/sdeMirror.js
+++ b/src/jobs/sdeMirror.js
@@ -23,10 +23,12 @@
 //     node:zlib inflates (zip entries are raw deflate). No unzip binary, no
 //     zip library.
 import { randomInt } from 'node:crypto'
-import { inflateRawSync } from 'node:zlib'
+import { Readable } from 'node:stream'
+import { createInflateRaw, inflateRawSync } from 'node:zlib'
 import { map, splitEvery } from 'ramda'
 
 import { userAgent } from '../esi.js'
+import { recordPeakRss } from '../observability.js'
 import { resolveAllIds } from '../resolveNames.js'
 import { recordHeartbeat, sudoSupabase } from '../supabase.js'
 import { cli, forEachSequential } from './lib.js'
@@ -170,19 +172,44 @@ export const listEntries = async (zipUrl) => {
   return files
 }
 
-// Range-read one entry's compressed bytes and inflate them. The local header's
+// Open one entry's decompressed bytes as a Node Readable, Range-reading only
+// that entry's compressed bytes and inflating them incrementally — the peak
+// held in memory is a decompression chunk, not the whole entry (typeDogma
+// inflates to hundreds of MB, and buffering compressed + inflated at once was
+// what forced the workflow function's memory sizing). The local header's
 // name/extra lengths can differ from the central directory's, so read it first
-// to find where the data actually starts.
-export const fetchEntryBuffer = async (zipUrl, file) => {
+// to find where the data actually starts. Abort `signal` to stop the download
+// mid-entry (the slice budget expiring).
+export const openEntryStream = async (zipUrl, file, signal) => {
   const local = await fetchRange(zipUrl, file.localOffset, file.localOffset + 29)
   if (local.readUInt32LE(0) !== LOC_SIG) throw new Error(`sde-mirror: bad local header for ${file.entry}`)
   const nameLen = local.readUInt16LE(26)
   const extraLen = local.readUInt16LE(28)
   const dataStart = file.localOffset + 30 + nameLen + extraLen
-  const raw = await fetchRange(zipUrl, dataStart, dataStart + file.compressedSize - 1)
-  if (file.method === 0) return raw
-  if (file.method === 8) return inflateRawSync(raw)
-  throw new Error(`sde-mirror: unsupported compression method ${file.method} for ${file.entry}`)
+  const dataEnd = dataStart + file.compressedSize - 1
+  if (file.method !== 0 && file.method !== 8)
+    throw new Error(`sde-mirror: unsupported compression method ${file.method} for ${file.entry}`)
+
+  const res = await fetch(zipUrl, {
+    headers: { 'User-Agent': userAgent, Range: `bytes=${dataStart}-${dataEnd}` },
+    signal,
+  })
+  if (res.status === 206) {
+    const source = Readable.fromWeb(res.body)
+    if (file.method === 0) return source
+    const inflate = createInflateRaw()
+    // pipe() doesn't forward errors; surface network failures to the consumer.
+    source.on('error', (e) => inflate.destroy(e))
+    return source.pipe(inflate)
+  }
+  // A server ignoring Range replies 200 with the whole zip; fall back to
+  // buffering and slicing locally, as the Range path used to for every entry.
+  if (res.status === 200) {
+    const whole = Buffer.from(await res.arrayBuffer())
+    const raw = whole.subarray(dataStart, dataEnd + 1)
+    return Readable.from([file.method === 0 ? Buffer.from(raw) : inflateRawSync(raw)])
+  }
+  throw new Error(`sde-mirror: GET ${zipUrl} bytes=${dataStart}-${dataEnd} → ${res.status}`)
 }
 
 // ── Ingest ──────────────────────────────────────────────────────────────────
@@ -204,25 +231,34 @@ const sweepStaleRows = async (table, build) => {
   if (error) throw new Error(`sde-mirror: stale sweep of ${table} failed: ${error.message}`)
 }
 
-const logMemory = (label) => {
-  const peakRssMb = Math.round((process.resourceUsage().maxRSS / 1024) * 10) / 10
-  console.log(`[sde-mirror] mem ${label} peakRss=${peakRssMb}MB`)
-}
+const logMemory = (label) => recordPeakRss({ job: 'sde-mirror', entry: label })
 
 // Ingest one entry from line `startLine`, upserting {_key, data, sde_build}
 // rows in bounded chunks until the entry is done (returns -1, after sweeping
 // stale rows) or the time budget runs out (returns the cursor to resume from).
 // Re-running a slice is idempotent — everything is keyed upserts — which is
 // what makes the workflow's bounded step retries safe.
+//
+// The entry is consumed as a stream (openEntryStream): each decompressed chunk
+// is walked for complete lines, with the partial trailing line carried into the
+// next chunk, so peak memory is one chunk + one line + the pending upsert chunk
+// rather than the whole inflated entry. Backpressure comes free — the download
+// only advances as fast as the upserts drain — and when the budget expires the
+// fetch is aborted instead of having already buffered the entry's tail.
+// Deliberately imperative buffer walk, as before.
 export const ingestEntrySlice = async (zipUrl, file, build, startLine = 0, budgetMs = STEP_BUDGET_MS) => {
   const t0 = Date.now()
-  const buf = await fetchEntryBuffer(zipUrl, file)
   const table = `sde_${file.stem}`
+  const abort = new AbortController()
+  const stream = await openEntryStream(zipUrl, file, abort.signal)
 
   let line = 0
   let upserted = 0
   let chunk = []
   let chunkBytes = 0
+  let carry = Buffer.alloc(0)
+  let pauseLine = null
+  let skipFile = false
 
   const flush = async () => {
     if (chunk.length === 0) return
@@ -232,44 +268,70 @@ export const ingestEntrySlice = async (zipUrl, file, build, startLine = 0, budge
     chunkBytes = 0
   }
 
-  // Deliberately imperative buffer walk (one pass, no full-string split) — the
-  // inflated entry can run to hundreds of MB and a .split('\n') would double it.
-  let pos = 0
-  while (pos < buf.length) {
-    let nl = buf.indexOf(10, pos)
-    if (nl === -1) nl = buf.length
-    const lineStart = pos
-    const lineEnd = nl
-    pos = nl + 1
-    const thisLine = line++
-    if (thisLine < startLine || lineEnd <= lineStart) continue
+  // Walk the complete lines in `combined`, returning the offset where the
+  // partial trailing line begins (carried into the next chunk). Sets pauseLine
+  // when the budget expires and skipFile when the entry has no _key to mirror.
+  const walkLines = async (combined) => {
+    let pos = 0
+    while (pauseLine === null && !skipFile) {
+      const nl = combined.indexOf(10, pos)
+      if (nl === -1) break
+      const lineStart = pos
+      pos = nl + 1
+      const thisLine = line++
+      if (thisLine < startLine || nl <= lineStart) continue
 
-    const text = buf.toString('utf8', lineStart, lineEnd)
-    if (text.trim() === '') continue
-    const parsed = JSON.parse(text)
+      const text = combined.toString('utf8', lineStart, nl)
+      if (text.trim() === '') continue
+      const parsed = JSON.parse(text)
 
-    // The first row of the file establishes the table (and its key type) —
-    // resumed slices (startLine > 0) land in the table the first slice made.
-    // An entry whose rows carry no _key (e.g. a metadata file) has no primary
-    // key to mirror on; skip the whole file rather than erroring.
-    if (startLine === 0 && upserted === 0 && chunk.length === 0) {
-      if (parsed._key === undefined) {
-        console.log(`[sde-mirror] ${file.entry}: rows carry no _key, skipping file`)
-        return -1
+      // The first row of the file establishes the table (and its key type) —
+      // resumed slices (startLine > 0) land in the table the first slice made.
+      // An entry whose rows carry no _key (e.g. a metadata file) has no primary
+      // key to mirror on; skip the whole file rather than erroring.
+      if (startLine === 0 && upserted === 0 && chunk.length === 0) {
+        if (parsed._key === undefined) {
+          console.log(`[sde-mirror] ${file.entry}: rows carry no _key, skipping file`)
+          skipFile = true
+          return pos
+        }
+        await ensureMirrorTable(file.stem, typeof parsed._key === 'number' ? 'bigint' : 'text')
       }
-      await ensureMirrorTable(file.stem, typeof parsed._key === 'number' ? 'bigint' : 'text')
-    }
 
-    chunk.push({ _key: parsed._key, data: parsed, sde_build: build })
-    chunkBytes += text.length
-    if (chunk.length >= CHUNK_ROWS || chunkBytes >= CHUNK_BYTES) {
-      await flush()
-      if (Date.now() - t0 > budgetMs) {
-        console.log(`[sde-mirror] ${file.entry}: +${upserted} rows, pausing at line ${thisLine + 1}`)
-        logMemory(file.entry)
-        return thisLine + 1
+      chunk.push({ _key: parsed._key, data: parsed, sde_build: build })
+      chunkBytes += text.length
+      if (chunk.length >= CHUNK_ROWS || chunkBytes >= CHUNK_BYTES) {
+        await flush()
+        if (Date.now() - t0 > budgetMs) pauseLine = thisLine + 1
       }
     }
+    return pos
+  }
+
+  try {
+    for await (const piece of stream) {
+      const combined = carry.length ? Buffer.concat([carry, piece]) : piece
+      const pos = await walkLines(combined)
+      if (pauseLine !== null || skipFile) break
+      carry = combined.subarray(pos)
+    }
+    // The last line of a drained entry may lack a trailing newline.
+    if (pauseLine === null && !skipFile && carry.length > 0) {
+      await walkLines(Buffer.concat([carry, Buffer.from('\n')]))
+    }
+  } finally {
+    // Whether paused, skipped, or drained: stop the download. Breaking out of
+    // for-await already destroyed the stream; swallow the abort-induced error
+    // so it can't surface as an unhandled 'error' event.
+    stream.on('error', () => {})
+    abort.abort()
+  }
+
+  if (skipFile) return -1
+  if (pauseLine !== null) {
+    console.log(`[sde-mirror] ${file.entry}: +${upserted} rows, pausing at line ${pauseLine}`)
+    logMemory(file.entry)
+    return pauseLine
   }
 
   await flush()

--- a/src/observability.js
+++ b/src/observability.js
@@ -40,6 +40,28 @@ export const recordEsiConditional = ({
     duration_ms: durationMs,
   })
 
+// One job invocation's memory footprint — emitted from the queue consumer
+// (src/app/api/queue/jobs/route.ts), the workflow heartbeat wrapper
+// (src/workflows/lib.ts), and per-entry from the sde-mirror ingest. Group by
+// (job) and chart max(peak_rss_mb) to size the function's `memory` limit
+// against real usage instead of guessing. `maxRSS` (process.resourceUsage, KB
+// on Linux) is the process-wide high-water mark; under Vercel Fluid Compute
+// the instance is reused across invocations, so it reflects the whole worker —
+// which is exactly the number the configured memory limit has to cover.
+//   entry: optional finer-grained label (e.g. the SDE zip entry a slice ingested)
+export const recordPeakRss = ({ job, entry = null }) => {
+  const mb = (bytes) => Math.round((bytes / 1024 / 1024) * 10) / 10
+  const mem = process.memoryUsage()
+  recordMetric('job.peak_rss', {
+    job,
+    entry,
+    peak_rss_mb: Math.round((process.resourceUsage().maxRSS / 1024) * 10) / 10,
+    rss_mb: mb(mem.rss),
+    heap_used_mb: mb(mem.heapUsed),
+    external_mb: mb(mem.external),
+  })
+}
+
 // One Discord interaction outcome — see src/app/api/discord/interactions/route.ts.
 // Group by (type, outcome) to watch signature rejections (portal validation and
 // spoof attempts) and, later, command traffic.

--- a/src/workflows/lib.ts
+++ b/src/workflows/lib.ts
@@ -23,12 +23,14 @@
 export async function runJobWithHeartbeat(job: string, load: () => Promise<() => Promise<unknown>>) {
   const { randomInt } = await import('node:crypto')
   const { recordHeartbeat } = await import('@/supabase.js')
+  const { recordPeakRss } = await import('@/observability.js')
   const run = await load()
   const runId = randomInt(1, 2 ** 48)
   await recordHeartbeat(job, 'start', { runId, source: 'vercel-workflow' })
   try {
     await run()
   } finally {
+    recordPeakRss({ job })
     await recordHeartbeat(job, 'end', { runId, source: 'vercel-workflow' })
   }
 }


### PR DESCRIPTION
Peak RSS sets the provisioned memory size a Vercel function needs, and provisioned memory × hours is what gets billed — so this PR attacks the memory high-water marks of the extract jobs, biggest first, and adds the instrumentation to size the memory limit against real usage afterward.

## Stream the SDE ingest (`src/jobs/sdeMirror.js`) — the big one

`ingestEntrySlice` used to Range-read an entry's **entire** compressed bytes and `inflateRawSync` the **entire** entry, holding both at once — and every *resumed* slice of a big entry re-paid that peak just to skip to its cursor line. The entry is now consumed as a stream: the Range fetch is piped through `createInflateRaw`, complete lines are walked per decompressed chunk with the partial tail carried into the next chunk, and the budget expiring aborts the fetch instead of having already buffered the entry's tail. Backpressure comes free — the download only advances as fast as the upserts drain.

The cursor contract, signature, chunk sizing, and idempotence are unchanged, so `src/workflows/sdeMirror.ts` and the CLI path need no changes. A server that ignores Range (non-206) falls back to the old buffered shape.

**Measured** (isolated processes, real CCP zip, largest entry `mapMoons.jsonl`, 224 MB inflated):

| | peak RSS |
|---|---|
| old buffered shape | 587 MB |
| streamed ingest | 191 MB (~100 MB of it baseline Node + modules) |

and the streamed peak no longer scales with entry size.

**Correctness harness**: ran the real `ingestEntrySlice` against the real zip with `SUPABASE_URL` pointed at a mock PostgREST server that records every upsert; a 9-slice resumed run of `typeDogma.jsonl` (budget forced low) produced the exact reference row sequence — same `_key` order, same payloads, no gaps or duplicates across pause/resume boundaries, one `ensure_sde_mirror_table`, one stale sweep.

## Sequence and release in `encodeEsfData` (`src/buildEsfData.js`)

The six protobuf source maps are now built sequentially (was `Promise.all`), encoded largest-first, and each map is released right after its encode — so `typeDogma`'s transient `Message.fromObject` copy never coexists with every other map plus all the finished buffers. `applyPatches` still sees all maps at once (inherent), and `ESF_FILE_NAMES` consumers treat the file list as a set, so the reorder is invisible.

## Compact the asset reconciles (`characterAssets.js`, `corpAssets.js`)

- `fetchCurrentRows` → `fetchCurrentByItem`: each PostgREST page of current rows is folded into a compact `item_id → { id, sig }` map as it arrives and discarded, instead of accumulating every open row's full columns — the classify step only ever compared signatures anyway. Vanished detection iterates the same map.
- `character-assets` no longer clones the whole fetched array to attach player-assigned names; the `names` Map is applied per item inside `reconcile`.

Peak drops from roughly 3–4× the asset set to ~1× (the fetched ESI array + compact maps). The same pattern can be applied to the five smaller reconcile jobs if the new metrics show they matter.

## Make job memory observable (`src/observability.js`)

New `recordPeakRss({ job, entry? })` emits a `job.peak_rss` metric line (same zero-dependency stdout-JSON convention as `esi.conditional_request`), called from the queue consumer's existing `finally` (replacing its ad-hoc log line), from `runJobWithHeartbeat` for workflow-run jobs, and per-entry from the sde-mirror ingest. Group by `job`, chart `max(peak_rss_mb)`, and the function `memory` setting can then be lowered against evidence — that config change is the follow-up that actually shrinks the bill, deliberately not part of this PR.

## Verification

- `pnpm run lint` and `pnpm run build` pass.
- Harness runs described above (real code, real zip, mock PostgREST): exact row-sequence equality on a single-slice small entry and a 9-slice resumed large entry.
- All changed JS modules import-smoke cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZV7i9d9gMhBUQetvEtGSy

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZV7i9d9gMhBUQetvEtGSy)_