### PR TITLE
Render the header's signed-in name in the serif face

### DIFF
--- a/src/app/layout/header.tsx
+++ b/src/app/layout/header.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { createClient } from '@/utils/supabase/server'
 import { Freshness } from '../Freshness'
+import { CharacterName } from '../names'
 import styles from './header.module.css'
 
 const Header = async () => {
@@ -46,7 +47,11 @@ const Header = async () => {
           <Link href="/" className={styles.brand}>
             Edencom Link
           </Link>
-          {displayName && <span className={styles.user}>{displayName}</span>}
+          {displayName && (
+            <span className={styles.user}>
+              <CharacterName name={displayName} />
+            </span>
+          )}
           {user && (
             <span className={styles.refresh}>
               <Freshness at={lastRefreshedAt} prefix="Refreshed" never="never refreshed" />


### PR DESCRIPTION
The signed-in name in the header is user-generated text — a character name, or the account email when no character is linked yet — so it belongs in the serif face like every other dynamic entity name (see the typography note in `globals.css`).

Wrapped it in `CharacterName` from `src/app/names.tsx` rather than hand-applying the `.serif` class, so it goes through the same component the rest of the app uses for dynamic names. The surrounding `styles.user` span keeps the faint color.

Lint passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_014ntKAwvv1kLiD8xyw18MtR)_