### PR TITLE
Name SDE ingest steps per file in the mirror workflow

### DIFF
--- a/scripts/genSdeIngestSteps.mjs
+++ b/scripts/genSdeIngestSteps.mjs
@@ -1,0 +1,84 @@
+// Regenerates src/workflows/sdeIngestSteps.ts — one `'use step'` function per
+// SDE file — from CCP's current export. Run when CCP adds/removes JSONL files
+// and you want the new ones to get their own named ingest step (unknown files
+// still ingest via sdeMirrorWorkflow's generic `ingestSlice` fallback in the
+// meantime, so this is a nice-to-have, not required to keep the mirror working).
+//
+//   SUPABASE_URL=… SUPABASE_KEY=… node scripts/genSdeIngestSteps.mjs
+//
+// (Any non-empty SUPABASE_* values work — this only reads CCP's zip central
+// directory over HTTP; the dummy client that src/jobs/sdeMirror.js constructs
+// at import time is never used on this path.)
+import { writeFileSync } from 'node:fs'
+
+import { fetchLatestBuild, listEntries } from '../src/jobs/sdeMirror.js'
+
+const OUT = 'src/workflows/sdeIngestSteps.ts'
+const fnName = (stem) => `ingest_${stem}`
+
+const { build, zipUrl } = await fetchLatestBuild()
+const files = await listEntries(zipUrl)
+const stems = files.map((f) => f.stem).sort()
+
+const header = `// AUTO-GENERATED — do not edit by hand.
+//
+// One \`'use step'\` function per SDE file, so each ingest slice shows up in
+// Vercel's Workflows observability under its own name (\`ingest_<stem>\`) instead
+// of a wall of identical \`ingestSlice\` rows. Workflow step names are baked from
+// the function name at build time (the runtime also uses them for replay-
+// divergence detection), so distinct names require distinct source functions —
+// hence this generated roster rather than a single parameterized step.
+//
+// The list is the JSONL entry set of CCP's SDE export, captured statically (see
+// scripts/genSdeIngestSteps.mjs to regenerate against the current build). Files
+// CCP adds later that aren't in this roster still ingest — sdeMirrorWorkflow
+// falls back to the generic \`ingestSlice\` step for any stem not found here.
+//
+// Roster captured from SDE build ${build} (${stems.length} files).
+
+export type SdeFile = {
+  entry: string
+  stem: string
+  method: number
+  compressedSize: number
+  localOffset: number
+}
+
+export type IngestSliceStep = (
+  zipUrl: string,
+  file: SdeFile,
+  build: number,
+  startLine: number,
+) => Promise<number>
+
+// The step body, shared by every per-stem step. Lazy-imports the job module
+// (its top-level supabase client needs env vars absent at build time), so the
+// per-stem functions below stay one-liners whose only real difference is the
+// name the workflow compiler reads off them.
+const slice: IngestSliceStep = async (zipUrl, file, build, startLine) => {
+  const { ingestEntrySlice } = await import('@/jobs/sdeMirror.js')
+  return ingestEntrySlice(zipUrl, file, build, startLine)
+}
+`
+
+const fns = stems
+  .map(
+    (stem) => `
+async function ${fnName(stem)}(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}`
+  )
+  .join('\n')
+
+const mapBlock = `
+
+// Stem → its named ingest step. sdeMirrorWorkflow looks a file's stem up here
+// and falls back to the generic \`ingestSlice\` for anything not listed.
+export const INGEST_STEPS: Record<string, IngestSliceStep> = {
+${stems.map((stem) => `  ${stem}: ${fnName(stem)},`).join('\n')}
+}
+`
+
+writeFileSync(OUT, `${header}\n${fns}\n${mapBlock}`)
+console.error(`wrote ${OUT} with ${stems.length} steps, build ${build}`)

--- a/src/workflows/sdeIngestSteps.ts
+++ b/src/workflows/sdeIngestSteps.ts
@@ -1,0 +1,514 @@
+// AUTO-GENERATED — do not edit by hand.
+//
+// One `'use step'` function per SDE file, so each ingest slice shows up in
+// Vercel's Workflows observability under its own name (`ingest_<stem>`) instead
+// of a wall of identical `ingestSlice` rows. Workflow step names are baked from
+// the function name at build time (the runtime also uses them for replay-
+// divergence detection), so distinct names require distinct source functions —
+// hence this generated roster rather than a single parameterized step.
+//
+// The list is the JSONL entry set of CCP's SDE export, captured statically (see
+// scripts/genSdeIngestSteps.mjs to regenerate against the current build). Files
+// CCP adds later that aren't in this roster still ingest — sdeMirrorWorkflow
+// falls back to the generic `ingestSlice` step for any stem not found here.
+//
+// Roster captured from SDE build 3442663 (78 files).
+
+export type SdeFile = {
+  entry: string
+  stem: string
+  method: number
+  compressedSize: number
+  localOffset: number
+}
+
+export type IngestSliceStep = (
+  zipUrl: string,
+  file: SdeFile,
+  build: number,
+  startLine: number,
+) => Promise<number>
+
+// The step body, shared by every per-stem step. Lazy-imports the job module
+// (its top-level supabase client needs env vars absent at build time), so the
+// per-stem functions below stay one-liners whose only real difference is the
+// name the workflow compiler reads off them.
+const slice: IngestSliceStep = async (zipUrl, file, build, startLine) => {
+  const { ingestEntrySlice } = await import('@/jobs/sdeMirror.js')
+  return ingestEntrySlice(zipUrl, file, build, startLine)
+}
+
+
+async function ingest_agent_types(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_agents_in_space(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_ancestries(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_archetypes(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_bloodlines(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_blueprints(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_categories(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_certificates(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_character_attributes(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_character_titles(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_clone_grades(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_compressible_types(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_contraband_types(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_control_tower_resources(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_corporation_activities(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_dbuff_collections(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_dogma_attribute_categories(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_dogma_attributes(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_dogma_effects(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_dogma_units(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_dungeons(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_dynamic_item_attributes(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_epic_arcs(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_factions(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_freelance_job_schemas(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_graphic_material_sets(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_graphics(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_groups(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_icons(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_landmarks(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_map_asteroid_belts(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_map_constellations(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_map_moons(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_map_planets(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_map_regions(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_map_secondary_suns(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_map_solar_systems(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_map_stargates(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_map_stars(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_market_groups(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_masteries(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_mercenary_tactical_operations(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_meta_groups(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_military_campaign_objectives(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_military_campaigns(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_missions(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_npc_characters(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_npc_corporation_divisions(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_npc_corporations(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_npc_stations(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_planet_resources(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_planet_schematics(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_races(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_ship_tree_elements(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_ship_tree_factions(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_ship_tree_groups(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_skin_licenses(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_skin_materials(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_skinr_component_categories(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_skinr_component_point_values(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_skinr_component_rarities(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_skinr_components(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_skinr_slot_categories(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_skinr_slot_configurations(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_skinr_slot_names(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_skinr_slots(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_skinr_tier_thresholds(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_skins(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_sovereignty_upgrades(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_station_operations(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_station_services(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_translation_languages(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_type_bonus(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_type_dogma(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_type_elements(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_type_lists(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_type_materials(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_types(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+
+// Stem → its named ingest step. sdeMirrorWorkflow looks a file's stem up here
+// and falls back to the generic `ingestSlice` for anything not listed.
+export const INGEST_STEPS: Record<string, IngestSliceStep> = {
+  agent_types: ingest_agent_types,
+  agents_in_space: ingest_agents_in_space,
+  ancestries: ingest_ancestries,
+  archetypes: ingest_archetypes,
+  bloodlines: ingest_bloodlines,
+  blueprints: ingest_blueprints,
+  categories: ingest_categories,
+  certificates: ingest_certificates,
+  character_attributes: ingest_character_attributes,
+  character_titles: ingest_character_titles,
+  clone_grades: ingest_clone_grades,
+  compressible_types: ingest_compressible_types,
+  contraband_types: ingest_contraband_types,
+  control_tower_resources: ingest_control_tower_resources,
+  corporation_activities: ingest_corporation_activities,
+  dbuff_collections: ingest_dbuff_collections,
+  dogma_attribute_categories: ingest_dogma_attribute_categories,
+  dogma_attributes: ingest_dogma_attributes,
+  dogma_effects: ingest_dogma_effects,
+  dogma_units: ingest_dogma_units,
+  dungeons: ingest_dungeons,
+  dynamic_item_attributes: ingest_dynamic_item_attributes,
+  epic_arcs: ingest_epic_arcs,
+  factions: ingest_factions,
+  freelance_job_schemas: ingest_freelance_job_schemas,
+  graphic_material_sets: ingest_graphic_material_sets,
+  graphics: ingest_graphics,
+  groups: ingest_groups,
+  icons: ingest_icons,
+  landmarks: ingest_landmarks,
+  map_asteroid_belts: ingest_map_asteroid_belts,
+  map_constellations: ingest_map_constellations,
+  map_moons: ingest_map_moons,
+  map_planets: ingest_map_planets,
+  map_regions: ingest_map_regions,
+  map_secondary_suns: ingest_map_secondary_suns,
+  map_solar_systems: ingest_map_solar_systems,
+  map_stargates: ingest_map_stargates,
+  map_stars: ingest_map_stars,
+  market_groups: ingest_market_groups,
+  masteries: ingest_masteries,
+  mercenary_tactical_operations: ingest_mercenary_tactical_operations,
+  meta_groups: ingest_meta_groups,
+  military_campaign_objectives: ingest_military_campaign_objectives,
+  military_campaigns: ingest_military_campaigns,
+  missions: ingest_missions,
+  npc_characters: ingest_npc_characters,
+  npc_corporation_divisions: ingest_npc_corporation_divisions,
+  npc_corporations: ingest_npc_corporations,
+  npc_stations: ingest_npc_stations,
+  planet_resources: ingest_planet_resources,
+  planet_schematics: ingest_planet_schematics,
+  races: ingest_races,
+  ship_tree_elements: ingest_ship_tree_elements,
+  ship_tree_factions: ingest_ship_tree_factions,
+  ship_tree_groups: ingest_ship_tree_groups,
+  skin_licenses: ingest_skin_licenses,
+  skin_materials: ingest_skin_materials,
+  skinr_component_categories: ingest_skinr_component_categories,
+  skinr_component_point_values: ingest_skinr_component_point_values,
+  skinr_component_rarities: ingest_skinr_component_rarities,
+  skinr_components: ingest_skinr_components,
+  skinr_slot_categories: ingest_skinr_slot_categories,
+  skinr_slot_configurations: ingest_skinr_slot_configurations,
+  skinr_slot_names: ingest_skinr_slot_names,
+  skinr_slots: ingest_skinr_slots,
+  skinr_tier_thresholds: ingest_skinr_tier_thresholds,
+  skins: ingest_skins,
+  sovereignty_upgrades: ingest_sovereignty_upgrades,
+  station_operations: ingest_station_operations,
+  station_services: ingest_station_services,
+  translation_languages: ingest_translation_languages,
+  type_bonus: ingest_type_bonus,
+  type_dogma: ingest_type_dogma,
+  type_elements: ingest_type_elements,
+  type_lists: ingest_type_lists,
+  type_materials: ingest_type_materials,
+  types: ingest_types,
+}

--- a/src/workflows/sdeMirror.ts
+++ b/src/workflows/sdeMirror.ts
@@ -10,7 +10,7 @@
 // CLI-runnable); every step lazy-imports it because the job module's
 // top-level supabase setup needs env vars absent at build time.
 
-type SdeFile = { entry: string; stem: string; method: number; compressedSize: number; localOffset: number }
+import { INGEST_STEPS, type IngestSliceStep, type SdeFile } from './sdeIngestSteps'
 
 type PlanResult = { runId: number; build: number; zipUrl: string }
 
@@ -40,11 +40,22 @@ async function listFiles(zipUrl: string): Promise<SdeFile[]> {
 // One bounded slice of one entry: upserts rows until the entry is done
 // (returns -1) or the step's time budget runs out (returns the resume cursor).
 // Idempotent keyed upserts make the step's bounded retries safe.
+//
+// This is the GENERIC fallback step, used only for a file whose stem isn't in
+// the static INGEST_STEPS roster (a file CCP added since it was generated). The
+// common case dispatches to a per-stem named step (ingest_<stem>) so each file
+// shows under its own name in Vercel's Workflows observability rather than as a
+// wall of identical "ingestSlice" rows — see src/workflows/sdeIngestSteps.ts.
 async function ingestSlice(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
   'use step'
   const { ingestEntrySlice } = await import('@/jobs/sdeMirror.js')
   return ingestEntrySlice(zipUrl, file, build, startLine)
 }
+
+// The named ingest step for a file, or the generic fallback for a stem the
+// static roster doesn't know. Deterministic per stem, so a replay resolves the
+// same step name it recorded.
+const ingestStepFor = (file: SdeFile): IngestSliceStep => INGEST_STEPS[file.stem] ?? ingestSlice
 
 async function stationNames(): Promise<void> {
   'use step'
@@ -109,11 +120,14 @@ export async function sdeMirrorWorkflow() {
   const plan = await planRun()
   const files = await listFiles(plan.zipUrl)
 
-  // Drain one entry: chase its slice cursor until the entry reports done.
+  // Drain one entry: chase its slice cursor until the entry reports done,
+  // through the file's own named step (ingest_<stem>) so the run tree names each
+  // file instead of showing a wall of "ingestSlice".
   const drainFile = async (file: SdeFile): Promise<void> => {
+    const step = ingestStepFor(file)
     let cursor = 0
     while (cursor !== -1) {
-      cursor = await ingestSlice(plan.zipUrl, file, plan.build, cursor)
+      cursor = await step(plan.zipUrl, file, plan.build, cursor)
     }
   }
 


### PR DESCRIPTION
## Summary

In Vercel's Workflows observability, the `sde-mirror` run showed `planRun` → `listFiles` → then a wall of identical `ingestSlice` rows — one per slice of every file, with no way to tell which file each was for. This makes every ingest slice show under its own name (`ingest_<stem>`) instead.

## Why it needs a function per file

Workflow step names are **baked from the function name at build time** by the `'use step'` compiler — there's no per-call label API, and `getStepMetadata()` only reads the name. The runtime also uses the step name for **replay-divergence detection** (it matches a replayed step event's `stepName` against the current consumer's), so the name has to be a stable compile-time constant. That means distinct step names require distinct *source functions* — a single parameterized step can't carry a dynamic name.

## What changed

- **`src/workflows/sdeIngestSteps.ts`** (generated) — one `'use step'` function per SDE file, `ingest_<stem>`, all delegating to a shared `slice` helper (the same `ingestEntrySlice` body as before). Roster captured statically from CCP's current export: **78 files, build 3442663**. Exports `INGEST_STEPS` (stem → step) and the shared `SdeFile` type.
- **`scripts/genSdeIngestSteps.mjs`** — regenerates that file from CCP's live zip central directory, so the roster can be refreshed when CCP adds/removes files.
- **`src/workflows/sdeMirror.ts`** — `drainFile` now dispatches each file to its named step via `ingestStepFor(file)`, **falling back to the generic `ingestSlice`** for any stem not in the static roster. So a file CCP adds later still ingests (under the generic name) and the mirror stays schema-agnostic. Dispatch is deterministic per stem, so replays resolve the same step name. The generic `ingestSlice` is kept as that fallback.

Nothing about the ingest behavior, lane concurrency, tail-step gating, or table minting changes — only the step a slice runs under, and thus its name in the run tree. A big file (e.g. `type_dogma`) still slices multiple times, but now those rows read `ingest_type_dogma` instead of anonymous `ingestSlice`.

## Notes

- Function identifiers can't contain `-` or `.`, so the name is `ingest_<stem>` (e.g. `ingest_types`) rather than a literal `ingest-{stem}-{entry}`; the stem already uniquely identifies the file.
- Deploying this while a mirror run is mid-flight could break that run's resumption (any step-name change does); the nightly run isn't normally in-flight, and a failed run just retries next cycle.

## Verification

- `pnpm run lint` clean; `tsc --noEmit` clean (0 errors).
- Roster pulled from CCP's live SDE central directory via the mirror's own `listEntries`, not hand-listed.
- The full `withWorkflow` build of the 78 step functions is exercised by the Vercel preview deploy on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdB1hhUFwKKP2KYVGjsodc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdB1hhUFwKKP2KYVGjsodc)_