### PR TITLE
Trim the mercenary den table and move the share picker left

### DIFF
--- a/src/app/mercenary-dens/mercenaryDens.module.css
+++ b/src/app/mercenary-dens/mercenaryDens.module.css
@@ -1,8 +1,9 @@
+/* Title, then the sharing picker beneath it — both flush left. */
 .pageHeader {
   display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 12pt;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6pt;
 }
 
 .pageHeader h1 {
@@ -18,7 +19,7 @@
 .share {
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: flex-start;
   gap: 3pt;
 }
 
@@ -30,7 +31,6 @@
 .shareList {
   display: flex;
   flex-wrap: wrap;
-  justify-content: flex-end;
   gap: 4pt 12pt;
 }
 

--- a/src/app/mercenary-dens/page.tsx
+++ b/src/app/mercenary-dens/page.tsx
@@ -1,12 +1,11 @@
 import { redirect } from 'next/navigation'
 
 import { getSdePlanets } from '@/sdePlanets'
-import { getSdeTypeNames } from '@/sdeTypes'
 import { createClient } from '@/utils/supabase/server'
 
 import { Countdown } from './countdown'
 import CopyDiscordPing from './copyDiscordPing'
-import { STAGING, TEMPERATE_PLANETS } from './data'
+import { TEMPERATE_PLANETS } from './data'
 import { formatDuration, formatUtc } from './duration'
 import EnemyDenIntel, { type EnemyDenIntelRow } from './enemyDenIntel'
 import ShareAlliance from './shareAlliance'
@@ -21,9 +20,7 @@ export const dynamic = 'force-dynamic'
 // intel.
 type DenRow = {
   character_id: string
-  den_id: number
   planet_id: number
-  type_id: number | null
   state: string | null
   development_level: string | null
   development_amount: number | null
@@ -31,8 +28,6 @@ type DenRow = {
   anarchy_amount: number | null
   infomorphs: number | null
   reinforcement_end: string | null
-  skyhook_id: number | null
-  skyhook_corporation_id: number | null
   status_observed_at: string | null
 }
 
@@ -40,7 +35,7 @@ type MergedRow = {
   system: string
   planet: string // roman numeral
   intel?: { owner: string; alliance: string | null; reinforced: boolean }
-  den?: DenRow & { ownerLabel: string; ownerCharacterId: string | null; typeName: string | null }
+  den?: DenRow & { ownerLabel: string; ownerCharacterId: string | null }
 }
 
 const isReinforced = (row: MergedRow): boolean =>
@@ -163,7 +158,6 @@ const MercenaryDensPage = async () => {
   // Computed on the server so the client's initial state matches (no hydration
   // mismatch) — the value is a plain string the client edits.
   const defaultReinforcementEnd = `${new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 10)}T`
-  const typeNames = await getSdeTypeNames(dens.map((d) => d.type_id).filter((t): t is number => t != null))
 
   // Merge the hand-maintained temperate-planet intel with our real dens, keyed by
   // system + roman numeral. A den's planet_id is resolved to (system, roman) via
@@ -188,10 +182,9 @@ const MercenaryDensPage = async () => {
       ownerLabel: ownReg?.name ?? 'Corpmate',
       // The EVE character id, shown in parens after the owner. Resolvable for
       // the caller's own characters and for shared dens' owners (via the
-      // security-definer RPC above); "Corpmate" only survives if resolution
-      // somehow fails.
+      // character_directory lookup above); "Corpmate" only survives if
+      // resolution somehow fails.
       ownerCharacterId: ownReg?.characterId ?? null,
-      typeName: den.type_id != null ? (typeNames[den.type_id] ?? null) : null,
     }
     const k = key(system, roman)
     const existing = rowsByKey.get(k)
@@ -245,9 +238,6 @@ const MercenaryDensPage = async () => {
         <h1>Mercenary Dens</h1>
         <ShareAlliance alliances={alliances} sharedAllianceIds={sharedAllianceIds} />
       </div>
-      <p className={styles.subtitle}>
-        Systems immediately accessible from our staging system, <span className={styles.system}>{STAGING}</span>.
-      </p>
 
       <Topology nodeColors={nodeColors} enemyIntel={enemyIntelSystems} />
 
@@ -258,15 +248,12 @@ const MercenaryDensPage = async () => {
             <tr>
               <th>System</th>
               <th>Planet</th>
-              <th>Den ID</th>
               <th>Owner</th>
-              <th>Type</th>
               <th>State</th>
               <th>Development</th>
               <th>Anarchy</th>
               <th>Infomorphs</th>
               <th>Reinforced</th>
-              <th>Skyhook</th>
               <th>Observed At</th>
             </tr>
           </thead>
@@ -279,13 +266,11 @@ const MercenaryDensPage = async () => {
                 <tr key={`${row.system}-${row.planet}-${i}`} className={color ? styles[`row_${color}`] : undefined}>
                   <td className={styles.system}>{row.system}</td>
                   <td className={styles.planet}>{row.planet || dash}</td>
-                  <td className={styles.planet}>{den ? den.den_id : dash}</td>
                   <td>
                     {owner ?? dash}
                     {den?.ownerCharacterId ? <span className={styles.alliance}> ({den.ownerCharacterId})</span> : null}
                     {row.intel?.alliance ? <span className={styles.alliance}> [{row.intel.alliance}]</span> : null}
                   </td>
-                  <td>{den?.typeName ?? dash}</td>
                   <td>{den?.state ?? dash}</td>
                   <td>{den ? evolution(den.development_level, den.development_amount) : dash}</td>
                   <td>{den ? evolution(den.anarchy_level, den.anarchy_amount) : dash}</td>
@@ -320,7 +305,6 @@ const MercenaryDensPage = async () => {
                       dash
                     )}
                   </td>
-                  <td>{den?.skyhook_corporation_id ? `corp ${den.skyhook_corporation_id}` : dash}</td>
                   <td>
                     {den?.status_observed_at ? (
                       <>


### PR DESCRIPTION
Presentation-only changes to `/mercenary-dens`. No behaviour, no schema.

## Changes

**Dropped three columns** from the friendly-dens table: `Den ID`, `Type` and `Skyhook`. Nothing else read them, so the enrichment behind them goes too — the per-den type-name lookup (`getSdeTypeNames`) and the now-unused `den_id` / `type_id` / `skyhook_id` / `skyhook_corporation_id` fields on the row type. Side benefit: one fewer SDE round trip per page load.

Header and body cell counts stay in step at 9 apiece: System, Planet, Owner, State, Development, Anarchy, Infomorphs, Reinforced, Observed At.

**Dropped the staging subtitle** ("Systems immediately accessible from our staging system, X1-IZ0."). `STAGING` is still exported from `data.ts` and used by the topology, and the `.subtitle` class is still used by the enemy-intel panel, so both stay put — only the page's now-unused import went.

**Moved the sharing picker from the right of the page header to the left.** `.pageHeader` becomes a column with the title above the picker, and the picker's own contents left-align (`align-items: flex-start`) instead of right-align. It now sits roughly where the removed subtitle was.

Also corrects a comment that still described owner-name resolution as going through the security-definer RPC — that became a `character_directory` lookup in #721.

## Verification

`pnpm run lint`, `pnpm run build` and `tsc --noEmit` all pass. Two `tsc` errors in `test/planetQuery.test.ts` are pre-existing on a clean `main` (confirmed by stashing this change) and unrelated.

Not visually verified — the page redirects unauthenticated visitors, so the preview deployment is the first real look at the new header layout.

---
_Generated by [Claude Code](https://claude.ai/code/session_012E3FzzHLjPTX2dqqhu2rSu)_