### PR TITLE
Add industry job slot bubbles to character tiles

### DIFF
--- a/src/app/character/character.module.css
+++ b/src/app/character/character.module.css
@@ -90,6 +90,44 @@
   padding-left: 0;
 }
 
+/* Industry job slot bubbles: one line per activity family, one bubble per
+   slot, filled while an active job occupies it. */
+.slots {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  margin-top: 6pt;
+}
+
+.slotRow {
+  display: flex;
+  gap: 3px;
+}
+
+.slot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  border: 1px solid var(--slot-color);
+  box-sizing: border-box;
+}
+
+.slotFilled {
+  background: var(--slot-color);
+}
+
+.manufacturing {
+  --slot-color: #e0862e;
+}
+
+.research {
+  --slot-color: #4a7fd4;
+}
+
+.reaction {
+  --slot-color: #2fb5c0;
+}
+
 .actions {
   display: flex;
   gap: 8pt;

--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
-import { ascend, reduce, sort, uniq } from 'ramda'
+import { ascend, range, reduce, sort, uniq } from 'ramda'
 
 import { createClient } from '@/utils/supabase/server'
 import { formatBisk } from '../isk'
@@ -10,6 +10,52 @@ import { register } from './actions'
 import { requiredScopes } from './scopes'
 import { getEnabledScopes } from './userScopes'
 import styles from './character.module.css'
+
+// A character can train up to 11 slots per activity family (1 base + two
+// rank-5 skills), so each bubble line shows 11 slots and fills one per
+// active job of that family.
+const SLOT_COUNT = 11
+
+type SlotFamily = 'manufacturing' | 'research' | 'reaction'
+
+const SLOT_ROWS: { family: SlotFamily; label: string }[] = [
+  { family: 'manufacturing', label: 'Manufacturing' },
+  { family: 'research', label: 'Research' },
+  { family: 'reaction', label: 'Reactions' },
+]
+
+// ESI activity_id → slot family. Science jobs (TE/ME research, copying,
+// reverse engineering, invention) all occupy research slots.
+const ACTIVITY_FAMILY: Record<number, SlotFamily> = {
+  1: 'manufacturing',
+  3: 'research',
+  4: 'research',
+  5: 'research',
+  7: 'research',
+  8: 'research',
+  9: 'reaction',
+}
+
+const emptySlotCounts = (): Record<SlotFamily, number> => ({ manufacturing: 0, research: 0, reaction: 0 })
+
+const JobSlots = ({ counts }: { counts: Record<SlotFamily, number> }) => (
+  <div className={styles.slots}>
+    {SLOT_ROWS.map(({ family, label }) => {
+      const active = counts[family]
+      return (
+        <div
+          key={family}
+          className={`${styles.slotRow} ${styles[family]}`}
+          title={`${label}: ${active} active job${active === 1 ? '' : 's'}`}
+        >
+          {range(0, SLOT_COUNT).map((i) => (
+            <span key={i} className={i < active ? `${styles.slot} ${styles.slotFilled}` : styles.slot} />
+          ))}
+        </div>
+      )
+    })}
+  </div>
+)
 
 const CharacterPage = async () => {
   const supabase = await createClient()
@@ -90,6 +136,24 @@ const CharacterPage = async () => {
     })
   )
 
+  const { data: industryJobs } = await supabase
+    .from('character_industry_job')
+    .select('character_id, activity_id')
+    .eq('status', 'active')
+  const jobSlotCounts = reduce(
+    (acc, j) => {
+      const family = ACTIVITY_FAMILY[Number(j.activity_id)]
+      if (family) {
+        const counts = acc.get(j.character_id as string) ?? emptySlotCounts()
+        counts[family] += 1
+        acc.set(j.character_id as string, counts)
+      }
+      return acc
+    },
+    new Map<string, Record<SlotFamily, number>>(),
+    industryJobs ?? []
+  )
+
   // If the player has turned off every optional ESI scope, characters they add
   // grant nothing beyond identification, so almost no features will work.
   const enabledScopes = await getEnabledScopes(supabase, data.user.id)
@@ -158,6 +222,7 @@ const CharacterPage = async () => {
                   </ul>
                 </div>
               )}
+              <JobSlots counts={jobSlotCounts.get(c.id) ?? emptySlotCounts()} />
             </div>
           </li>
         ))}


### PR DESCRIPTION
Each character tile on `/character` now ends with three lines of slot bubbles showing industry activity at a glance:

- **Orange** — Manufacturing (activity 1)
- **Blue** — Research (all science activities: TE/ME research, copying, reverse engineering, invention — they share science slots)
- **Cyan** — Reactions (activity 9)

Each line renders 11 bubbles — the trainable per-family slot cap (1 base + two rank-5 skills) — and one bubble is colored in per active job from `character_industry_job` (`status = 'active'`, the same filter the industry page uses). A character with no active jobs shows three rows of hollow bubbles. Each row carries a `title` tooltip like "Manufacturing: 3 active jobs".

No schema or job changes — this is a read-only addition to the character list server component plus CSS module styles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZSKwKL7sbmu7Hwr9kgYoG

---
_Generated by [Claude Code](https://claude.ai/code/session_01TZSKwKL7sbmu7Hwr9kgYoG)_