### PR TITLE
Request the saved-fittings ESI scope (fittings 1/3)

### DIFF
--- a/docs/fittings.md
+++ b/docs/fittings.md
@@ -1,0 +1,170 @@
+# Plan: saved ship fittings (`/fitting`)
+
+Extract the ship fittings players have saved in the game client, list them on
+a page, and open any one of them in the eveship.fit viewer the `/ship/[itemId]`
+page already renders.
+
+Three PRs, in order: **grant the scope**, **extract the data**, **build the
+page**.
+
+---
+
+## Read this first: ESI has no corporation or alliance fittings endpoint
+
+This feature was asked for as "the fittings saved in the game as **corp or
+alliance** fittings." That is not something ESI can currently give us, and the
+gap is not one we can close from this side.
+
+The fitting window in the client has Personal / Corporation / Alliance tabs.
+ESI exposes only the first one:
+
+| Endpoint                                | Scope                            | Notes                             |
+| --------------------------------------- | -------------------------------- | --------------------------------- |
+| `GET /characters/{id}/fittings`         | `esi-fittings.read_fittings.v1`  | The character's **personal** fits |
+| `POST /characters/{id}/fittings`        | `esi-fittings.write_fittings.v1` | Save a fit (we don't write)       |
+| `DELETE /characters/{id}/fittings/{id}` | `esi-fittings.write_fittings.v1` | Delete a fit (we don't write)     |
+
+Verified against CCP's current OpenAPI document (`esi.evetech.net/meta/openapi.json`)
+and the legacy `/latest/swagger.json`: **`fitting` appears in exactly those two
+paths in both.** There is no `/corporations/{id}/fittings`, no
+`/alliances/{id}/fittings`, no corporation- or alliance-fittings scope, and the
+character response carries no folder/owner discriminator that would let us tell
+a copied doctrine fit from a personal one:
+
+```jsonc
+{
+  "fitting_id": 1,
+  "name": "Doctrine Hurricane",
+  "description": "",
+  "ship_type_id": 24702,
+  "items": [{ "type_id": 2048, "flag": "LoSlot0", "quantity": 1 }],
+}
+```
+
+**So what we build extracts personal fittings, per character, for every
+character a player has linked.** In practice this covers most of the intent: a
+pilot who flies a corp doctrine almost always has that fit saved personally
+(the client's "copy to personal" is one click), and a player linking their
+director alt gets that alt's whole doctrine library. What it cannot do is show
+a corp fit nobody on the account has personally saved.
+
+The schema below is therefore built with an `owner_scope` column
+(`character` today) so that if CCP ever ships a corp/alliance fittings
+endpoint, ingesting it is a new job writing a new `owner_scope` value into the
+same table, plus a filter on the page — not a migration of everything.
+
+A second, cheaper approximation is available later if wanted: reuse the
+alliance-sharing pattern already built for mercenary dens
+(`character_mercenary_den_share`, `my_alliance_ids()`) so a player can opt into
+publishing their fittings to their alliance. That turns "the doctrine fits my
+FC has saved" into something the whole alliance can read. It is deliberately
+**out of scope** for these three PRs — get the data in and visible first.
+
+---
+
+## PR 1 — request the `esi-fittings.read_fittings.v1` scope
+
+Smallest possible change, shipped on its own so players can start granting the
+scope while PRs 2 and 3 are still in review. A token's scopes are fixed at
+issue time, so the extract job in PR 2 sees nothing until a player re-adds
+their characters — the earlier this lands, the more data PR 2 has on day one.
+
+- `src/app/character/scopes.ts` — one new `esiScopes` entry. Everything else
+  derives from that list: `defaultScopes` (what a player with no saved
+  preferences is asked for), `optionalScopes` (the settings-page checkbox),
+  and `sso.ts`'s request set.
+- This doc.
+
+No table, no job, no UI. The scope is optional like every other non-`publicData`
+scope, so declining it costs a player only this feature.
+
+## PR 2 — extract fittings into `character_fitting_over_time`
+
+### Table
+
+SCD Type 2, the house pattern for anything ESI reports as a full snapshot
+(`character_blueprint_over_time`, `character_mercenary_den_over_time`). A
+fitting is edited in place in the client — same `fitting_id`, new modules — so
+history is worth keeping, and a deleted fit should stop showing without losing
+what it was.
+
+```
+character_fitting_over_time
+  id            bigint identity pk
+  character_id  uuid → registration(id) on delete cascade
+  owner_scope   text not null default 'character'   -- see the ESI note above
+  fitting_id    bigint not null
+  name          text
+  description   text
+  ship_type_id  bigint not null
+  items         jsonb not null   -- [{ type_id, flag, quantity }]
+  is_current    boolean, valid_from timestamptz, valid_until timestamptz
+```
+
+- Unique partial index on `(character_id, fitting_id) where is_current` — one
+  live row per fit, and the collision guard the reconcile relies on.
+- `items` stays jsonb rather than a child table: a fit is a small, opaque blob
+  that is always read whole and never joined against, exactly like
+  `character_clone_over_time.implants`.
+- RLS: `character_id in (select id from registration where user_id = auth.uid())`,
+  the same policy every `character_*` table carries. A `character_fitting` view
+  (`security_invoker`) exposes the `is_current` snapshot.
+- Written to `schema.sql` (the from-scratch reset) **and** a new
+  `supabase/migrations/` file, per CLAUDE.md.
+
+### Job
+
+`character-fittings`, one job per ESI endpoint, following the established
+shape end to end:
+
+- `src/esi.js` — `fittings(access_token, characterID, ifNoneMatch)`. The
+  endpoint returns the whole collection in one un-paginated request and sends
+  an ETag, so it qualifies for `esiConditionalJson`: a `304` skips the
+  reconcile entirely. Fittings change rarely, so the hit rate should be high.
+- `src/jobs/characterFittings.js` — `runCharacterFittings()` over
+  `forEachCharacter`, plus the SCD-2 reconcile (signature compare → touch /
+  close+open / close vanished) and the `esi_etag` store-after-commit dance the
+  orders/transactions/industry-jobs jobs use.
+- `src/workflows/characterFittings.ts` — the per-character fan-out workflow
+  shape from phase 3 of the cron → Workflows migration (`enumerateCharacters`,
+  lanes, `AggregateError`).
+- `src/app/api/cron/character-fittings/route.ts` + a `vercel.json` crons entry.
+  Every 6h at `:34`, in the gap between `character-mercenary-dens` (`:30`) and
+  `corp-wallet-journal` (`:37`).
+- Queue consumer entry + `PER_CHARACTER_JOBS` so adding a character pulls
+  fittings immediately and the `/character/refresh` matrix gets a row.
+- `package.json` script, for the CLI path.
+
+### Deliberately not in PR 2
+
+Type-name resolution of the fitted modules. The page resolves names through
+the existing `sde_*` loaders at render time; storing names in the table would
+just be a stale copy of the SDE mirror.
+
+## PR 3 — the `/fitting` page
+
+- `/fitting` — every fitting visible to the signed-in user (RLS does the
+  scoping), grouped by ship with the hull name and icon, the fit's name and
+  description, the owning character, and a module count. Sorted by ship name,
+  then fit name. A header nav link next to `blueprint`.
+- `/fitting/[characterId]/[fittingId]` — the detail page. `fitting_id` is only
+  unique per character (ESI numbers them from 1 per pilot), so the route
+  carries the registration uuid too rather than pretending the id is global.
+- The detail page renders `ShipFitViewDynamic` — the same `ssr:false` wrapper
+  `/ship/[itemId]` uses, which is what keeps the dogma-engine WASM and the
+  eveship.fit data payload out of every other route's bundle. Its `esiFit`
+  prop is the ESI fitting shape already, so the reshape is a two-line map
+  (ESI's fitting items carry no `item_id`; the viewer's `EsiFit` type wants
+  one, so the index is used as a synthetic id — it is only an identity key for
+  the viewer's slot bookkeeping and never leaves the browser).
+- No write path. The viewer is interactive (drag a charge onto a slot to
+  simulate ammo) exactly as it is on `/ship/[itemId]`; nothing is ever sent
+  back to ESI, which is also why `esi-fittings.write_fittings.v1` is not
+  requested.
+
+## Verification
+
+`pnpm run lint` and `pnpm run build` per PR — the codebase's standing check for
+the I/O-heavy paths, since the extract jobs aren't unit-tested. The SCD-2
+reconcile follows a pattern with several existing implementations to diff
+against; the page is a server component reading a view.

--- a/src/app/character/scopes.ts
+++ b/src/app/character/scopes.ts
@@ -107,7 +107,8 @@ export const esiScopes: EsiScope[] = [
     scope: 'esi-skills.read_skills.v1',
     name: 'Character skills',
     why: 'Reads this character’s trained skill levels, used to show how many parallel manufacturing, research, and reaction jobs they can run.',
-    without: 'this character’s industry job-slot capacity will fall back to the untrained minimum of one slot per activity.',
+    without:
+      'this character’s industry job-slot capacity will fall back to the untrained minimum of one slot per activity.',
   },
   {
     scope: 'esi-location.read_ship_type.v1',
@@ -121,6 +122,12 @@ export const esiScopes: EsiScope[] = [
     name: 'Mercenary dens',
     why: 'Tracks the Mercenary Dens this character has deployed — each den’s development and anarchy levels, running state, and reinforcement timer.',
     without: 'this character’s mercenary dens and their status will not be tracked.',
+  },
+  {
+    scope: 'esi-fittings.read_fittings.v1',
+    name: 'Saved fittings',
+    why: 'Lists the ship fittings this character has saved in the game, so they can be browsed and opened in the fitting viewer. Read-only — fittings are never created, edited or deleted in game.',
+    without: 'this character’s saved fittings will not be listed.',
   },
   {
     scope: 'esi-universe.read_structures.v1',


### PR DESCRIPTION
First of three PRs adding saved ship fittings: list every fitting a linked character has saved in the game, and click into one to see it in the eveship.fit viewer.

This PR asks for the scope and nothing else — `esi-fittings.read_fittings.v1`, one new entry in `src/app/character/scopes.ts` (optional, like every non-`publicData` scope). A token's scopes are fixed when it is issued, so the extract job in PR 2 sees nothing until players have re-added their characters; landing the request on its own gives that a head start while PRs 2 and 3 are in review.

`docs/fittings.md` is the plan for all three.

## ⚠️ Please read: ESI has no corp or alliance fittings endpoint

The feature was asked for as "the fittings saved in the game as **corp or alliance** fittings," and that isn't something ESI can give us. I checked both of CCP's specs — the current `esi.evetech.net/meta/openapi.json` and the legacy `/latest/swagger.json` — and `fitting` appears in exactly two paths in each:

| Endpoint | Scope |
| --- | --- |
| `GET /characters/{id}/fittings` | `esi-fittings.read_fittings.v1` |
| `POST` / `DELETE /characters/{id}/fittings` | `esi-fittings.write_fittings.v1` (we don't write) |

No `/corporations/{id}/fittings`, no `/alliances/{id}/fittings`, no corp/alliance fittings scope. The character response carries no folder or owner field either, so a doctrine fit copied to personal is indistinguishable from any other personal fit.

**What these three PRs build is therefore per-character personal fittings**, for every character on the account. In practice that covers most of the intent — flying a corp doctrine generally means having it saved, and linking a director alt brings that alt's whole library — but it can't show a corp fit nobody on the account has saved personally. The table in PR 2 carries an `owner_scope` column so that if CCP ever ships a corp/alliance endpoint, ingesting it is a new job writing a new value, not a migration of everything.

The plan also notes a follow-up worth considering separately: reusing the alliance-sharing pattern already built for mercenary dens (`character_mercenary_den_share` / `my_alliance_ids()`) so a player can opt into publishing their fittings to their alliance. Out of scope here.

## Testing

`pnpm run lint` clean. No table, job, or UI in this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfmtG8kgpyC6vtXeNwRPM7)_