### PR TITLE
Rename lib.js's handler field character_id to registration_id

### DIFF
--- a/docs/registration-id-rename.md
+++ b/docs/registration-id-rename.md
@@ -101,10 +101,10 @@ Return columns (`character_id uuid`): `character_asset_location_summary`,
 
 ### JavaScript / TypeScript — 4 modules
 
-- **`src/jobs/lib.js`** — the `characterID` / `character_id` pair described
-  above, plus the `characterIds` option (registration uuids) on
-  `forEachCharacter` / `forEachCharacterAnyScope` / `forEachCorporation`. Every
-  extract job inherits the naming into its locals.
+- **`src/jobs/lib.js`** — ~~the `characterID` / `character_id` pair~~ (done);
+  the `characterIds` option (registration uuids) on `forEachCharacter` /
+  `forEachCharacterAnyScope` / `forEachCorporation` remains, and shares its
+  name with three unrelated contracts — see step 2.
 - **`src/supabase.js`** — `recordHeartbeat(opts.characterId)`,
   `selectCharacterIdsWithScopes()` (returns uuids), `selectToken(character_id)`,
   `upsertToken`'s `onConflict: ['character_id']`.
@@ -157,12 +157,22 @@ Smallest blast radius first, and ordered so each step makes the next easier.
    constraint and indexes by itself, with no view or function to recreate. It
    also touched `src/app/character/callback/route.ts`, `src/refresh.js` and
    `src/jobs/universeStructures.js`, which the original sketch here missed.
-2. **`src/jobs/lib.js`'s handler contract.** Rename the handler field to
-   `registration_id` and the option to `registrationIds`, then sweep the extract
-   jobs. This is the step that actually retires the `characterID` /
-   `character_id` collision, and it's pure JS — no migration, no deploy-ordering
-   risk. (`characterFittings.js` already aliases it locally; that alias goes
-   away here.)
+2. ~~**`src/jobs/lib.js`'s handler contract.**~~ **Field done.** The handler
+   argument is now `registration_id`, swept through all 14 job modules and both
+   `sync*` helper signatures — which retires the `characterID` /
+   `character_id` collision. Note the intermediate state it leaves: where a job
+   writes that value into a column still called `character_id`, the payload is
+   now an explicit `character_id: registration_id` rather than shorthand. That
+   reads awkwardly on purpose, and each one disappears as step 4 renames its
+   table.
+
+   The **`characterIds` option** was deliberately left alone. It looked like
+   part of the same rename, but `characterIds` turns out to name three other
+   unrelated contracts too — `OwnerContext.characterIds` in the MCP layer,
+   `resolvePlayer`'s return in `src/utils/apiToken.ts`, and the `character_ids`
+   RPC parameter — spanning ~55 files. Renaming only lib.js's would leave the
+   name meaning two things at once. It belongs with those, as its own step.
+
 3. **Infrastructure tables** — `heartbeat`, `refresh_task`. Small, and
    `heartbeat` also drags `latest_heartbeats()`'s return column, so it's a good
    dry run of the function-recreation dance.

--- a/src/jobs/characterAssets.js
+++ b/src/jobs/characterAssets.js
@@ -56,7 +56,7 @@ const fetchNames = async (access_token, characterID, fetched) => {
 // holding every current row's full 10 columns just multiplied peak memory.
 const PAGE = 1000
 
-const fetchCurrentByItem = async (character_id) => {
+const fetchCurrentByItem = async (registration_id) => {
   const cols =
     'id, item_id, type_id, location_id, location_flag, location_type, quantity, is_singleton, is_blueprint_copy, name'
   const byItem = new Map()
@@ -64,7 +64,7 @@ const fetchCurrentByItem = async (character_id) => {
     const { data, error } = await sudoSupabase
       .from('character_asset_over_time')
       .select(cols)
-      .eq('character_id', character_id)
+      .eq('character_id', registration_id)
       .eq('is_current', true)
       .order('id', { ascending: true })
       .range(from, from + PAGE - 1)
@@ -82,8 +82,8 @@ const fetchCurrentByItem = async (character_id) => {
 // their old row closed and a new one inserted, and vanished items are closed.
 // `names` is the player-assigned-name Map from fetchNames, applied here per
 // item instead of pre-merged onto a full copy of the fetched array.
-const reconcile = async (character_id, fetched, names) => {
-  const currentByItem = await fetchCurrentByItem(character_id)
+const reconcile = async (registration_id, fetched, names) => {
+  const currentByItem = await fetchCurrentByItem(registration_id)
 
   // ESI can return the same item twice across pages if assets shift mid-fetch;
   // collapse to one entry per item so we never queue two inserts for it.
@@ -108,7 +108,7 @@ const reconcile = async (character_id, fetched, names) => {
         // valid_from is left to its `default now()` so it marks this version's debut.
         acc.inserts.push({
           item_id: a.item_id,
-          character_id,
+          character_id: registration_id,
           type_id: a.type_id,
           location_id: a.location_id ?? null,
           location_flag: a.location_flag ?? null,
@@ -157,11 +157,11 @@ const reconcile = async (character_id, fetched, names) => {
 }
 
 export const runCharacterAssets = ({ characterIds } = {}) =>
-  forEachCharacter(TAG, { scope: SCOPE, characterIds }, async ({ access_token, characterID, character_id, ctx }) => {
+  forEachCharacter(TAG, { scope: SCOPE, characterIds }, async ({ access_token, characterID, registration_id, ctx }) => {
     const t0 = Date.now()
     const fetched = await fetchAllPages((page) => assets(access_token, characterID, page))
     const names = await fetchNames(access_token, characterID, fetched)
-    const { touched, opened, closed } = await reconcile(character_id, fetched, names)
+    const { touched, opened, closed } = await reconcile(registration_id, fetched, names)
 
     const dt = Date.now() - t0
     console.log(

--- a/src/jobs/characterBlueprints.js
+++ b/src/jobs/characterBlueprints.js
@@ -31,27 +31,27 @@ const signature = (b) =>
 // with thousands of blueprints doesn't silently truncate the "current" set.
 const PAGE = 1000
 
-const fetchCurrentRows = async (character_id, cols, from = 0) => {
+const fetchCurrentRows = async (registration_id, cols, from = 0) => {
   const { data, error } = await sudoSupabase
     .from('character_blueprint_over_time')
     .select(cols)
-    .eq('character_id', character_id)
+    .eq('character_id', registration_id)
     .eq('is_current', true)
     .order('id', { ascending: true })
     .range(from, from + PAGE - 1)
   if (error) throw error
   const page = data ?? []
   if (page.length < PAGE) return page
-  return [...page, ...(await fetchCurrentRows(character_id, cols, from + PAGE))]
+  return [...page, ...(await fetchCurrentRows(registration_id, cols, from + PAGE))]
 }
 
 // Reconcile freshly fetched blueprints against the character's current (open)
 // rows: unchanged blueprints get their valid_until extended, changed ones
 // have their old row closed and a new one inserted, and vanished ones
 // (scrapped, transferred away, converted) are closed.
-const reconcile = async (character_id, fetched) => {
+const reconcile = async (registration_id, fetched) => {
   const cols = 'id, item_id, type_id, location_id, location_flag, quantity, material_efficiency, time_efficiency, runs'
-  const current = await fetchCurrentRows(character_id, cols)
+  const current = await fetchCurrentRows(registration_id, cols)
 
   const currentByItem = new Map(current.map((c) => [Number(c.item_id), c]))
   // ESI can return the same item twice across pages if blueprints shift
@@ -75,7 +75,7 @@ const reconcile = async (character_id, fetched) => {
         // valid_from is left to its `default now()` so it marks this version's debut.
         acc.inserts.push({
           item_id: b.item_id,
-          character_id,
+          character_id: registration_id,
           type_id: b.type_id,
           location_id: b.location_id ?? null,
           location_flag: b.location_flag ?? null,
@@ -124,10 +124,10 @@ const reconcile = async (character_id, fetched) => {
 }
 
 export const runCharacterBlueprints = ({ characterIds } = {}) =>
-  forEachCharacter(TAG, { scope: SCOPE, characterIds }, async ({ access_token, characterID, character_id, ctx }) => {
+  forEachCharacter(TAG, { scope: SCOPE, characterIds }, async ({ access_token, characterID, registration_id, ctx }) => {
     const t0 = Date.now()
     const fetched = await fetchAllPages((page) => blueprints(access_token, characterID, page))
-    const { touched, opened, closed } = await reconcile(character_id, fetched)
+    const { touched, opened, closed } = await reconcile(registration_id, fetched)
 
     const dt = Date.now() - t0
     console.log(

--- a/src/jobs/characterClones.js
+++ b/src/jobs/characterClones.js
@@ -77,11 +77,11 @@ export const makeSystemResolver = () => {
   }
 }
 
-const fetchCurrentRows = async (character_id) => {
+const fetchCurrentRows = async (registration_id) => {
   const { data, error } = await sudoSupabase
     .from('character_clone_over_time')
     .select('id, jump_clone_id, is_home, location_id, location_type, name, implants, system_id')
-    .eq('character_id', character_id)
+    .eq('character_id', registration_id)
     .eq('is_current', true)
   if (error) throw error
   return data ?? []
@@ -92,8 +92,8 @@ const fetchCurrentRows = async (character_id) => {
 // backfilled if resolution newly succeeded), a changed clone has its old row
 // closed and a new one inserted, and a clone that's gone (jump clone
 // destroyed/consumed) is closed.
-const reconcile = async (character_id, fetchedClones) => {
-  const current = await fetchCurrentRows(character_id)
+const reconcile = async (registration_id, fetchedClones) => {
+  const current = await fetchCurrentRows(registration_id)
   const currentByKey = new Map(map((c) => [cloneKey(c), c], current))
   const fetchedByKey = new Map(map((c) => [cloneKey(c), c], fetchedClones))
 
@@ -111,7 +111,7 @@ const reconcile = async (character_id, fetchedClones) => {
       } else {
         if (cur) acc.closeIds.push(cur.id)
         acc.inserts.push({
-          character_id,
+          character_id: registration_id,
           jump_clone_id: c.is_home ? null : c.jump_clone_id,
           is_home: !!c.is_home,
           location_id: c.location_id,
@@ -171,7 +171,7 @@ const reconcile = async (character_id, fetchedClones) => {
 // makeSystemResolver) so a whole run's clones — which cluster in the same few
 // stations/structures — resolve each location once. Exported so the combined
 // character-status job (characterStatus.js) can reuse it with a shared resolver.
-export const syncCharacterClones = async ({ access_token, characterID, character_id, ctx }, resolveSystem) => {
+export const syncCharacterClones = async ({ access_token, characterID, registration_id, ctx }, resolveSystem) => {
   const payload = await characterClones(access_token, characterID)
   const home = payload.home_location
     ? [
@@ -201,7 +201,7 @@ export const syncCharacterClones = async ({ access_token, characterID, character
 
   const { error: stateErr } = await sudoSupabase.from('character_clone_state').upsert(
     {
-      character_id,
+      character_id: registration_id,
       last_clone_jump_date: payload.last_clone_jump_date ?? null,
       last_station_change_date: payload.last_station_change_date ?? null,
       recorded_at: new Date().toISOString(),
@@ -210,7 +210,7 @@ export const syncCharacterClones = async ({ access_token, characterID, character
   )
   if (stateErr) throw stateErr
 
-  const { touched, opened, closed } = await reconcile(character_id, clones)
+  const { touched, opened, closed } = await reconcile(registration_id, clones)
   console.log(`[${TAG}] ${ctx}: ${touched} unchanged, ${opened} opened, ${closed} closed`)
 }
 

--- a/src/jobs/characterFittings.js
+++ b/src/jobs/characterFittings.js
@@ -130,7 +130,7 @@ export const runCharacterFittings = ({ characterIds } = {}) =>
   forEachCharacter(
     TAG,
     { scope: SCOPE, characterIds },
-    async ({ access_token, characterID, character_id: registration_id, name }) => {
+    async ({ access_token, characterID, registration_id, name }) => {
       const cacheKey = `${TAG}:${registration_id}`
       const priorEtag = await getEsiEtag(cacheKey)
       const t0 = Date.now()

--- a/src/jobs/characterImplants.js
+++ b/src/jobs/characterImplants.js
@@ -10,11 +10,11 @@ export const SCOPE = 'esi-clones.read_implants.v1'
 // current-state data, like character-location — a plain upsert rather than
 // an SCD reconcile. Exported so the combined character-status job
 // (characterStatus.js) can reuse this per-character pull.
-export const syncCharacterImplants = async ({ access_token, characterID, character_id, ctx }) => {
+export const syncCharacterImplants = async ({ access_token, characterID, registration_id, ctx }) => {
   const typeIds = await characterImplants(access_token, characterID)
   const { error } = await sudoSupabase.from('character_implant').upsert(
     {
-      character_id,
+      character_id: registration_id,
       type_ids: typeIds ?? [],
       recorded_at: new Date().toISOString(),
     },

--- a/src/jobs/characterIndustryJobs.js
+++ b/src/jobs/characterIndustryJobs.js
@@ -29,18 +29,18 @@ const signature = (j) =>
 // with a long job history doesn't silently truncate the "current" set.
 const PAGE = 1000
 
-const fetchCurrentRows = async (character_id, cols, from = 0) => {
+const fetchCurrentRows = async (registration_id, cols, from = 0) => {
   const { data, error } = await sudoSupabase
     .from('character_industry_job_over_time')
     .select(cols)
-    .eq('character_id', character_id)
+    .eq('character_id', registration_id)
     .eq('is_current', true)
     .order('id', { ascending: true })
     .range(from, from + PAGE - 1)
   if (error) throw error
   const page = data ?? []
   if (page.length < PAGE) return page
-  return [...page, ...(await fetchCurrentRows(character_id, cols, from + PAGE))]
+  return [...page, ...(await fetchCurrentRows(registration_id, cols, from + PAGE))]
 }
 
 // Reconcile freshly fetched jobs against the character's current (open) rows in
@@ -51,9 +51,9 @@ const fetchCurrentRows = async (character_id, cols, from = 0) => {
 // include_completed's window) is NOT closed — its terminal row stays is_current
 // so the character_industry_job view keeps every job the endpoint ever
 // reported, matching the old plain table (which never swept completed jobs).
-const reconcile = async (character_id, fetched) => {
+const reconcile = async (registration_id, fetched) => {
   const cols = 'id, job_id, status, pause_date, completed_date, completed_character_id, successful_runs'
-  const current = await fetchCurrentRows(character_id, cols)
+  const current = await fetchCurrentRows(registration_id, cols)
 
   const currentByJob = new Map(current.map((c) => [Number(c.job_id), c]))
   // ESI could report the same job twice if the set shifts mid-response;
@@ -75,7 +75,7 @@ const reconcile = async (character_id, fetched) => {
         // valid_from is left to its `default now()` so it marks this version's debut.
         acc.inserts.push({
           job_id: j.job_id,
-          character_id,
+          character_id: registration_id,
           installer_id: j.installer_id,
           facility_id: j.facility_id,
           station_id: j.station_id ?? null,
@@ -135,41 +135,45 @@ const reconcile = async (character_id, fetched) => {
 // is unchanged since last run (nothing started or completed), so the whole
 // reconcile is skipped.
 export const runCharacterIndustryJobs = ({ characterIds } = {}) =>
-  forEachCharacter(TAG, { scope: SCOPE, characterIds }, async ({ access_token, characterID, character_id, name }) => {
-    const cacheKey = `${TAG}:${character_id}`
-    const priorEtag = await getEsiEtag(cacheKey)
-    const t0 = Date.now()
-    const { status, json: jobs, etag } = await industryJobs(access_token, characterID, priorEtag)
-    const durationMs = Date.now() - t0
-    if (status === 304) {
+  forEachCharacter(
+    TAG,
+    { scope: SCOPE, characterIds },
+    async ({ access_token, characterID, registration_id, name }) => {
+      const cacheKey = `${TAG}:${registration_id}`
+      const priorEtag = await getEsiEtag(cacheKey)
+      const t0 = Date.now()
+      const { status, json: jobs, etag } = await industryJobs(access_token, characterID, priorEtag)
+      const durationMs = Date.now() - t0
+      if (status === 304) {
+        recordEsiConditional({
+          job: TAG,
+          characterId: registration_id,
+          characterName: name,
+          outcome: 'not_modified',
+          conditional: true,
+          durationMs,
+        })
+        console.log(`[${TAG}] ${name} ${registration_id} (${characterID}): not modified`)
+        return
+      }
+
+      const { touched, opened, closed } = await reconcile(registration_id, jobs)
+
+      // Store the ETag only after the reconcile committed (see characterOrders.js).
+      await putEsiEtag(cacheKey, etag)
       recordEsiConditional({
         job: TAG,
-        characterId: character_id,
+        characterId: registration_id,
         characterName: name,
-        outcome: 'not_modified',
-        conditional: true,
+        outcome: 'modified',
+        conditional: priorEtag != null,
+        rows: jobs.length,
         durationMs,
       })
-      console.log(`[${TAG}] ${name} ${character_id} (${characterID}): not modified`)
-      return
+      console.log(
+        `[${TAG}] ${name} ${registration_id} (${characterID}): ${jobs.length} jobs; ${touched} unchanged, ${opened} opened, ${closed} closed`
+      )
     }
-
-    const { touched, opened, closed } = await reconcile(character_id, jobs)
-
-    // Store the ETag only after the reconcile committed (see characterOrders.js).
-    await putEsiEtag(cacheKey, etag)
-    recordEsiConditional({
-      job: TAG,
-      characterId: character_id,
-      characterName: name,
-      outcome: 'modified',
-      conditional: priorEtag != null,
-      rows: jobs.length,
-      durationMs,
-    })
-    console.log(
-      `[${TAG}] ${name} ${character_id} (${characterID}): ${jobs.length} jobs; ${touched} unchanged, ${opened} opened, ${closed} closed`
-    )
-  })
+  )
 
 cli(import.meta.url, TAG, runCharacterIndustryJobs)

--- a/src/jobs/characterLocation.js
+++ b/src/jobs/characterLocation.js
@@ -9,11 +9,11 @@ export const SCOPE = 'esi-location.read_location.v1'
 // data — ESI only ever reports "where is the character right now" — so this
 // is a plain upsert rather than an SCD reconcile. Exported so the combined
 // character-status job (characterStatus.js) can reuse this per-character pull.
-export const syncCharacterLocation = async ({ access_token, characterID, character_id, ctx }) => {
+export const syncCharacterLocation = async ({ access_token, characterID, registration_id, ctx }) => {
   const location = await characterLocation(access_token, characterID)
   const { error } = await sudoSupabase.from('character_location').upsert(
     {
-      character_id,
+      character_id: registration_id,
       solar_system_id: location.solar_system_id,
       station_id: location.station_id ?? null,
       structure_id: location.structure_id ?? null,

--- a/src/jobs/characterMercenaryDens.js
+++ b/src/jobs/characterMercenaryDens.js
@@ -27,7 +27,7 @@ const signature = (d) =>
     d.skyhook_corporation_id == null ? null : Number(d.skyhook_corporation_id),
   ])
 
-export const syncCharacterMercenaryDens = async ({ access_token, characterID, character_id, name }) => {
+export const syncCharacterMercenaryDens = async ({ access_token, characterID, registration_id, name }) => {
   const { mercenary_dens: listed = [] } = await characterMercenaryDens(access_token, characterID)
 
   // One timestamp for the whole character so valid_from/valid_until line up per run.
@@ -37,7 +37,7 @@ export const syncCharacterMercenaryDens = async ({ access_token, characterID, ch
   const { data: currentRows, error: curErr } = await sudoSupabase
     .from('character_mercenary_den_over_time')
     .select('id, den_id, planet_id, type_id, skyhook_id, skyhook_corporation_id')
-    .eq('character_id', character_id)
+    .eq('character_id', registration_id)
     .eq('is_current', true)
   if (curErr) throw curErr
   const currentByDen = new Map((currentRows ?? []).map((r) => [Number(r.den_id), r]))
@@ -72,13 +72,13 @@ export const syncCharacterMercenaryDens = async ({ access_token, characterID, ch
       // valid_from is left to its `default now()` so it marks this version's debut.
       const { error } = await sudoSupabase
         .from('character_mercenary_den_over_time')
-        .insert({ character_id, den_id: den.id, ...config, valid_until: now })
+        .insert({ character_id: registration_id, den_id: den.id, ...config, valid_until: now })
       if (error) throw error
     }
 
     // Observed volatile state — appended as a new history row every run.
     const { error: statusError } = await sudoSupabase.from('character_mercenary_den_status').insert({
-      character_id,
+      character_id: registration_id,
       den_id: den.id,
       state: detail.state ?? null,
       development_level: detail.evolution?.development?.level ?? null,
@@ -104,7 +104,7 @@ export const syncCharacterMercenaryDens = async ({ access_token, characterID, ch
     if (closeErr) throw closeErr
   }
 
-  console.log(`[${TAG}] ${name} ${character_id} (${characterID}): ${listed.length} den(s)`)
+  console.log(`[${TAG}] ${name} ${registration_id} (${characterID}): ${listed.length} den(s)`)
 }
 
 export const runCharacterMercenaryDens = ({ characterIds } = {}) =>

--- a/src/jobs/characterOrders.js
+++ b/src/jobs/characterOrders.js
@@ -27,18 +27,18 @@ const signature = (o) =>
 // with thousands of orders doesn't silently truncate the "current" set.
 const PAGE = 1000
 
-const fetchCurrentRows = async (character_id, cols, from = 0) => {
+const fetchCurrentRows = async (registration_id, cols, from = 0) => {
   const { data, error } = await sudoSupabase
     .from('character_order_over_time')
     .select(cols)
-    .eq('character_id', character_id)
+    .eq('character_id', registration_id)
     .eq('is_current', true)
     .order('id', { ascending: true })
     .range(from, from + PAGE - 1)
   if (error) throw error
   const page = data ?? []
   if (page.length < PAGE) return page
-  return [...page, ...(await fetchCurrentRows(character_id, cols, from + PAGE))]
+  return [...page, ...(await fetchCurrentRows(registration_id, cols, from + PAGE))]
 }
 
 // Reconcile freshly fetched open orders against the character's current (open)
@@ -47,9 +47,9 @@ const fetchCurrentRows = async (character_id, cols, from = 0) => {
 // row and open a new one, and vanished ones (filled, expired or cancelled)
 // are closed. The character_order view of is_current rows then holds exactly
 // the still-open orders.
-const reconcile = async (character_id, fetched) => {
+const reconcile = async (registration_id, fetched) => {
   const cols = 'id, order_id, price, volume_remain, escrow, min_volume, range, duration'
-  const current = await fetchCurrentRows(character_id, cols)
+  const current = await fetchCurrentRows(registration_id, cols)
 
   const currentByOrder = new Map(current.map((c) => [Number(c.order_id), c]))
   // ESI could report the same order twice if the set shifts mid-response;
@@ -73,7 +73,7 @@ const reconcile = async (character_id, fetched) => {
         // valid_from is left to its `default now()` so it marks this version's debut.
         acc.inserts.push({
           order_id: o.order_id,
-          character_id,
+          character_id: registration_id,
           type_id: o.type_id,
           region_id: o.region_id,
           location_id: o.location_id,
@@ -127,42 +127,46 @@ const reconcile = async (character_id, fetched) => {
 // Conditional: a 304 means the open-order set is byte-identical to last run —
 // nothing filled, expired or re-priced — so the whole reconcile is skipped.
 export const runCharacterOrders = ({ characterIds } = {}) =>
-  forEachCharacter(TAG, { scope: SCOPE, characterIds }, async ({ access_token, characterID, character_id, name }) => {
-    const cacheKey = `${TAG}:${character_id}`
-    const priorEtag = await getEsiEtag(cacheKey)
-    const t0 = Date.now()
-    const { status, json: fetched, etag } = await orders(access_token, characterID, priorEtag)
-    const durationMs = Date.now() - t0
-    if (status === 304) {
+  forEachCharacter(
+    TAG,
+    { scope: SCOPE, characterIds },
+    async ({ access_token, characterID, registration_id, name }) => {
+      const cacheKey = `${TAG}:${registration_id}`
+      const priorEtag = await getEsiEtag(cacheKey)
+      const t0 = Date.now()
+      const { status, json: fetched, etag } = await orders(access_token, characterID, priorEtag)
+      const durationMs = Date.now() - t0
+      if (status === 304) {
+        recordEsiConditional({
+          job: TAG,
+          characterId: registration_id,
+          characterName: name,
+          outcome: 'not_modified',
+          conditional: true,
+          durationMs,
+        })
+        console.log(`[${TAG}] ${name} ${registration_id} (${characterID}): not modified`)
+        return
+      }
+
+      const { touched, opened, closed } = await reconcile(registration_id, fetched)
+
+      // Store the ETag only after the reconcile committed, so a mid-run failure
+      // never leaves us skipping a fetch whose data we didn't persist.
+      await putEsiEtag(cacheKey, etag)
       recordEsiConditional({
         job: TAG,
-        characterId: character_id,
+        characterId: registration_id,
         characterName: name,
-        outcome: 'not_modified',
-        conditional: true,
+        outcome: 'modified',
+        conditional: priorEtag != null,
+        rows: fetched.length,
         durationMs,
       })
-      console.log(`[${TAG}] ${name} ${character_id} (${characterID}): not modified`)
-      return
+      console.log(
+        `[${TAG}] ${name} ${registration_id} (${characterID}): ${fetched.length} open; ${touched} unchanged, ${opened} opened, ${closed} closed`
+      )
     }
-
-    const { touched, opened, closed } = await reconcile(character_id, fetched)
-
-    // Store the ETag only after the reconcile committed, so a mid-run failure
-    // never leaves us skipping a fetch whose data we didn't persist.
-    await putEsiEtag(cacheKey, etag)
-    recordEsiConditional({
-      job: TAG,
-      characterId: character_id,
-      characterName: name,
-      outcome: 'modified',
-      conditional: priorEtag != null,
-      rows: fetched.length,
-      durationMs,
-    })
-    console.log(
-      `[${TAG}] ${name} ${character_id} (${characterID}): ${fetched.length} open; ${touched} unchanged, ${opened} opened, ${closed} closed`
-    )
-  })
+  )
 
 cli(import.meta.url, TAG, runCharacterOrders)

--- a/src/jobs/characterShip.js
+++ b/src/jobs/characterShip.js
@@ -18,11 +18,11 @@ export const SCOPE = 'esi-location.read_ship_type.v1'
 // row's ship_name is updated in place (like the clones job backfilling
 // system_id), so the history reads as one stint per ship, not per name.
 
-const fetchCurrentRow = async (character_id) => {
+const fetchCurrentRow = async (registration_id) => {
   const { data, error } = await sudoSupabase
     .from('character_ship_over_time')
     .select('id, ship_item_id, ship_type_id, ship_name')
-    .eq('character_id', character_id)
+    .eq('character_id', registration_id)
     .eq('is_current', true)
     .maybeSingle()
   if (error) throw error
@@ -33,8 +33,8 @@ const fetchCurrentRow = async (character_id) => {
 // row: the same ship extends valid_until (refreshing ship_name in place if
 // it was renamed); a different ship closes the old row (if any) and opens a
 // new one.
-const reconcile = async (character_id, fetchedShip) => {
-  const current = await fetchCurrentRow(character_id)
+const reconcile = async (registration_id, fetchedShip) => {
+  const current = await fetchCurrentRow(registration_id)
   const now = new Date().toISOString()
 
   if (current && Number(current.ship_item_id) === Number(fetchedShip.ship_item_id)) {
@@ -55,7 +55,7 @@ const reconcile = async (character_id, fetchedShip) => {
     if (error) throw error
   }
   const { error } = await sudoSupabase.from('character_ship_over_time').insert({
-    character_id,
+    character_id: registration_id,
     ship_item_id: fetchedShip.ship_item_id,
     ship_type_id: fetchedShip.ship_type_id,
     ship_name: fetchedShip.ship_name ?? null,
@@ -67,9 +67,9 @@ const reconcile = async (character_id, fetchedShip) => {
 
 // Exported so the combined character-status job (characterStatus.js) can
 // reuse this per-character pull.
-export const syncCharacterShip = async ({ access_token, characterID, character_id, ctx }) => {
+export const syncCharacterShip = async ({ access_token, characterID, registration_id, ctx }) => {
   const ship = await characterShip(access_token, characterID)
-  const changed = await reconcile(character_id, ship)
+  const changed = await reconcile(registration_id, ship)
   console.log(`[${TAG}] ${ctx}: ship_item_id=${ship.ship_item_id}${changed ? ' (changed)' : ''}`)
 }
 

--- a/src/jobs/characterSkills.js
+++ b/src/jobs/characterSkills.js
@@ -23,26 +23,26 @@ const signature = (s) => JSON.stringify([Number(s.active_skill_level) || 0, Numb
 // with hundreds of skills doesn't silently truncate the "current" set.
 const PAGE = 1000
 
-const fetchCurrentRows = async (character_id, from = 0) => {
+const fetchCurrentRows = async (registration_id, from = 0) => {
   const { data, error } = await sudoSupabase
     .from('character_skill_over_time')
     .select('id, skill_id, active_skill_level, trained_skill_level')
-    .eq('character_id', character_id)
+    .eq('character_id', registration_id)
     .eq('is_current', true)
     .order('id', { ascending: true })
     .range(from, from + PAGE - 1)
   if (error) throw error
   const page = data ?? []
   if (page.length < PAGE) return page
-  return [...page, ...(await fetchCurrentRows(character_id, from + PAGE))]
+  return [...page, ...(await fetchCurrentRows(registration_id, from + PAGE))]
 }
 
 // Reconcile freshly fetched skills against the character's current (open) rows:
 // unchanged skills get their valid_until extended, changed ones have their old
 // row closed and a new one inserted. Nothing is closed for vanishing — a
 // character never loses a skill.
-const reconcile = async (character_id, fetched) => {
-  const current = await fetchCurrentRows(character_id)
+const reconcile = async (registration_id, fetched) => {
+  const current = await fetchCurrentRows(registration_id)
   const currentBySkill = new Map(current.map((c) => [Number(c.skill_id), c]))
   const fetchedBySkill = new Map(fetched.map((s) => [Number(s.skill_id), s]))
 
@@ -60,7 +60,7 @@ const reconcile = async (character_id, fetched) => {
         if (cur) acc.closeIds.push(cur.id)
         // valid_from is left to its `default now()` so it marks this version's debut.
         acc.inserts.push({
-          character_id,
+          character_id: registration_id,
           skill_id: s.skill_id,
           active_skill_level: s.active_skill_level ?? 0,
           trained_skill_level: s.trained_skill_level ?? 0,
@@ -93,9 +93,9 @@ const reconcile = async (character_id, fetched) => {
   return { touched: touchIds.length, opened: inserts.length, closed: closeIds.length }
 }
 
-export const syncCharacterSkills = async ({ access_token, characterID, character_id, ctx }) => {
+export const syncCharacterSkills = async ({ access_token, characterID, registration_id, ctx }) => {
   const { skills } = await characterSkills(access_token, characterID)
-  const { touched, opened, closed } = await reconcile(character_id, skills ?? [])
+  const { touched, opened, closed } = await reconcile(registration_id, skills ?? [])
   console.log(
     `[${TAG}] ${ctx}: ${(skills ?? []).length} skill(s); ${touched} unchanged, ${opened} opened, ${closed} closed`
   )

--- a/src/jobs/characterWallet.js
+++ b/src/jobs/characterWallet.js
@@ -9,11 +9,11 @@ export const SCOPE = 'esi-wallet.read_character_wallet.v1'
 // character per run, building the balance-over-time history the character page
 // charts. Exported so the combined character-status job (characterStatus.js)
 // can reuse this exact per-character pull alongside the other live-state ones.
-export const syncCharacterWallet = async ({ access_token, characterID, character_id, name }) => {
+export const syncCharacterWallet = async ({ access_token, characterID, registration_id, name }) => {
   const balance = await wallet(access_token, characterID)
-  const { error } = await sudoSupabase.from('character_wallet').insert({ character_id, balance })
+  const { error } = await sudoSupabase.from('character_wallet').insert({ character_id: registration_id, balance })
   if (error) throw error
-  console.log(`[${TAG}] ${name} ${character_id} (${characterID}): ${balance}`)
+  console.log(`[${TAG}] ${name} ${registration_id} (${characterID}): ${balance}`)
 }
 
 export const runCharacterWallet = ({ characterIds } = {}) =>

--- a/src/jobs/characterWalletTransactions.js
+++ b/src/jobs/characterWalletTransactions.js
@@ -11,55 +11,59 @@ const SCOPE = 'esi-wallet.read_character_wallet.v1'
 // the same recent history. Conditional: a 304 means no new transactions since
 // last run, so the upsert is skipped.
 export const runCharacterWalletTransactions = ({ characterIds } = {}) =>
-  forEachCharacter(TAG, { scope: SCOPE, characterIds }, async ({ access_token, characterID, character_id, name }) => {
-    const cacheKey = `${TAG}:${character_id}`
-    const priorEtag = await getEsiEtag(cacheKey)
-    const t0 = Date.now()
-    const { status, json: txns, etag } = await transactions(access_token, characterID, priorEtag)
-    const durationMs = Date.now() - t0
-    if (status === 304) {
+  forEachCharacter(
+    TAG,
+    { scope: SCOPE, characterIds },
+    async ({ access_token, characterID, registration_id, name }) => {
+      const cacheKey = `${TAG}:${registration_id}`
+      const priorEtag = await getEsiEtag(cacheKey)
+      const t0 = Date.now()
+      const { status, json: txns, etag } = await transactions(access_token, characterID, priorEtag)
+      const durationMs = Date.now() - t0
+      if (status === 304) {
+        recordEsiConditional({
+          job: TAG,
+          characterId: registration_id,
+          characterName: name,
+          outcome: 'not_modified',
+          conditional: true,
+          durationMs,
+        })
+        console.log(`[${TAG}] ${name} ${registration_id} (${characterID}): not modified`)
+        return
+      }
+      if (txns.length > 0) {
+        const rows = txns.map((t) => ({
+          transaction_id: t.transaction_id,
+          character_id: registration_id,
+          date: t.date,
+          type_id: t.type_id,
+          quantity: t.quantity,
+          unit_price: t.unit_price,
+          is_buy: t.is_buy,
+          is_personal: t.is_personal,
+          client_id: t.client_id,
+          location_id: t.location_id,
+          journal_ref_id: t.journal_ref_id,
+        }))
+        const { error } = await sudoSupabase
+          .from('character_wallet_transaction')
+          .upsert(rows, { onConflict: 'transaction_id', ignoreDuplicates: true })
+        if (error) throw error
+      }
+      // Store the ETag only after the upsert committed (see characterOrders.js).
+      await putEsiEtag(cacheKey, etag)
       recordEsiConditional({
         job: TAG,
-        characterId: character_id,
+        characterId: registration_id,
         characterName: name,
-        outcome: 'not_modified',
-        conditional: true,
+        outcome: 'modified',
+        conditional: priorEtag != null,
+        rows: txns.length,
         durationMs,
       })
-      console.log(`[${TAG}] ${name} ${character_id} (${characterID}): not modified`)
-      return
+      console.log(`[${TAG}] ${name} ${registration_id} (${characterID}): ${txns.length} fetched`)
     }
-    if (txns.length > 0) {
-      const rows = txns.map((t) => ({
-        transaction_id: t.transaction_id,
-        character_id,
-        date: t.date,
-        type_id: t.type_id,
-        quantity: t.quantity,
-        unit_price: t.unit_price,
-        is_buy: t.is_buy,
-        is_personal: t.is_personal,
-        client_id: t.client_id,
-        location_id: t.location_id,
-        journal_ref_id: t.journal_ref_id,
-      }))
-      const { error } = await sudoSupabase
-        .from('character_wallet_transaction')
-        .upsert(rows, { onConflict: 'transaction_id', ignoreDuplicates: true })
-      if (error) throw error
-    }
-    // Store the ETag only after the upsert committed (see characterOrders.js).
-    await putEsiEtag(cacheKey, etag)
-    recordEsiConditional({
-      job: TAG,
-      characterId: character_id,
-      characterName: name,
-      outcome: 'modified',
-      conditional: priorEtag != null,
-      rows: txns.length,
-      durationMs,
-    })
-    console.log(`[${TAG}] ${name} ${character_id} (${characterID}): ${txns.length} fetched`)
-  })
+  )
 
 cli(import.meta.url, TAG, runCharacterWalletTransactions)

--- a/src/jobs/corpWalletTransactions.js
+++ b/src/jobs/corpWalletTransactions.js
@@ -9,7 +9,7 @@ const WALLET_DIVISIONS = [1, 2, 3, 4, 5, 6, 7]
 
 // GET /corporations/{id}/wallets/{division}/transactions/ → corp_wallet_transaction.
 // Pulls market transactions from every wallet division, tagged with
-// `character_id` — the registration whose token scanned them — so RLS only shows
+// `registration_id` — the registration whose token scanned them — so RLS only shows
 // each row to that character's owner. The market page unions these with the
 // per-character character_wallet_transaction rows. transaction_id is globally
 // unique in EVE, so the upsert dedupes across divisions and re-scans (first
@@ -19,7 +19,7 @@ export const runCorpWalletTransactions = ({ characterIds } = {}) =>
   forEachCorporation(
     TAG,
     { scope: SCOPE, characterIds },
-    async ({ access_token, corporation_id, character_id, ctx }) => {
+    async ({ access_token, corporation_id, registration_id, ctx }) => {
       let failures = 0
       await forEachSequential(WALLET_DIVISIONS, async (division) => {
         try {
@@ -30,7 +30,7 @@ export const runCorpWalletTransactions = ({ characterIds } = {}) =>
           }
           const rows = txns.map((t) => ({
             transaction_id: t.transaction_id,
-            character_id,
+            character_id: registration_id,
             corporation_id,
             division,
             date: t.date,

--- a/src/jobs/lib.js
+++ b/src/jobs/lib.js
@@ -83,10 +83,7 @@ const runTokenLoop = async (tag, tokens, { characterName, characterUserId, heart
         handler({
           access_token,
           characterID,
-          // Still `character_id` on the handler side even though the column is
-          // now registration_id: renaming this field means touching every
-          // extract job, which is step 2 of docs/registration-id-rename.md.
-          character_id: tokenRow.registration_id,
+          registration_id: tokenRow.registration_id,
           userId,
           name,
           ctx,
@@ -105,8 +102,8 @@ const runTokenLoop = async (tag, tokens, { characterName, characterUserId, heart
 }
 
 // Iterate the tokens that carry `scope`, calling handler once per token with
-// { access_token, characterID, character_id, userId, name, ctx, scopes }.
-// `characterID` is the EVE character id from the token; `character_id` is the
+// { access_token, characterID, registration_id, userId, name, ctx, scopes }.
+// `characterID` is the EVE character id from the token; `registration_id` is the
 // registration uuid. Each call is wrapped in a start/end heartbeat attributed
 // to that character (job/character_id/user_id), unless `heartbeat: false` — set
 // by forEachCorporation, which records its own corp-attributed heartbeat instead
@@ -156,7 +153,7 @@ export const forEachCharacterAnyScope = async (tag, { scopes, characterIds, hear
 }
 
 // Iterate the corporations reachable through tokens carrying `scope`, calling
-// handler once per corporation with { access_token, corporation_id, character_id,
+// handler once per corporation with { access_token, corporation_id, registration_id,
 // ctx }. Two characters in the same corp resolve to one handler call per run —
 // unless the first one's call fails (most commonly a character that carries the
 // OAuth scope but lacks the in-game role — director, accountant, etc — the corp
@@ -173,7 +170,7 @@ export const forEachCorporation = async (tag, { scope, characterIds }, handler) 
   await forEachCharacter(
     tag,
     { scope, characterIds, heartbeat: false },
-    async ({ access_token, characterID, character_id, userId, ctx }) => {
+    async ({ access_token, characterID, registration_id, userId, ctx }) => {
       const info = await fetchCharacter(access_token, characterID)
       const corporation_id = info?.corporation_id
       if (!corporation_id) {
@@ -183,7 +180,7 @@ export const forEachCorporation = async (tag, { scope, characterIds }, handler) 
       const { error: charUpdateErr } = await sudoSupabase
         .from('registration')
         .update({ corporation_id })
-        .eq('id', character_id)
+        .eq('id', registration_id)
       if (charUpdateErr) {
         console.error(`[${tag}] ${ctx}: registration.corporation_id update failed: ${charUpdateErr.message}`)
       }
@@ -191,8 +188,8 @@ export const forEachCorporation = async (tag, { scope, characterIds }, handler) 
         console.log(`[${tag}] ${ctx}: corp ${corporation_id} already pulled this run, skipping`)
         return
       }
-      await withHeartbeat(tag, { characterId: character_id, corporationId: corporation_id, userId }, () =>
-        handler({ access_token, corporation_id, character_id, ctx })
+      await withHeartbeat(tag, { characterId: registration_id, corporationId: corporation_id, userId }, () =>
+        handler({ access_token, corporation_id, registration_id, ctx })
       )
       // Only mark the corp as handled once the pull actually succeeds.
       seenCorps.add(corporation_id)


### PR DESCRIPTION
Step 2 of `docs/registration-id-rename.md` — and the one that actually retires the hazard the doc was written about.

`forEachCharacter` handed every extract job `characterID` (the EVE id) and `character_id` (a registration uuid) in the same destructure, one capital letter apart. The second is now `registration_id`, swept through all 14 job modules, both `sync*` helper signatures, and `forEachCorporation`'s own inner destructure and emitted handler object.

Pure JavaScript — no migration, no deploy-ordering risk.

## The intermediate state, on purpose

Where a job writes that value into a column *still* named `character_id`, the payload is now an explicit `character_id: registration_id` instead of shorthand:

```js
acc.inserts.push({
  character_id: registration_id,   // column still named character_id (step 4)
  ...
})
```

That reads awkwardly, deliberately — it puts the mismatch at exactly the site that still has it, and each one disappears as step 4 renames its table.

## Two bugs worth calling out

A mechanical rename turned two inline shorthand payloads into inserts against a column that **doesn't exist**:

```js
- .insert({ character_id, balance })       // character_wallet
+ .insert({ registration_id, balance })    // ← would fail at runtime
```

Same in `characterMercenaryDens.js`. Neither `eslint` nor `next build` can see this — it's a runtime PostgREST error on a table with no such column, and it would have surfaced as silently broken extracts. Caught by reading the generated diff and auditing every `insert`/`upsert` payload in `src/jobs/`; both are fixed, and the audit is in the PR history.

## Scope: `characterIds` deliberately left alone

The plan doc originally bundled the `characterIds` option into this step. Measuring it first showed why that's wrong: `characterIds` also names three unrelated contracts — `OwnerContext.characterIds` in the MCP layer, `resolvePlayer`'s return in `src/utils/apiToken.ts`, and the `character_ids` RPC parameter — spanning ~55 files. Renaming only lib.js's would leave the name meaning two things at once. The doc is updated to stage it with those instead.

## A note on the diff size

Three files (`characterIndustryJobs`, `characterOrders`, `characterWalletTransactions`) show more churn than a rename should. That's prettier re-wrapping: `registration_id` is four characters longer, so `forEachCharacter(TAG, {...}, async ({...}) => {` no longer fits the print width and the callback body re-indents. Same reflow `characterFittings.js` already took on `main`. Every other file is rename-only, verified line by line.

Separately — `src/jobs/universeStructures.js` and `src/jobs/sdeMirror.js` are **not** prettier-clean on `main` today. I reverted the incidental reformatting rather than smuggle it in here, but it's worth knowing: `CLAUDE.md` claims pre-commit runs lint-staged auto-formatting, and there's no `lint-staged` config — the hook only runs `eslint .`.

## Testing

`pnpm test` 90/90, `pnpm run lint` / `pnpm run build` clean. No schema changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfmtG8kgpyC6vtXeNwRPM7)_