### PR TITLE
Rebuild the homepage as a landing page, and drop the version stamp

### DIFF
--- a/src/app/home.module.css
+++ b/src/app/home.module.css
@@ -21,44 +21,58 @@
   margin-right: 8px;
 }
 
-.tip {
+.lede {
   margin: 12px 0 0;
+  max-width: 68ch;
   color: var(--ink-soft);
   font-size: 13px;
 }
 
-.version {
-  margin: 12px 0 0;
-  color: var(--ink-faint);
-  font-size: 11px;
+.features {
+  margin: 18px 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 10px 24px;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
 }
 
-.prompt {
+.feature {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   gap: 10px;
-  margin: 22px auto 0;
-  padding: 12px 16px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: var(--paper-raised);
+  font-size: 13px;
+}
+
+.name {
+  flex: none;
+  width: 92px;
+  font-family: var(--mono);
+  font-size: 12px;
   color: var(--ink-faint);
 }
 
-.caret {
-  color: var(--accent);
-  font-weight: 600;
+a.name {
+  color: var(--link);
 }
 
-.hints {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px 18px;
-  margin: 14px auto 0;
+a.name:visited {
+  color: var(--link-visited);
+}
+
+.blurb {
+  color: var(--ink-soft);
+}
+
+.note {
+  margin: 20px 0 0;
+  max-width: 68ch;
   color: var(--ink-faint);
   font-size: 12px;
 }
 
-.hints a {
+.cta {
+  margin: 16px 0 0;
   color: var(--ink-soft);
+  font-size: 13px;
 }

--- a/src/app/home.module.css
+++ b/src/app/home.module.css
@@ -28,40 +28,40 @@
   font-size: 13px;
 }
 
-.features {
-  margin: 18px 0 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 10px 24px;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+.heading {
+  margin: 26px 0 0;
+  font-size: 14px;
+  color: var(--ink);
 }
 
-.feature {
-  display: flex;
-  align-items: baseline;
-  gap: 10px;
+/*
+ * The capability list: each term is the thing you can do, each definition is
+ * why it isn't otherwise possible. Two columns once there's room, so the six
+ * of them read as a set rather than a scroll.
+ */
+.capabilities {
+  margin: 12px 0 0;
+  display: grid;
+  gap: 16px 28px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.capabilities dt {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--ink);
+}
+
+.capabilities dd {
+  margin: 4px 0 0;
+  max-width: 58ch;
+  color: var(--ink-soft);
   font-size: 13px;
 }
 
-.name {
-  flex: none;
-  width: 92px;
-  font-family: var(--mono);
+.capabilities code {
   font-size: 12px;
   color: var(--ink-faint);
-}
-
-a.name {
-  color: var(--link);
-}
-
-a.name:visited {
-  color: var(--link-visited);
-}
-
-.blurb {
-  color: var(--ink-soft);
 }
 
 .note {

--- a/src/app/home.module.css
+++ b/src/app/home.module.css
@@ -1,19 +1,32 @@
-.wrap {
-  margin: 24px auto;
+/*
+ * Landing page for signed-out visitors and a launchpad for signed-in ones.
+ * Built entirely from the theme's custom properties, so the marketing surface
+ * inherits dark mode and the warm palette along with the rest of the app.
+ */
+
+.page {
+  max-width: 1040px;
+  margin: 0 auto;
 }
 
-.welcome {
+/* Hero ------------------------------------------------------------------- */
+
+.hero {
+  margin-top: 28px;
+  padding: 44px 36px 40px;
+  text-align: center;
   border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: var(--paper-raised);
-  padding: 18px 20px;
+  border-radius: calc(var(--radius) * 2);
+  background: radial-gradient(120% 140% at 50% 0%, var(--accent-tint) 0%, var(--paper-raised) 62%);
 }
 
-.title {
+.eyebrow {
   margin: 0;
-  font-size: 15px;
+  font-size: 11px;
   font-weight: 600;
-  color: var(--ink);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
 }
 
 .spark {
@@ -21,58 +34,266 @@
   margin-right: 8px;
 }
 
-.lede {
-  margin: 12px 0 0;
-  max-width: 68ch;
-  color: var(--ink-soft);
-  font-size: 13px;
-}
-
-.heading {
-  margin: 26px 0 0;
-  font-size: 14px;
+.headline {
+  margin: 14px auto 0;
+  max-width: 18ch;
+  font-family: var(--serif);
+  font-size: 44px;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
   color: var(--ink);
 }
 
-/*
- * The capability list: each term is the thing you can do, each definition is
- * why it isn't otherwise possible. Two columns once there's room, so the six
- * of them read as a set rather than a scroll.
- */
-.capabilities {
-  margin: 12px 0 0;
-  display: grid;
-  gap: 16px 28px;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+.sub {
+  margin: 18px auto 0;
+  max-width: 62ch;
+  font-size: 15px;
+  line-height: 1.65;
+  color: var(--ink-soft);
 }
 
-.capabilities dt {
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 26px;
+}
+
+.primary,
+.secondary {
+  padding: 10px 20px;
+  border-radius: var(--radius-sm);
+  font-size: 13px;
   font-weight: 600;
-  font-size: 13px;
+  border: 1px solid transparent;
+  transition:
+    background 0.12s ease,
+    border-color 0.12s ease,
+    transform 0.04s ease;
+}
+
+.primary,
+.primary:visited {
+  color: var(--paper-raised);
+  background: var(--accent);
+  border-color: var(--accent-strong);
+}
+
+.primary:hover {
+  background: var(--accent-strong);
+  text-decoration: none;
+}
+
+.secondary,
+.secondary:visited {
+  color: var(--ink);
+  background: var(--paper-raised);
+  border-color: var(--line);
+}
+
+.secondary:hover {
+  border-color: var(--accent);
+  text-decoration: none;
+}
+
+.primary:active,
+.secondary:active {
+  transform: translateY(1px);
+}
+
+.microcopy {
+  margin: 18px 0 0;
+  font-size: 12px;
+  color: var(--ink-faint);
+}
+
+/* Stat strip ------------------------------------------------------------- */
+
+.stats {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-top: 14px;
+}
+
+.stat {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  padding: 16px 18px;
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius);
+  background: var(--paper-raised);
+}
+
+.statValue {
+  font-family: var(--mono);
+  font-size: 26px;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--accent);
+}
+
+.statLabel {
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--ink-soft);
+}
+
+/* Sections --------------------------------------------------------------- */
+
+.section {
+  margin-top: 52px;
+}
+
+.sectionTitle {
+  margin: 8px 0 0;
+  font-family: var(--serif);
+  font-size: 26px;
+  font-weight: 500;
+  letter-spacing: -0.015em;
   color: var(--ink);
 }
 
-.capabilities dd {
-  margin: 4px 0 0;
-  max-width: 58ch;
-  color: var(--ink-soft);
+/* Capability cards ------------------------------------------------------- */
+
+.cards {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  margin-top: 22px;
+}
+
+.card {
+  padding: 20px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper-raised);
+  transition:
+    border-color 0.12s ease,
+    transform 0.12s ease;
+}
+
+.card:hover {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+}
+
+.cardLabel {
+  margin: 0;
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--accent-tint);
+  color: var(--accent-strong);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.cardTitle {
+  margin: 12px 0 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.cardBody {
+  margin: 8px 0 0;
   font-size: 13px;
-}
-
-.capabilities code {
-  font-size: 12px;
-  color: var(--ink-faint);
-}
-
-.note {
-  margin: 20px 0 0;
-  max-width: 68ch;
-  color: var(--ink-faint);
-  font-size: 12px;
-}
-
-.cta {
-  margin: 16px 0 0;
+  line-height: 1.6;
   color: var(--ink-soft);
+}
+
+/* How it works ----------------------------------------------------------- */
+
+.steps {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  margin: 22px 0 0;
+  padding: 0;
+  list-style: none;
+  counter-reset: step;
+}
+
+.step {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.stepNumber {
+  flex: none;
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--paper-raised);
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--accent);
+}
+
+.stepTitle {
+  margin: 3px 0 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.stepBody {
+  margin: 6px 0 0;
   font-size: 13px;
+  line-height: 1.6;
+  color: var(--ink-soft);
+}
+
+/* Closing call to action ------------------------------------------------- */
+
+.closing {
+  margin: 56px 0 8px;
+  padding: 38px 30px;
+  text-align: center;
+  border: 1px solid var(--line);
+  border-radius: calc(var(--radius) * 2);
+  background: var(--accent-tint);
+}
+
+.closingTitle {
+  margin: 0;
+  font-family: var(--serif);
+  font-size: 26px;
+  font-weight: 500;
+  letter-spacing: -0.015em;
+  color: var(--ink);
+}
+
+.closingBody {
+  margin: 12px auto 0;
+  max-width: 54ch;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--ink-soft);
+}
+
+@media (max-width: 640px) {
+  .hero {
+    padding: 32px 20px;
+  }
+
+  .headline {
+    font-size: 32px;
+    max-width: none;
+  }
+
+  .sectionTitle,
+  .closingTitle {
+    font-size: 22px;
+  }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,36 @@
 import Link from 'next/link'
+import { createClient } from '@/utils/supabase/server'
 import styles from './home.module.css'
-import { version } from '../../package.json'
 
-export default function Home() {
+// The tour of the app, shown to everyone: signed-in visitors get working links,
+// signed-out ones get the same list as a description of what an account buys.
+const FEATURES = [
+  { href: '/character/', name: '/characters', blurb: 'Where each pilot is, their clones, implants and jump timer.' },
+  { href: '/asset', name: '/asset', blurb: 'Every hangar, container and ship, searchable across all of them.' },
+  { href: '/market', name: '/market', blurb: 'Open orders and trade history, character and corporation together.' },
+  {
+    href: '/industry',
+    name: '/industry',
+    blurb: 'Jobs in flight, free slots per pilot, and the cost indexes you watch.',
+  },
+  {
+    href: '/blueprint',
+    name: '/blueprint',
+    blurb: 'Research state, material bills, and which rigs actually bonus a build.',
+  },
+  {
+    href: '/structure',
+    name: '/structure',
+    blurb: 'Upwell structures with their fuel clocks, services and fitted rigs.',
+  },
+]
+
+const Home = async () => {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
   return (
     <main className={styles.wrap}>
       <section className={styles.welcome}>
@@ -10,18 +38,46 @@ export default function Home() {
           <span className={styles.spark}>✻</span>
           Welcome to Edencom Link
         </p>
-        <p className={styles.tip}>Your market, industry, and structure data — tracked from ESI and ready to read.</p>
-        <p className={styles.version}>v{version}</p>
+        <p className={styles.lede}>
+          A quiet ledger for your corner of New Eden. Link your characters once and scheduled jobs pull their assets,
+          wallets, orders, blueprints, industry and structures out of ESI for you — keeping every change as history, so
+          you can see not just what you have, but what changed while you were docked.
+        </p>
       </section>
 
-      <nav className={styles.hints}>
-        <Link href="/character/">/characters</Link>
-        <Link href="/asset">/asset</Link>
-        <Link href="/market">/market</Link>
-        <Link href="/industry">/industry</Link>
-        <Link href="/structure">/structure</Link>
-        <Link href="/account/settings">/settings</Link>
-      </nav>
+      <ul className={styles.features}>
+        {FEATURES.map(({ href, name, blurb }) => (
+          <li key={href} className={styles.feature}>
+            {user ? (
+              <Link href={href} className={styles.name}>
+                {name}
+              </Link>
+            ) : (
+              <span className={styles.name}>{name}</span>
+            )}
+            <span className={styles.blurb}>{blurb}</span>
+          </li>
+        ))}
+      </ul>
+
+      <p className={styles.note}>
+        Pages read from the database rather than calling ESI live, so everything is dated and nothing rate-limits you.
+        The same data leaves by three other doors: CSV endpoints for Google Sheets, share links for a single ship or
+        hangar, and an MCP server your AI assistant can query directly.
+      </p>
+
+      {user ? (
+        <p className={styles.cta}>
+          <Link href="/character/">Add or refresh a character</Link> to keep the extracts flowing.
+        </p>
+      ) : (
+        <p className={styles.cta}>
+          <Link href="/account/login">Log in</Link> to pick up where you left off, or{' '}
+          <Link href="/account/register">register</Link> with an invite code — this is a small, invite-only outfit.
+        </p>
+      )}
     </main>
   )
 }
+
+export default Home

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,29 +2,6 @@ import Link from 'next/link'
 import { createClient } from '@/utils/supabase/server'
 import styles from './home.module.css'
 
-// The tour of the app, shown to everyone: signed-in visitors get working links,
-// signed-out ones get the same list as a description of what an account buys.
-const FEATURES = [
-  { href: '/character/', name: '/characters', blurb: 'Where each pilot is, their clones, implants and jump timer.' },
-  { href: '/asset', name: '/asset', blurb: 'Every hangar, container and ship, searchable across all of them.' },
-  { href: '/market', name: '/market', blurb: 'Open orders and trade history, character and corporation together.' },
-  {
-    href: '/industry',
-    name: '/industry',
-    blurb: 'Jobs in flight, free slots per pilot, and the cost indexes you watch.',
-  },
-  {
-    href: '/blueprint',
-    name: '/blueprint',
-    blurb: 'Research state, material bills, and which rigs actually bonus a build.',
-  },
-  {
-    href: '/structure',
-    name: '/structure',
-    blurb: 'Upwell structures with their fuel clocks, services and fitted rigs.',
-  },
-]
-
 const Home = async () => {
   const supabase = await createClient()
   const {
@@ -39,36 +16,76 @@ const Home = async () => {
           Welcome to Edencom Link
         </p>
         <p className={styles.lede}>
-          A quiet ledger for your corner of New Eden. Link your characters once and scheduled jobs pull their assets,
-          wallets, orders, blueprints, industry and structures out of ESI for you — keeping every change as history, so
-          you can see not just what you have, but what changed while you were docked.
+          Link your characters once and scheduled jobs pull their assets, wallets, orders, blueprints, industry and
+          structures out of ESI on your behalf — every change kept as history rather than overwritten. What that buys
+          you is the part the client can&rsquo;t do: handing someone exactly one slice of it.
         </p>
       </section>
 
-      <ul className={styles.features}>
-        {FEATURES.map(({ href, name, blurb }) => (
-          <li key={href} className={styles.feature}>
-            {user ? (
-              <Link href={href} className={styles.name}>
-                {name}
-              </Link>
-            ) : (
-              <span className={styles.name}>{name}</span>
-            )}
-            <span className={styles.blurb}>{blurb}</span>
-          </li>
-        ))}
-      </ul>
+      <h2 className={styles.heading}>Cut it thinner than the game lets you</h2>
+      <dl className={styles.capabilities}>
+        <div>
+          <dt>Share one ship, not your hangar</dt>
+          <dd>
+            Mint a public link to a single fitted ship — the fit wheel, its cargo, where it&rsquo;s parked. A buyer or a
+            fleetmate opens it without an account and sees that ship and nothing else. Revoke it when the deal closes.
+          </dd>
+        </div>
+
+        <div>
+          <dt>Show dens to one alliance</dt>
+          <dd>
+            Mercenary den sharing is opt-in per alliance: pick which of yours can see your dens and the hostile-den map
+            you&rsquo;ve been keeping. Everyone else — the rest of your corp included, if you want it that way — sees
+            nothing.
+          </dd>
+        </div>
+
+        <div>
+          <dt>Hand out a corpse collection</dt>
+          <dd>
+            Your trophies get a public page of their own, no login on either end, with anything you picked up in the
+            last two days badged as new.
+          </dd>
+        </div>
+
+        <div>
+          <dt>Let an assistant ask on your behalf</dt>
+          <dd>
+            An MCP server at <code>/api/mcp</code>, authorized over OAuth, so Claude can answer &ldquo;which blueprints
+            are worth researching&rdquo; or &ldquo;what&rsquo;s sitting in my Jita hangar&rdquo; against exactly the
+            data your account can see — never more.
+          </dd>
+        </div>
+
+        <div>
+          <dt>Feed a spreadsheet</dt>
+          <dd>
+            CSV endpoints built for <code>=IMPORTDATA()</code> and keyed to a personal token, several of which take an{' '}
+            <code>at=</code> timestamp — so a sheet can pull last Tuesday&rsquo;s hangar instead of today&rsquo;s.
+          </dd>
+        </div>
+
+        <div>
+          <dt>Ask what changed</dt>
+          <dd>
+            Assets, orders, jobs and blueprints are versioned, not replaced. &ldquo;When did that stack move?&rdquo; and
+            &ldquo;what did I own before downtime?&rdquo; both have answers.
+          </dd>
+        </div>
+      </dl>
 
       <p className={styles.note}>
-        Pages read from the database rather than calling ESI live, so everything is dated and nothing rate-limits you.
-        The same data leaves by three other doors: CSV endpoints for Google Sheets, share links for a single ship or
-        hangar, and an MCP server your AI assistant can query directly.
+        You decide how much to hand over in the first place: adding a character asks EVE for one permission at a time,
+        and the features you skip are simply the ones you don&rsquo;t get. Pages then read from that stored copy rather
+        than calling ESI live, so everything is stamped with when it landed.{' '}
+        {user ? <Link href="/settings/grants">Review your grants</Link> : null}
       </p>
 
       {user ? (
         <p className={styles.cta}>
-          <Link href="/character/">Add or refresh a character</Link> to keep the extracts flowing.
+          <Link href="/character/">Add or refresh a character</Link> to keep the extracts flowing, or start from{' '}
+          <Link href="/asset">your hangars</Link>.
         </p>
       ) : (
         <p className={styles.cta}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,56 @@ import Link from 'next/link'
 import { createClient } from '@/utils/supabase/server'
 import styles from './home.module.css'
 
+// The capability pitch: each card names something the game client can't do,
+// because it can't hold history or hand out a slice of your account.
+const CAPABILITIES = [
+  {
+    label: 'Sharing',
+    title: 'Share one ship, not your hangar',
+    body: 'Mint a public link to a single fitted ship — the fit wheel, its cargo, where it is parked. A buyer or a fleetmate opens it without an account, sees that ship and nothing else, and the link dies when you revoke it.',
+  },
+  {
+    label: 'Intel',
+    title: 'Show dens to one alliance',
+    body: 'Mercenary den sharing is opt-in per alliance. Pick which of yours can see your dens and the hostile-den map you keep — everyone else, corpmates included, sees nothing.',
+  },
+  {
+    label: 'Public pages',
+    title: 'Hand out a corpse collection',
+    body: 'Your trophies get a page of their own that needs no login on either end, with anything you picked up in the last two days badged as new.',
+  },
+  {
+    label: 'MCP',
+    title: 'Let an assistant answer for you',
+    body: 'An OAuth-authorized MCP server, so Claude can field “which blueprints are worth researching” or “what is sitting in my Jita hangar” against exactly the data your account can see — never more.',
+  },
+  {
+    label: 'Exports',
+    title: 'Feed a spreadsheet',
+    body: 'CSV endpoints built for =IMPORTDATA() and keyed to a personal token, several of which take an at= timestamp — so a sheet can pull last Tuesday’s hangar instead of today’s.',
+  },
+  {
+    label: 'History',
+    title: 'Ask what changed',
+    body: 'Assets, orders, jobs and blueprints are versioned rather than replaced. “When did that stack move?” and “what did I own before downtime?” both have answers.',
+  },
+]
+
+const STEPS = [
+  {
+    title: 'Link a character',
+    body: 'EVE SSO asks for one permission at a time. Grant what you want; the features you skip are simply the ones you do not get.',
+  },
+  {
+    title: 'Let the extracts run',
+    body: 'Scheduled jobs pull each endpoint into storage and keep every version. Nothing here writes to your account, ever.',
+  },
+  {
+    title: 'Read it, slice it, query it',
+    body: 'Browse the pages, hand out a link to exactly one thing, pipe it into Sheets, or point an AI assistant at it.',
+  },
+]
+
 const Home = async () => {
   const supabase = await createClient()
   const {
@@ -9,90 +59,118 @@ const Home = async () => {
   } = await supabase.auth.getUser()
 
   return (
-    <main className={styles.wrap}>
-      <section className={styles.welcome}>
-        <p className={styles.title}>
+    <main className={styles.page}>
+      <section className={styles.hero}>
+        <p className={styles.eyebrow}>
           <span className={styles.spark}>✻</span>
-          Welcome to Edencom Link
+          EVE Online · assets, industry &amp; intel
         </p>
-        <p className={styles.lede}>
-          Link your characters once and scheduled jobs pull their assets, wallets, orders, blueprints, industry and
-          structures out of ESI on your behalf — every change kept as history rather than overwritten. What that buys
-          you is the part the client can&rsquo;t do: handing someone exactly one slice of it.
+        <h1 className={styles.headline}>Your empire, extracted — and sliceable.</h1>
+        <p className={styles.sub}>
+          Edencom Link keeps a versioned copy of what your characters and corporations own, earn, build and hold space
+          with. Then it lets you hand out exactly one piece of it — a single ship, one alliance&rsquo;s worth of den
+          intel, a spreadsheet, an AI assistant&rsquo;s question — without opening the rest.
         </p>
+        <div className={styles.actions}>
+          {user ? (
+            <>
+              <Link href="/asset" className={styles.primary}>
+                Open your hangars
+              </Link>
+              <Link href="/character/" className={styles.secondary}>
+                Add a character
+              </Link>
+            </>
+          ) : (
+            <>
+              <Link href="/account/register" className={styles.primary}>
+                Redeem an invite
+              </Link>
+              <Link href="/account/login" className={styles.secondary}>
+                Log in
+              </Link>
+            </>
+          )}
+        </div>
+        <p className={styles.microcopy}>Invite-only · read-only ESI access · you choose the scopes</p>
       </section>
 
-      <h2 className={styles.heading}>Cut it thinner than the game lets you</h2>
-      <dl className={styles.capabilities}>
-        <div>
-          <dt>Share one ship, not your hangar</dt>
-          <dd>
-            Mint a public link to a single fitted ship — the fit wheel, its cargo, where it&rsquo;s parked. A buyer or a
-            fleetmate opens it without an account and sees that ship and nothing else. Revoke it when the deal closes.
-          </dd>
+      <section className={styles.stats}>
+        <div className={styles.stat}>
+          <span className={styles.statValue}>18</span>
+          <span className={styles.statLabel}>scheduled extracts keeping your copy current</span>
         </div>
-
-        <div>
-          <dt>Show dens to one alliance</dt>
-          <dd>
-            Mercenary den sharing is opt-in per alliance: pick which of yours can see your dens and the hostile-den map
-            you&rsquo;ve been keeping. Everyone else — the rest of your corp included, if you want it that way — sees
-            nothing.
-          </dd>
+        <div className={styles.stat}>
+          <span className={styles.statValue}>6h</span>
+          <span className={styles.statLabel}>between passes, or refresh any of them on demand</span>
         </div>
-
-        <div>
-          <dt>Hand out a corpse collection</dt>
-          <dd>
-            Your trophies get a public page of their own, no login on either end, with anything you picked up in the
-            last two days badged as new.
-          </dd>
+        <div className={styles.stat}>
+          <span className={styles.statValue}>0</span>
+          <span className={styles.statLabel}>writes back to your account — it only ever reads</span>
         </div>
+      </section>
 
-        <div>
-          <dt>Let an assistant ask on your behalf</dt>
-          <dd>
-            An MCP server at <code>/api/mcp</code>, authorized over OAuth, so Claude can answer &ldquo;which blueprints
-            are worth researching&rdquo; or &ldquo;what&rsquo;s sitting in my Jita hangar&rdquo; against exactly the
-            data your account can see — never more.
-          </dd>
+      <section className={styles.section}>
+        <p className={styles.eyebrow}>Capabilities</p>
+        <h2 className={styles.sectionTitle}>Cut it thinner than the game lets you</h2>
+        <div className={styles.cards}>
+          {CAPABILITIES.map(({ label, title, body }) => (
+            <article key={title} className={styles.card}>
+              <p className={styles.cardLabel}>{label}</p>
+              <h3 className={styles.cardTitle}>{title}</h3>
+              <p className={styles.cardBody}>{body}</p>
+            </article>
+          ))}
         </div>
+      </section>
 
-        <div>
-          <dt>Feed a spreadsheet</dt>
-          <dd>
-            CSV endpoints built for <code>=IMPORTDATA()</code> and keyed to a personal token, several of which take an{' '}
-            <code>at=</code> timestamp — so a sheet can pull last Tuesday&rsquo;s hangar instead of today&rsquo;s.
-          </dd>
-        </div>
+      <section className={styles.section}>
+        <p className={styles.eyebrow}>How it works</p>
+        <h2 className={styles.sectionTitle}>Three steps, then it runs itself</h2>
+        <ol className={styles.steps}>
+          {STEPS.map(({ title, body }, index) => (
+            <li key={title} className={styles.step}>
+              <span className={styles.stepNumber}>{index + 1}</span>
+              <div>
+                <p className={styles.stepTitle}>{title}</p>
+                <p className={styles.stepBody}>{body}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </section>
 
-        <div>
-          <dt>Ask what changed</dt>
-          <dd>
-            Assets, orders, jobs and blueprints are versioned, not replaced. &ldquo;When did that stack move?&rdquo; and
-            &ldquo;what did I own before downtime?&rdquo; both have answers.
-          </dd>
-        </div>
-      </dl>
-
-      <p className={styles.note}>
-        You decide how much to hand over in the first place: adding a character asks EVE for one permission at a time,
-        and the features you skip are simply the ones you don&rsquo;t get. Pages then read from that stored copy rather
-        than calling ESI live, so everything is stamped with when it landed.{' '}
-        {user ? <Link href="/settings/grants">Review your grants</Link> : null}
-      </p>
-
-      {user ? (
-        <p className={styles.cta}>
-          <Link href="/character/">Add or refresh a character</Link> to keep the extracts flowing, or start from{' '}
-          <Link href="/asset">your hangars</Link>.
+      <section className={styles.closing}>
+        <h2 className={styles.closingTitle}>
+          {user ? 'Everything is where you left it.' : 'Bring your own invite code.'}
+        </h2>
+        <p className={styles.closingBody}>
+          {user
+            ? 'Your extracts are running. Check what landed recently, or grant a scope you skipped the first time.'
+            : 'This is a small outfit, so accounts are handed out by invite. If you have a code, it takes about a minute to link your first character.'}
         </p>
-      ) : (
-        <p className={styles.cta}>
-          <Link href="/account/login">Log in</Link> to pick up where you left off, or{' '}
-          <Link href="/account/register">register</Link> with an invite code — this is a small, invite-only outfit.
-        </p>
-      )}
+        <div className={styles.actions}>
+          {user ? (
+            <>
+              <Link href="/character/refresh" className={styles.primary}>
+                See what is fresh
+              </Link>
+              <Link href="/settings/grants" className={styles.secondary}>
+                Review your grants
+              </Link>
+            </>
+          ) : (
+            <>
+              <Link href="/account/register" className={styles.primary}>
+                Redeem an invite
+              </Link>
+              <Link href="/account/login" className={styles.secondary}>
+                Log in
+              </Link>
+            </>
+          )}
+        </div>
+      </section>
     </main>
   )
 }


### PR DESCRIPTION
The root page greeted visitors with one line of copy plus a version number, then repeated the header's nav verbatim. This replaces it with a landing page that leads on what the stored data makes possible.

## What changed

`src/app/page.tsx` is now an auth-aware server component (same `createClient()` + `getUser()` shape the header uses), laid out in five bands:

- **Hero** — eyebrow kicker, serif headline, a subhead that states the premise concretely (a versioned copy of what you own, and the ability to hand out exactly one slice of it), paired calls to action, and a trust line: invite-only, read-only ESI access, you choose the scopes.
- **Stat strip** — `18` scheduled extracts, `6h` between passes, `0` writes back. The first two are counted from `vercel.json` (18 cron entries; the character jobs run every six hours) rather than asserted.
- **Capabilities** — six labelled cards for the things the game client can't do, because it can't hold history or hand out a slice of an account: a share link to one fitted ship rather than a whole hangar, per-alliance mercenary den sharing, the login-free corpse page, the OAuth MCP server, `=IMPORTDATA()` CSV with an `at=` snapshot, and change history.
- **How it works** — three numbered steps: link a character, let the extracts run, read/slice/query.
- **Closing CTA band.**

Every call to action branches on auth, so a signed-in visitor gets destinations (hangars, add a character, freshness matrix, grants) instead of a signup pitch.

**Version stamp removed**, along with the `import { version } from '../../package.json'` it needed.

`src/app/home.module.css` is rewritten to match: hero with a radial accent-tint wash, button-styled anchors for the two CTA weights, stat/capability/step grids on `auto-fit` so they collapse cleanly, and a `max-width: 640px` block for phone sizing. Everything is built from the theme's existing custom properties — serif headlines, indigo accent, warm paper — so dark mode follows without a second set of rules.

Not touched: the header and footer still run full-bleed while the page content centers at 1040px. Aligning them would mean changing app-wide chrome, which is outside this change.

## Testing

- `pnpm run lint` — clean
- `pnpm run build` — succeeds; `/` builds as a dynamic route, since it reads the session
- Rendered locally against the dev server and screenshotted in both light and dark schemes to check the hero wash, card contrast and CTA colors