### PR TITLE
Move mercenary dens link from the header to the structures page

### DIFF
--- a/src/app/layout/header.tsx
+++ b/src/app/layout/header.tsx
@@ -73,8 +73,6 @@ const Header = async () => {
             <>
               <Link href="/indexes">indexes</Link>
               <span className={styles.sep}>|</span>
-              <Link href="/mercenary-dens">mercenary&nbsp;dens</Link>
-              <span className={styles.sep}>|</span>
               <Link href="/character/">characters</Link>
               <span className={styles.sep}>|</span>
               <Link href="/asset">assets</Link>

--- a/src/app/mercenary-dens/mercenaryDens.module.css
+++ b/src/app/mercenary-dens/mercenaryDens.module.css
@@ -10,6 +10,10 @@
   margin: 0;
 }
 
+.backLink {
+  font-size: 13px;
+}
+
 .subtitle {
   color: var(--ink-soft);
   margin-top: 4pt;

--- a/src/app/mercenary-dens/page.tsx
+++ b/src/app/mercenary-dens/page.tsx
@@ -235,6 +235,10 @@ const MercenaryDensPage = async () => {
   return (
     <>
       <div className={styles.pageHeader}>
+        {/* The header nav no longer carries this page — it's reached from /structure. */}
+        <a href="/structure" className={styles.backLink}>
+          &laquo; Structures
+        </a>
         <h1>Mercenary Dens</h1>
         <ShareAlliance alliances={alliances} sharedAllianceIds={sharedAllianceIds} />
       </div>

--- a/src/app/structure/page.tsx
+++ b/src/app/structure/page.tsx
@@ -287,6 +287,10 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
           <WindowSelect days={windowDays} />
         </span>
       </div>
+      <p className={styles.pageLinks}>
+        <a href="/structure/revenue">Tax revenue events &raquo;</a>
+        <a href="/mercenary-dens">Mercenary dens &raquo;</a>
+      </p>
       {list.length > 0 ? (
         <>
           <ul className={styles.grid}>
@@ -438,10 +442,6 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
           hourly job can fetch them.
         </p>
       )}
-      <p className={styles.pageLinks}>
-        <a href="/structure/revenue">Tax revenue events &raquo;</a>
-        <a href="/mercenary-dens">Mercenary dens &raquo;</a>
-      </p>
       <p className={styles.lastRun}>
         Structures last refreshed:{' '}
         {lastRun?.run_url ? (

--- a/src/app/structure/page.tsx
+++ b/src/app/structure/page.tsx
@@ -438,8 +438,9 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
           hourly job can fetch them.
         </p>
       )}
-      <p className={styles.revenueLink}>
+      <p className={styles.pageLinks}>
         <a href="/structure/revenue">Tax revenue events &raquo;</a>
+        <a href="/mercenary-dens">Mercenary dens &raquo;</a>
       </p>
       <p className={styles.lastRun}>
         Structures last refreshed:{' '}

--- a/src/app/structure/structures.module.css
+++ b/src/app/structure/structures.module.css
@@ -314,7 +314,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 4px 16px;
-  margin: 16px 0 0;
+  margin: 8px 0 16px;
   font-size: 13px;
 }
 

--- a/src/app/structure/structures.module.css
+++ b/src/app/structure/structures.module.css
@@ -310,7 +310,10 @@
   font-size: 12px;
 }
 
-.revenueLink {
+.pageLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 16px;
   margin: 16px 0 0;
   font-size: 13px;
 }


### PR DESCRIPTION
The mercenary dens page is structure-adjacent, so it now hangs off `/structure` instead of taking a slot in the top nav.

- `src/app/layout/header.tsx` — drop the `mercenary dens` nav entry (and its separator).
- `src/app/structure/page.tsx` — the footer link line now carries both `Tax revenue events »` and `Mercenary dens »`; the single-purpose `.revenueLink` class became `.pageLinks`, a flex row with a gap so the two links sit side by side and wrap on narrow screens.
- `src/app/mercenary-dens/page.tsx` — add a `« Structures` back link above the `<h1>`, since the header no longer gets you back.

Nothing about the dens data, RLS, or sharing changed — this is navigation only. `pnpm run lint` and `pnpm run build` both pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_015VUKiuxLGbstyzKhV1JVsj)_