### PR TITLE
Add appraise buttons to the asset viewer

### DIFF
--- a/docs/appraisals/03-asset-viewer-appraisal.md
+++ b/docs/appraisals/03-asset-viewer-appraisal.md
@@ -69,9 +69,12 @@ Server flow:
 4. **Guard the batch.** Zero lines → `{ ok: false, error: "nothing to
    appraise" }` (e.g. a container of only blueprints). More than **500
    distinct types** → refuse with a clear error rather than truncating (a
-   silently partial total is worse than no total). 500 is a guess at the
-   API's comfortable batch size — verify once with a real large request
-   while implementing, and adjust the constant + this doc.
+   silently partial total is worse than no total). 500 was **verified against
+   the live API** (2026-08-01, one `save: false` request): a 500-entry batch
+   returns `200` with all 500 appraisals present and no truncation, so the
+   constant stands. The true ceiling is somewhere above 500 and was
+   deliberately not probed — finding it would cost several more requests out
+   of the 200/hour budget to raise a limit no real hangar has hit.
 5. **Resolve names and appraise.** `getSdeTypeNames` over the type ids;
    types the SDE can't name are dropped into an `unpriced` list (the API is
    name-keyed, so an unnamed type can't be priced). One `appraise(lines,

--- a/src/app/api/appraisal/route.ts
+++ b/src/app/api/appraisal/route.ts
@@ -1,0 +1,142 @@
+// Lazy ISK appraisal for the asset viewer (docs/appraisals/03): one row, or a
+// whole container/ship/hangar, priced via innomin.at. Client-triggered, so a
+// route handler rather than a server action — it wants JSON, status codes and
+// no form semantics.
+//
+// Every query runs on the cookie-session client, NEVER the service role: the
+// *_asset_subtree_items() functions are SECURITY INVOKER and rely on RLS to
+// scope their walk, so a service-role caller would happily walk (and price)
+// another user's items. This is the same caveat the *_location_contents() calls
+// in /asset/[locationId]/page.tsx document, and it's why the anonymous
+// share-token path gets no appraise button at all.
+import { forEach } from 'ramda'
+import { NextResponse } from 'next/server'
+
+import { appraise, MARKETS, type AppraisalItemInput, type Market } from '@/innominate'
+import { getSdeTypes } from '@/sdeTypes'
+import { createClient } from '@/utils/supabase/server'
+import { BLUEPRINT_CATEGORY_ID } from '../mcp/lib'
+
+// One appraisal is always exactly one upstream request — the 200/hour budget is
+// deployment-wide, so looping per item is never an option. A hangar with more
+// distinct types than a single batch can carry is therefore refused outright
+// rather than truncated: a partial total still looks authoritative, and being
+// quietly wrong about how much someone's stuff is worth is worse than saying no.
+const MAX_LINES = 500
+
+type SubtreeRow = { type_id: number | string; quantity: number | string }
+type SelfRow = { type_id: number | string; quantity: number | string | null; is_singleton: boolean | null }
+
+const fail = (status: number, error: string, extra: Record<string, unknown> = {}) =>
+  NextResponse.json({ ok: false, error, ...extra }, { status })
+
+export async function POST(request: Request) {
+  const supabase = await createClient()
+  const { data: auth, error: authError } = await supabase.auth.getUser()
+  if (authError || !auth?.user) return fail(401, 'Sign in to appraise items.')
+
+  const body = (await request.json().catch(() => null)) as { target?: unknown; market?: unknown } | null
+  const target = typeof body?.target === 'string' ? body.target.trim() : ''
+  // Ids are bigints kept as strings end to end; anything else can't be one.
+  if (!/^\d+$/.test(target)) return fail(400, 'A numeric target id is required.')
+  // Validated rather than passed through, so the UI can grow a market picker
+  // later without this route changing.
+  const market: Market = MARKETS.includes(body?.market as Market) ? (body?.market as Market) : 'jita'
+
+  // The target is either one of the caller's own items (ship, container or plain
+  // stack) or a bare place id — a station, structure or solar system. RLS
+  // decides what's visible, so an id the caller doesn't own simply reads as a
+  // location whose subtree comes back empty.
+  const { data: characterSelf } = await supabase
+    .from('character_asset')
+    .select('type_id, quantity, is_singleton')
+    .eq('item_id', target)
+    .maybeSingle<SelfRow>()
+  const { data: corpSelf } = characterSelf
+    ? { data: null }
+    : await supabase
+        .from('corp_asset')
+        .select('type_id, quantity, is_singleton')
+        .eq('item_id', target)
+        .maybeSingle<SelfRow>()
+  const self = characterSelf ?? corpSelf
+
+  // Everything nested under the target, from both hangars. An item lives in
+  // exactly one of the two tables, so unioning the two can't double-count.
+  const [{ data: characterRows }, { data: corpRows }] = await Promise.all([
+    supabase.rpc('character_asset_subtree_items', { parent: target }),
+    supabase.rpc('corp_asset_subtree_items', { parent: target }),
+  ])
+
+  const quantities = new Map<number, number>()
+  const add = (typeId: number, quantity: number) => quantities.set(typeId, (quantities.get(typeId) ?? 0) + quantity)
+  forEach(
+    (r: SubtreeRow) => add(Number(r.type_id), Number(r.quantity)),
+    [...((characterRows ?? []) as SubtreeRow[]), ...((corpRows ?? []) as SubtreeRow[])]
+  )
+  // Those functions return strictly the contents, so an item target still owes
+  // its own line — the hull of a ship, the container itself. A bare location has
+  // nothing to add.
+  if (self) add(Number(self.type_id), self.is_singleton ? 1 : Number(self.quantity ?? 1))
+
+  const typeIds = [...quantities.keys()]
+  const sdeTypes = await getSdeTypes(typeIds)
+
+  // Asset rows carry no way to tell a worthless copy from an original, so
+  // pricing blueprints would be wrong more often than right. Skipped, and said
+  // out loud rather than silently folded into the total.
+  const priceable = typeIds.filter((id) => sdeTypes[id]?.categoryID !== BLUEPRINT_CATEGORY_ID)
+  const skippedBlueprints = typeIds.length - priceable.length
+
+  // The API is keyed on item name, so a type the SDE can't name can't be priced
+  // at all. Reported by id rather than dropped on the floor.
+  const unnamed = priceable.filter((id) => !sdeTypes[id]?.name).map((id) => `#${id}`)
+
+  // Distinct type ids sharing one name are rare but real in the SDE; merging
+  // here keeps them from being sent as two lines and counted twice.
+  const lines = new Map<string, AppraisalItemInput>()
+  forEach((id: number) => {
+    const name = sdeTypes[id]?.name
+    if (!name) return
+    const existing = lines.get(name)
+    lines.set(name, { name, quantity: (existing?.quantity ?? 0) + (quantities.get(id) ?? 1) })
+  }, priceable)
+
+  if (lines.size === 0) {
+    return fail(422, 'Nothing here can be appraised.', {
+      ...(skippedBlueprints > 0 && { skipped_blueprints: skippedBlueprints }),
+    })
+  }
+  if (lines.size > MAX_LINES) {
+    return fail(422, `Too many distinct item types here to appraise at once (${lines.size}, limit ${MAX_LINES}).`)
+  }
+
+  const result = await appraise([...lines.values()], market)
+  if (!result.ok) {
+    if (result.kind === 'unconfigured') return fail(503, "Appraisals aren't configured on this deployment.")
+    if (result.kind === 'rate_limited') {
+      return fail(429, result.message, { retry_after_seconds: result.retryAfterSeconds })
+    }
+    return fail(502, result.message)
+  }
+
+  const { appraisal } = result
+  const unpriced = [...unnamed, ...appraisal.items.filter((i) => i.error != null).map((i) => i.name)]
+
+  // Per-line prices are deliberately not returned: the UI shows totals only, and
+  // a 500-type hangar's itemization would be pointless payload. The MCP
+  // appraise_items tool is the itemized view.
+  return NextResponse.json({
+    ok: true,
+    market: appraisal.market,
+    total_sell_value: appraisal.totalSellValue,
+    total_buy_value: appraisal.totalBuyValue,
+    price_split: appraisal.priceSplit,
+    total_volume_m3: appraisal.totalVol,
+    line_count: lines.size,
+    ...(skippedBlueprints > 0 && { skipped_blueprints: skippedBlueprints }),
+    ...(unpriced.length > 0 && { unpriced }),
+    ...(appraisal.cached && { cached: true }),
+    ...(appraisal.rateLimitRemaining != null && { rate_limit_remaining: appraisal.rateLimitRemaining }),
+  })
+}

--- a/src/app/asset/[locationId]/appraiseButton.module.css
+++ b/src/app/asset/[locationId]/appraiseButton.module.css
@@ -1,0 +1,41 @@
+/*
+ * Appraise control: a quiet text button that swaps in place for the figures it
+ * fetches. Sized to sit inside a dense table cell without changing the row
+ * height, so a column of them doesn't make the table jump as answers arrive.
+ */
+.button {
+  font: inherit;
+  font-size: 10pt;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--ink-soft);
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.button:hover {
+  color: var(--ink);
+}
+
+/* In-flight. Same footprint as the button it replaces. */
+.pending {
+  font-size: 10pt;
+  color: var(--ink-faint);
+}
+
+/* The answer. Tabular figures so stacked rows line up on the decimal. */
+.value {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  cursor: help;
+}
+
+/* Errors stay quiet and inline — no toast, no retry, per the design. */
+.error {
+  font-size: 10pt;
+  color: var(--ink-faint);
+  white-space: normal;
+}

--- a/src/app/asset/[locationId]/appraiseButton.tsx
+++ b/src/app/asset/[locationId]/appraiseButton.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { useState } from 'react'
+
+import { formatBisk, formatIsk, formatKisk } from '../../isk'
+import styles from './appraiseButton.module.css'
+
+// What POST /api/appraisal answers with on success (totals only — see the route).
+type Appraised = {
+  total_sell_value: number
+  total_buy_value: number
+  line_count: number
+  skipped_blueprints?: number
+  unpriced?: string[]
+  cached?: boolean
+}
+
+type State =
+  { phase: 'idle' } | { phase: 'loading' } | { phase: 'done'; value: Appraised } | { phase: 'error'; message: string }
+
+// Small values in bISK round to a meaningless "0 bISK", so anything under a
+// tenth of a billion reads better in kISK. Both figures share whichever unit the
+// larger one picks, so sell and buy stay comparable at a glance.
+const BISK_FLOOR = 100_000_000
+const formatPair = (sell: number, buy: number): string => {
+  const format = Math.max(sell, buy) < BISK_FLOOR ? formatKisk : formatBisk
+  return `${format(sell)} / ${format(buy)}`
+}
+
+// Everything the totals don't say: exact ISK, how many lines were priced, and
+// anything deliberately left out. Shown on hover rather than in the cell,
+// because the table is dense and this is the answer to "why that number".
+const describe = (value: Appraised): string =>
+  [
+    `${formatIsk(value.total_sell_value)} sell / ${formatIsk(value.total_buy_value)} buy`,
+    `${value.line_count} ${value.line_count === 1 ? 'type' : 'types'}`,
+    ...(value.skipped_blueprints ? [`${value.skipped_blueprints} blueprints skipped`] : []),
+    ...(value.unpriced?.length ? [`${value.unpriced.length} unpriced`] : []),
+    ...(value.cached ? ['cached'] : []),
+  ].join(' · ')
+
+// Appraise one target on demand: an item id (a stack, or a ship/container and
+// everything inside it) or a location id for the whole hangar. Deliberately
+// lazy and per-mount — pricing every row of a station on load would blow the
+// shared 200/hour budget in a single page view, and navigating away is meant to
+// discard the answer rather than cache it client-side.
+export const AppraiseButton = ({ target, label = 'appraise' }: { target: string; label?: string }) => {
+  const [state, setState] = useState<State>({ phase: 'idle' })
+
+  const run = async () => {
+    setState({ phase: 'loading' })
+    try {
+      const response = await fetch('/api/appraisal', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ target }),
+      })
+      const body = await response.json().catch(() => null)
+      if (!response.ok || !body?.ok) {
+        // The route's own message is the useful one (it knows whether this was a
+        // rate limit, a blueprint-only container, or an upstream failure).
+        const retry = typeof body?.retry_after_seconds === 'number' ? ` — retry in ${body.retry_after_seconds}s` : ''
+        setState({ phase: 'error', message: `${body?.error ?? 'appraisal unavailable'}${retry}` })
+        return
+      }
+      setState({ phase: 'done', value: body as Appraised })
+    } catch {
+      setState({ phase: 'error', message: 'appraisal unavailable' })
+    }
+  }
+
+  if (state.phase === 'loading') return <span className={styles.pending}>…</span>
+  if (state.phase === 'error') return <span className={styles.error}>{state.message}</span>
+  if (state.phase === 'done') {
+    return (
+      <span className={styles.value} title={describe(state.value)}>
+        {formatPair(state.value.total_sell_value, state.value.total_buy_value)}
+        {/* Cheap honesty about staleness: this came from the 5-minute cache. */}
+        {state.value.cached ? '*' : ''}
+      </span>
+    )
+  }
+  return (
+    <button type="button" className={styles.button} onClick={run}>
+      {label}
+    </button>
+  )
+}

--- a/src/app/asset/[locationId]/locationAssets.tsx
+++ b/src/app/asset/[locationId]/locationAssets.tsx
@@ -7,6 +7,7 @@ import retro from '../../retro.module.css'
 import { TypeName } from '../../typeName'
 import styles from '../assets.module.css'
 import { OWNER_STORAGE_KEY } from '../filterKey'
+import { AppraiseButton } from './appraiseButton'
 import { Quantity } from './quantity'
 
 export type ItemRow = {
@@ -33,9 +34,13 @@ type LocationAssetsProps = {
   rows: ItemRow[]
   owners: Owners
   typeNamesPromise: Promise<Record<number, string>>
+  // False on the anonymous share-token path, which has no session to authorize
+  // /api/appraisal with — the column is dropped entirely rather than rendering
+  // buttons that could only ever 401.
+  canAppraise: boolean
 }
 
-export const LocationAssets = ({ rows, owners, typeNamesPromise }: LocationAssetsProps) => {
+export const LocationAssets = ({ rows, owners, typeNamesPromise, canAppraise }: LocationAssetsProps) => {
   const [ownerId, setOwnerId] = useOwnerFilter(OWNER_STORAGE_KEY, owners)
 
   const filtered = rows.filter((r) => ownerId === ALL_OWNERS || r.ownerId === ownerId)
@@ -57,6 +62,7 @@ export const LocationAssets = ({ rows, owners, typeNamesPromise }: LocationAsset
               <th className={retro.num}>Quantity</th>
               <th>Hangar</th>
               <th className={retro.num}>Contents</th>
+              {canAppraise && <th className={retro.num}>Value</th>}
             </tr>
           </thead>
           <tbody>
@@ -77,13 +83,20 @@ export const LocationAssets = ({ rows, owners, typeNamesPromise }: LocationAsset
                 <td className={retro.num}>{row.isSingleton ? '—' : <Quantity value={row.quantity} />}</td>
                 <td>{row.flag ?? '—'}</td>
                 <td className={retro.num}>{row.contents > 0 ? row.contents : '—'}</td>
+                {canAppraise && (
+                  // A container or ship prices itself plus everything nested
+                  // inside it; a plain stack prices just itself.
+                  <td className={retro.num}>
+                    <AppraiseButton target={row.itemId} />
+                  </td>
+                )}
               </tr>
             ))}
             {filtered.length === 0 && (
               // Keep the table (and the owner dropdown in its header) rendered
               // so the filter can be changed back when an owner has nothing here.
               <tr>
-                <td colSpan={5}>No assets here for this owner.</td>
+                <td colSpan={canAppraise ? 6 : 5}>No assets here for this owner.</td>
               </tr>
             )}
           </tbody>

--- a/src/app/asset/[locationId]/page.tsx
+++ b/src/app/asset/[locationId]/page.tsx
@@ -12,7 +12,9 @@ import { fetchStationNames, fetchStationSystems } from '../../stationNames'
 import { fetchSystemNames } from '../../systemNames'
 import { fetchTypeNames } from '../../typeNames'
 import type { Owners } from '../../ownerFilter'
+import styles from '../assets.module.css'
 import { type Location } from '../assetsTable'
+import { AppraiseButton } from './appraiseButton'
 import { LocationAssets, type ItemRow } from './locationAssets'
 import { SystemLocations } from './systemLocations'
 
@@ -372,7 +374,12 @@ const AssetLocationPage = async ({
   return (
     <>
       {!scope ? <AssetPath crumbs={crumbs} current={heading} /> : null}
-      <h1 className="serif">{heading}</h1>
+      <div className={styles.header}>
+        <h1 className="serif">{heading}</h1>
+        {/* Prices this whole place in one request — the same endpoint each row
+            uses, just aimed at the location instead of an item. */}
+        {!scope ? <AppraiseButton target={locationId} label="Appraise everything here" /> : null}
+      </div>
       {systemName && systemName !== heading ? (
         <p>
           System: <span className="serif">{systemName}</span>
@@ -387,12 +394,12 @@ const AssetLocationPage = async ({
           {rootItems.length > 0 ? (
             <>
               <h2 className="serif">In space</h2>
-              <LocationAssets rows={rows} owners={owners} typeNamesPromise={typeNamesPromise} />
+              <LocationAssets rows={rows} owners={owners} typeNamesPromise={typeNamesPromise} canAppraise={!scope} />
             </>
           ) : null}
         </>
       ) : (
-        <LocationAssets rows={rows} owners={owners} typeNamesPromise={typeNamesPromise} />
+        <LocationAssets rows={rows} owners={owners} typeNamesPromise={typeNamesPromise} canAppraise={!scope} />
       )}
     </>
   )


### PR DESCRIPTION
**Milestone 2** of `docs/appraisals` ([03-asset-viewer-appraisal.md](https://github.com/philihp/edencom-link/blob/main/docs/appraisals/03-asset-viewer-appraisal.md)) — the last piece of the appraisal project. Depends on the client from Milestone 1 and the subtree functions from #764, both merged.

Each row of `/asset/[locationId]` gains a **Value** column with an appraise button, plus an **Appraise everything here** button next to the heading. A plain stack prices itself; a ship or container prices itself *and everything nested inside it*.

## `POST /api/appraisal`

Classify the target as one of the caller's items or a bare location → union both hangars' subtrees → add the target's own line when it's an item → drop blueprints → resolve names from the SDE → make **exactly one** innomin.at call.

A route handler rather than a server action, because this is a client-triggered lazy fetch that wants JSON and status codes, not form semantics.

**It runs on the cookie-session client and never the service role.** That isn't incidental: `*_asset_subtree_items()` are SECURITY INVOKER and lean on RLS to scope their walk, so a service-role caller would happily walk *and price* another user's items — the same caveat the `*_location_contents()` calls already document. This is also why the anonymous share-token path gets no column and no button, rather than buttons that could only ever 401.

## Judgement calls

- **Blueprints are skipped and counted, not priced.** An asset row can't tell a worthless copy from an original, so a total including them would be confidently wrong. Reported as `skipped_blueprints`.
- **Unnameable types are reported, not dropped.** The API is name-keyed, so a type the SDE can't name can't be priced; it lands in `unpriced` as `#id` rather than silently vanishing from a total.
- **Distinct type ids sharing one name are merged** before sending — rare but real in the SDE, and two lines would be counted twice.
- **A too-big hangar is refused, not truncated.** A partial total still reads as authoritative. Everything is one request per click because the 200/hour budget is deployment-wide.

## The 500-line cap is now verified, not guessed

The spec flagged 500 as a guess and asked for one real check. Done — a single `save: false` request with 500 distinct entries returned `200` with all 500 appraisals present, no truncation (387 priced, 113 unknown names erroring per-item as documented). The constant stands and the doc now records it. The true ceiling is somewhere above 500 and was deliberately **not** probed: finding it would cost several more requests out of the hourly budget to raise a limit no real hangar has hit.

Cost of the whole exercise: 1 request, `x-ratelimit-remaining: 199`.

## Verification

- `pnpm run lint` — clean.
- `pnpm run build` — passes; `/api/appraisal` registers as a dynamic route.
- Batch-size probe against the live API, as above.
- **Auth gate confirmed on this PR's preview deployment:** `POST /api/appraisal` with no session returns `401 {"ok":false,"error":"Sign in to appraise items."}`. That's the last bullet of the spec's manual checklist.
- The `Migration order` workflow doesn't run here, correctly — it's path-filtered to `supabase/migrations/**`, and this PR adds no migration.

**Still wants a signed-in pass.** This sandbox has no Supabase credentials, so I couldn't sign in and click the buttons. The remaining checklist items — a plain stack, a fitted ship totalling above its hull, a blueprint-only container hitting the 422, the cached second click showing `*`, and the share-token page rendering no Value column — are best done on the preview above. Everything reachable without a session is verified.

## Note on the spec

One deliberate deviation: `AppraiseButton` takes an optional `label` so the heading button can read "Appraise everything here" while rows stay a terse "appraise". The spec's signature was `({ target })` only; same component and endpoint either way.