### PR TITLE
Only show character job-slot bubbles for characters who shared skills

### DIFF
--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -238,7 +238,12 @@ const CharacterPage = async () => {
             )}
             <div className={styles.body}>
               <div className={styles.name}>{c.name}</div>
-              <JobSlots counts={jobSlotCounts.get(c.id) ?? emptyCounts()} max={slotMax.get(c.id) ?? baseSlotMax()} />
+              {/* Only show the job-slot bubbles for characters who have shared their
+                  skills — slotMax has an entry only when character_skill rows exist,
+                  so without the scope we don't guess a capacity, we show nothing. */}
+              {slotMax.has(c.id) && (
+                <JobSlots counts={jobSlotCounts.get(c.id) ?? emptyCounts()} max={slotMax.get(c.id)!} />
+              )}
               <div className={styles.meta}>
                 <span className={styles.metaLabel}>ISK:</span>
                 {latestBalance.has(c.id) ? formatBisk(latestBalance.get(c.id)!) : '—'}


### PR DESCRIPTION
## What

The skills pipeline this PR originally added turned out to duplicate **#707** ("Drive character job-slot bubbles from trained skills"), which merged to `main` first and is a superset (SCD `character_skill` table, folded into `character-status`, CSS animation, the scope/wrapper/job/workflow). So I dropped the duplicate work and rebased this branch onto `main` (with #707).

What remains is the **one behavior #707 doesn't have** and that was originally asked for: the job-slot bubbles should appear **only for characters who have shared their skills**. #707 renders them for every character, falling back to a base 1-slot-per-family display when no skills are shared.

## Change

A single edit in `src/app/character/page.tsx`: gate the `<JobSlots>` render on `slotMax.has(c.id)`. That map is built solely from `character_skill` rows, so it has an entry only for characters who granted `esi-skills.read_skills.v1` — meaning the bubbles show only when we actually have their skills, instead of showing a guessed minimum.

## Verification

- `pnpm run lint` ✅ and `pnpm run build` ✅ (TypeScript passes; `baseSlotMax()` is still used by the slot-ceiling reduce, so no dead code).
- After deploy: a character without the skills scope shows no bubbles; one who has shared skills shows real per-family slot counts (unchanged from #707).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHuJrLNkvBVeLSSmYjWzBk