### PR TITLE
Add asset-proximity project plan (jump graph, hourly location, nearby sort)

### DIFF
--- a/docs/asset-proximity/01-jump-graph.md
+++ b/docs/asset-proximity/01-jump-graph.md
@@ -1,0 +1,133 @@
+# PR 1 — `sde_system_jump` view + jump-distance loader
+
+Foundation PR: expose the stargate graph as an app-shaped view and add a
+DB-backed loader `src/sdeJumps.ts` that answers "how many jumps from system A
+to systems B, C, D…" with an in-process BFS. No UI changes; nothing consumes
+it yet (doc 03 does).
+
+## 1. The view (migration + `schema.sql`)
+
+The nightly mirror already lands `sde_map_stargates` (13,978 rows — one per
+directed gate; every gate has a paired return gate, so this is the complete
+directed edge set). Each row's `data` jsonb carries the edge directly:
+
+```json
+{"_key": 50000001, "destination": {"solarSystemID": 30000778, "stargateID": 50000482},
+ "position": {...}, "solarSystemID": 30000777, "typeID": 29633}
+```
+
+Add an app-shaped projection next to `sde_kspace_system` / `sde_station` /
+`sde_planet`, following their exact pattern (see
+`supabase/migrations/20260716010000_sde_mirror.sql` and the `sde_*` section
+of `schema.sql`):
+
+```sql
+-- Ensure the mirror table exists before the view does (a fresh reset runs
+-- before the first ingest) — same trick the sde_mirror migration uses for
+-- the other app-critical mirror tables.
+select public.ensure_sde_mirror_table('map_stargates');
+
+-- Directed system→system stargate edges. Both directions are present because
+-- CCP ships every gate with its paired return gate; consumers can treat the
+-- row set as a complete directed adjacency list.
+create view public.sde_system_jump
+with (security_invoker = true) as
+select
+  (data ->> 'solarSystemID')::bigint as from_system_id,
+  (data -> 'destination' ->> 'solarSystemID')::bigint as to_system_id
+from public.sde_map_stargates;
+
+grant select on public.sde_system_jump to anon, authenticated, service_role;
+revoke insert, update, delete on public.sde_system_jump from anon, authenticated;
+```
+
+Dual-write: add the incremental migration (`pnpm run db:new
+sde_system_jump`) **and** put the same statements into `schema.sql` alongside
+the other `sde_*` views (the `ensure_sde_mirror_table('map_stargates')`
+pre-create goes next to the existing
+`select public.ensure_sde_mirror_table(stem) from unnest(...)` call — just
+add `map_stargates` to that array in `schema.sql`; the migration calls it
+directly). No RLS work: the view is `security_invoker` over a mirror table
+that already has the anyone-reads policy.
+
+No materialized view needed — the view is a two-field jsonb projection the
+loader reads a handful of times per process lifetime.
+
+## 2. The loader — `src/sdeJumps.ts`
+
+New async loader following the `src/sde*.ts` house pattern (header comment,
+`sdeSupabase()` client from `src/utils/supabase/sde.ts`, errors logged and
+degraded rather than thrown). It differs from the by-id loaders in one way:
+the unit of caching is the **whole graph**, not individual rows, so it does
+not use `createByIdCache` — it keeps a module-level cached promise with the
+same 6h TTL (`src/sdeCache.ts` uses `TTL_MS = 6 * 60 * 60 * 1000`; either
+export that constant from `sdeCache.ts` or restate it locally with a comment
+pointing there).
+
+### Fetching the graph
+
+Page through the view with the tail-recursive range-paging shape from
+CLAUDE.md (14 pages of 1000 at today's row count):
+
+```ts
+type Edge = { from_system_id: number; to_system_id: number }
+
+const PAGE_SIZE = 1000
+
+const readEdges = async (from = 0, acc: Edge[] = []): Promise<Edge[]> => {
+  const { data, error } = await sdeSupabase()
+    .from('sde_system_jump')
+    .select('from_system_id, to_system_id')
+    .order('from_system_id')
+    .order('to_system_id')
+    .range(from, from + PAGE_SIZE - 1)
+  if (error) throw new Error(`reading sde_system_jump failed: ${error.message}`)
+  forEach((row) => acc.push(row as Edge), data ?? []) // ramda forEach, push-mutated accumulator
+  return (data ?? []).length < PAGE_SIZE ? acc : readEdges(from + PAGE_SIZE, acc)
+}
+```
+
+Build `Map<number, number[]>` adjacency from the edges. Cache the built
+adjacency (not the raw rows) with the fetch timestamp; on any fetch error,
+log and return an **empty** graph without caching it — mirroring the
+"misses are never cached" rule, so a fresh deploy before the first ingest
+(empty table) or a DB hiccup degrades to "no distances known" and heals on
+the next call. Guard against concurrent warm-ups by caching the in-flight
+promise, but clear it on rejection.
+
+### BFS
+
+```ts
+// jumps from origin to each target, by shortest stargate path; null when
+// unreachable (wormholes, abyssal systems, Pochven-style disconnected
+// pockets, or an origin/target with no gates).
+export const getJumpDistances = async (
+  originSystemID: number,
+  targetSystemIDs: Iterable<number>
+): Promise<Record<number, number | null>>
+
+export const getJumpDistance = async (from: number, to: number): Promise<number | null>
+```
+
+Plain breadth-first search from the origin over the adjacency map, written as
+a tail-recursive frontier walk (no `while`): recurse on the next frontier
+while it's non-empty **and** targets remain unfound — early exit once every
+requested target has a distance. Fill unreached targets with `null`.
+Measured worst case (all targets unreachable → full traversal of 5,268
+systems) is ~8 ms; typical asset pages ask for a few dozen targets within
+~15 jumps and exit in well under that. Don't memoize per-origin BFS results
+— the traversal is cheaper than the bookkeeping.
+
+The origin itself is distance 0; an origin absent from the graph (docked in
+a wormhole, say) yields `null` for everything, which doc 03 renders as
+"no sort available", not an error.
+
+## Gates
+
+- `pnpm run lint` and `pnpm run build` pass.
+- Migration applies cleanly (`pnpm run db:push` on the linked project, or
+  let the `Migrate` workflow do it on merge).
+- Manual check in a dev console / scratch route: `getJumpDistance(30000142,
+  30002187)` (Jita→Amarr) returns **11**, `getJumpDistance(30000142,
+  30000142)` returns **0**, and a wormhole system id (e.g. 31000005) returns
+  **null**. These values were validated against SDE build 3442663.

--- a/docs/asset-proximity/02-hourly-location.md
+++ b/docs/asset-proximity/02-hourly-location.md
@@ -1,0 +1,88 @@
+# PR 2 — hourly `character-location` schedule
+
+Make "where is the character right now" fresh to within an hour instead of
+six. Everything already exists except the schedule:
+
+- The job module `src/jobs/characterLocation.js` (`runCharacterLocation`,
+  scope `esi-location.read_location.v1`) upserts one row per character into
+  `character_location` and is already CLI-runnable and registered in the
+  queue consumer's `JOBS` map (`src/app/api/queue/jobs/route.ts` —
+  `'character-location'`).
+- The 6-hourly `character-status` combo job already covers location (among
+  wallet/implants/clones/ship); it stays untouched. Both jobs write the same
+  upsert, so overlap is harmless.
+
+ESI's `/characters/{id}/location/` is about the cheapest authed endpoint
+there is — a three-field JSON body with a 5-second server cache — so hourly
+per-character polling is negligible load on both ESI and our queue (one tiny
+queue message per scoped character per hour).
+
+## Changes
+
+**New cron route** `src/app/api/cron/character-location/route.ts`, an exact
+mirror of the existing per-character fan-out routes (copy
+`src/app/api/cron/character-orders/route.ts` and adjust):
+
+```ts
+import { NextRequest, NextResponse } from 'next/server'
+
+import { fanOutPerCharacterCronJob, requireCronSecret } from '@/utils/cron'
+
+const SCOPE = 'esi-location.read_location.v1'
+
+// Hourly location poll backing the /asset proximity sort (docs/asset-proximity/):
+// fans out one queue message per scoped character. character-status still covers
+// location every 6h; both do the same character_location upsert, so they overlap
+// harmlessly — this route just tightens the freshness to ~an hour.
+export const runtime = 'nodejs'
+export const maxDuration = 60
+
+export async function GET(request: NextRequest) {
+  const denied = requireCronSecret(request)
+  if (denied) return denied
+
+  const dispatched = await fanOutPerCharacterCronJob('character-location', SCOPE)
+
+  return NextResponse.json({ ok: true, dispatched })
+}
+```
+
+**`vercel.json`**: add a crons entry. Hourly, on a minute not used by the
+6-hourly jobs (which sit at :07–:58 on their 6-hour marks); e.g.
+
+```json
+{ "path": "/api/cron/character-location", "schedule": "3 * * * *" }
+```
+
+Fan out to **all** scoped characters, not just mains: `is_main` can be
+re-pointed at any time, an alt's location is useful the moment doc 03's
+fallback (most recently recorded location) kicks in, and filtering the
+fan-out would need a new `selectCharacterIdsWithScopes` variant for no real
+saving.
+
+## Deliberate non-changes (note these in the PR description)
+
+- **No history table.** `character_location` stays a single upserted row per
+  character. A `character_location_over_time` SCD table ("where does my main
+  actually spend time?") is parked in the README's future-ideas list.
+- **`/character/refresh` matrix unchanged.** The matrix shows
+  `character-status`, which remains the on-demand/6-hourly umbrella. The
+  hourly job still records per-character heartbeats (via
+  `forEachCharacter`), so `latest_heartbeats()` reflects it; it just doesn't
+  get its own matrix row.
+- **Known side effect:** the header's "Refreshed N minutes ago" indicator
+  shows the user's most recent extract heartbeat, so it will now read ≤ ~1h
+  essentially always. Accepted — the data genuinely is that fresh — but
+  worth a sentence in the PR body so it isn't mistaken for a freshness-
+  grading bug.
+- **No ETag plumbing.** The conditional-request machinery (`esi_etag`) is
+  for skipping expensive reconciles; this endpoint's response is smaller
+  than the bookkeeping.
+
+## Gates
+
+- `pnpm run lint` and `pnpm run build` pass.
+- After deploy, hit the route once with the `CRON_SECRET` bearer to confirm
+  fan-out (`{ ok: true, dispatched: N }`), then check `character_location.
+  recorded_at` advances hourly and per-character `character-location`
+  heartbeats appear.

--- a/docs/asset-proximity/03-assets-sort.md
+++ b/docs/asset-proximity/03-assets-sort.md
@@ -1,0 +1,126 @@
+# PR 3 — proximity sort on `/asset`
+
+Wire docs 01 + 02 together: the Assets page computes the jump distance from
+the main character's current system to every system it lists, and the table
+gains a "Nearby" sort that puts the closest systems first. Depends on PR 1
+(`getJumpDistances`) and benefits from PR 2 (fresh `character_location`);
+it works without PR 2, just with staler positions.
+
+## 1. Origin helper — `src/app/mainLocation.ts`
+
+Small server helper answering "which system is this account's main character
+in right now", shaped like `src/app/owners.ts` (accepts an optional Supabase
+client so the MCP tools can reuse it later with a bearer-token client):
+
+```ts
+export type MainLocation = {
+  characterId: string // registration uuid
+  characterName: string
+  solarSystemID: number
+  recordedAt: string
+}
+
+export const fetchMainLocation = async (client?: SupabaseClient): Promise<MainLocation | null>
+```
+
+Implementation: two RLS-scoped queries —
+`registration.select('id, name, is_main')` and
+`character_location.select('character_id, solar_system_id, recorded_at')`
+(the existing "Users read own location" policy already scopes this to the
+caller's registrations). Pick the location row belonging to the `is_main`
+registration; when the main has no location row (its token lacks
+`esi-location.read_location.v1`, or no extract has run yet), fall back to
+the user's **most recently recorded** location row; return `null` when there
+are none at all. `is_main` is auto-assigned to the account's oldest
+character on first link (`src/app/character/callback/route.ts`) and
+re-pickable at `/account/settings`, so the fallback is a corner case, not
+the norm.
+
+## 2. Server side — `src/app/asset/page.tsx`
+
+The `Locations` component already resolves every root location and
+`resolveLocations` (`src/app/resolveLocations.ts`) already exposes
+`systemIdFor` — today the page only uses `nameFor`/`systemFor`:
+
+```ts
+const { nameFor, systemFor } = await resolveLocations(map(({ root }) => root, [...byLocation.values()]))
+```
+
+Changes:
+
+- Also destructure `systemIdFor`.
+- Fetch the origin: `const origin = await fetchMainLocation()` — add it to
+  the existing `Promise.all` batch alongside the summaries/owners/heartbeat
+  fetches (it's independent of them).
+- Collect each location's `systemIdFor(root)` and call
+  `getJumpDistances(origin.solarSystemID, systemIds)` from `src/sdeJumps.ts`
+  (skip entirely when `origin` is `null`).
+- Extend the `Location` shape passed to the client with the distance, and
+  pass the origin for display:
+
+```ts
+export type Location = {
+  id: string
+  name: string
+  system: string | null
+  jumps: number | null // stargate jumps from the main's current system; null = unknown/unreachable
+  counts: Record<string, number>
+}
+```
+
+`jumps` is `null` when the origin is unknown, the location has no resolvable
+system (unresolved structure), or BFS can't reach it (wormhole/Pochven/
+abyssal). One BFS answers every location on the page (~8 ms worst case,
+in-process — see docs/asset-proximity/README.md), so this adds no measurable
+server time to a page that already walks hangars in Postgres.
+
+Pass `originSystem: string | null` (the origin system's *name*, resolved via
+`getSdeSystemNames` or the page's existing name plumbing) and
+`originCharacter: string | null` into `AssetsTable` so the sort control can
+say what it's measuring from.
+
+## 3. Client side — `src/app/asset/assetsTable.tsx`
+
+Today the table groups locations by system and sorts groups busiest-first
+(`b.total - a.total || a.system.localeCompare(b.system)`). Add a sort mode:
+
+- **`activity`** (default, unchanged): busiest system first.
+- **`nearby`**: fewest jumps first; `null` jumps sort last; ties broken by
+  the existing busiest-first ordering. Every location in a group shares its
+  system, so a group's distance is the first non-null `jumps` among its
+  rows.
+
+UI:
+
+- A second control in the header next to the owner filter:
+  `Sort: [Activity | Nearby]` (a `<select>` matching the `OwnerSelect`
+  styling). Persist the choice in `localStorage` the same way the owner
+  filter does (`OWNER_STORAGE_KEY` lives in `src/app/asset/filterKey.ts`;
+  add `SORT_STORAGE_KEY` beside it, with the same read-after-mount hydration
+  pattern `useOwnerFilter` uses so SSR output stays deterministic).
+- When `nearby` is active, show the distance on each system's header row,
+  e.g. `Uemon · 4 jumps` (`0 jumps` for the origin system itself, `—` for
+  unreachable), and a caption under the header:
+  `Distances from <originSystem> (<originCharacter>)`.
+- When no origin exists (`originSystem === null`) or every `jumps` is
+  `null`, render the sort control disabled with a title explaining why
+  ("No recent location for your characters — link a character with the
+  esi-location.read_location.v1 scope"). Don't hide it; discoverability is
+  the point.
+- Changing sort mode resets to page 1, same as changing owner does today.
+
+Sorting stays entirely client-side over data already in memory — same reason
+owner switching is instant.
+
+## Gates
+
+- `pnpm run lint` and `pnpm run build` pass.
+- Manual checks on `/asset`:
+  - Activity sort renders exactly as before (default unchanged).
+  - Nearby sort puts the main's current system first with `0 jumps`;
+    known distances spot-checked against the in-game route planner
+    (remember in-game "shortest" must be selected — this sort is
+    security-agnostic shortest-path).
+  - Wormhole/unreachable systems group at the bottom under `—`.
+  - An account with no location rows sees the disabled control, not a crash.
+  - Owner filter + sort mode compose (switching either keeps the other).

--- a/docs/asset-proximity/README.md
+++ b/docs/asset-proximity/README.md
@@ -1,0 +1,102 @@
+# Asset proximity: sort the Assets page by jumps from your main
+
+Sort the systems on `/asset` by how many stargate jumps they are from wherever
+the account's main character currently is, so the stuff you can actually go
+get sits at the top. Three deliverables, shipped as **separate PRs, in
+order** — each numbered document is a self-contained implementation spec:
+
+| Doc | PR | What | Status / dependency |
+|---|---|---|---|
+| [01-jump-graph.md](01-jump-graph.md) | small | `sde_system_jump` view over the mirrored stargate data + `src/sdeJumps.ts` loader with a BFS jump-distance function | Independent; do first |
+| [02-hourly-location.md](02-hourly-location.md) | tiny | Schedule the existing `character-location` extract hourly via Vercel Cron | Independent of 01 |
+| [03-assets-sort.md](03-assets-sort.md) | medium | `/asset` computes jumps from the main character's current system and gains a "Nearby" sort | After 01 **and** 02 |
+
+Future ideas deliberately **not** in scope (park them unless asked): a
+`character_location_over_time` history table (where does my main actually
+hang out?), proximity in `/asset/search` results and the `search_assets` MCP
+tool, security-aware routing preferences (shortest vs. high-sec-only — this
+plan is plain shortest-path), Thera/Turnur wormhole shortcuts, and showing
+jump distance on `/structure` or `/mercenary-dens`.
+
+## Feasibility (validated 2026-07-23 against SDE build 3442663)
+
+The question was whether the SDE carries a **precalculated** distance
+function. It doesn't — the legacy `mapSolarSystemJumps` /
+`mapRegionJumps` tables from the old community SQL conversions did not
+survive into CCP's JSONL export, and no all-pairs distance file exists. What
+the export *does* carry is the full stargate graph, and that turns out to be
+all we need:
+
+- **`mapStargates.jsonl`** → already mirrored nightly as
+  **`sde_map_stargates`** (13,978 rows; the mirror ingests every JSONL file
+  in the export, so this table exists in production today — no ingest change
+  needed). Each row is one directed gate and carries the system→system edge
+  directly, no gate-id join required:
+
+  ```json
+  {"_key": 50000001,
+   "destination": {"solarSystemID": 30000778, "stargateID": 50000482},
+   "position": {...}, "solarSystemID": 30000777, "typeID": 29633}
+  ```
+
+  Every gate has a paired return gate, so the 13,978 rows are the complete
+  directed edge set (~2.65 edges/system average).
+
+- **`mapSolarSystems.jsonl`** (`sde_map_solar_systems`, 8,490 rows) also
+  carries `position` (x/y/z meters) per system — usable for light-year
+  distances later, but jumps are what a hauler cares about.
+
+- **BFS over the whole graph is trivially cheap.** Measured in Node on the
+  real data: 5,268 systems have gates; a full breadth-first traversal from
+  Jita (30000142) reaches 5,228 systems in **8 ms**, max depth 57. Sanity
+  checks: Jita→Amarr = 11 jumps, Jita→Dodixie = 12 (both correct
+  post-Pochven shortest routes). The 40 gated-but-unreached systems are the
+  Pochven/Zarzakh style disconnected pockets; wormhole and abyssal systems
+  have no gates at all. Those come back "unreachable" and sort last, which
+  is the right answer.
+
+### Where the computation lives (decision)
+
+**In the Node process, as an `src/sde*.ts` loader** (doc 01), not in
+Postgres and not precomputed:
+
+- A Postgres recursive-CTE BFS is awkward (recursive CTEs can't dedup the
+  visited set across iterations without carrying arrays) and slower than
+  8 ms of in-process work.
+- A precomputed all-pairs table is 5,268² ≈ 27.7M rows to answer a question
+  one page asks about ~a few dozen systems.
+- The graph is ~14k tiny rows: one paged fetch through PostgREST
+  (14 requests of 1000), cached per server process for 6h exactly like the
+  other SDE loaders (`src/sdeCache.ts` TTL). After warm-up a request costs
+  one in-memory BFS.
+
+### Freshness of "where is the main" (decision)
+
+`character_location` already exists (single upserted row per character,
+written by the `character-location` job / the 6-hourly `character-status`
+combo job). ESI's `/characters/{id}/location/` is one of the cheapest
+authed endpoints there is (tiny JSON, 5s server-side cache), so doc 02 just
+puts the **existing** `character-location` job on an hourly Vercel Cron
+fan-out — no new job module, no new table, no schema change. The
+main-character designation also already exists: `registration.is_main`
+(picker at `/account/settings`, auto-assigned to the oldest character by
+`src/app/character/callback/route.ts`).
+
+## House rules (from CLAUDE.md — these bite)
+
+- **No test runner.** Gates are `pnpm run lint` + `pnpm run build`, plus
+  manually exercising the touched pages. Every PR passes both.
+- **Schema changes are dual-write:** edit `schema.sql` (full-reset source of
+  truth) **and** add an incremental migration under `supabase/migrations/`
+  (`pnpm run db:new <name>`); **never rename an existing migration file.**
+- **Ramda over `for`/`while`** for synchronous iteration; unbounded paging
+  loops are tail-recursive async functions (see the `readMirror` shape in
+  CLAUDE.md). A BFS frontier loop is the same shape: recurse on the next
+  frontier while it's non-empty.
+- **Server components never call ESI.** All ESI traffic stays in the extract
+  jobs; the UI reads the DB and the `sde_*` mirror.
+- **Never** use Fuzzwork's third-party SDE mirror for anything.
+- **`git fetch origin && git rebase origin/main`** immediately before
+  pushing and opening each PR. No exceptions.
+- Line numbers quoted in these docs will drift — anchor on the quoted code,
+  not the numbers, and re-verify each call site before editing.


### PR DESCRIPTION
Project plan (docs only, no code) for sorting the `/asset` systems by stargate jumps from the main character's current location — `docs/asset-proximity/`, in the house tiered-PR spec format.

## Feasibility findings (validated against live SDE build 3442663)

- **The SDE has no precalculated distances.** The legacy `mapSolarSystemJumps` table from the old community SQL conversions did not survive into CCP's JSONL export.
- **But it has the full stargate graph, already in our DB.** `mapStargates.jsonl` is mirrored nightly as `sde_map_stargates` (13,978 rows), and each row carries the system→system edge directly (`solarSystemID` + `destination.solarSystemID`) — no ingest change needed.
- **BFS over the whole graph is trivially cheap**: 5,268 gated systems, full traversal from Jita in ~8 ms in Node, correct results (Jita→Amarr = 11 jumps, Jita→Dodixie = 12, post-Pochven). Wormhole/Pochven/abyssal systems come back unreachable and sort last, which is the right answer.
- So: compute distances in-process behind the usual 6h SDE-loader cache — no all-pairs precompute (would be ~27.7M rows), no recursive-CTE SQL BFS.

## The plan — three PRs

1. **`01-jump-graph.md`** — `sde_system_jump` view over `sde_map_stargates` (migration + `schema.sql`) and a `src/sdeJumps.ts` loader exposing `getJumpDistances(origin, targets)` via in-process BFS.
2. **`02-hourly-location.md`** — schedule the *existing* `character-location` job hourly (new `/api/cron/character-location` fan-out route + a `vercel.json` crons entry). ESI's location endpoint is tiny and 5s-cached, so hourly polling is negligible; `character-status` keeps covering it 6-hourly with a harmless identical upsert.
3. **`03-assets-sort.md`** — `/asset` computes jumps from the `registration.is_main` character's `character_location` (fallback: most recently recorded location) and gains a persisted "Nearby" sort next to the owner filter, with per-system jump counts.

Two discoveries that shrank the plan: `resolveLocations` already exposes `systemIdFor`, and the main-character designation already exists (`registration.is_main` + the `/account/settings` picker) — so no new settings work is needed.

Parked (listed in the README): location history table, proximity in `/asset/search` / MCP `search_assets`, security-aware routing, Thera shortcuts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8aE5iifiBoSu18Zo9LMDb

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8aE5iifiBoSu18Zo9LMDb)_