### PR TITLE
Rename the character_ids RPC parameter to registration_ids

### DIFF
--- a/docs/registration-id-rename.md
+++ b/docs/registration-id-rename.md
@@ -93,11 +93,10 @@ step-5 tranches so far)
 
 ### Function signatures — 11
 
-Parameters (`character_ids uuid[]`): `character_asset_snapshot_at`,
+Parameters (`character_ids uuid[]` → `registration_ids`): ~~`character_asset_snapshot_at`,
 `character_blueprints`, `character_orders`, `character_industry_jobs`,
-`corp_assets`, `corp_blueprints`, `blueprint_search`, `corp_industry_jobs`
-(all still pending — only the _parameters_ remain; their bodies have already
-been moved onto `registration_id` by the step-5 tranches)
+`corp_assets`, `corp_blueprints`, `blueprint_search`, `corp_industry_jobs`~~
+— **all done** in step 7.
 
 Return columns (`character_id uuid`): ~~`character_asset_location_summary`~~,
 ~~`character_asset_search`~~, ~~`latest_heartbeats`~~ — **all done**. Each
@@ -361,10 +360,34 @@ uuid) returns boolean` is untouched — only its body moves. So
    _"still references sh.character_id"_. Cheap to do, and the only way to know
    an assertion works is to watch it fail.
 
-7. **Function parameters** (`character_ids uuid[]` on eight functions), in
-   lockstep with their ~11 call sites in `src/app/api/**` and the MCP tools.
-   supabase-js passes RPC arguments **by name**, so there is no backward
-   compatibility at all here: schema and callers must ship in the same commit.
+7. ~~**Function parameters**~~ **Done.** The thing the sketch above missed:
+   **a parameter rename requires DROP, not CREATE OR REPLACE.** Postgres
+   refuses outright —
+
+   ```
+   ERROR:  cannot change name of input parameter "character_ids"
+   HINT:   Use DROP FUNCTION f(uuid[]) first.
+   ```
+
+   — which makes step 7 structurally unlike steps 5's tranches, where only
+   bodies moved. Confirmed against a real Postgres before writing anything.
+   Dropping was safe because none of the eight is called from a policy, and the
+   DROPs name the _old_ signature, which still resolves: a drop matches on
+   parameter **types**, and those don't change. Grants had to be re-applied.
+
+   The no-backward-compatibility warning held exactly as written, and it makes
+   this the one migration in the whole cleanup whose deploy window is a real
+   (if brief) outage rather than harmless skew — a stale deployment sending
+   `character_ids` gets "function does not exist" rather than a wrong answer.
+
+   Two tests turned out to pin the old names, and neither is run by
+   `pnpm test` alone finding them: `test/sql/blueprint_search.sql` (which
+   `\i`-includes the migration defining the function) and a JS↔SQL parity test
+   in `test/blueprintQuery.test.ts` that read a **hardcoded** migration path.
+   The parity test was rewritten to locate the newest migration defining
+   `blueprint_search` itself, so the next redefinition doesn't silently assert
+   against a superseded signature — and it was verified to still fail on a
+   deliberately wrong parameter name.
 
 8. **The JS-only contracts** — the `characterIds` option on `forEachCharacter`,
    `OwnerContext.characterIds`, `resolvePlayer`'s return, and

--- a/schema.sql
+++ b/schema.sql
@@ -504,7 +504,7 @@ grant execute on function public.character_asset_subtree_items(bigint)     to au
 -- columns come out in that exact order. Called with the service role over the
 -- caller's own registration ids, so it takes them as a parameter rather than
 -- leaning on RLS.
-create or replace function public.character_asset_snapshot_at(character_ids uuid[], as_of timestamptz)
+create or replace function public.character_asset_snapshot_at(registration_ids uuid[], as_of timestamptz)
 returns json
 language sql
 stable
@@ -530,7 +530,7 @@ as $$
   from public.character_asset_over_time a
   join public.registration r on r.id = a.registration_id
   left join public.sde_published_type t on t.type_id = a.type_id
-  where a.registration_id = any(character_ids)
+  where a.registration_id = any(registration_ids)
     and a.valid_from <= as_of
     and (a.is_current or a.valid_until >= as_of)
     and (not a.is_singleton or a.is_blueprint_copy);
@@ -596,7 +596,7 @@ grant all    on public.character_blueprint_over_time to service_role;
 -- PostgREST's max-rows cap. Live snapshot only (no time-travel `as_of`, unlike
 -- character_asset_snapshot_at) — a blueprint's current research level and
 -- location is what the sheet needs.
-create or replace function public.character_blueprints(character_ids uuid[])
+create or replace function public.character_blueprints(registration_ids uuid[])
 returns json
 language sql
 stable
@@ -622,7 +622,7 @@ as $$
   from public.character_blueprint b
   join public.registration r on r.id = b.registration_id
   left join public.sde_published_type t on t.type_id = b.type_id
-  where b.registration_id = any(character_ids);
+  where b.registration_id = any(registration_ids);
 $$;
 
 grant execute on function public.character_blueprints(uuid[]) to service_role;
@@ -950,7 +950,7 @@ grant all    on public.character_order_over_time to service_role;
 -- json array (json, not jsonb, so json_build_object's key order is preserved for
 -- the sheet's columns) and sidesteps PostgREST's max-rows cap. The stored
 -- `is_buy` flag is exposed as `is_buy_order` to match ESI's field name.
-create or replace function public.character_orders(character_ids uuid[], as_of timestamptz default now())
+create or replace function public.character_orders(registration_ids uuid[], as_of timestamptz default now())
 returns json
 language sql
 stable
@@ -982,7 +982,7 @@ as $$
   from public.character_order_over_time o
   join public.registration r on r.id = o.registration_id
   left join public.sde_published_type t on t.type_id = o.type_id
-  where o.registration_id = any(character_ids)
+  where o.registration_id = any(registration_ids)
     and o.valid_from <= as_of
     and (o.is_current or o.valid_until >= as_of);
 $$;
@@ -1070,7 +1070,7 @@ grant all    on public.character_industry_job_over_time to service_role;
 -- a job that is delivered now but was active at `as_of` shows as active. At the
 -- default now() this returns the is_current set, matching the
 -- character_industry_job view.
-create or replace function public.character_industry_jobs(character_ids uuid[], include_delivered boolean default false, as_of timestamptz default now())
+create or replace function public.character_industry_jobs(registration_ids uuid[], include_delivered boolean default false, as_of timestamptz default now())
 returns json
 language sql
 stable
@@ -1120,7 +1120,7 @@ as $$
     -- (11); everything else (manufacturing = 1 in both) lines up already.
     and bp.activity_id = case j.activity_id when 9 then 11 else j.activity_id end
     and bp.product_type_id = j.product_type_id
-  where j.registration_id = any(character_ids)
+  where j.registration_id = any(registration_ids)
     and j.valid_from <= as_of
     and (j.is_current or j.valid_until >= as_of)
     and (include_delivered or j.status not in ('delivered', 'cancelled', 'archived'));
@@ -2528,7 +2528,7 @@ grant execute on function public.asset_ancestors(bigint) to authenticated;
 -- shape for the per-character assets endpoint. Returns json (not jsonb) so
 -- json_build_object's key order is preserved for the sheet's columns, and a
 -- single scalar sidesteps PostgREST's max-rows cap.
-create or replace function public.corp_assets(character_ids uuid[])
+create or replace function public.corp_assets(registration_ids uuid[])
 returns json
 language sql
 stable
@@ -2555,7 +2555,7 @@ as $$
   left join public.sde_published_type t on t.type_id = a.type_id
   where a.corporation_id in (
     select corporation_id from public.registration
-    where id = any(character_ids) and corporation_id is not null
+    where id = any(registration_ids) and corporation_id is not null
   );
 $$;
 
@@ -2613,7 +2613,7 @@ grant all    on public.corp_blueprint_over_time to service_role;
 -- /api/corp/blueprints IMPORTDATA endpoint: the caller's corporation(s)
 -- current blueprint rows, mirroring corp_assets()'s shape for the
 -- per-corporation assets endpoint.
-create or replace function public.corp_blueprints(character_ids uuid[])
+create or replace function public.corp_blueprints(registration_ids uuid[])
 returns json
 language sql
 stable
@@ -2640,7 +2640,7 @@ as $$
   left join public.sde_published_type t on t.type_id = b.type_id
   where b.corporation_id in (
     select corporation_id from public.registration
-    where id = any(character_ids) and corporation_id is not null
+    where id = any(registration_ids) and corporation_id is not null
   );
 $$;
 
@@ -2671,7 +2671,7 @@ grant execute on function public.corp_blueprints(uuid[]) to service_role;
 --   type_ids          null = every type, else the resolved item-name matches
 --   system_ids        null = everywhere, else solar systems to scope to
 --   structure_ids     null = anywhere, else structures to scope to
---   character_ids     null = every character; '{}' excludes all character rows
+--   registration_ids  null = every character; '{}' excludes all character rows
 --   corporation_ids   null = every corporation; '{}' excludes all corp rows
 --   kind_filter       'all' (default) | 'original' | 'copy'
 --   below_me/below_te research floors, OR'd when both are given (see below)
@@ -2683,7 +2683,7 @@ create or replace function public.blueprint_search(
   type_ids bigint[] default null,
   system_ids bigint[] default null,
   structure_ids bigint[] default null,
-  character_ids uuid[] default null,
+  registration_ids uuid[] default null,
   corporation_ids bigint[] default null,
   kind_filter text default 'all',
   below_me int default null,
@@ -2714,7 +2714,7 @@ as $$
       case when b.quantity > 0 then b.quantity else 1 end  as quantity
     from public.character_blueprint b
     where (type_ids is null or b.type_id = any(type_ids))
-      and (character_ids is null or b.registration_id = any(character_ids))
+      and (registration_ids is null or b.registration_id = any(registration_ids))
     union all
     select
       b.type_id::bigint,
@@ -2965,7 +2965,7 @@ grant all    on public.corp_industry_job_over_time to service_role;
 -- max-rows cap.
 -- `as_of` (default now) time-travels through the SCD-2 history exactly like the
 -- per-character character_industry_jobs above.
-create or replace function public.corp_industry_jobs(character_ids uuid[], include_delivered boolean default false, as_of timestamptz default now())
+create or replace function public.corp_industry_jobs(registration_ids uuid[], include_delivered boolean default false, as_of timestamptz default now())
 returns json
 language sql
 stable
@@ -3016,7 +3016,7 @@ as $$
     and bp.product_type_id = j.product_type_id
   where j.corporation_id in (
     select corporation_id from public.registration
-    where id = any(character_ids) and corporation_id is not null
+    where id = any(registration_ids) and corporation_id is not null
   )
   and j.valid_from <= as_of
   and (j.is_current or j.valid_until >= as_of)

--- a/src/app/api/character/assets/route.ts
+++ b/src/app/api/character/assets/route.ts
@@ -55,7 +55,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
   // of this function is what kept the endpoint under Vercel's timeout, and a single
   // json scalar sidesteps PostgREST's max-rows cap.
   const { data: rows, error: rowsError } = await player.supabase.rpc('character_asset_snapshot_at', {
-    character_ids: player.characterIds,
+    registration_ids: player.characterIds,
     as_of: atIso,
   })
   if (rowsError) {

--- a/src/app/api/character/blueprints/route.ts
+++ b/src/app/api/character/blueprints/route.ts
@@ -43,7 +43,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
   // which keeps the field order for the sheet's columns and sidesteps
   // PostgREST's max-rows cap.
   const { data: rows, error: rowsError } = await player.supabase.rpc('character_blueprints', {
-    character_ids: player.characterIds,
+    registration_ids: player.characterIds,
   })
   if (rowsError) {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })

--- a/src/app/api/character/jobs/route.ts
+++ b/src/app/api/character/jobs/route.ts
@@ -79,7 +79,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
   // which keeps the field order for the sheet's columns and sidesteps PostgREST's
   // max-rows cap.
   const { data: rows, error: rowsError } = await player.supabase.rpc('character_industry_jobs', {
-    character_ids: player.characterIds,
+    registration_ids: player.characterIds,
     include_delivered: includeDelivered,
     as_of: at.iso,
   })

--- a/src/app/api/character/orders/route.ts
+++ b/src/app/api/character/orders/route.ts
@@ -57,7 +57,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
   // Built and returned as one json array by Postgres (character_orders), which keeps
   // the field order for the sheet's columns and sidesteps PostgREST's max-rows cap.
   const { data: rows, error: rowsError } = await player.supabase.rpc('character_orders', {
-    character_ids: player.characterIds,
+    registration_ids: player.characterIds,
     as_of: at.iso,
   })
   if (rowsError) {

--- a/src/app/api/corp/assets/route.ts
+++ b/src/app/api/corp/assets/route.ts
@@ -43,7 +43,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
   // Built and returned as one json array by Postgres (corp_assets), which keeps
   // the field order for the sheet's columns and sidesteps PostgREST's max-rows cap.
   const { data: rows, error: rowsError } = await player.supabase.rpc('corp_assets', {
-    character_ids: player.characterIds,
+    registration_ids: player.characterIds,
   })
   if (rowsError) {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })

--- a/src/app/api/corp/blueprints/route.ts
+++ b/src/app/api/corp/blueprints/route.ts
@@ -43,7 +43,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
   // keeps the field order for the sheet's columns and sidesteps PostgREST's
   // max-rows cap.
   const { data: rows, error: rowsError } = await player.supabase.rpc('corp_blueprints', {
-    character_ids: player.characterIds,
+    registration_ids: player.characterIds,
   })
   if (rowsError) {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })

--- a/src/app/api/corp/jobs/route.ts
+++ b/src/app/api/corp/jobs/route.ts
@@ -79,7 +79,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
   // keeps the field order for the sheet's columns and sidesteps PostgREST's
   // max-rows cap.
   const { data: rows, error: rowsError } = await player.supabase.rpc('corp_industry_jobs', {
-    character_ids: player.characterIds,
+    registration_ids: player.characterIds,
     include_delivered: includeDelivered,
     as_of: at.iso,
   })

--- a/src/app/api/mcp/blueprintQuery.ts
+++ b/src/app/api/mcp/blueprintQuery.ts
@@ -26,7 +26,7 @@ export type BlueprintSearchParams = {
   type_ids: number[] | null
   system_ids: number[] | null
   structure_ids: number[] | null
-  character_ids: string[] | null
+  registration_ids: string[] | null
   corporation_ids: number[] | null
   kind_filter: BlueprintKind
   below_me: number | null
@@ -44,11 +44,11 @@ export type OwnerIds = { characterIds: string[]; corporationIds: string[] }
 export const partitionOwnerIds = (
   ownerIds: Set<string> | null,
   owners: OwnerIds
-): Pick<BlueprintSearchParams, 'character_ids' | 'corporation_ids'> =>
+): Pick<BlueprintSearchParams, 'registration_ids' | 'corporation_ids'> =>
   ownerIds == null
-    ? { character_ids: null, corporation_ids: null }
+    ? { registration_ids: null, corporation_ids: null }
     : {
-        character_ids: owners.characterIds.filter((id) => ownerIds.has(id)),
+        registration_ids: owners.characterIds.filter((id) => ownerIds.has(id)),
         corporation_ids: owners.corporationIds.filter((id) => ownerIds.has(id)).map(Number),
       }
 

--- a/src/app/api/mcp/tools.ts
+++ b/src/app/api/mcp/tools.ts
@@ -1036,12 +1036,12 @@ export const registerTools = (server: McpServer): void => {
         const includeDelivered = !['active', 'ready', 'paused'].includes(wantedStatus)
         const [{ data: chr, error: chrError }, { data: corp, error: corpError }] = await Promise.all([
           supabase.rpc('character_industry_jobs', {
-            character_ids: wantedCharacterIds,
+            registration_ids: wantedCharacterIds,
             include_delivered: includeDelivered,
             as_of: at.iso,
           }),
           supabase.rpc('corp_industry_jobs', {
-            character_ids: owners.characterIds,
+            registration_ids: owners.characterIds,
             include_delivered: includeDelivered,
             as_of: at.iso,
           }),
@@ -1185,7 +1185,7 @@ export const registerTools = (server: McpServer): void => {
       let orders: NormalizedOrder[]
       if (timeTravel) {
         const { data, error } = await supabase.rpc('character_orders', {
-          character_ids: owners.characterIds,
+          registration_ids: owners.characterIds,
           as_of: at.iso,
         })
         if (error) return textResult(`Couldn't read the order history: ${error.message}`)

--- a/supabase/migrations/20260801140000_rpc_registration_ids.sql
+++ b/supabase/migrations/20260801140000_rpc_registration_ids.sql
@@ -1,0 +1,362 @@
+-- Rename the character_ids parameter to registration_ids on every function
+-- that takes one — step 7 of docs/registration-id-rename.md. These arrays have
+-- always held registration uuids; the columns they compare against were
+-- renamed in steps 1-6, which is why the bodies currently read
+-- `where o.registration_id = any(character_ids)`.
+--
+-- Every function here must be DROPPED and recreated, not replaced. Postgres
+-- refuses to rename an input parameter through CREATE OR REPLACE:
+--
+--   ERROR:  cannot change name of input parameter "character_ids"
+--   HINT:   Use DROP FUNCTION f(uuid[]) first.
+--
+-- Verified against a real Postgres rather than inferred. That makes this step
+-- structurally different from #759/#760/#761, where only bodies moved.
+--
+-- Dropping is safe here: none of these is called from an RLS policy — they are
+-- all reached over RPC — so nothing has to come down ahead of them. The DROPs
+-- below name the OLD signature; a drop matches on parameter TYPES, which are
+-- unchanged, so `(uuid[], timestamptz)` still resolves the pre-rename function.
+--
+-- Grants are re-applied because DROP discards the ACL.
+--
+-- THIS MIGRATION IS NOT BACKWARD COMPATIBLE and cannot be. supabase-js passes
+-- RPC arguments BY NAME (`supabase.rpc('character_orders', { character_ids })`),
+-- so the moment this lands, any deployment still sending character_ids gets
+-- "function does not exist". Schema and callers must ship together — the
+-- JavaScript half is in the same commit. The usual deploy-ordering window
+-- (Migrate finishes before Vercel's build) is therefore a real, if brief,
+-- outage for these seven endpoints rather than the harmless skew the earlier
+-- column renames had.
+--
+-- blueprint_search() is the eighth and is redefined in the migration that
+-- immediately follows, for the same reason as #761: test/sql/blueprint_search.sql
+-- `\i`-includes the migration defining it, so that one has to live in a file
+-- containing nothing but the function and its grant.
+
+drop function if exists public.character_asset_snapshot_at(uuid[], timestamptz);
+create function public.character_asset_snapshot_at(registration_ids uuid[], as_of timestamptz)
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'is_blueprint_copy', a.is_blueprint_copy,
+        'is_singleton',      a.is_singleton,
+        'item_id',           a.item_id,
+        'location_flag',     a.location_flag,
+        'location_id',       a.location_id,
+        'location_type',     a.location_type,
+        'quantity',          a.quantity,
+        'type_id',           a.type_id,
+        'character_name',    r.name,
+        'type_name',         t.name
+      )
+      order by a.item_id
+    ),
+    '[]'::json
+  )
+  from public.character_asset_over_time a
+  join public.registration r on r.id = a.registration_id
+  left join public.sde_published_type t on t.type_id = a.type_id
+  where a.registration_id = any(registration_ids)
+    and a.valid_from <= as_of
+    and (a.is_current or a.valid_until >= as_of)
+    and (not a.is_singleton or a.is_blueprint_copy);
+$$;
+
+grant execute on function public.character_asset_snapshot_at(uuid[], timestamptz) to service_role;
+
+drop function if exists public.character_blueprints(uuid[]);
+create function public.character_blueprints(registration_ids uuid[])
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'item_id',             b.item_id,
+        'location_flag',       b.location_flag,
+        'location_id',         b.location_id,
+        'material_efficiency', b.material_efficiency,
+        'quantity',            b.quantity,
+        'runs',                b.runs,
+        'time_efficiency',     b.time_efficiency,
+        'type_id',             b.type_id,
+        'character_name',      r.name,
+        'type_name',           t.name
+      )
+      order by b.item_id
+    ),
+    '[]'::json
+  )
+  from public.character_blueprint b
+  join public.registration r on r.id = b.registration_id
+  left join public.sde_published_type t on t.type_id = b.type_id
+  where b.registration_id = any(registration_ids);
+$$;
+
+grant execute on function public.character_blueprints(uuid[]) to service_role;
+
+drop function if exists public.character_orders(uuid[], timestamptz);
+create function public.character_orders(registration_ids uuid[], as_of timestamptz default now())
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'duration',       o.duration,
+        'escrow',         o.escrow,
+        'is_buy_order',   o.is_buy,
+        'is_corporation', o.is_corporation,
+        'issued',         o.issued,
+        'location_id',    o.location_id,
+        'min_volume',     o.min_volume,
+        'order_id',       o.order_id,
+        'price',          o.price,
+        'range',          o.range,
+        'region_id',      o.region_id,
+        'type_id',        o.type_id,
+        'volume_remain',  o.volume_remain,
+        'volume_total',   o.volume_total,
+        'character_name', r.name,
+        'type_name',      t.name
+      )
+      order by o.issued desc
+    ),
+    '[]'::json
+  )
+  from public.character_order_over_time o
+  join public.registration r on r.id = o.registration_id
+  left join public.sde_published_type t on t.type_id = o.type_id
+  where o.registration_id = any(registration_ids)
+    and o.valid_from <= as_of
+    and (o.is_current or o.valid_until >= as_of);
+$$;
+
+grant execute on function public.character_orders(uuid[], timestamptz) to service_role;
+
+drop function if exists public.character_industry_jobs(uuid[], boolean, timestamptz);
+create function public.character_industry_jobs(registration_ids uuid[], include_delivered boolean default false, as_of timestamptz default now())
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'activity_id',            j.activity_id,
+        'blueprint_id',           j.blueprint_id,
+        'blueprint_location_id',  j.blueprint_location_id,
+        'blueprint_type_id',      j.blueprint_type_id,
+        'completed_character_id', j.completed_character_id,
+        'completed_date',         j.completed_date,
+        'cost',                   j.cost,
+        'duration',               j.duration,
+        'end_date',               j.end_date,
+        'facility_id',            j.facility_id,
+        'installer_id',           j.installer_id,
+        'job_id',                 j.job_id,
+        'licensed_runs',          j.licensed_runs,
+        'output_location_id',     j.output_location_id,
+        'pause_date',             j.pause_date,
+        'probability',            j.probability,
+        'product_type_id',        j.product_type_id,
+        'runs',                   j.runs,
+        'start_date',             j.start_date,
+        'station_id',             j.station_id,
+        'status',                 j.status,
+        'successful_runs',        j.successful_runs,
+        'character_name',         r.name,
+        'blueprint_type_name',    bt.name,
+        'product_type_name',      pt.name,
+        'output_count',           j.runs * bp.product_quantity
+      )
+      order by j.start_date desc
+    ),
+    '[]'::json
+  )
+  from public.character_industry_job_over_time j
+  join public.registration r on r.id = j.registration_id
+  left join public.sde_published_type bt on bt.type_id = j.blueprint_type_id
+  left join public.sde_published_type pt on pt.type_id = j.product_type_id
+  left join public.sde_blueprint_product bp
+    on bp.blueprint_type_id = j.blueprint_type_id
+    -- ESI's job activity_id (9 = Reactions) doesn't match the SDE-internal
+    -- dogma activity id sde_blueprint_product carries for the same activity
+    -- (11); everything else (manufacturing = 1 in both) lines up already.
+    and bp.activity_id = case j.activity_id when 9 then 11 else j.activity_id end
+    and bp.product_type_id = j.product_type_id
+  where j.registration_id = any(registration_ids)
+    and j.valid_from <= as_of
+    and (j.is_current or j.valid_until >= as_of)
+    and (include_delivered or j.status not in ('delivered', 'cancelled', 'archived'));
+$$;
+
+grant execute on function public.character_industry_jobs(uuid[], boolean, timestamptz) to service_role;
+
+drop function if exists public.corp_assets(uuid[]);
+create function public.corp_assets(registration_ids uuid[])
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'item_id',           a.item_id,
+        'corporation_id',    a.corporation_id,
+        'type_id',           a.type_id,
+        'location_id',       a.location_id,
+        'location_flag',     a.location_flag,
+        'location_type',     a.location_type,
+        'quantity',          a.quantity,
+        'is_singleton',      a.is_singleton,
+        'is_blueprint_copy', a.is_blueprint_copy,
+        'type_name',         t.name
+      )
+      order by a.item_id
+    ),
+    '[]'::json
+  )
+  from public.corp_asset a
+  left join public.sde_published_type t on t.type_id = a.type_id
+  where a.corporation_id in (
+    select corporation_id from public.registration
+    where id = any(registration_ids) and corporation_id is not null
+  );
+$$;
+
+grant execute on function public.corp_assets(uuid[]) to service_role;
+
+drop function if exists public.corp_blueprints(uuid[]);
+create function public.corp_blueprints(registration_ids uuid[])
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'item_id',             b.item_id,
+        'corporation_id',      b.corporation_id,
+        'location_flag',       b.location_flag,
+        'location_id',         b.location_id,
+        'material_efficiency', b.material_efficiency,
+        'quantity',            b.quantity,
+        'runs',                b.runs,
+        'time_efficiency',     b.time_efficiency,
+        'type_id',             b.type_id,
+        'type_name',           t.name
+      )
+      order by b.item_id
+    ),
+    '[]'::json
+  )
+  from public.corp_blueprint b
+  left join public.sde_published_type t on t.type_id = b.type_id
+  where b.corporation_id in (
+    select corporation_id from public.registration
+    where id = any(registration_ids) and corporation_id is not null
+  );
+$$;
+
+grant execute on function public.corp_blueprints(uuid[]) to service_role;
+
+drop function if exists public.corp_industry_jobs(uuid[], boolean, timestamptz);
+create function public.corp_industry_jobs(registration_ids uuid[], include_delivered boolean default false, as_of timestamptz default now())
+returns json
+language sql
+stable
+as $$
+  select coalesce(
+    json_agg(
+      json_build_object(
+        'activity_id',            j.activity_id,
+        'blueprint_id',           j.blueprint_id,
+        'blueprint_location_id',  j.blueprint_location_id,
+        'blueprint_type_id',      j.blueprint_type_id,
+        'completed_character_id', j.completed_character_id,
+        'completed_date',         j.completed_date,
+        'corporation_id',         j.corporation_id,
+        'cost',                   j.cost,
+        'duration',               j.duration,
+        'end_date',               j.end_date,
+        'facility_id',            j.facility_id,
+        'installer_id',           j.installer_id,
+        'job_id',                 j.job_id,
+        'licensed_runs',          j.licensed_runs,
+        'output_location_id',     j.output_location_id,
+        'pause_date',             j.pause_date,
+        'probability',            j.probability,
+        'product_type_id',        j.product_type_id,
+        'runs',                   j.runs,
+        'start_date',             j.start_date,
+        'station_id',             j.station_id,
+        'status',                 j.status,
+        'successful_runs',        j.successful_runs,
+        'blueprint_type_name',    bt.name,
+        'product_type_name',      pt.name,
+        'output_count',           j.runs * bp.product_quantity
+      )
+      order by j.start_date desc
+    ),
+    '[]'::json
+  )
+  from public.corp_industry_job_over_time j
+  left join public.sde_published_type bt on bt.type_id = j.blueprint_type_id
+  left join public.sde_published_type pt on pt.type_id = j.product_type_id
+  left join public.sde_blueprint_product bp
+    on bp.blueprint_type_id = j.blueprint_type_id
+    -- ESI's job activity_id (9 = Reactions) doesn't match the SDE-internal
+    -- dogma activity id sde_blueprint_product carries for the same activity
+    -- (11); everything else (manufacturing = 1 in both) lines up already.
+    and bp.activity_id = case j.activity_id when 9 then 11 else j.activity_id end
+    and bp.product_type_id = j.product_type_id
+  where j.corporation_id in (
+    select corporation_id from public.registration
+    where id = any(registration_ids) and corporation_id is not null
+  )
+  and j.valid_from <= as_of
+  and (j.is_current or j.valid_until >= as_of)
+  and (include_delivered or j.status not in ('delivered', 'cancelled', 'archived'));
+$$;
+
+grant execute on function public.corp_industry_jobs(uuid[], boolean, timestamptz) to service_role;
+
+-- Assert every function came back with the new parameter name and none kept
+-- the old one. A DROP that succeeded followed by a CREATE that quietly kept
+-- character_ids would leave the database working and every caller in this same
+-- commit broken, which is the one failure this migration can actually produce.
+do $$
+declare
+  fn text;
+  n integer;
+begin
+  foreach fn in array array['character_asset_snapshot_at', 'character_blueprints',
+                            'character_orders', 'character_industry_jobs',
+                            'corp_assets', 'corp_blueprints', 'corp_industry_jobs'] loop
+    select count(*) into n
+    from pg_proc p
+    join pg_namespace ns on ns.oid = p.pronamespace
+    cross join unnest(p.proargnames) as arg
+    where ns.nspname = 'public' and p.proname = fn and arg = 'registration_ids';
+    if n = 0 then
+      raise exception '%() does not take a registration_ids parameter', fn;
+    end if;
+
+    select count(*) into n
+    from pg_proc p
+    join pg_namespace ns on ns.oid = p.pronamespace
+    cross join unnest(p.proargnames) as arg
+    where ns.nspname = 'public' and p.proname = fn and arg = 'character_ids';
+    if n > 0 then
+      raise exception '%() still takes a character_ids parameter — its callers ship in this commit and would break', fn;
+    end if;
+  end loop;
+end $$;

--- a/supabase/migrations/20260801150000_blueprint_search_registration_ids.sql
+++ b/supabase/migrations/20260801150000_blueprint_search_registration_ids.sql
@@ -1,0 +1,255 @@
+-- blueprint_search(), redefined with its character_ids parameter renamed to
+-- registration_ids — the companion to the migration immediately before this
+-- one, which does the same for the other seven functions.
+--
+-- Dropped and recreated rather than replaced: Postgres refuses to rename an
+-- input parameter through CREATE OR REPLACE ("cannot change name of input
+-- parameter"). The DROP names the old signature, which still resolves because
+-- a drop matches on parameter types and those are unchanged.
+--
+-- This file deliberately contains nothing but the function and its grant.
+-- test/sql/blueprint_search.sql creates stand-in tables and then `\i`-includes
+-- the migration defining this function, so anything else here would break that
+-- test — the same split as #761.
+
+drop function if exists public.blueprint_search(
+  bigint[], bigint[], bigint[], uuid[], bigint[], text, int, int, boolean, text, int
+);
+
+create function public.blueprint_search(
+  type_ids bigint[] default null,
+  system_ids bigint[] default null,
+  structure_ids bigint[] default null,
+  registration_ids uuid[] default null,
+  corporation_ids bigint[] default null,
+  kind_filter text default 'all',
+  below_me int default null,
+  below_te int default null,
+  researchable_only boolean default false,
+  group_mode text default 'none',
+  row_limit int default 100
+)
+returns json
+language sql
+stable
+as $$
+  with owned as (
+    -- ESI encoding: `runs = -1` marks an original; any other value is a copy
+    -- with that many runs left. `quantity` carries its own sentinels (-1
+    -- singleton, -2 BPC stack) and must never be summed raw, so it is
+    -- normalised to a real item count here and nowhere else.
+    select
+      b.type_id::bigint                                    as type_id,
+      b.registration_id::text                                 as owner_id,
+      'character'::text                                    as owner_kind,
+      b.location_id::bigint                                as location_id,
+      b.location_flag                                      as location_flag,
+      case when b.runs = -1 or b.runs is null then 'original' else 'copy' end as kind,
+      b.material_efficiency                                as material_efficiency,
+      b.time_efficiency                                    as time_efficiency,
+      b.runs                                               as runs,
+      case when b.quantity > 0 then b.quantity else 1 end  as quantity
+    from public.character_blueprint b
+    where (type_ids is null or b.type_id = any(type_ids))
+      and (registration_ids is null or b.registration_id = any(registration_ids))
+    union all
+    select
+      b.type_id::bigint,
+      b.corporation_id::text,
+      'corporation'::text,
+      b.location_id::bigint,
+      b.location_flag,
+      case when b.runs = -1 or b.runs is null then 'original' else 'copy' end,
+      b.material_efficiency,
+      b.time_efficiency,
+      b.runs,
+      case when b.quantity > 0 then b.quantity else 1 end
+    from public.corp_blueprint b
+    where (type_ids is null or b.type_id = any(type_ids))
+      and (corporation_ids is null or b.corporation_id = any(corporation_ids))
+  ),
+  -- Blueprints carry a bare location_id. NPC stations resolve through the SDE
+  -- mirror, player structures through the universe_structure cache — the same
+  -- two sources resolveLocations() uses in the app. KNOWN LIMITATION (called
+  -- out in the spec): a blueprint inside a container or ship has an item id
+  -- here, not a structure id, so it resolves to no system and drops out of a
+  -- location-scoped query. Container traversal is out of scope for this change.
+  located as (
+    select
+      o.*,
+      coalesce(st.system_id, us.system_id) as system_id,
+      coalesce(st.name, us.name)           as location_name,
+      -- Researchable = the blueprint has a manufacturing activity. Reaction
+      -- formulas only ever have the reaction activity (11); they cannot be
+      -- researched, always report ME/TE 0/0, and would otherwise flood any
+      -- "still needs research" result. Deriving this from the activity the SDE
+      -- actually records beats both name matching (fragile, per the spec) and a
+      -- hardcoded list of reaction-formula group ids.
+      exists (
+        select 1 from public.sde_blueprint_product bp
+        where bp.blueprint_type_id = o.type_id and bp.activity_id = 1
+      ) as researchable
+    from owned o
+    left join public.sde_station st        on st.station_id = o.location_id
+    left join public.universe_structure us on us.structure_id = o.location_id
+  ),
+  filtered as (
+    select *
+    from located
+    where (system_ids is null or system_id = any(system_ids))
+      and (structure_ids is null or location_id = any(structure_ids))
+      and (kind_filter is null or kind_filter = 'all' or kind = kind_filter)
+      and (not researchable_only or researchable)
+      -- below_me and below_te are OR'd when both are given: "short of either
+      -- target", which is how the question is actually asked ("which blueprints
+      -- are not at 10/20 yet"). Deliberately not the obvious AND reading.
+      and (
+        (below_me is null and below_te is null)
+        or (below_me is not null and coalesce(material_efficiency, 0) < below_me)
+        or (below_te is not null and coalesce(time_efficiency, 0) < below_te)
+      )
+  ),
+  named as (
+    select f.*, coalesce(t.name, 'Type #' || f.type_id) as type_name
+    from filtered f
+    left join public.sde_published_type t on t.type_id = f.type_id
+  ),
+  totals as (
+    select
+      count(*)                                    as total_stacks,
+      coalesce(sum(quantity), 0)                  as total_quantity,
+      (count(*) filter (where kind = 'original')) as originals,
+      (count(*) filter (where kind = 'copy'))     as copies,
+      count(distinct type_id)                     as distinct_types
+    from named
+  ),
+  -- 'type' collapses identical (type, ME, TE) rows into one carrying a count —
+  -- the fix for a hangar holding 37 indistinguishable copies of one BPC.
+  -- 'type_location' keeps them split per location. `stacks` sums back to
+  -- total_stacks across the whole grouped set.
+  grouped as (
+    select
+      type_id,
+      type_name,
+      material_efficiency,
+      time_efficiency,
+      case when group_mode = 'type_location' then location_id end   as location_id,
+      case when group_mode = 'type_location' then location_name end as location_name,
+      case when group_mode = 'type_location' then system_id end     as system_id,
+      count(*)                                                as stacks,
+      coalesce(sum(quantity), 0)                              as quantity,
+      (count(*) filter (where kind = 'original'))             as originals,
+      (count(*) filter (where kind = 'copy'))                 as copies,
+      coalesce(sum(runs) filter (where kind = 'copy'), 0)     as copy_runs,
+      bool_or(researchable)                                   as researchable
+    from named
+    group by
+      type_id,
+      type_name,
+      material_efficiency,
+      time_efficiency,
+      case when group_mode = 'type_location' then location_id end,
+      case when group_mode = 'type_location' then location_name end,
+      case when group_mode = 'type_location' then system_id end
+  ),
+  capped as (
+    select least(greatest(coalesce(row_limit, 100), 1), 500) as n
+  )
+  select json_build_object(
+    'group',          case when group_mode in ('type', 'type_location') then group_mode else 'none' end,
+    'total_stacks',   (select total_stacks   from totals),
+    'total_quantity', (select total_quantity from totals),
+    'originals',      (select originals      from totals),
+    'copies',         (select copies         from totals),
+    'distinct_types', (select distinct_types from totals),
+    'total_groups',   case when group_mode in ('type', 'type_location') then (select count(*) from grouped) end,
+    'rows',
+      case when group_mode in ('type', 'type_location') then
+        coalesce(
+          (
+            select json_agg(
+              json_build_object(
+                'type_id',             g.type_id,
+                'type_name',           g.type_name,
+                'material_efficiency', g.material_efficiency,
+                'time_efficiency',     g.time_efficiency,
+                'stacks',              g.stacks,
+                'quantity',            g.quantity,
+                'originals',           g.originals,
+                'copies',              g.copies,
+                'copy_runs',           g.copy_runs,
+                'researchable',        g.researchable,
+                'location_id',         g.location_id,
+                'location_name',       g.location_name,
+                'system_id',           g.system_id
+              )
+              order by g.stacks desc, g.type_name, g.material_efficiency, g.time_efficiency
+            )
+            from (
+              select * from grouped
+              order by stacks desc, type_name, material_efficiency, time_efficiency
+              limit (select n from capped)
+            ) g
+          ),
+          '[]'::json
+        )
+      else
+        coalesce(
+          (
+            select json_agg(
+              json_build_object(
+                'type_id',             d.type_id,
+                'type_name',           d.type_name,
+                'owner_id',            d.owner_id,
+                'owner_kind',          d.owner_kind,
+                'kind',                d.kind,
+                'material_efficiency', d.material_efficiency,
+                'time_efficiency',     d.time_efficiency,
+                'runs',                d.runs,
+                'quantity',            d.quantity,
+                'researchable',        d.researchable,
+                'location_id',         d.location_id,
+                'location_name',       d.location_name,
+                'location_flag',       d.location_flag,
+                'system_id',           d.system_id
+              )
+              order by d.type_name, d.material_efficiency, d.time_efficiency, d.owner_id, d.location_id
+            )
+            from (
+              select * from named
+              order by type_name, material_efficiency, time_efficiency, owner_id, location_id
+              limit (select n from capped)
+            ) d
+          ),
+          '[]'::json
+        )
+      end
+  );
+$$;
+
+grant execute on function public.blueprint_search(
+  bigint[], bigint[], bigint[], uuid[], bigint[], text, int, int, boolean, text, int
+) to authenticated;
+
+do $$
+declare
+  n integer;
+begin
+  select count(*) into n
+  from pg_proc p
+  join pg_namespace ns on ns.oid = p.pronamespace
+  cross join unnest(p.proargnames) as arg
+  where ns.nspname = 'public' and p.proname = 'blueprint_search' and arg = 'registration_ids';
+  if n = 0 then
+    raise exception 'blueprint_search() does not take a registration_ids parameter';
+  end if;
+
+  select count(*) into n
+  from pg_proc p
+  join pg_namespace ns on ns.oid = p.pronamespace
+  cross join unnest(p.proargnames) as arg
+  where ns.nspname = 'public' and p.proname = 'blueprint_search' and arg = 'character_ids';
+  if n > 0 then
+    raise exception 'blueprint_search() still takes a character_ids parameter';
+  end if;
+end $$;

--- a/test/blueprintQuery.test.ts
+++ b/test/blueprintQuery.test.ts
@@ -10,7 +10,7 @@
 // The SQL semantics those parameters drive (what `below_me` actually excludes,
 // how the collapse counts) are asserted against a real Postgres in
 // test/sql/blueprint_search.sql.
-import { readFileSync } from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import assert from 'node:assert/strict'
 import test from 'node:test'
@@ -101,20 +101,20 @@ test('a resolved structure travels to SQL as structure_ids', () => {
 
 test('owner scoping splits into the character and corporation id arrays', () => {
   const params = buildBlueprintParams({ ownerIds: new Set(['char-b']) }, OWNERS)
-  assert.deepEqual(params.character_ids, ['char-b'])
+  assert.deepEqual(params.registration_ids, ['char-b'])
   // Empty (not null) so the corp half of the union matches nothing.
   assert.deepEqual(params.corporation_ids, [])
 })
 
 test('a corporation-only owner filter excludes every character row', () => {
   const split = partitionOwnerIds(new Set(['98000002']), OWNERS)
-  assert.deepEqual(split.character_ids, [])
+  assert.deepEqual(split.registration_ids, [])
   assert.deepEqual(split.corporation_ids, [98000002])
 })
 
 test('no owner argument leaves both owner filters unset', () => {
   const params = buildBlueprintParams({}, OWNERS)
-  assert.equal(params.character_ids, null)
+  assert.equal(params.registration_ids, null)
   assert.equal(params.corporation_ids, null)
 })
 
@@ -279,14 +279,23 @@ test('an untruncated result gets no note', () => {
 // The RPC is called by name with a parameter object, so a rename on either side
 // fails silently at runtime (PostgREST reports "function does not exist").
 test('every parameter buildBlueprintParams emits is declared by blueprint_search()', () => {
-  const sql = readFileSync(
-    join(import.meta.dirname, '..', 'supabase', 'migrations', '20260725000000_blueprint_search.sql'),
-    'utf8'
-  )
-  const signature = sql.slice(
-    sql.indexOf('create or replace function public.blueprint_search('),
-    sql.indexOf('returns json')
-  )
+  // Find the newest migration that (re)defines blueprint_search rather than
+  // naming one: the function has been redefined twice by the registration_id
+  // rename, and each time a hardcoded path here would have gone on asserting
+  // against a superseded signature — or, once the definition changed from
+  // `create or replace` to `create`, stopped finding it at all.
+  const migrations = join(import.meta.dirname, '..', 'supabase', 'migrations')
+  const DEFINES = /create (?:or replace )?function public\.blueprint_search\(/
+  const newest = readdirSync(migrations)
+    .filter((f) => f.endsWith('.sql'))
+    .sort()
+    .reverse()
+    .find((f) => DEFINES.test(readFileSync(join(migrations, f), 'utf8')))
+  assert.ok(newest, 'no migration defines blueprint_search()')
+
+  const sql = readFileSync(join(migrations, newest), 'utf8')
+  const start = sql.search(DEFINES)
+  const signature = sql.slice(start, sql.indexOf('returns json', start))
   const params = buildBlueprintParams({ ownerIds: new Set(['char-a']) }, OWNERS)
   Object.keys(params).forEach((name) => {
     assert.match(signature, new RegExp(`\\b${name}\\b`), `blueprint_search() declares no "${name}" parameter`)

--- a/test/sql/blueprint_search.sql
+++ b/test/sql/blueprint_search.sql
@@ -71,7 +71,7 @@ insert into public.corp_blueprint values
 -- registration_id, and the stand-in above matches the current schema. That
 -- migration deliberately contains nothing but the function and its grant, so
 -- including it here stays a one-line change each time the function moves.
-\i supabase/migrations/20260801030000_blueprint_search_registration_id.sql
+\i supabase/migrations/20260801150000_blueprint_search_registration_ids.sql
 
 do $$
 declare


### PR DESCRIPTION
Step 7 of `docs/registration-id-rename.md`: the eight functions taking a `character_ids uuid[]`, plus every call site, in one commit.

These arrays have always held registration uuids. Steps 1–6 renamed the columns they compare against, which is why the bodies have read `where o.registration_id = any(character_ids)` since #759.

## ⚠️ Read before merging: this one has a real deploy window

Every other migration in this cleanup had harmless skew — a stale deployment queried an old column name and got an error on one page. **This one has no backward compatibility and no way to have any.** supabase-js passes RPC arguments *by name*, so from the moment `Migrate` finishes until Vercel's build swaps in, any request hitting these endpoints gets `function does not exist`:

`/api/character/{assets,blueprints,orders,jobs}`, `/api/corp/{assets,blueprints,jobs}`, and the MCP `list_blueprints` / `list_market_orders` / `list_industry_jobs` tools.

Schema and callers are in the same commit, which is the most that can be done. Merging at a quiet moment is worth it.

## The plan was wrong: a parameter rename requires DROP

The doc assumed `CREATE OR REPLACE` would do. Postgres refuses:

```
ERROR:  cannot change name of input parameter "character_ids"
HINT:   Use DROP FUNCTION f(uuid[]) first.
```

I checked that against a real Postgres before writing the migration. It makes step 7 structurally unlike step 5's tranches, where only bodies moved.

Dropping is safe here: none of the eight is called from an RLS policy — all are reached over RPC — so nothing had to come down first. The `DROP`s name the **old** signature and still resolve, because a drop matches on parameter *types*, which are unchanged. Grants are re-applied, since `DROP` discards the ACL.

`blueprint_search()` is split into its own migration for the same reason as #761 — `test/sql/blueprint_search.sql` `\i`-includes the migration defining it.

## Two tests pinned the old name; `pnpm test` alone found one

The other needs a database (`pnpm run test:sql`).

The one it did find is the JS↔SQL parity check in `test/blueprintQuery.test.ts`, and it was worse than a simple breakage: it read a **hardcoded** migration path, so it had been asserting against a superseded signature ever since #761 redefined the function — and would have stopped finding it entirely once the definition changed from `create or replace` to plain `create`.

It now locates the newest migration defining `blueprint_search` itself, so the next redefinition can't silently orphan it. Verified still live by pointing a parameter at a bogus name and watching it fail:

```
error: 'blueprint_search() declares no "bogus_param" parameter'
```

## Changes

- `supabase/migrations/20260801140000_rpc_registration_ids.sql` — seven functions, dropped and recreated, bodies extracted verbatim from `schema.sql`
- `supabase/migrations/20260801150000_blueprint_search_registration_ids.sql` — the eighth
- `schema.sql` — all eight signatures and bodies
- 7 API routes, `src/app/api/mcp/tools.ts` (3 call sites), `src/app/api/mcp/blueprintQuery.ts` (the `BlueprintSearchParams` type)
- `test/blueprintQuery.test.ts`, `test/sql/blueprint_search.sql`

## Verification

`pnpm run lint`, `pnpm test` (90/90), `pnpm run test:sql` against a real throwaway Postgres, `pnpm run build`, and `.github/scripts/check-migrations.mjs` — all clean, re-run after rebasing onto #764 and #765. Confirmed #764's new asset-subtree functions don't take this parameter, and that all eight extracted function bodies are byte-identical to `schema.sql`.

Only step 8 (JS-only naming, no migration) remains after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfmtG8kgpyC6vtXeNwRPM7

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfmtG8kgpyC6vtXeNwRPM7)_