### PR TITLE
Move the corpses link from the header to the assets page

### DIFF
--- a/src/app/asset/assets.module.css
+++ b/src/app/asset/assets.module.css
@@ -4,6 +4,11 @@
   font-size: 12px;
 }
 
+.corpses {
+  margin: 0;
+  font-size: 12px;
+}
+
 .header {
   display: flex;
   align-items: center;

--- a/src/app/asset/page.tsx
+++ b/src/app/asset/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { Suspense } from 'react'
 import { map, reduce } from 'ramda'
@@ -73,19 +74,30 @@ const Locations = async () => {
   // to us and corp rows to corps we have a registered character in). The
   // "last refreshed" heartbeat doesn't depend on any of this, so it's fetched
   // in the same batch instead of after everything else resolves.
-  const [{ data: characterSummary }, { data: corpSummary }, owners, { data: lastRun }] = await Promise.all([
-    supabase.rpc('character_asset_location_summary'),
-    supabase.rpc('corp_asset_location_summary'),
-    fetchOwners(),
-    supabase
-      .from('heartbeat')
-      .select('ended_at, run_url')
-      .eq('job', 'character-assets')
-      .not('ended_at', 'is', null)
-      .order('ended_at', { ascending: false })
-      .limit(1)
-      .maybeSingle(),
-  ])
+  const [{ data: characterSummary }, { data: corpSummary }, owners, { data: lastRun }, { data: mainCharacter }] =
+    await Promise.all([
+      supabase.rpc('character_asset_location_summary'),
+      supabase.rpc('corp_asset_location_summary'),
+      fetchOwners(),
+      supabase
+        .from('heartbeat')
+        .select('ended_at, run_url')
+        .eq('job', 'character-assets')
+        .not('ended_at', 'is', null)
+        .order('ended_at', { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+      // The corpses share page is keyed on a character id; link the signed-in
+      // user to their own (their main character's), like the header used to.
+      supabase
+        .from('registration')
+        .select('character_id')
+        .order('is_main', { ascending: false })
+        .order('created_at', { ascending: true })
+        .limit(1)
+        .maybeSingle(),
+    ])
+  const mainCharacterId = mainCharacter?.character_id ?? null
 
   const summary: SummaryRow[] = [
     ...map(
@@ -125,6 +137,11 @@ const Locations = async () => {
 
   return (
     <>
+      {mainCharacterId != null && (
+        <p className={styles.corpses}>
+          <Link href={`/corpses/${mainCharacterId}`}>View frozen corpses</Link>
+        </p>
+      )}
       <AssetSearchForm />
       <AssetsTable locations={locations} owners={owners} />
       <p className={styles.lastRun}>

--- a/src/app/layout/header.tsx
+++ b/src/app/layout/header.tsx
@@ -14,20 +14,16 @@ const Header = async () => {
   // earliest one, and to their email if they haven't registered a character yet.
   // Mirrors the inviter lookup on /account/invite.
   let displayName: string | undefined
-  let mainCharacterId: number | string | null = null
   let lastRefreshedAt: string | null = null
   if (user) {
     const { data: mainCharacter } = await supabase
       .from('registration')
-      .select('name, character_id')
+      .select('name')
       .order('is_main', { ascending: false })
       .order('created_at', { ascending: true })
       .limit(1)
       .maybeSingle()
     displayName = mainCharacter?.name ?? user.email ?? undefined
-    // The corpses share page is keyed on a character id; link the signed-in
-    // user to their own (their main character's).
-    mainCharacterId = mainCharacter?.character_id ?? null
 
     // When this user's ESI data last landed: the most recent completed extract
     // heartbeat attributed to them, whether a scheduled cron pull or an
@@ -74,12 +70,6 @@ const Header = async () => {
               <span className={styles.sep}>|</span>
               <Link href="/mercenary-dens">mercenary&nbsp;dens</Link>
               <span className={styles.sep}>|</span>
-              {mainCharacterId != null && (
-                <>
-                  <Link href={`/corpses/${mainCharacterId}`}>corpses</Link>
-                  <span className={styles.sep}>|</span>
-                </>
-              )}
               <Link href="/character/">characters</Link>
               <span className={styles.sep}>|</span>
               <Link href="/asset">assets</Link>


### PR DESCRIPTION
## What

The `/corpses/[characterID]` page lists corpse-type items pulled from a character's assets, so the link to it fits better on the assets page than as a top-level header nav item.

- **Header** (`src/app/layout/header.tsx`): removed the `corpses` nav link, and the `mainCharacterId` lookup that existed only to build it (the `registration` query now selects just `name` for the display name).
- **Assets page** (`src/app/asset/page.tsx`): resolve the signed-in user's main character id (added to the existing `Promise.all` batch, same ordering the header used — `is_main` desc, then earliest) and render a "View frozen corpses" link at the top of the assets content.
- Small muted `.corpses` style in `assets.module.css`.

Behavior is otherwise unchanged — the link still points at `/corpses/<mainCharacterId>` and only renders when the user has a registered character.

## Verification

- `pnpm run lint` ✅ and `pnpm run build` ✅ (TypeScript passes).
- After deploy: the header no longer shows "corpses"; the assets page shows a "View frozen corpses" link that opens the same share page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHuJrLNkvBVeLSSmYjWzBk

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHuJrLNkvBVeLSSmYjWzBk)_