### PR TITLE
Add asset subtree item-aggregation functions for appraisals

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "pretty": "prettier --write src/",
     "start": "next start",
     "test": "node --test \"test/**/*.test.ts\"",
-    "test:sql": "psql \"$DATABASE_URL\" -v ON_ERROR_STOP=1 -f test/sql/blueprint_search.sql"
+    "test:sql": "for f in test/sql/*.sql; do echo \"── $f\" && psql \"$DATABASE_URL\" -v ON_ERROR_STOP=1 -f \"$f\" || exit 1; done"
   },
   "prettier": "@philihp/prettier-config",
   "devDependencies": {

--- a/schema.sql
+++ b/schema.sql
@@ -33,6 +33,8 @@ drop function if exists public.corp_asset_location_contents(bigint)      cascade
 drop function if exists public.asset_ancestors(bigint)                   cascade;
 drop function if exists public.character_asset_search(bigint[])          cascade;
 drop function if exists public.corp_asset_search(bigint[])               cascade;
+drop function if exists public.character_asset_subtree_items(bigint)     cascade;
+drop function if exists public.corp_asset_subtree_items(bigint)          cascade;
 drop function if exists public.blueprint_search(bigint[], bigint[], bigint[], uuid[], bigint[], text, int, int, boolean, text, int) cascade;
 drop function if exists public.character_asset_snapshot_at(uuid[], timestamptz) cascade;
 drop function if exists public.character_industry_jobs(uuid[], boolean)             cascade;
@@ -361,6 +363,38 @@ as $$
   group by root_child;
 $$;
 
+-- appraisal (/asset/[locationId]): everything inside `parent` — a container or
+-- ship item id, or a bare location id (station, structure, solar system) —
+-- summed into one row per item type, ready to be priced. The parent itself is
+-- excluded, so a caller appraising an item adds its own (type_id, 1) line;
+-- appraising a bare location has nothing to add. Singletons (assembled ships,
+-- containers, fitted modules) count as 1 apiece, the same reading of a stack
+-- the asset pages and MCP tools use. Reports the raw contents: blueprint
+-- copies price like originals here, and callers that care drop them by type.
+-- Seeded from `parent` alone, so cost scales with the subtree rather than the
+-- hangar (cf. character_asset_search below).
+create or replace function public.character_asset_subtree_items(parent bigint)
+returns table (type_id bigint, quantity bigint)
+language sql
+stable
+as $$
+  with recursive descend as (
+    select a.item_id, a.type_id, a.quantity, a.is_singleton, 1 as depth
+    from public.character_asset a
+    where a.location_id = parent
+    union all
+    select c.item_id, c.type_id, c.quantity, c.is_singleton, d.depth + 1
+    from descend d
+    join public.character_asset c on c.location_id = d.item_id
+    where d.depth < 64
+  )
+  select
+    d.type_id,
+    sum(case when d.is_singleton then 1 else coalesce(d.quantity, 1) end)::bigint as quantity
+  from descend d
+  group by d.type_id;
+$$;
+
 -- item search (/asset/search): every current item whose type_id is in
 -- `type_ids`, with its root location and nested-item count. Seeded from just
 -- the matched items (rather than every asset, like the two functions above),
@@ -455,6 +489,7 @@ $$;
 grant execute on function public.character_asset_location_summary()        to authenticated;
 grant execute on function public.character_asset_location_contents(bigint) to authenticated;
 grant execute on function public.character_asset_search(bigint[])          to authenticated;
+grant execute on function public.character_asset_subtree_items(bigint)     to authenticated;
 
 -- /api/character/assets IMPORTDATA endpoint: the player's raw asset rows (one
 -- per item stack), with the owning character's name, as of `as_of`,
@@ -2335,6 +2370,31 @@ as $$
   group by root_child;
 $$;
 
+-- appraisal (/asset/[locationId]): mirrors character_asset_subtree_items()
+-- over corp assets — everything inside `parent`, summed to one row per item
+-- type, with the parent itself excluded.
+create or replace function public.corp_asset_subtree_items(parent bigint)
+returns table (type_id bigint, quantity bigint)
+language sql
+stable
+as $$
+  with recursive descend as (
+    select a.item_id, a.type_id, a.quantity, a.is_singleton, 1 as depth
+    from public.corp_asset a
+    where a.location_id = parent
+    union all
+    select c.item_id, c.type_id, c.quantity, c.is_singleton, d.depth + 1
+    from descend d
+    join public.corp_asset c on c.location_id = d.item_id
+    where d.depth < 64
+  )
+  select
+    d.type_id,
+    sum(case when d.is_singleton then 1 else coalesce(d.quantity, 1) end)::bigint as quantity
+  from descend d
+  group by d.type_id;
+$$;
+
 -- item search (/asset/search): mirrors character_asset_search() over corp
 -- assets, seeded from just the matched items.
 create or replace function public.corp_asset_search(type_ids bigint[])
@@ -2423,6 +2483,7 @@ $$;
 grant execute on function public.corp_asset_location_summary()        to authenticated;
 grant execute on function public.corp_asset_location_contents(bigint) to authenticated;
 grant execute on function public.corp_asset_search(bigint[])          to authenticated;
+grant execute on function public.corp_asset_subtree_items(bigint)     to authenticated;
 
 -- breadcrumb (/asset/[locationId], /ship/[itemId]): the materialized path of
 -- one item — the item itself, then each enclosing container outward, ordered

--- a/supabase/migrations/20260801110000_asset_subtree_items.sql
+++ b/supabase/migrations/20260801110000_asset_subtree_items.sql
@@ -1,0 +1,68 @@
+-- Price appraisals in the asset viewer (docs/appraisals/03) need to send a
+-- whole container, ship or hangar to innomin.at as one batch of
+-- (type, quantity) lines — the rate limit is 200 requests/hour, so an
+-- appraisal is one API call over an aggregate, never a call per item. The
+-- existing walk functions don't produce that aggregate: location_contents()
+-- descends correctly but returns per-child counts, and asset_search() is
+-- seeded by type filter rather than by location. Add the missing shape for
+-- both owner scopes. Both are SECURITY INVOKER over the character_asset /
+-- corp_asset views, so RLS scopes the walk to the caller's own items exactly
+-- like the neighbors.
+
+-- appraisal (/asset/[locationId]): everything inside `parent` — a container or
+-- ship item id, or a bare location id (station, structure, solar system) —
+-- summed into one row per item type, ready to be priced. The parent itself is
+-- excluded, so a caller appraising an item adds its own (type_id, 1) line;
+-- appraising a bare location has nothing to add. Singletons (assembled ships,
+-- containers, fitted modules) count as 1 apiece, the same reading of a stack
+-- the asset pages and MCP tools use. Reports the raw contents: blueprint
+-- copies price like originals here, and callers that care drop them by type.
+-- Seeded from `parent` alone, so cost scales with the subtree rather than the
+-- hangar (cf. character_asset_search).
+create or replace function public.character_asset_subtree_items(parent bigint)
+returns table (type_id bigint, quantity bigint)
+language sql
+stable
+as $$
+  with recursive descend as (
+    select a.item_id, a.type_id, a.quantity, a.is_singleton, 1 as depth
+    from public.character_asset a
+    where a.location_id = parent
+    union all
+    select c.item_id, c.type_id, c.quantity, c.is_singleton, d.depth + 1
+    from descend d
+    join public.character_asset c on c.location_id = d.item_id
+    where d.depth < 64
+  )
+  select
+    d.type_id,
+    sum(case when d.is_singleton then 1 else coalesce(d.quantity, 1) end)::bigint as quantity
+  from descend d
+  group by d.type_id;
+$$;
+
+-- The same over corp assets.
+create or replace function public.corp_asset_subtree_items(parent bigint)
+returns table (type_id bigint, quantity bigint)
+language sql
+stable
+as $$
+  with recursive descend as (
+    select a.item_id, a.type_id, a.quantity, a.is_singleton, 1 as depth
+    from public.corp_asset a
+    where a.location_id = parent
+    union all
+    select c.item_id, c.type_id, c.quantity, c.is_singleton, d.depth + 1
+    from descend d
+    join public.corp_asset c on c.location_id = d.item_id
+    where d.depth < 64
+  )
+  select
+    d.type_id,
+    sum(case when d.is_singleton then 1 else coalesce(d.quantity, 1) end)::bigint as quantity
+  from descend d
+  group by d.type_id;
+$$;
+
+grant execute on function public.character_asset_subtree_items(bigint) to authenticated;
+grant execute on function public.corp_asset_subtree_items(bigint)      to authenticated;

--- a/test/sql/asset_subtree_items.sql
+++ b/test/sql/asset_subtree_items.sql
@@ -1,0 +1,161 @@
+-- SQL-level coverage for character_asset_subtree_items() /
+-- corp_asset_subtree_items() — the aggregate the asset-viewer appraisal sends
+-- to innomin.at as one batch (docs/appraisals/02-asset-subtree-items.md). All
+-- of the behaviour lives in Postgres, so node:test can't reach any of it.
+--
+-- Run against a THROWAWAY database (it creates stand-in tables named after the
+-- real views in `public`) from the repo root, so the \i below resolves:
+--
+--   initdb -D /tmp/pg && pg_ctl -D /tmp/pg -o '-k /tmp -p 55432' start
+--   createdb -h /tmp -p 55432 subtree
+--   DATABASE_URL='postgresql://…/subtree' pnpm run test:sql
+--
+-- The migration is loaded by this script (not before it), because a SQL-language
+-- function is parsed and validated at creation time and so needs the stand-in
+-- tables to already exist. Everything — the fixtures, the functions, the checks
+-- — runs inside one transaction and rolls back at the end, so nothing is left
+-- behind. Each check is an `assert`, so psql exits non-zero on the first
+-- mismatch.
+begin;
+
+-- Stand-ins for the two views the functions read, carrying just the columns
+-- they touch. RLS is irrelevant here (both functions are security invoker, so
+-- scoping is the views' job, not theirs).
+create table public.character_asset (
+  item_id bigint, type_id bigint, location_id bigint,
+  quantity bigint, is_singleton boolean
+);
+create table public.corp_asset (
+  item_id bigint, type_id bigint, location_id bigint,
+  quantity bigint, is_singleton boolean
+);
+
+-- A hangar in Jita holding one fitted ship, a loose stack and a null-quantity
+-- row, with a container nested inside the ship's cargo so the walk has to go
+-- three levels deep:
+--
+--   60003760 (station)
+--   ├── 100 Rifter (singleton)
+--   │   ├── 101 Damage Control (singleton, fitted)
+--   │   ├── 102 Damage Control (singleton, fitted)
+--   │   ├── 103 Tritanium ×1000
+--   │   └── 104 Station Container (singleton)
+--   │       └── 105 Tritanium ×500
+--   ├── 110 Tritanium ×250
+--   └── 111 Tritanium (null quantity)
+insert into public.character_asset values
+  (100, 587,  60003760, null, true),
+  (101, 578,  100,      null, true),
+  (102, 578,  100,      null, true),
+  (103, 34,   100,      1000, false),
+  -- A singleton's own quantity is not trusted: ESI reports assembled items with
+  -- a sentinel, and summing it raw would subtract from the stack it sits in.
+  (104, 3465, 100,      -1,   true),
+  (105, 34,   104,      500,  false),
+  (110, 34,   60003760, 250,  false),
+  (111, 34,   60003760, null, false);
+
+-- A 70-link chain, each item inside the last, rooted in a second station. Only
+-- the depth cap stops the walk short of the end.
+insert into public.character_asset
+  select 200 + i, 34, case when i = 0 then 500000 else 199 + i end, 1, false
+  from generate_series(0, 69) as i;
+
+-- Two items each claiming to be inside the other. ESI shouldn't produce this,
+-- but a recursive CTE that met one without a cap would never terminate.
+insert into public.character_asset values
+  (300, 34, 301, 1, false),
+  (301, 34, 300, 1, false);
+
+-- The corp side gets the same shape in miniature: an office holding a container
+-- with a stack inside it.
+insert into public.corp_asset values
+  (400, 27,  1050603051889, null, true),
+  (401, 3465, 400,          null, true),
+  (402, 34,   401,          700,  false);
+
+-- Supabase provisions `authenticated`; a bare initdb cluster like the one in
+-- the header doesn't, and the migration ends in a grant to it. Rolled back with
+-- everything else below.
+do $$
+begin
+  if not exists (select 1 from pg_roles where rolname = 'authenticated') then
+    create role authenticated;
+  end if;
+end $$;
+
+-- The functions under test, defined against the fixtures above.
+\i supabase/migrations/20260801110000_asset_subtree_items.sql
+
+do $$
+declare
+  q bigint;
+  n int;
+begin
+  -- ── an item parent: a ship and everything in it ─────────────────────────
+  select count(*) into n from public.character_asset_subtree_items(100);
+  assert n = 3, 'a ship aggregates its contents to one row per type';
+
+  -- The parent is excluded, so the hull is the caller's line to add, not ours.
+  assert not exists (select 1 from public.character_asset_subtree_items(100) where type_id = 587),
+    'the parent item is not part of its own subtree';
+
+  -- Two fitted singletons of one type count 1 apiece, not their null quantity.
+  select quantity into q from public.character_asset_subtree_items(100) where type_id = 578;
+  assert q = 2, 'singletons count as one each';
+
+  -- Cargo plus the nested container's contents, summed across two depths.
+  select quantity into q from public.character_asset_subtree_items(100) where type_id = 34;
+  assert q = 1500, 'quantities sum through a nested container';
+
+  -- The container itself is contents of the ship, even though it also has some,
+  -- and it counts as 1 rather than as the sentinel quantity it carries.
+  select quantity into q from public.character_asset_subtree_items(100) where type_id = 3465;
+  assert q = 1, 'a container counts as an item as well as a parent, at quantity one';
+
+  -- ── a bare location parent: the whole hangar ────────────────────────────
+  select count(*) into n from public.character_asset_subtree_items(60003760);
+  assert n = 4, 'a station id walks every type in the hangar';
+
+  -- The ship is contents here, having been the parent a moment ago.
+  select quantity into q from public.character_asset_subtree_items(60003760) where type_id = 587;
+  assert q = 1, 'a station''s ships are part of its subtree';
+
+  -- 1000 in cargo + 500 in the container + 250 loose + 1 for the null row.
+  select quantity into q from public.character_asset_subtree_items(60003760) where type_id = 34;
+  assert q = 1751, 'a null quantity counts as one, not as zero or null';
+
+  -- ── narrower and empty parents ──────────────────────────────────────────
+  select quantity into q from public.character_asset_subtree_items(104) where type_id = 34;
+  assert q = 500, 'a container parent reports only what is inside it';
+
+  select count(*) into n from public.character_asset_subtree_items(105);
+  assert n = 0, 'an item holding nothing has an empty subtree';
+
+  select count(*) into n from public.character_asset_subtree_items(999999);
+  assert n = 0, 'an id the caller cannot see returns no rows rather than erroring';
+
+  -- ── depth cap ───────────────────────────────────────────────────────────
+  -- 64, the same ceiling every other walk in schema.sql uses — the chain is 70
+  -- long, so a missing cap would show up as 70.
+  select quantity into q from public.character_asset_subtree_items(500000);
+  assert q = 64, 'the walk stops at depth 64';
+
+  -- Reaching this line at all is the assertion: a cycle terminates.
+  select quantity into q from public.character_asset_subtree_items(300);
+  assert q = 64, 'a location cycle terminates at the depth cap';
+
+  -- ── corp assets behave identically ──────────────────────────────────────
+  select count(*) into n from public.corp_asset_subtree_items(1050603051889);
+  assert n = 3, 'the corp function walks corp assets the same way';
+
+  select quantity into q from public.corp_asset_subtree_items(400) where type_id = 34;
+  assert q = 700, 'the corp function descends through nested containers too';
+
+  assert not exists (select 1 from public.corp_asset_subtree_items(400) where type_id = 27),
+    'the corp function excludes the parent as well';
+
+  raise notice 'asset_subtree_items: all checks passed';
+end $$;
+
+rollback;


### PR DESCRIPTION
Step 2 of `docs/appraisals` ([02-asset-subtree-items.md](https://github.com/philihp/edencom-link/blob/main/docs/appraisals/02-asset-subtree-items.md)) — the DB half of the asset-viewer appraisal, and the last thing blocking Milestone 2. DB-only; nothing calls these yet.

Given a container or ship item id, or a bare location id (station, structure, solar system), `character_asset_subtree_items()` / `corp_asset_subtree_items()` return everything nested inside it summed to one row per item type — the shape the innomin.at batch endpoint takes.

## Why a new function shape

The aggregate is the point. The rate limit is 200 requests/hour for the whole deployment, so an appraisal has to be one call over a whole hangar rather than a call per stack. None of the existing walks produce it:

- `*_asset_location_contents()` descends correctly but returns per-child counts.
- `*_asset_search()` descends too, but is seeded by type filter rather than by location.

This is the seeded-recursion shape CLAUDE.md asks for: it starts from one parent, so cost scales with the subtree rather than the hangar.

Both read the `character_asset` / `corp_asset` views and are SECURITY INVOKER, so RLS scopes the walk to the caller exactly like their neighbours. Neither names the owner column, so the `character_id` → `registration_id` sweep that landed underneath this branch (#762, #763) leaves them alone.

## Decisions carried over from the spec

Fixed by the doc rather than chosen here, and each one pinned by a test:

- **The parent is excluded.** An item's caller already holds that row and adds its own `(type_id, 1)` line; a bare location has nothing to add.
- **Singletons count 1 apiece**, not their reported quantity — matching the `is_singleton ? 1 : quantity` mapping the asset pages and MCP tools already use. An assembled item carries a sentinel quantity that would otherwise *subtract* from the stack it sits in.
- **No filtering in SQL.** Blueprint copies price like originals here; the caller that cares drops them by SDE category. The function reports the raw truth.
- **Depth cap 64**, same as every other walk in `schema.sql`.

## Tests

Adds SQL-level coverage in the manner of `blueprint_search.sql` — `node:test` can't reach any of this, since all of the behaviour is in Postgres. Covers the nested/multi-depth sum, the null and sentinel quantity paths, empty and unknown parents, the corp mirror, the depth cap, and the location cycle that cap exists for.

Verified by mutation rather than assumed — removing the singleton case, the `coalesce`, the depth cap, or the parent exclusion each fails a named check:

| Mutation | Check that fires |
|---|---|
| singleton case → raw quantity | `a container counts as an item as well as a parent, at quantity one` |
| drop the `coalesce` | `a null quantity counts as one, not as zero or null` |
| cap 64 → 200 | `the walk stops at depth 64` |
| include the parent in the seed | `a ship aggregates its contents to one row per type` |
| stop descending after depth 1 | `quantities sum through a nested container` |

`test:sql` now runs every file in `test/sql/` instead of naming one. The new suite also creates the `authenticated` role if absent (rolled back with everything else), so the bare-`initdb` workflow both file headers document actually works.

## Verification

- `pnpm run lint` — clean.
- `pnpm run build` — passes.
- `pnpm run test:sql` — both suites pass against a throwaway PG 16 cluster; `blueprint_search` is unchanged and still passes under the generalized runner.
- Migration-order guard passes.
- Function bodies in `schema.sql` and the migration diffed byte-identical.

The migration has been renumbered twice (now `20260801110000`) as the `registration_id` rename sweep merged migrations underneath this branch. It has never been applied anywhere, which is the case the guard itself calls safe to renumber — no already-merged file was touched.

Not yet exercised against production data — the `/asset` sanity check in the spec's verification section wants a real hangar, and there's no caller until doc 03.