### PR TITLE
Rename the characterIds JS contracts to registrationIds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,9 +139,9 @@ All functions take `(accessToken, id, ...)` unless noted. Returns raw ESI respon
 
 ### `src/jobs/lib.js` — shared extract-job plumbing
 
-- `forEachCharacter(tag, { scope, characterIds, heartbeat = true }, handler)` — iterate tokens carrying an ESI scope, refresh each, call handler with `{ access_token, characterID, registration_id, userId, name, ctx, scopes }` (`scopes` is the token's fresh scope list). Wraps each call in a start/end `heartbeat` row attributed to that character (`registration_id`/`user_id`) unless `heartbeat: false` (forEachCorporation passes this to avoid a redundant row)
-- `forEachCharacterAnyScope(tag, { scopes, characterIds, heartbeat = true }, handler)` — like `forEachCharacter` but selects tokens carrying **any** of `scopes` (array overlap) rather than one required scope, for a job fronting several endpoints with different scopes (`character-status`); the handler reads `scopes` to run only the endpoints the token is authorized for
-- `forEachCorporation(tag, { scope, characterIds }, handler)` — same, deduped to one handler call per corporation; also keeps `registration.corporation_id` fresh (corp-table RLS keys off it). Wraps each call in its own start/end `heartbeat` row attributed to the corp and the character whose token authorized the pull (`corporation_id`/`registration_id`/`user_id`)
+- `forEachCharacter(tag, { scope, registrationIds, heartbeat = true }, handler)` — iterate tokens carrying an ESI scope, refresh each, call handler with `{ access_token, characterID, registration_id, userId, name, ctx, scopes }` (`scopes` is the token's fresh scope list). Wraps each call in a start/end `heartbeat` row attributed to that character (`registration_id`/`user_id`) unless `heartbeat: false` (forEachCorporation passes this to avoid a redundant row)
+- `forEachCharacterAnyScope(tag, { scopes, registrationIds, heartbeat = true }, handler)` — like `forEachCharacter` but selects tokens carrying **any** of `scopes` (array overlap) rather than one required scope, for a job fronting several endpoints with different scopes (`character-status`); the handler reads `scopes` to run only the endpoints the token is authorized for
+- `forEachCorporation(tag, { scope, registrationIds }, handler)` — same, deduped to one handler call per corporation; also keeps `registration.corporation_id` fresh (corp-table RLS keys off it). Wraps each call in its own start/end `heartbeat` row attributed to the corp and the character whose token authorized the pull (`corporation_id`/`registration_id`/`user_id`)
 - `fetchAllPages(fetchPage)` — drain an x-pages-paginated ESI endpoint
 - `forEachSequential(items, fn)` — the jobs' ramda-based stand-in for `for (const x of items) { await fn(x) }`; runs `fn` once per item in order, awaiting each before the next
 - `cli(import.meta.url, tag, run)` — self-run a job module when invoked directly as a CLI
@@ -156,8 +156,8 @@ All functions take `(accessToken, id, ...)` unless noted. Returns raw ESI respon
 - `upsertToken(characterId, accessToken, refreshToken, issuedAt, expiresAt, scope[])` — store OAuth tokens
 - `upsertAssets(characterId, assets[])` — asset upsert (legacy `refresh.js` utility)
 - `selectCharacters(columns, owner?)` — registration rows (given select-column list), optionally filtered by `owner`
-- `selectCharacterIdsWithScopes(scopes[])` — character IDs that have all listed ESI scopes
-- `groupCharacterIdsByCorporation(scopes)` — `{ byCorp, unresolved }`: scoped character ids grouped by corporation, for the per-corporation job fan-out
+- `selectRegistrationIdsWithScopes(scopes[])` — character IDs that have all listed ESI scopes
+- `groupRegistrationIdsByCorporation(scopes)` — `{ byCorp, unresolved }`: scoped character ids grouped by corporation, for the per-corporation job fan-out
 - `selectToken(characterId, scope?[])` — fetch stored token for a character, optionally requiring scopes
 - `getEsiEtag(cacheKey)` / `putEsiEtag(cacheKey, etag)` — read/store the last ESI ETag for a conditional-request cache key (`esi_etag` table); both are best-effort (a DB failure degrades to an unconditional fetch rather than throwing). Used by the single-request snapshot jobs (`character-orders`/`-wallet-transactions`/`-industry-jobs`/`-fittings`) to send `If-None-Match` and skip re-processing on a `304`
 
@@ -188,7 +188,7 @@ All functions take `(accessToken, id, ...)` unless noted. Returns raw ESI respon
 
 ### `src/utils/apiToken.ts`
 
-- `resolvePlayer(token: string)` — look up `user_settings.api_token` for Sheets API endpoints; returns `{ ok: true, supabase, characterIds }` or `{ ok: false, status, error }`
+- `resolvePlayer(token: string)` — look up `user_settings.api_token` for Sheets API endpoints; returns `{ ok: true, supabase, registrationIds }` or `{ ok: false, status, error }`
 
 ### `src/utils/csv.ts`
 

--- a/docs/registration-id-rename.md
+++ b/docs/registration-id-rename.md
@@ -106,18 +106,16 @@ column is a return-type change.
 ### JavaScript / TypeScript — 4 modules
 
 - **`src/jobs/lib.js`** — ~~the `characterID` / `character_id` pair~~ (done);
-  the `characterIds` option (registration uuids) on `forEachCharacter` /
-  `forEachCharacterAnyScope` / `forEachCorporation` remains, and shares its
-  name with three unrelated contracts — see step 2.
+  ~~the `characterIds` option~~ (done in step 8).
 - **`src/supabase.js`** — ~~`recordHeartbeat(opts.characterId)`~~ (done),
   ~~`selectToken`~~ and ~~`upsertToken`~~ (done in step 1);
-  `selectCharacterIdsWithScopes()` still returns uuids under a
-  character-flavoured name — see step 8.
+  ~~`selectCharacterIdsWithScopes()`~~ (done in step 8, along with
+  `groupCharacterIdsByCorporation()`).
 - **`src/observability.js`** — `recordEsiConditional({ characterId })` emits a
   `character_id` metric field holding a uuid. Renaming changes the shape of
   metric lines already queried in Vercel Observability.
-- **`src/app/api/mcp/lib.ts`** — `OwnerContext.characterIds` is registration
-  uuids, and it's what `resolveOwnerFilter` matches on across every MCP tool.
+- **`src/app/api/mcp/lib.ts`** — ~~`OwnerContext.characterIds`~~ (done in
+  step 8).
 
 ## Migration mechanics: what a rename does and doesn't carry
 
@@ -389,13 +387,32 @@ uuid) returns boolean` is untouched — only its body moves. So
    against a superseded signature — and it was verified to still fail on a
    deliberately wrong parameter name.
 
-8. **The JS-only contracts** — the `characterIds` option on `forEachCharacter`,
-   `OwnerContext.characterIds`, `resolvePlayer`'s return, and
-   `recordEsiConditional`'s metric field. No migration, no deploy window, so
-   these can be interleaved anywhere. Do the three `characterIds` contracts
-   together, since they share the name. `src/observability.js` is the one thing
-   worth _not_ doing: renaming the metric field breaks continuity of any saved
-   Vercel Observability query for no correctness gain.
+8. ~~**The JS-only contracts**~~ **Done.** 175 identifier occurrences across 56
+   files — `characterIds` → `registrationIds`, plus
+   `selectCharacterIdsWithScopes` / `groupCharacterIdsByCorporation` and the
+   locals derived from them.
+
+   The **singular** `characterId` was surveyed and deliberately left alone. It
+   is genuinely mixed — `/fitting/[characterId]`, the portrait URLs,
+   `ownerCharacterId` and `mainCharacterId` are all real EVE ids, and
+   `initialCharacterId` is a third-party eveship.fit prop. Only the plural was
+   uniformly a registration uuid, which is what made a tree-wide rename safe;
+   sorting out the singular is its own survey, not a sweep.
+
+   One thing this step turned out to touch that "JS-only, no deploy window"
+   didn't cover: the **Vercel queue message shape**. `characterIds` is a wire
+   contract between `dispatchRefresh` and `/api/queue/jobs`, and a message
+   already in the queue at deploy time would lose its scoping — silently, since
+   an absent key means "run for everyone" rather than an error, so the job
+   would just do more work than asked. The consumer therefore reads the old key
+   as a fallback for one release; the comment there says when to delete it.
+
+   `src/observability.js` is deliberately untouched: renaming its metric field
+   breaks continuity of any saved Vercel Observability query for no correctness
+   gain.
+
+**The cleanup is complete.** All 19 columns, 8 views, 11 function signatures,
+and the JS contracts.
 
 `src/observability.js` can be left alone or done last: renaming the metric
 field breaks continuity of any saved Observability query, which is a cost with

--- a/src/app/api/character/assets/route.ts
+++ b/src/app/api/character/assets/route.ts
@@ -55,7 +55,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
   // of this function is what kept the endpoint under Vercel's timeout, and a single
   // json scalar sidesteps PostgREST's max-rows cap.
   const { data: rows, error: rowsError } = await player.supabase.rpc('character_asset_snapshot_at', {
-    registration_ids: player.characterIds,
+    registration_ids: player.registrationIds,
     as_of: atIso,
   })
   if (rowsError) {

--- a/src/app/api/character/blueprints/route.ts
+++ b/src/app/api/character/blueprints/route.ts
@@ -43,7 +43,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
   // which keeps the field order for the sheet's columns and sidesteps
   // PostgREST's max-rows cap.
   const { data: rows, error: rowsError } = await player.supabase.rpc('character_blueprints', {
-    registration_ids: player.characterIds,
+    registration_ids: player.registrationIds,
   })
   if (rowsError) {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })

--- a/src/app/api/character/jobs/route.ts
+++ b/src/app/api/character/jobs/route.ts
@@ -79,7 +79,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
   // which keeps the field order for the sheet's columns and sidesteps PostgREST's
   // max-rows cap.
   const { data: rows, error: rowsError } = await player.supabase.rpc('character_industry_jobs', {
-    registration_ids: player.characterIds,
+    registration_ids: player.registrationIds,
     include_delivered: includeDelivered,
     as_of: at.iso,
   })

--- a/src/app/api/character/orders/route.ts
+++ b/src/app/api/character/orders/route.ts
@@ -57,7 +57,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
   // Built and returned as one json array by Postgres (character_orders), which keeps
   // the field order for the sheet's columns and sidesteps PostgREST's max-rows cap.
   const { data: rows, error: rowsError } = await player.supabase.rpc('character_orders', {
-    registration_ids: player.characterIds,
+    registration_ids: player.registrationIds,
     as_of: at.iso,
   })
   if (rowsError) {

--- a/src/app/api/corp/assets/route.ts
+++ b/src/app/api/corp/assets/route.ts
@@ -43,7 +43,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
   // Built and returned as one json array by Postgres (corp_assets), which keeps
   // the field order for the sheet's columns and sidesteps PostgREST's max-rows cap.
   const { data: rows, error: rowsError } = await player.supabase.rpc('corp_assets', {
-    registration_ids: player.characterIds,
+    registration_ids: player.registrationIds,
   })
   if (rowsError) {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })

--- a/src/app/api/corp/blueprints/route.ts
+++ b/src/app/api/corp/blueprints/route.ts
@@ -43,7 +43,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
   // keeps the field order for the sheet's columns and sidesteps PostgREST's
   // max-rows cap.
   const { data: rows, error: rowsError } = await player.supabase.rpc('corp_blueprints', {
-    registration_ids: player.characterIds,
+    registration_ids: player.registrationIds,
   })
   if (rowsError) {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })

--- a/src/app/api/corp/jobs/route.ts
+++ b/src/app/api/corp/jobs/route.ts
@@ -79,7 +79,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
   // keeps the field order for the sheet's columns and sidesteps PostgREST's
   // max-rows cap.
   const { data: rows, error: rowsError } = await player.supabase.rpc('corp_industry_jobs', {
-    registration_ids: player.characterIds,
+    registration_ids: player.registrationIds,
     include_delivered: includeDelivered,
     as_of: at.iso,
   })

--- a/src/app/api/mcp/blueprintQuery.ts
+++ b/src/app/api/mcp/blueprintQuery.ts
@@ -39,7 +39,7 @@ export type BlueprintSearchParams = {
 // Owner ids are registration uuids for characters and corporation ids for
 // corp-owned rows (the convention fetchOwnerContext uses), so a resolved owner
 // filter has to be split back into the two typed arrays the RPC takes.
-export type OwnerIds = { characterIds: string[]; corporationIds: string[] }
+export type OwnerIds = { registrationIds: string[]; corporationIds: string[] }
 
 export const partitionOwnerIds = (
   ownerIds: Set<string> | null,
@@ -48,7 +48,7 @@ export const partitionOwnerIds = (
   ownerIds == null
     ? { registration_ids: null, corporation_ids: null }
     : {
-        registration_ids: owners.characterIds.filter((id) => ownerIds.has(id)),
+        registration_ids: owners.registrationIds.filter((id) => ownerIds.has(id)),
         corporation_ids: owners.corporationIds.filter((id) => ownerIds.has(id)).map(Number),
       }
 

--- a/src/app/api/mcp/estateTools.ts
+++ b/src/app/api/mcp/estateTools.ts
@@ -294,7 +294,7 @@ export const registerEstateTools = (server: McpServer): void => {
       // character_wallet is append-only (one row per extract run), so the latest
       // balance is a per-character limit(1) rather than a scan of all history.
       const balances = await Promise.all(
-        owners.characterIds.map(async (characterId) => {
+        owners.registrationIds.map(async (characterId) => {
           const { data } = await supabase
             .from('character_wallet')
             .select('balance, recorded_at')

--- a/src/app/api/mcp/industryTools.ts
+++ b/src/app/api/mcp/industryTools.ts
@@ -202,7 +202,7 @@ export const registerIndustryTools = (server: McpServer): void => {
         }
       )
 
-      const characters = owners.characterIds
+      const characters = owners.registrationIds
         .map((characterId) => {
           const used = counts.get(characterId) ?? emptyCounts()
           const max = maxes.get(characterId) ?? baseSlotMax()

--- a/src/app/api/mcp/lib.ts
+++ b/src/app/api/mcp/lib.ts
@@ -73,7 +73,7 @@ export const resolveTypeFilter = async (
 // corporation ids for corp-owned rows — the same convention the web pages use.
 export type OwnerContext = {
   nameById: Map<string, string>
-  characterIds: string[]
+  registrationIds: string[]
   corporationIds: string[]
 }
 
@@ -81,7 +81,7 @@ export const fetchOwnerContext = async (supabase: SupabaseClient): Promise<Owner
   const owners = await fetchOwners(supabase)
   return {
     nameById: new Map([...owners.characters, ...owners.corporations].map((o) => [o.id, o.name])),
-    characterIds: owners.characters.map((o) => o.id),
+    registrationIds: owners.characters.map((o) => o.id),
     corporationIds: owners.corporations.map((o) => o.id),
   }
 }

--- a/src/app/api/mcp/tools.ts
+++ b/src/app/api/mcp/tools.ts
@@ -646,7 +646,7 @@ export const registerTools = (server: McpServer): void => {
         })
       )
 
-      const characters = owners.characterIds.map((characterId) => {
+      const characters = owners.registrationIds.map((characterId) => {
         const location = locationByCharacter.get(characterId)
         const dockedId = location?.station_id ?? location?.structure_id
         const lastJump = jumpByCharacter.get(characterId)
@@ -1016,10 +1016,10 @@ export const registerTools = (server: McpServer): void => {
       // historical) never fetches owners the caller filtered out. Corp rows
       // can't be pre-filtered this way — the corp function maps characters to
       // their corporations — so those are filtered by corporation_id below.
-      const wantedCharacterIds =
+      const wantedRegistrationIds =
         ownerFilter.ownerIds == null
-          ? owners.characterIds
-          : owners.characterIds.filter((id) => ownerFilter.ownerIds!.has(id))
+          ? owners.registrationIds
+          : owners.registrationIds.filter((id) => ownerFilter.ownerIds!.has(id))
       const corpWanted = (corporationId: number | string) =>
         ownerFilter.ownerIds == null || ownerFilter.ownerIds.has(String(corporationId))
 
@@ -1036,12 +1036,12 @@ export const registerTools = (server: McpServer): void => {
         const includeDelivered = !['active', 'ready', 'paused'].includes(wantedStatus)
         const [{ data: chr, error: chrError }, { data: corp, error: corpError }] = await Promise.all([
           supabase.rpc('character_industry_jobs', {
-            registration_ids: wantedCharacterIds,
+            registration_ids: wantedRegistrationIds,
             include_delivered: includeDelivered,
             as_of: at.iso,
           }),
           supabase.rpc('corp_industry_jobs', {
-            registration_ids: owners.characterIds,
+            registration_ids: owners.registrationIds,
             include_delivered: includeDelivered,
             as_of: at.iso,
           }),
@@ -1057,7 +1057,7 @@ export const registerTools = (server: McpServer): void => {
           .filter((j) => ofWantedStatus(j) && corpWanted(j.corporation_id))
           .map((j) => ({ ...j, ownerLabel: owners.nameById.get(String(j.corporation_id)) ?? String(j.corporation_id) }))
       } else {
-        const wantedCharacterIdSet = new Set(wantedCharacterIds)
+        const wantedRegistrationIdSet = new Set(wantedRegistrationIds)
         const [chr, corp] = await Promise.all([
           fetchAllRows<JobRow & { registration_id: string }>((from, to) => {
             let q = supabase.from('character_industry_job').select(`${COLUMNS}, registration_id`)
@@ -1071,7 +1071,7 @@ export const registerTools = (server: McpServer): void => {
           }),
         ])
         characterJobs = chr
-          .filter((j) => wantedCharacterIdSet.has(j.registration_id))
+          .filter((j) => wantedRegistrationIdSet.has(j.registration_id))
           .map((j) => ({ ...j, ownerLabel: owners.nameById.get(j.registration_id) ?? j.registration_id }))
         corpJobs = corp
           .filter((j) => corpWanted(j.corporation_id))
@@ -1185,7 +1185,7 @@ export const registerTools = (server: McpServer): void => {
       let orders: NormalizedOrder[]
       if (timeTravel) {
         const { data, error } = await supabase.rpc('character_orders', {
-          registration_ids: owners.characterIds,
+          registration_ids: owners.registrationIds,
           as_of: at.iso,
         })
         if (error) return textResult(`Couldn't read the order history: ${error.message}`)

--- a/src/app/api/queue/jobs/route.ts
+++ b/src/app/api/queue/jobs/route.ts
@@ -11,61 +11,61 @@ export const runtime = 'nodejs'
 // limit on one of those is a real risk to watch for via their heartbeat durations.
 
 // One extract job per ESI endpoint, named after that endpoint. The per-character
-// jobs accept { characterIds }; the account-wide ones (characterIds: false) do
+// jobs accept { registrationIds }; the account-wide ones (registrationIds: false) do
 // batch work over everything at once. Each entry imports lazily so loading the
 // route (and `next build`) never runs the job modules' top-level supabase
 // service-client setup, which needs env vars absent at build time.
 const JOBS = {
   'character-assets': {
-    characterIds: true,
+    registrationIds: true,
     load: async () => (await import('@/jobs/characterAssets.js')).runCharacterAssets,
   },
   'character-blueprints': {
-    characterIds: true,
+    registrationIds: true,
     load: async () => (await import('@/jobs/characterBlueprints.js')).runCharacterBlueprints,
   },
   'character-orders': {
-    characterIds: true,
+    registrationIds: true,
     load: async () => (await import('@/jobs/characterOrders.js')).runCharacterOrders,
   },
   'character-wallet': {
-    characterIds: true,
+    registrationIds: true,
     load: async () => (await import('@/jobs/characterWallet.js')).runCharacterWallet,
   },
   'character-wallet-transactions': {
-    characterIds: true,
+    registrationIds: true,
     load: async () => (await import('@/jobs/characterWalletTransactions.js')).runCharacterWalletTransactions,
   },
   'character-industry-jobs': {
-    characterIds: true,
+    registrationIds: true,
     load: async () => (await import('@/jobs/characterIndustryJobs.js')).runCharacterIndustryJobs,
   },
   'character-mercenary-dens': {
-    characterIds: true,
+    registrationIds: true,
     load: async () => (await import('@/jobs/characterMercenaryDens.js')).runCharacterMercenaryDens,
   },
   'character-fittings': {
-    characterIds: true,
+    registrationIds: true,
     load: async () => (await import('@/jobs/characterFittings.js')).runCharacterFittings,
   },
   'character-location': {
-    characterIds: true,
+    registrationIds: true,
     load: async () => (await import('@/jobs/characterLocation.js')).runCharacterLocation,
   },
   'character-clones': {
-    characterIds: true,
+    registrationIds: true,
     load: async () => (await import('@/jobs/characterClones.js')).runCharacterClones,
   },
   'character-implants': {
-    characterIds: true,
+    registrationIds: true,
     load: async () => (await import('@/jobs/characterImplants.js')).runCharacterImplants,
   },
   'character-ship': {
-    characterIds: true,
+    registrationIds: true,
     load: async () => (await import('@/jobs/characterShip.js')).runCharacterShip,
   },
   'character-skills': {
-    characterIds: true,
+    registrationIds: true,
     load: async () => (await import('@/jobs/characterSkills.js')).runCharacterSkills,
   },
   // Combined live-state job: runs character-wallet + character-location +
@@ -74,58 +74,58 @@ const JOBS = {
   // manual/backfill runs, but the cron and the /character/refresh UI dispatch
   // this one instead.
   'character-status': {
-    characterIds: true,
+    registrationIds: true,
     load: async () => (await import('@/jobs/characterStatus.js')).runCharacterStatus,
   },
   'corp-structures': {
-    characterIds: true,
+    registrationIds: true,
     load: async () => (await import('@/jobs/corpStructures.js')).runCorpStructures,
   },
   'corp-assets': {
-    characterIds: true,
+    registrationIds: true,
     load: async () => (await import('@/jobs/corpAssets.js')).runCorpAssets,
   },
   'corp-blueprints': {
-    characterIds: true,
+    registrationIds: true,
     load: async () => (await import('@/jobs/corpBlueprints.js')).runCorpBlueprints,
   },
   'corp-wallet-journal': {
-    characterIds: true,
+    registrationIds: true,
     load: async () => (await import('@/jobs/corpWalletJournal.js')).runCorpWalletJournal,
   },
   'corp-wallet-transactions': {
-    characterIds: true,
+    registrationIds: true,
     load: async () => (await import('@/jobs/corpWalletTransactions.js')).runCorpWalletTransactions,
   },
   'corp-industry-jobs': {
-    characterIds: true,
+    registrationIds: true,
     load: async () => (await import('@/jobs/corpIndustryJobs.js')).runCorpIndustryJobs,
   },
   'character-directory': {
-    characterIds: false,
+    registrationIds: false,
     load: async () => (await import('@/jobs/characterDirectory.js')).runCharacterDirectory,
   },
   'universe-names': {
-    characterIds: false,
+    registrationIds: false,
     load: async () => (await import('@/jobs/universeNames.js')).runUniverseNames,
   },
   'universe-structures': {
-    characterIds: false,
+    registrationIds: false,
     load: async () => (await import('@/jobs/universeStructures.js')).runUniverseStructures,
   },
   'industry-systems': {
-    characterIds: false,
+    registrationIds: false,
     load: async () => (await import('@/jobs/industrySystems.js')).runIndustrySystems,
   },
 } satisfies Record<
   string,
-  { characterIds: boolean; load: () => Promise<(opts?: { characterIds?: string[] }) => Promise<unknown>> }
+  { registrationIds: boolean; load: () => Promise<(opts?: { registrationIds?: string[] }) => Promise<unknown>> }
 >
 
 type JobName = keyof typeof JOBS
 
 // characterId is a registration uuid (per-character fan-out); absent runs the job
-// for everyone. characterIds carries more than one — used for the corp-scoped jobs,
+// for everyone. registrationIds carries more than one — used for the corp-scoped jobs,
 // where a single queue message covers every character known to carry the corp's
 // scope, so forEachCorporation (src/jobs/lib.js) can fall back to the next one if an
 // earlier character turns out to lack the in-game role the corp endpoint requires.
@@ -134,6 +134,12 @@ type JobName = keyof typeof JOBS
 type Msg = {
   job: JobName
   characterId?: string
+  registrationIds?: string[]
+  // Transitional: messages enqueued before the registrationIds rename carry the
+  // old key. Read for one deploy so a message already in the queue keeps its
+  // scoping — dropping it silently would widen the message to every character
+  // rather than error, and the job would just do more work than asked. Safe to
+  // delete once the queue has drained past this release.
   characterIds?: string[]
   taskId?: string
 }
@@ -151,9 +157,9 @@ const logMemoryUsage = async (job: string) => {
 // A thrown error fails the callback, so the Vercel queue retries the message
 // (per retryAfterSeconds in vercel.json).
 export const POST = handleCallback(async (message: Msg) => {
-  const { job, characterId, characterIds, taskId } = message
-  const ids = characterIds ?? (characterId != null ? [characterId] : undefined)
-  console.log(`[queue/jobs] consume job=${job} characterIds=${ids?.join(',') ?? '-'} taskId=${taskId ?? '-'}`)
+  const { job, characterId, registrationIds, characterIds, taskId } = message
+  const ids = registrationIds ?? characterIds ?? (characterId != null ? [characterId] : undefined)
+  console.log(`[queue/jobs] consume job=${job} registrationIds=${ids?.join(',') ?? '-'} taskId=${taskId ?? '-'}`)
 
   // Pilot: character-implants runs as a Vercel Workflow instead of inline, to
   // validate the queue → workflow chain before any other job migrates (see
@@ -175,8 +181,8 @@ export const POST = handleCallback(async (message: Msg) => {
 
     const runJob = async () => {
       const run = await entry.load()
-      if (entry.characterIds) {
-        await run(ids ? { characterIds: ids } : undefined)
+      if (entry.registrationIds) {
+        await run(ids ? { registrationIds: ids } : undefined)
         return
       }
       // Account-wide jobs consume a single whole-job message, so the consumer records

--- a/src/app/asset/[locationId]/page.tsx
+++ b/src/app/asset/[locationId]/page.tsx
@@ -87,7 +87,7 @@ const AssetLocationPage = async ({
 
   // In the token path every query must stay inside the sharer's scope; an
   // empty corp list still needs a filter that matches nothing.
-  const characterScope = scope?.characterIds ?? null
+  const characterScope = scope?.registrationIds ?? null
   const corpScope = scope ? (scope.corporationIds.length > 0 ? scope.corporationIds : [-1]) : null
 
   // Root-level assets at this location: ships, containers and loose stacks that

--- a/src/app/character/dispatchRefresh.ts
+++ b/src/app/character/dispatchRefresh.ts
@@ -110,12 +110,12 @@ export const dispatchRefresh = async (userId: string, characters: Character[]): 
   // For each corp-scoped job, group every account-wide character carrying its
   // scope by corporation, so the message sent for a corp's task isn't limited
   // to just the one representative character chosen above.
-  const { groupCharacterIdsByCorporation } = await import('@/supabase.js')
+  const { groupRegistrationIdsByCorporation } = await import('@/supabase.js')
   const corpGroupsByJob = new Map<string, Map<number, string[]>>()
   await Promise.all(
     PER_CORPORATION_JOBS.map(async ({ job, loadScope }) => {
       const scope = await loadScope()
-      const { byCorp } = await groupCharacterIdsByCorporation([scope])
+      const { byCorp } = await groupRegistrationIdsByCorporation([scope])
       corpGroupsByJob.set(job, byCorp)
     })
   )
@@ -159,7 +159,7 @@ export const dispatchRefresh = async (userId: string, characters: Character[]): 
   // A corp-scoped task's message carries every scoped character for its
   // corporation (see corpGroupsByJob above); every other task's message
   // carries just its own single character (or none, for the account-wide jobs).
-  const characterIdsForTask = (t: { job: string; registration_id: string | null }): string[] | undefined => {
+  const registrationIdsForTask = (t: { job: string; registration_id: string | null }): string[] | undefined => {
     if (t.registration_id == null) return undefined
     const byCorp = corpGroupsByJob.get(t.job)
     if (!byCorp) return [t.registration_id]
@@ -170,7 +170,7 @@ export const dispatchRefresh = async (userId: string, characters: Character[]): 
 
   const { send } = await import('@/utils/queue')
   const sent = await Promise.all(
-    (inserted ?? []).map((t) => send('jobs', { job: t.job, characterIds: characterIdsForTask(t), taskId: t.id }))
+    (inserted ?? []).map((t) => send('jobs', { job: t.job, registrationIds: registrationIdsForTask(t), taskId: t.id }))
   )
   console.log(
     `[dispatchRefresh] enqueued ${sent.length} jobs to topic "jobs" region=${process.env.QUEUE_REGION ?? 'sfo1'}`
@@ -187,9 +187,9 @@ export const dispatchRefresh = async (userId: string, characters: Character[]): 
 // representative lacks the in-game role the corp endpoint requires.
 export const dispatchSingleJob = async (userId: string, job: string, character: Character | null): Promise<void> => {
   // Imported lazily for the same build-time reason as dispatchRefresh above.
-  const { sudoSupabase, groupCharacterIdsByCorporation } = await import('@/supabase.js')
+  const { sudoSupabase, groupRegistrationIdsByCorporation } = await import('@/supabase.js')
 
-  const characterIdsForMessage = async (): Promise<string[] | undefined> => {
+  const registrationIdsForMessage = async (): Promise<string[] | undefined> => {
     if (!character) return undefined
     const corpJob = PER_CORPORATION_JOBS.find((j) => j.job === job)
     if (!corpJob) return [character.id]
@@ -202,10 +202,10 @@ export const dispatchSingleJob = async (userId: string, job: string, character: 
     const corporationId = registration?.corporation_id
     if (corporationId == null) return [character.id]
     const scope = await corpJob.loadScope()
-    const { byCorp } = await groupCharacterIdsByCorporation([scope])
+    const { byCorp } = await groupRegistrationIdsByCorporation([scope])
     return byCorp.get(corporationId) ?? [character.id]
   }
-  const characterIds = await characterIdsForMessage()
+  const registrationIds = await registrationIdsForMessage()
 
   const { data: inserted, error } = await sudoSupabase
     .from('refresh_task')
@@ -221,6 +221,6 @@ export const dispatchSingleJob = async (userId: string, job: string, character: 
   if (error) throw error
 
   const { send } = await import('@/utils/queue')
-  await send('jobs', { job, characterIds, taskId: inserted.id })
+  await send('jobs', { job, registrationIds, taskId: inserted.id })
   console.log(`[dispatchSingleJob] enqueued ${job} for ${character?.name ?? 'account'} taskId=${inserted.id}`)
 }

--- a/src/app/ship/[itemId]/page.tsx
+++ b/src/app/ship/[itemId]/page.tsx
@@ -199,7 +199,7 @@ const SharedShipPage = async ({ itemId, token }: { itemId: string; token: string
     .from('character_asset')
     .select('item_id, registration_id, type_id, name')
     .eq('item_id', itemId)
-    .in('registration_id', scope.characterIds)
+    .in('registration_id', scope.registrationIds)
     .maybeSingle<ShipRow>()
   const { data: corpSelf } = characterSelf
     ? { data: null }
@@ -218,7 +218,7 @@ const SharedShipPage = async ({ itemId, token }: { itemId: string; token: string
       .from('character_asset')
       .select('item_id, type_id, location_flag, quantity, is_singleton, name')
       .eq('location_id', itemId)
-      .in('registration_id', scope.characterIds),
+      .in('registration_id', scope.registrationIds),
     supabase
       .from('corp_asset')
       .select('item_id, type_id, location_flag, quantity, is_singleton')

--- a/src/app/ship/access.ts
+++ b/src/app/ship/access.ts
@@ -10,7 +10,7 @@ import { createServiceClient } from '@/utils/supabase/service'
 export type ShareScope = {
   userId: string
   // registration uuids (character_asset.registration_id values) of the sharer
-  characterIds: string[]
+  registrationIds: string[]
   // character name per registration uuid, for owner display
   characterNames: Map<string, string>
   // EVE corporation ids the sharer's characters belong to (corp_asset scope)
@@ -36,7 +36,7 @@ export const resolveShareToken = async (token: string, itemId: string): Promise<
 
   return {
     userId: share.user_id,
-    characterIds: rows.map((r) => r.id),
+    registrationIds: rows.map((r) => r.id),
     characterNames: new Map(rows.map((r) => [r.id, r.name])),
     corporationIds: [...new Set(rows.filter((r) => r.corporation_id != null).map((r) => Number(r.corporation_id)))],
   }

--- a/src/jobs/characterAssets.js
+++ b/src/jobs/characterAssets.js
@@ -156,17 +156,21 @@ const reconcile = async (registration_id, fetched, names) => {
   return { touched: touchIds.length, opened: inserts.length, closed: allCloseIds.length }
 }
 
-export const runCharacterAssets = ({ characterIds } = {}) =>
-  forEachCharacter(TAG, { scope: SCOPE, characterIds }, async ({ access_token, characterID, registration_id, ctx }) => {
-    const t0 = Date.now()
-    const fetched = await fetchAllPages((page) => assets(access_token, characterID, page))
-    const names = await fetchNames(access_token, characterID, fetched)
-    const { touched, opened, closed } = await reconcile(registration_id, fetched, names)
+export const runCharacterAssets = ({ registrationIds } = {}) =>
+  forEachCharacter(
+    TAG,
+    { scope: SCOPE, registrationIds },
+    async ({ access_token, characterID, registration_id, ctx }) => {
+      const t0 = Date.now()
+      const fetched = await fetchAllPages((page) => assets(access_token, characterID, page))
+      const names = await fetchNames(access_token, characterID, fetched)
+      const { touched, opened, closed } = await reconcile(registration_id, fetched, names)
 
-    const dt = Date.now() - t0
-    console.log(
-      `[${TAG}] ${ctx}: ${fetched.length} asset(s); ${touched} unchanged, ${opened} opened, ${closed} closed in ${dt}ms`
-    )
-  })
+      const dt = Date.now() - t0
+      console.log(
+        `[${TAG}] ${ctx}: ${fetched.length} asset(s); ${touched} unchanged, ${opened} opened, ${closed} closed in ${dt}ms`
+      )
+    }
+  )
 
 cli(import.meta.url, TAG, runCharacterAssets)

--- a/src/jobs/characterBlueprints.js
+++ b/src/jobs/characterBlueprints.js
@@ -123,16 +123,20 @@ const reconcile = async (registration_id, fetched) => {
   return { touched: touchIds.length, opened: inserts.length, closed: allCloseIds.length }
 }
 
-export const runCharacterBlueprints = ({ characterIds } = {}) =>
-  forEachCharacter(TAG, { scope: SCOPE, characterIds }, async ({ access_token, characterID, registration_id, ctx }) => {
-    const t0 = Date.now()
-    const fetched = await fetchAllPages((page) => blueprints(access_token, characterID, page))
-    const { touched, opened, closed } = await reconcile(registration_id, fetched)
+export const runCharacterBlueprints = ({ registrationIds } = {}) =>
+  forEachCharacter(
+    TAG,
+    { scope: SCOPE, registrationIds },
+    async ({ access_token, characterID, registration_id, ctx }) => {
+      const t0 = Date.now()
+      const fetched = await fetchAllPages((page) => blueprints(access_token, characterID, page))
+      const { touched, opened, closed } = await reconcile(registration_id, fetched)
 
-    const dt = Date.now() - t0
-    console.log(
-      `[${TAG}] ${ctx}: ${fetched.length} blueprint(s); ${touched} unchanged, ${opened} opened, ${closed} closed in ${dt}ms`
-    )
-  })
+      const dt = Date.now() - t0
+      console.log(
+        `[${TAG}] ${ctx}: ${fetched.length} blueprint(s); ${touched} unchanged, ${opened} opened, ${closed} closed in ${dt}ms`
+      )
+    }
+  )
 
 cli(import.meta.url, TAG, runCharacterBlueprints)

--- a/src/jobs/characterClones.js
+++ b/src/jobs/characterClones.js
@@ -214,9 +214,9 @@ export const syncCharacterClones = async ({ access_token, characterID, registrat
   console.log(`[${TAG}] ${ctx}: ${touched} unchanged, ${opened} opened, ${closed} closed`)
 }
 
-export const runCharacterClones = ({ characterIds } = {}) => {
+export const runCharacterClones = ({ registrationIds } = {}) => {
   const resolveSystem = makeSystemResolver()
-  return forEachCharacter(TAG, { scope: SCOPE, characterIds }, (handlerCtx) =>
+  return forEachCharacter(TAG, { scope: SCOPE, registrationIds }, (handlerCtx) =>
     syncCharacterClones(handlerCtx, resolveSystem)
   )
 }

--- a/src/jobs/characterFittings.js
+++ b/src/jobs/characterFittings.js
@@ -126,10 +126,10 @@ const reconcile = async (registration_id, fetched) => {
 // added, edited or deleted since last run — the common case, since a fitting
 // library changes far less often than assets or orders — so the whole
 // reconcile is skipped.
-export const runCharacterFittings = ({ characterIds } = {}) =>
+export const runCharacterFittings = ({ registrationIds } = {}) =>
   forEachCharacter(
     TAG,
-    { scope: SCOPE, characterIds },
+    { scope: SCOPE, registrationIds },
     async ({ access_token, characterID, registration_id, name }) => {
       const cacheKey = `${TAG}:${registration_id}`
       const priorEtag = await getEsiEtag(cacheKey)

--- a/src/jobs/characterImplants.js
+++ b/src/jobs/characterImplants.js
@@ -24,7 +24,7 @@ export const syncCharacterImplants = async ({ access_token, characterID, registr
   console.log(`[${TAG}] ${ctx}: ${(typeIds ?? []).length} implant(s)`)
 }
 
-export const runCharacterImplants = ({ characterIds } = {}) =>
-  forEachCharacter(TAG, { scope: SCOPE, characterIds }, syncCharacterImplants)
+export const runCharacterImplants = ({ registrationIds } = {}) =>
+  forEachCharacter(TAG, { scope: SCOPE, registrationIds }, syncCharacterImplants)
 
 cli(import.meta.url, TAG, runCharacterImplants)

--- a/src/jobs/characterIndustryJobs.js
+++ b/src/jobs/characterIndustryJobs.js
@@ -134,10 +134,10 @@ const reconcile = async (registration_id, fetched) => {
 // status recorded too. Conditional: a 304 means the job list and every status
 // is unchanged since last run (nothing started or completed), so the whole
 // reconcile is skipped.
-export const runCharacterIndustryJobs = ({ characterIds } = {}) =>
+export const runCharacterIndustryJobs = ({ registrationIds } = {}) =>
   forEachCharacter(
     TAG,
-    { scope: SCOPE, characterIds },
+    { scope: SCOPE, registrationIds },
     async ({ access_token, characterID, registration_id, name }) => {
       const cacheKey = `${TAG}:${registration_id}`
       const priorEtag = await getEsiEtag(cacheKey)

--- a/src/jobs/characterLocation.js
+++ b/src/jobs/characterLocation.js
@@ -25,7 +25,7 @@ export const syncCharacterLocation = async ({ access_token, characterID, registr
   console.log(`[${TAG}] ${ctx}: solar_system_id=${location.solar_system_id}`)
 }
 
-export const runCharacterLocation = ({ characterIds } = {}) =>
-  forEachCharacter(TAG, { scope: SCOPE, characterIds }, syncCharacterLocation)
+export const runCharacterLocation = ({ registrationIds } = {}) =>
+  forEachCharacter(TAG, { scope: SCOPE, registrationIds }, syncCharacterLocation)
 
 cli(import.meta.url, TAG, runCharacterLocation)

--- a/src/jobs/characterMercenaryDens.js
+++ b/src/jobs/characterMercenaryDens.js
@@ -107,7 +107,7 @@ export const syncCharacterMercenaryDens = async ({ access_token, characterID, re
   console.log(`[${TAG}] ${name} ${registration_id} (${characterID}): ${listed.length} den(s)`)
 }
 
-export const runCharacterMercenaryDens = ({ characterIds } = {}) =>
-  forEachCharacter(TAG, { scope: SCOPE, characterIds }, syncCharacterMercenaryDens)
+export const runCharacterMercenaryDens = ({ registrationIds } = {}) =>
+  forEachCharacter(TAG, { scope: SCOPE, registrationIds }, syncCharacterMercenaryDens)
 
 cli(import.meta.url, TAG, runCharacterMercenaryDens)

--- a/src/jobs/characterOrders.js
+++ b/src/jobs/characterOrders.js
@@ -126,10 +126,10 @@ const reconcile = async (registration_id, fetched) => {
 // open-orders endpoint is a full snapshot, reconciled into versioned history.
 // Conditional: a 304 means the open-order set is byte-identical to last run —
 // nothing filled, expired or re-priced — so the whole reconcile is skipped.
-export const runCharacterOrders = ({ characterIds } = {}) =>
+export const runCharacterOrders = ({ registrationIds } = {}) =>
   forEachCharacter(
     TAG,
-    { scope: SCOPE, characterIds },
+    { scope: SCOPE, registrationIds },
     async ({ access_token, characterID, registration_id, name }) => {
       const cacheKey = `${TAG}:${registration_id}`
       const priorEtag = await getEsiEtag(cacheKey)

--- a/src/jobs/characterShip.js
+++ b/src/jobs/characterShip.js
@@ -73,7 +73,7 @@ export const syncCharacterShip = async ({ access_token, characterID, registratio
   console.log(`[${TAG}] ${ctx}: ship_item_id=${ship.ship_item_id}${changed ? ' (changed)' : ''}`)
 }
 
-export const runCharacterShip = ({ characterIds } = {}) =>
-  forEachCharacter(TAG, { scope: SCOPE, characterIds }, syncCharacterShip)
+export const runCharacterShip = ({ registrationIds } = {}) =>
+  forEachCharacter(TAG, { scope: SCOPE, registrationIds }, syncCharacterShip)
 
 cli(import.meta.url, TAG, runCharacterShip)

--- a/src/jobs/characterSkills.js
+++ b/src/jobs/characterSkills.js
@@ -98,7 +98,7 @@ export const syncCharacterSkills = async ({ access_token, characterID, registrat
   )
 }
 
-export const runCharacterSkills = ({ characterIds } = {}) =>
-  forEachCharacter(TAG, { scope: SCOPE, characterIds }, syncCharacterSkills)
+export const runCharacterSkills = ({ registrationIds } = {}) =>
+  forEachCharacter(TAG, { scope: SCOPE, registrationIds }, syncCharacterSkills)
 
 cli(import.meta.url, TAG, runCharacterSkills)

--- a/src/jobs/characterStatus.js
+++ b/src/jobs/characterStatus.js
@@ -26,7 +26,7 @@ const TAG = 'character-status'
 // UI merge into this job.
 export const SCOPES = [WALLET_SCOPE, LOCATION_SCOPE, IMPLANTS_SCOPE, CLONES_SCOPE, SHIP_SCOPE, SKILLS_SCOPE]
 
-export const runCharacterStatus = ({ characterIds } = {}) => {
+export const runCharacterStatus = ({ registrationIds } = {}) => {
   // One resolver memo for the whole run: clones across characters cluster in the
   // same few stations/structures, so each location resolves at most once.
   const resolveSystem = makeSystemResolver()
@@ -40,7 +40,7 @@ export const runCharacterStatus = ({ characterIds } = {}) => {
     { scope: SKILLS_SCOPE, label: 'skills', run: syncCharacterSkills },
   ]
 
-  return forEachCharacterAnyScope(TAG, { scopes: SCOPES, characterIds }, async (handlerCtx) => {
+  return forEachCharacterAnyScope(TAG, { scopes: SCOPES, registrationIds }, async (handlerCtx) => {
     const { scopes, ctx } = handlerCtx
     // Run each endpoint the token is authorized for, isolating failures so a
     // partial outage still records the parts that succeeded. The character's

--- a/src/jobs/characterWallet.js
+++ b/src/jobs/characterWallet.js
@@ -16,7 +16,7 @@ export const syncCharacterWallet = async ({ access_token, characterID, registrat
   console.log(`[${TAG}] ${name} ${registration_id} (${characterID}): ${balance}`)
 }
 
-export const runCharacterWallet = ({ characterIds } = {}) =>
-  forEachCharacter(TAG, { scope: SCOPE, characterIds }, syncCharacterWallet)
+export const runCharacterWallet = ({ registrationIds } = {}) =>
+  forEachCharacter(TAG, { scope: SCOPE, registrationIds }, syncCharacterWallet)
 
 cli(import.meta.url, TAG, runCharacterWallet)

--- a/src/jobs/characterWalletTransactions.js
+++ b/src/jobs/characterWalletTransactions.js
@@ -10,10 +10,10 @@ const SCOPE = 'esi-wallet.read_character_wallet.v1'
 // transaction_id is globally unique in EVE, so the upsert dedupes re-fetches of
 // the same recent history. Conditional: a 304 means no new transactions since
 // last run, so the upsert is skipped.
-export const runCharacterWalletTransactions = ({ characterIds } = {}) =>
+export const runCharacterWalletTransactions = ({ registrationIds } = {}) =>
   forEachCharacter(
     TAG,
-    { scope: SCOPE, characterIds },
+    { scope: SCOPE, registrationIds },
     async ({ access_token, characterID, registration_id, name }) => {
       const cacheKey = `${TAG}:${registration_id}`
       const priorEtag = await getEsiEtag(cacheKey)

--- a/src/jobs/corpAssets.js
+++ b/src/jobs/corpAssets.js
@@ -126,8 +126,8 @@ const reconcile = async (corporation_id, fetched) => {
   return { touched: touchIds.length, opened: inserts.length, closed: allCloseIds.length }
 }
 
-export const runCorpAssets = ({ characterIds } = {}) =>
-  forEachCorporation(TAG, { scope: SCOPE, characterIds }, async ({ access_token, corporation_id, ctx }) => {
+export const runCorpAssets = ({ registrationIds } = {}) =>
+  forEachCorporation(TAG, { scope: SCOPE, registrationIds }, async ({ access_token, corporation_id, ctx }) => {
     const t0 = Date.now()
 
     // Our structures double as asset location_ids; only keep rigs fitted to them.

--- a/src/jobs/corpBlueprints.js
+++ b/src/jobs/corpBlueprints.js
@@ -114,8 +114,8 @@ const reconcile = async (corporation_id, fetched) => {
   return { touched: touchIds.length, opened: inserts.length, closed: allCloseIds.length }
 }
 
-export const runCorpBlueprints = ({ characterIds } = {}) =>
-  forEachCorporation(TAG, { scope: SCOPE, characterIds }, async ({ access_token, corporation_id, ctx }) => {
+export const runCorpBlueprints = ({ registrationIds } = {}) =>
+  forEachCorporation(TAG, { scope: SCOPE, registrationIds }, async ({ access_token, corporation_id, ctx }) => {
     const t0 = Date.now()
     const fetched = await fetchAllPages((page) => corpBlueprints(access_token, corporation_id, page))
     const { touched, opened, closed } = await reconcile(corporation_id, fetched)

--- a/src/jobs/corpIndustryJobs.js
+++ b/src/jobs/corpIndustryJobs.js
@@ -117,8 +117,8 @@ const reconcile = async (corporation_id, fetched) => {
 // GET /corporations/{id}/industry/jobs/ → corp_industry_job_over_time (SCD type
 // 2). Fetched with include_completed, so finished jobs get their terminal
 // status recorded too. installer_id is the character who started each job.
-export const runCorpIndustryJobs = ({ characterIds } = {}) =>
-  forEachCorporation(TAG, { scope: SCOPE, characterIds }, async ({ access_token, corporation_id, ctx }) => {
+export const runCorpIndustryJobs = ({ registrationIds } = {}) =>
+  forEachCorporation(TAG, { scope: SCOPE, registrationIds }, async ({ access_token, corporation_id, ctx }) => {
     const t0 = Date.now()
     const jobs = await fetchAllPages((page) => corpIndustryJobs(access_token, corporation_id, page))
     const { touched, opened, closed } = await reconcile(corporation_id, jobs)

--- a/src/jobs/corpStructures.js
+++ b/src/jobs/corpStructures.js
@@ -7,8 +7,8 @@ const SCOPE = 'esi-corporations.read_structures.v1'
 
 // GET /corporations/{id}/structures/ → corp_structure. Upserts the corp's
 // Upwell structures (state, fuel, reinforcement windows, services).
-export const runCorpStructures = ({ characterIds } = {}) =>
-  forEachCorporation(TAG, { scope: SCOPE, characterIds }, async ({ access_token, corporation_id, ctx }) => {
+export const runCorpStructures = ({ registrationIds } = {}) =>
+  forEachCorporation(TAG, { scope: SCOPE, registrationIds }, async ({ access_token, corporation_id, ctx }) => {
     const t0 = Date.now()
     const all = await fetchAllPages((page) => corpStructures(access_token, corporation_id, page))
 

--- a/src/jobs/corpWalletJournal.js
+++ b/src/jobs/corpWalletJournal.js
@@ -55,8 +55,8 @@ const fetchDivisionPage = async (access_token, corporation_id, division, cutoff,
 const fetchDivision = (access_token, corporation_id, division, cutoff) =>
   fetchDivisionPage(access_token, corporation_id, division, cutoff, 1)
 
-export const runCorpWalletJournal = ({ characterIds } = {}) =>
-  forEachCorporation(TAG, { scope: SCOPE, characterIds }, async ({ access_token, corporation_id, ctx }) => {
+export const runCorpWalletJournal = ({ registrationIds } = {}) =>
+  forEachCorporation(TAG, { scope: SCOPE, registrationIds }, async ({ access_token, corporation_id, ctx }) => {
     const cutoff = Date.now() - JOURNAL_LOOKBACK_MS
     let failures = 0
     await forEachSequential(WALLET_DIVISIONS, async (division) => {

--- a/src/jobs/corpWalletTransactions.js
+++ b/src/jobs/corpWalletTransactions.js
@@ -15,10 +15,10 @@ const WALLET_DIVISIONS = [1, 2, 3, 4, 5, 6, 7]
 // unique in EVE, so the upsert dedupes across divisions and re-scans (first
 // scanner wins attribution). Each division is isolated: one division failing
 // (e.g. a permissions edge) doesn't abort the others.
-export const runCorpWalletTransactions = ({ characterIds } = {}) =>
+export const runCorpWalletTransactions = ({ registrationIds } = {}) =>
   forEachCorporation(
     TAG,
-    { scope: SCOPE, characterIds },
+    { scope: SCOPE, registrationIds },
     async ({ access_token, corporation_id, registration_id, ctx }) => {
       let failures = 0
       await forEachSequential(WALLET_DIVISIONS, async (division) => {

--- a/src/jobs/lib.js
+++ b/src/jobs/lib.js
@@ -26,7 +26,7 @@ const withHeartbeat = async (tag, owner, fn) => {
 
 // Shared plumbing for the per-endpoint extract jobs. Every job follows the same
 // shape: enumerate the tokens carrying the endpoint's ESI scope (optionally
-// narrowed to specific registrations by `characterIds`, e.g. a single character
+// narrowed to specific registrations by `registrationIds`, e.g. a single character
 // fanned out from the Vercel queue), refresh each token, and hand the fresh
 // access token to the job's handler. A failing character/corp is logged and
 // skipped so one bad token never aborts the rest of the run; a fatal lookup
@@ -109,11 +109,11 @@ const runTokenLoop = async (tag, tokens, { characterName, characterUserId, heart
 // by forEachCorporation, which records its own corp-attributed heartbeat instead
 // so a corp job doesn't get two rows (one bare-character, one per-corp) for
 // the same unit of work.
-export const forEachCharacter = async (tag, { scope, characterIds, heartbeat = true }, handler) => {
+export const forEachCharacter = async (tag, { scope, registrationIds, heartbeat = true }, handler) => {
   const { characterName, characterUserId } = await loadCharacterMaps(tag)
 
   let tokenQuery = sudoSupabase.from('token').select('id, registration_id, refresh_token').contains('scope', [scope])
-  if (characterIds) tokenQuery = tokenQuery.in('registration_id', characterIds)
+  if (registrationIds) tokenQuery = tokenQuery.in('registration_id', registrationIds)
   const { data: tokens, error } = await tokenQuery
   if (error) {
     console.error(`[${tag}] token lookup failed:`, error)
@@ -130,11 +130,11 @@ export const forEachCharacter = async (tag, { scope, characterIds, heartbeat = t
 // least one of `scopes` (Postgres array overlap), and passes the token's fresh
 // scope list to the handler as `scopes` so it can run only the endpoints that
 // token is actually authorized for. One heartbeat per character, under `tag`.
-export const forEachCharacterAnyScope = async (tag, { scopes, characterIds, heartbeat = true }, handler) => {
+export const forEachCharacterAnyScope = async (tag, { scopes, registrationIds, heartbeat = true }, handler) => {
   const { characterName, characterUserId } = await loadCharacterMaps(tag)
 
   let tokenQuery = sudoSupabase.from('token').select('id, registration_id, refresh_token').overlaps('scope', scopes)
-  if (characterIds) tokenQuery = tokenQuery.in('registration_id', characterIds)
+  if (registrationIds) tokenQuery = tokenQuery.in('registration_id', registrationIds)
   const { data: tokens, error } = await tokenQuery
   if (error) {
     console.error(`[${tag}] token lookup failed:`, error)
@@ -165,11 +165,11 @@ export const forEachCharacterAnyScope = async (tag, { scopes, characterIds, hear
 // the character whose token authorized the pull, so "which user" is derivable
 // too); the inner forEachCharacter's own per-character heartbeat is disabled to
 // avoid a redundant second row for the same unit of work.
-export const forEachCorporation = async (tag, { scope, characterIds }, handler) => {
+export const forEachCorporation = async (tag, { scope, registrationIds }, handler) => {
   const seenCorps = new Set()
   await forEachCharacter(
     tag,
-    { scope, characterIds, heartbeat: false },
+    { scope, registrationIds, heartbeat: false },
     async ({ access_token, characterID, registration_id, userId, ctx }) => {
       const info = await fetchCharacter(access_token, characterID)
       const corporation_id = info?.corporation_id

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -135,7 +135,7 @@ export const selectCharacters = async (columns, owner) => {
 // Distinct registration ids that hold a token with ANY of the given ESI scopes.
 // The Vercel cron producers use this to enumerate the characters to fan out one
 // queue message per character. Throws on a lookup failure.
-export const selectCharacterIdsWithScopes = async (scopes) => {
+export const selectRegistrationIdsWithScopes = async (scopes) => {
   const perScope = await Promise.all(
     map(async (scope) => {
       const { data, error } = await sudoSupabase.from('token').select('registration_id').contains('scope', [scope])
@@ -157,14 +157,14 @@ export const selectCharacterIdsWithScopes = async (scopes) => {
 // needs the full group to fall back through if the first one it tries can't.
 // Sending two *separate* messages for the same corp instead would race two
 // concurrent reconciles against each other and corrupt the SCD-2 tables.
-export const groupCharacterIdsByCorporation = async (scopes) => {
-  const characterIds = await selectCharacterIdsWithScopes(scopes)
-  if (characterIds.length === 0) return { byCorp: new Map(), unresolved: [] }
+export const groupRegistrationIdsByCorporation = async (scopes) => {
+  const registrationIds = await selectRegistrationIdsWithScopes(scopes)
+  if (registrationIds.length === 0) return { byCorp: new Map(), unresolved: [] }
 
   const { data: registrations, error } = await sudoSupabase
     .from('registration')
     .select('id, corporation_id')
-    .in('id', characterIds)
+    .in('id', registrationIds)
   if (error) throw error
 
   const byCorp = new Map()

--- a/src/utils/apiToken.ts
+++ b/src/utils/apiToken.ts
@@ -1,7 +1,7 @@
 import { createServiceClient } from '@/utils/supabase/service'
 
 type Resolved =
-  | { ok: true; supabase: ReturnType<typeof createServiceClient>; characterIds: string[] }
+  | { ok: true; supabase: ReturnType<typeof createServiceClient>; registrationIds: string[] }
   | { ok: false; status: number; error: string }
 
 // Resolve a per-user api_token (from the IMPORTDATA query string) to the owner's
@@ -35,5 +35,5 @@ export const resolvePlayer = async (token: string | undefined): Promise<Resolved
     return { ok: false, status: 500, error: 'Lookup failed' }
   }
 
-  return { ok: true, supabase, characterIds: (characters ?? []).map((c) => c.id) }
+  return { ok: true, supabase, registrationIds: (characters ?? []).map((c) => c.id) }
 }

--- a/src/utils/cron.ts
+++ b/src/utils/cron.ts
@@ -38,25 +38,25 @@ export const runDirectCronJob = async (job: string, run: () => Promise<unknown>)
 // many characters are registered, and records its own per-character
 // heartbeat (see forEachCharacter/forEachCorporation in src/jobs/lib.js).
 export const fanOutPerCharacterCronJob = async (job: string, scope: string) => {
-  const { selectCharacterIdsWithScopes } = await import('@/supabase.js')
+  const { selectRegistrationIdsWithScopes } = await import('@/supabase.js')
   const { send } = await import('@/utils/queue')
-  const characterIds = await selectCharacterIdsWithScopes([scope])
-  await Promise.all(characterIds.map((characterId) => send('jobs', { job, characterId })))
-  return characterIds.length
+  const registrationIds = await selectRegistrationIdsWithScopes([scope])
+  await Promise.all(registrationIds.map((characterId) => send('jobs', { job, characterId })))
+  return registrationIds.length
 }
 
 // Same fan-out as fanOutPerCharacterCronJob, but for a job that fronts several
 // endpoints with different scopes (character-status): enumerate every character
-// carrying *any* of `scopes` (selectCharacterIdsWithScopes already unions them)
+// carrying *any* of `scopes` (selectRegistrationIdsWithScopes already unions them)
 // and send one message each. The consumer's handler
 // (forEachCharacterAnyScope) then runs only the endpoints each token is
 // authorized for.
 export const fanOutPerCharacterAnyScopeCronJob = async (job: string, scopes: string[]) => {
-  const { selectCharacterIdsWithScopes } = await import('@/supabase.js')
+  const { selectRegistrationIdsWithScopes } = await import('@/supabase.js')
   const { send } = await import('@/utils/queue')
-  const characterIds = await selectCharacterIdsWithScopes(scopes)
-  await Promise.all(characterIds.map((characterId) => send('jobs', { job, characterId })))
-  return characterIds.length
+  const registrationIds = await selectRegistrationIdsWithScopes(scopes)
+  await Promise.all(registrationIds.map((characterId) => send('jobs', { job, characterId })))
+  return registrationIds.length
 }
 
 // For the corp-scoped extract jobs (corp-assets, corp-industry-jobs,
@@ -80,12 +80,12 @@ export const fanOutPerCharacterAnyScopeCronJob = async (job: string, scopes: str
 // character up front had no way to know which of them ESI would actually let
 // through.
 export const fanOutPerCorporationCronJob = async (job: string, scope: string) => {
-  const { groupCharacterIdsByCorporation } = await import('@/supabase.js')
+  const { groupRegistrationIdsByCorporation } = await import('@/supabase.js')
   const { send } = await import('@/utils/queue')
-  const { byCorp, unresolved } = await groupCharacterIdsByCorporation([scope])
+  const { byCorp, unresolved } = await groupRegistrationIdsByCorporation([scope])
 
   const groups = [...byCorp.values(), ...unresolved.map((id: string) => [id])]
-  await Promise.all(groups.map((characterIds) => send('jobs', { job, characterIds })))
+  await Promise.all(groups.map((registrationIds) => send('jobs', { job, registrationIds })))
   return groups.length
 }
 

--- a/src/workflows/characterAssets.ts
+++ b/src/workflows/characterAssets.ts
@@ -41,7 +41,7 @@ const LANES = 4
 async function syncCharacter(characterId: number) {
   'use step'
   const { runCharacterAssets } = await import('@/jobs/characterAssets.js')
-  await runCharacterAssets({ characterIds: [characterId] })
+  await runCharacterAssets({ registrationIds: [characterId] })
 }
 
 export async function characterAssetsWorkflow() {

--- a/src/workflows/characterBlueprints.ts
+++ b/src/workflows/characterBlueprints.ts
@@ -40,7 +40,7 @@ const LANES = 4
 async function syncCharacter(characterId: number) {
   'use step'
   const { runCharacterBlueprints } = await import('@/jobs/characterBlueprints.js')
-  await runCharacterBlueprints({ characterIds: [characterId] })
+  await runCharacterBlueprints({ registrationIds: [characterId] })
 }
 
 export async function characterBlueprintsWorkflow() {

--- a/src/workflows/characterFittings.ts
+++ b/src/workflows/characterFittings.ts
@@ -33,7 +33,7 @@ const LANES = 4
 async function syncCharacter(characterId: number) {
   'use step'
   const { runCharacterFittings } = await import('@/jobs/characterFittings.js')
-  await runCharacterFittings({ characterIds: [characterId] })
+  await runCharacterFittings({ registrationIds: [characterId] })
 }
 
 export async function characterFittingsWorkflow() {

--- a/src/workflows/characterImplants.ts
+++ b/src/workflows/characterImplants.ts
@@ -7,18 +7,18 @@
 // invocation with its own duration budget — the two things the queue consumer's
 // single 60s invocation can't offer.
 
-async function syncImplants(characterIds?: string[]) {
+async function syncImplants(registrationIds?: string[]) {
   'use step'
   // Lazy import, same reason as the consumer's JOBS registry: the job module's
   // top-level supabase/esi setup needs env vars absent at build time.
   const { runCharacterImplants } = await import('@/jobs/characterImplants.js')
-  await runCharacterImplants(characterIds ? { characterIds } : undefined)
+  await runCharacterImplants(registrationIds ? { registrationIds } : undefined)
 }
 
 // One run per queue message; the step gets Workflows' default bounded retries.
 // runCharacterImplants (forEachCharacter in src/jobs/lib.js) still does token
 // refresh, per-character heartbeats, and the character_implant upsert unchanged.
-export async function characterImplantsWorkflow(characterIds?: string[]) {
+export async function characterImplantsWorkflow(registrationIds?: string[]) {
   'use workflow'
-  await syncImplants(characterIds)
+  await syncImplants(registrationIds)
 }

--- a/src/workflows/characterIndustryJobs.ts
+++ b/src/workflows/characterIndustryJobs.ts
@@ -34,7 +34,7 @@ const LANES = 4
 async function syncCharacter(characterId: number) {
   'use step'
   const { runCharacterIndustryJobs } = await import('@/jobs/characterIndustryJobs.js')
-  await runCharacterIndustryJobs({ characterIds: [characterId] })
+  await runCharacterIndustryJobs({ registrationIds: [characterId] })
 }
 
 export async function characterIndustryJobsWorkflow() {

--- a/src/workflows/characterMercenaryDens.ts
+++ b/src/workflows/characterMercenaryDens.ts
@@ -42,7 +42,7 @@ const LANES = 4
 async function syncCharacter(characterId: number) {
   'use step'
   const { runCharacterMercenaryDens } = await import('@/jobs/characterMercenaryDens.js')
-  await runCharacterMercenaryDens({ characterIds: [characterId] })
+  await runCharacterMercenaryDens({ registrationIds: [characterId] })
 }
 
 export async function characterMercenaryDensWorkflow() {

--- a/src/workflows/characterOrders.ts
+++ b/src/workflows/characterOrders.ts
@@ -34,7 +34,7 @@ const LANES = 4
 async function syncCharacter(characterId: number) {
   'use step'
   const { runCharacterOrders } = await import('@/jobs/characterOrders.js')
-  await runCharacterOrders({ characterIds: [characterId] })
+  await runCharacterOrders({ registrationIds: [characterId] })
 }
 
 export async function characterOrdersWorkflow() {

--- a/src/workflows/characterSkills.ts
+++ b/src/workflows/characterSkills.ts
@@ -30,7 +30,7 @@ const LANES = 4
 async function syncCharacter(characterId: number) {
   'use step'
   const { runCharacterSkills } = await import('@/jobs/characterSkills.js')
-  await runCharacterSkills({ characterIds: [characterId] })
+  await runCharacterSkills({ registrationIds: [characterId] })
 }
 
 export async function characterSkillsWorkflow() {

--- a/src/workflows/characterStatus.ts
+++ b/src/workflows/characterStatus.ts
@@ -6,7 +6,7 @@
 // Same fan-out shape as the three per-character jobs already migrated, with one
 // wrinkle: character-status fronts five endpoints with *different* scopes, so it
 // enumerates every character carrying *any* of them. enumerateCharacters passes
-// the scopes straight to selectCharacterIdsWithScopes, which unions them (array
+// the scopes straight to selectRegistrationIdsWithScopes, which unions them (array
 // overlap) — exactly what fanOutPerCharacterAnyScopeCronJob did. The job's
 // handler (forEachCharacterAnyScope) still runs only the endpoints each token is
 // authorized for.
@@ -51,7 +51,7 @@ const LANES = 4
 async function syncCharacter(characterId: number) {
   'use step'
   const { runCharacterStatus } = await import('@/jobs/characterStatus.js')
-  await runCharacterStatus({ characterIds: [characterId] })
+  await runCharacterStatus({ registrationIds: [characterId] })
 }
 
 export async function characterStatusWorkflow() {

--- a/src/workflows/characterWalletTransactions.ts
+++ b/src/workflows/characterWalletTransactions.ts
@@ -34,7 +34,7 @@ const LANES = 4
 async function syncCharacter(characterId: number) {
   'use step'
   const { runCharacterWalletTransactions } = await import('@/jobs/characterWalletTransactions.js')
-  await runCharacterWalletTransactions({ characterIds: [characterId] })
+  await runCharacterWalletTransactions({ registrationIds: [characterId] })
 }
 
 export async function characterWalletTransactionsWorkflow() {

--- a/src/workflows/corpAssets.ts
+++ b/src/workflows/corpAssets.ts
@@ -38,12 +38,12 @@ const LANES = 2
 // job module's top-level supabase/esi setup needs env vars absent at build
 // time). forEachCorporation still refreshes tokens, dedupes to one handler call
 // per corp, falls back through the group on a role failure, and records the
-// per-corp heartbeat pair — all unchanged. characterIds (registration uuids) is
+// per-corp heartbeat pair — all unchanged. registrationIds (registration uuids) is
 // the only thing crossing the step boundary, and serializable.
-async function syncCorporation(characterIds: string[]) {
+async function syncCorporation(registrationIds: string[]) {
   'use step'
   const { runCorpAssets } = await import('@/jobs/corpAssets.js')
-  await runCorpAssets({ characterIds })
+  await runCorpAssets({ registrationIds })
 }
 
 export async function corpAssetsWorkflow() {

--- a/src/workflows/corpIndustryJobs.ts
+++ b/src/workflows/corpIndustryJobs.ts
@@ -35,12 +35,12 @@ const LANES = 2
 // job module's top-level supabase/esi setup needs env vars absent at build
 // time). forEachCorporation still refreshes tokens, dedupes to one handler call
 // per corp, falls back through the group on a role failure, and records the
-// per-corp heartbeat pair — all unchanged. characterIds (registration uuids) is
+// per-corp heartbeat pair — all unchanged. registrationIds (registration uuids) is
 // the only thing crossing the step boundary, and serializable.
-async function syncCorporation(characterIds: string[]) {
+async function syncCorporation(registrationIds: string[]) {
   'use step'
   const { runCorpIndustryJobs } = await import('@/jobs/corpIndustryJobs.js')
-  await runCorpIndustryJobs({ characterIds })
+  await runCorpIndustryJobs({ registrationIds })
 }
 
 export async function corpIndustryJobsWorkflow() {

--- a/src/workflows/corpWalletTransactions.ts
+++ b/src/workflows/corpWalletTransactions.ts
@@ -40,12 +40,12 @@ const LANES = 2
 // job module's top-level supabase/esi setup needs env vars absent at build
 // time). forEachCorporation still refreshes tokens, dedupes to one handler call
 // per corp, falls back through the group on a role failure, and records the
-// per-corp heartbeat pair — all unchanged. characterIds (registration uuids) is
+// per-corp heartbeat pair — all unchanged. registrationIds (registration uuids) is
 // the only thing crossing the step boundary, and serializable.
-async function syncCorporation(characterIds: string[]) {
+async function syncCorporation(registrationIds: string[]) {
   'use step'
   const { runCorpWalletTransactions } = await import('@/jobs/corpWalletTransactions.js')
-  await runCorpWalletTransactions({ characterIds })
+  await runCorpWalletTransactions({ registrationIds })
 }
 
 export async function corpWalletTransactionsWorkflow() {

--- a/src/workflows/lib.ts
+++ b/src/workflows/lib.ts
@@ -50,8 +50,8 @@ export async function runJobWithHeartbeat(job: string, load: () => Promise<() =>
 // JS number — safe to serialize as a step result.
 export async function enumerateCharacters(scopes: string[]): Promise<number[]> {
   'use step'
-  const { selectCharacterIdsWithScopes } = await import('@/supabase.js')
-  return (await selectCharacterIdsWithScopes(scopes)) as number[]
+  const { selectRegistrationIdsWithScopes } = await import('@/supabase.js')
+  return (await selectRegistrationIdsWithScopes(scopes)) as number[]
 }
 
 // Step: build the exact per-corp fan-out set fanOutPerCorporationCronJob
@@ -68,7 +68,7 @@ export async function enumerateCharacters(scopes: string[]): Promise<number[]> {
 // safe to serialize as a step result.
 export async function enumerateCorporations(scope: string): Promise<string[][]> {
   'use step'
-  const { groupCharacterIdsByCorporation } = await import('@/supabase.js')
-  const { byCorp, unresolved } = await groupCharacterIdsByCorporation([scope])
+  const { groupRegistrationIdsByCorporation } = await import('@/supabase.js')
+  const { byCorp, unresolved } = await groupRegistrationIdsByCorporation([scope])
   return [...byCorp.values(), ...unresolved.map((id: string) => [id])]
 }

--- a/test/blueprintQuery.test.ts
+++ b/test/blueprintQuery.test.ts
@@ -28,7 +28,7 @@ import {
   type BlueprintSearchPayload,
 } from '../src/app/api/mcp/blueprintQuery.ts'
 
-const OWNERS = { characterIds: ['char-a', 'char-b'], corporationIds: ['98000001', '98000002'] }
+const OWNERS = { registrationIds: ['char-a', 'char-b'], corporationIds: ['98000001', '98000002'] }
 
 const lookups = {
   ownerName: (id: string) => `Owner ${id}`,


### PR DESCRIPTION
Step 8 of `docs/registration-id-rename.md` — the last one. No migration, no schema change.

175 identifier occurrences across 56 files: the `characterIds` option on `forEachCharacter` / `forEachCharacterAnyScope` / `forEachCorporation`, `OwnerContext.characterIds`, `resolvePlayer`'s return, `selectCharacterIdsWithScopes`, `groupCharacterIdsByCorporation`, and the locals derived from them.

## The one thing "JS-only, no deploy window" missed

`characterIds` is also the **Vercel queue message shape** — a wire contract between `dispatchRefresh` and `/api/queue/jobs`.

A message already sitting in the queue at deploy time would lose its scoping, and *silently*: an absent key means "run for everyone" rather than an error, so the job would quietly fan out to every character instead of failing. Idempotent, but not what was asked for.

The consumer therefore reads the old key as a fallback:

```ts
const ids = registrationIds ?? characterIds ?? (characterId != null ? [characterId] : undefined)
```

The comment there says it's safe to delete once the queue has drained past this release. That's the only `characterIds` left in the tree.

## What was deliberately left alone

**The singular `characterId`.** Surveyed, not swept. It's genuinely mixed — `/fitting/[characterId]`, the `images.evetech.net` portrait URLs, `ownerCharacterId` and `mainCharacterId` are all real EVE ids, and `initialCharacterId` is a third-party eveship.fit prop. Only the *plural* was uniformly a registration uuid, which is what made a tree-wide replace safe. Sorting out the singular is its own survey.

**`esi.js`'s `characterAffiliations(characterIds)`** — those really are EVE ids.

**`src/observability.js`** — renaming its metric field would break continuity of any saved Vercel Observability query for no correctness gain. This was flagged as "worth *not* doing" in the doc from the start.

## Verification

`pnpm run lint`, `pnpm test` (90/90), `pnpm run build` — all clean, re-run after rebasing onto merged #769. Diff audited: every change is the rename except the four comment lines explaining the queue fallback.

---

## The cleanup is complete

Fourteen PRs, #751 through this one:

| | |
| --- | --- |
| Table columns | 19 |
| Views dropped/recreated | 8 |
| Function signatures | 11 |
| JS identifier occurrences | 175 |

Exactly three columns are still named `character_id` — `registration`, `character_directory`, `character_affiliation` — all `bigint`, all genuinely the EVE id CCP assigns. That's the end state the doc set out to reach.

And the thing that motivated it, from the doc's opening:

```js
async ({ access_token, characterID, character_id, name }) => { … }
//                     ^ EVE id      ^ registration uuid
```

Two identifiers one capital letter apart, meaning different things, destructured side by side in a dozen job modules. That's gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfmtG8kgpyC6vtXeNwRPM7

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfmtG8kgpyC6vtXeNwRPM7)_