### PR TITLE
Fix two schema.sql comments left stale by the registration_id renames

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -596,7 +596,7 @@ grant execute on function public.character_blueprints(uuid[]) to service_role;
 -- One row per scheduled-job run. Workflows write a 'start' step (stamps
 -- started_at) and an 'end' step (stamps ended_at), both keyed on the GitHub
 -- Actions run so they land on the same row. run_url links back to that run.
--- character_id/corporation_id/user_id attribute a run to the entity a
+-- registration_id/corporation_id/user_id attribute a run to the entity a
 -- per-character or per-corp job processed it for (null for whole-job/
 -- account-wide runs, e.g. universe-names); owner_key folds those two
 -- nullable columns into a single non-null discriminator so the start/end
@@ -2171,7 +2171,7 @@ grant all    on public.corp_wallet_journal to service_role;
 -- corp-wallet-transactions job. Market transactions (buys and sells) pulled
 -- from every corporation wallet division
 -- (esi-wallet.read_corporation_wallets.v1), unioned into the market page beside
--- the per-character character_wallet_transaction rows. `character_id` is the
+-- the per-character character_wallet_transaction rows. `registration_id` is the
 -- registration whose token scanned the row; RLS scopes reads to that
 -- character's owner, so a corp transaction is only visible to the player who
 -- pulled it (like personal transactions). transaction_id is globally unique in


### PR DESCRIPTION
Comments only — no schema change, two lines.

Found by auditing what `character_id` is left in the tree now that steps 1–6 are done. Two comments still described columns that no longer exist:

- **`heartbeat`** — still said `character_id/corporation_id/user_id attribute a run…` after #754 renamed that column
- **`corp_wallet_transaction`** — still called its owner column `character_id` after #753 renamed it

A comment naming a column that doesn't exist is worse than the original misnomer: the misnomer was at least consistent with the schema.

## Where that leaves the audit

With these fixed, a full-repo sweep leaves exactly **three** columns named `character_id`:

| Table | Column |
| --- | --- |
| `registration` | `character_id bigint` |
| `character_directory` | `character_id bigint` (PK) |
| `character_affiliation` | `character_id bigint` (PK) |

All `bigint`, all genuinely the EVE id CCP assigns — which is exactly the end state `docs/registration-id-rename.md` set out to reach. Everything else that survives the grep is either the `character_ids` RPC parameter (step 7), `completed_character_id` (a real EVE id), `src/observability.js`'s metric field (deliberately excluded), or prose explaining the convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfmtG8kgpyC6vtXeNwRPM7

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfmtG8kgpyC6vtXeNwRPM7)_