### PR TITLE
Fix intermittent 502s when appraising a large hangar

### DIFF
--- a/src/innominate.ts
+++ b/src/innominate.ts
@@ -18,8 +18,7 @@
 // Supabase row until the consumer fills it in (or a ~50s budget elapses). Local
 // dev (no VERCEL) skips the queue and calls directly — a single developer isn't
 // a threat to the shared budget, and it keeps `pnpm run dev` working.
-import { sortBy } from 'ramda'
-
+import { requestKeyFor } from '@/innominateKey'
 import { send } from '@/utils/queue'
 import { createServiceClient } from '@/utils/supabase/service'
 
@@ -125,9 +124,10 @@ const CACHE_MAX_ENTRIES = 200
 const cache = new Map<string, { at: number; appraisal: Appraisal }>()
 
 // Key on market + the item list sorted by name, so batches that differ only in
-// input order hit the same entry. Doubles as the shared row's request_key.
-const cacheKey = (items: AppraisalItemInput[], market: Market): string =>
-  JSON.stringify({ market, items: sortBy((i) => i.name, items).map((i) => [i.name, i.quantity]) })
+// input order hit the same entry. Doubles as the shared row's request_key and
+// the queue's idempotency key, both of which cap the key's size — see
+// src/innominateKey.ts for why it's a digest and not the list itself.
+const cacheKey = requestKeyFor
 
 const cacheGet = (key: string): Appraisal | null => {
   const hit = cache.get(key)
@@ -290,7 +290,7 @@ const appraiseViaQueue = async (items: AppraisalItemInput[], market: Market, key
     // stale row. Concurrent producers for the same key share this one row and both
     // poll it. (A rare race can reset a just-finished 'done' row back to pending,
     // costing one extra throttled call — harmless given the low request volume.)
-    await supabase.from('innominate_appraisal').upsert(
+    const { error: upsertError } = await supabase.from('innominate_appraisal').upsert(
       {
         request_key: key,
         market,
@@ -302,6 +302,13 @@ const appraiseViaQueue = async (items: AppraisalItemInput[], market: Market, key
       },
       { onConflict: 'request_key' }
     )
+    // supabase-js returns write errors rather than throwing, so an unchecked
+    // upsert fails silently: the consumer then finds no row to fill in and the
+    // producer polls the full 50s budget before reporting a rate limit that was
+    // never the problem. Surface it instead of enqueueing work with no row.
+    if (upsertError) {
+      return { ok: false, kind: 'upstream', message: `Could not record the appraisal request: ${upsertError.message}` }
+    }
 
     const bucket = Math.floor(Date.now() / CACHE_TTL_MS)
     await send('innominate', { requestKey: key }, { idempotencyKey: `${key}:${bucket}` })

--- a/src/innominateKey.ts
+++ b/src/innominateKey.ts
@@ -1,0 +1,33 @@
+// The identity of an appraisal request: same market + same items = same key.
+//
+// Split out of src/innominate.ts as a pure seam (no I/O, no path aliases) so
+// `pnpm test` can exercise it without a Supabase or queue client — the same
+// reason blueprintQuery/structureQuery/planetQuery live apart from their tools.
+//
+// This key is load-bearing in two places that both impose a size limit, which
+// is why it is a digest rather than the serialized item list it describes:
+//
+//   1. It is `innominate_appraisal.request_key`, a `text primary key`. A btree
+//      index row caps at 2704 bytes, so a long key makes the upsert fail
+//      outright ("index row size N exceeds btree version 4 maximum 2704").
+//   2. It rides to the queue as the `Vqs-Idempotency-Key` HTTP header, which
+//      is rejected long before that.
+//
+// Serializing the items inline hit both on any sizeable hangar, and because the
+// threshold depends on how well the names happen to compress, it failed
+// unpredictably — small stacks fine, a station's worth of types not. A digest
+// is fixed-width no matter how many lines go in.
+import { createHash } from 'node:crypto'
+
+import { sortBy } from 'ramda'
+
+export type KeyItem = { name: string; quantity: number }
+
+// The canonical form the digest is taken over. Sorted by name so batches that
+// differ only in order share a key (and therefore a cache entry); quantities
+// included so a different amount is genuinely a different request.
+export const canonicalRequest = (items: KeyItem[], market: string): string =>
+  JSON.stringify({ market, items: sortBy((i: KeyItem) => i.name, items).map((i) => [i.name, i.quantity]) })
+
+export const requestKeyFor = (items: KeyItem[], market: string): string =>
+  createHash('sha256').update(canonicalRequest(items, market)).digest('hex')

--- a/test/innominateKey.test.ts
+++ b/test/innominateKey.test.ts
@@ -1,0 +1,52 @@
+// Unit coverage for the appraisal request key (src/innominateKey.ts).
+//
+// What's worth pinning here is the property whose absence broke production:
+// the key is the innominate_appraisal primary key AND the queue's
+// Vqs-Idempotency-Key header, so it has to stay a fixed, small width no matter
+// how many item lines go into the request. It used to be the serialized item
+// list, which grew past both limits on a real hangar — and only on a big one,
+// so /api/appraisal returned 502 for some targets and 200 for others.
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { canonicalRequest, requestKeyFor, type KeyItem } from '../src/innominateKey.ts'
+
+const items = (n: number): KeyItem[] =>
+  Array.from({ length: n }, (_, i) => ({ name: `Some Reasonably Long Item Name ${i}`, quantity: 1000 + i }))
+
+// A btree index row caps at 2704 bytes; the header limit is lower still. 64 hex
+// characters leaves both untouched at any batch size.
+const SHA256_HEX = 64
+
+test('the key is fixed-width regardless of how many items it describes', () => {
+  for (const n of [1, 10, 100, 500, 5000]) {
+    const key = requestKeyFor(items(n), 'jita')
+    assert.equal(key.length, SHA256_HEX, `${n} items should still key to ${SHA256_HEX} chars`)
+    assert.match(key, /^[0-9a-f]+$/, 'the key should be plain lowercase hex, safe in a header and a text PK')
+  }
+})
+
+test('the key stays far under the btree index-row limit that broke the upsert', () => {
+  // The regression in one assertion: the old key was the canonical JSON itself,
+  // which blows past 2704 bytes long before 500 lines.
+  const big = items(500)
+  assert.ok(Buffer.byteLength(canonicalRequest(big, 'jita')) > 2704, 'the canonical form is the thing that got too big')
+  assert.ok(Buffer.byteLength(requestKeyFor(big, 'jita')) < 100, 'the key derived from it must not be')
+})
+
+test('input order does not change the key, so a cache entry is shared', () => {
+  const forward = items(25)
+  const reversed = [...forward].reverse()
+  assert.equal(requestKeyFor(forward, 'jita'), requestKeyFor(reversed, 'jita'))
+})
+
+test('market and quantity are part of the identity', () => {
+  const base = items(3)
+  assert.notEqual(requestKeyFor(base, 'jita'), requestKeyFor(base, 'amarr'), 'a different hub is a different price')
+  const moved = [{ ...base[0], quantity: base[0].quantity + 1 }, ...base.slice(1)]
+  assert.notEqual(requestKeyFor(base, 'jita'), requestKeyFor(moved, 'jita'), 'a different amount is a different total')
+})
+
+test('the same request keys identically across calls', () => {
+  assert.equal(requestKeyFor(items(40), 'jita'), requestKeyFor(items(40), 'jita'))
+})


### PR DESCRIPTION
Appraising a big container or a whole station sometimes came back with *"Could not queue the appraisal request (queue or database error)"*, while a plain stack worked fine. Production confirms it — `POST /api/appraisal` alternating 200 and 502 within the same minute:

```
01:35:20 POST /api/appraisal 502
01:30:52 POST /api/appraisal 200
01:30:43 POST /api/appraisal 200
01:30:30 POST /api/appraisal 502
01:30:20 POST /api/appraisal 502
01:30:02 POST /api/appraisal 200
```

## Cause

The request key was the **serialized item list itself**, and that string is load-bearing in two places that both bound its size:

1. `innominate_appraisal.request_key` is a `text primary key`. A btree index row caps at **2704 bytes**, so a long key fails the upsert outright: `index row size N exceeds btree version 4 maximum 2704`.
2. It travels to the queue as the `Vqs-Idempotency-Key` **HTTP header** (`@vercel/queue` sets it via `headers.set`), which is rejected well before that — and unlike the upsert, that one *throws*, which is the path that produced the message users actually saw.

Both thresholds sit somewhere north of 200 distinct types, and exactly where depends on **how well the item names happen to compress** — btree limits the post-compression tuple. That's the "sometimes": the same click fails on one hangar and succeeds on another.

Measured against a local PG 16 with realistic EVE type names:

| distinct types | key size | upsert |
|---|---|---|
| 150 | 5.7 kB | OK |
| 200 | 7.6 kB | OK |
| 250 | 9.4 kB | OK |
| 300 | 11.3 kB | **FAIL** — index row size 2832 > 2704 |
| 500 | 19.5 kB | **FAIL** — index row size 4320 > 2704 |

The "Appraise everything here" button added in #766 is what made keys that big easy to produce. The MCP `appraise_items` tool caps at 100 items, so it rarely got there — which is why this only showed up now.

## Fix

Hash the canonical form instead of using it. The key is now a SHA-256 digest — a fixed 64 characters at any batch size — which is what the table's own comment always claimed it was:

> keyed by request_key (the same hash the in-process cache uses)

It wasn't a hash. Now it is, so the comment is true and both limits are untouchable.

Identity is unchanged: still market plus the name-sorted item list, so order-insensitivity and the cache sharing it buys are preserved. **No migration needed** — the column already takes text, and the stale long-key rows are a 5-minute TTL cache that ages out on its own.

**Also: stop discarding the upsert's error.** supabase-js returns write errors rather than throwing, so failure mode 1 was completely silent — the consumer found no row to fill in, and the producer polled its full 50 s budget before reporting a rate limit that was never the problem. It now says what actually happened, immediately.

## Tests

The key moves to `src/innominateKey.ts` as a pure seam so `pnpm test` can reach it without a Supabase or queue client — same split as `blueprintQuery` / `structureQuery` / `planetQuery`.

The test pins the property whose absence caused this: fixed width at 1 / 10 / 100 / 500 / 5000 items, plus order-insensitivity and that market and quantity remain part of the identity. Verified it isn't vacuous — reverting the digest to the old serialized form fails exactly the two size assertions:

```
not ok 38 - the key is fixed-width regardless of how many items it describes
not ok 39 - the key stays far under the btree index-row limit that broke the upsert
# pass 93  # fail 2
```

## Verification

- `pnpm test` — 95 pass, 0 fail (5 new).
- `pnpm run lint` — clean.
- `pnpm run build` — passes.
- Threshold table above reproduced against a throwaway PG 16 cluster.

Not re-tested against production, since that needs a signed-in session and a hangar large enough to have been failing — worth one click on a big station once this deploys.

---
_Generated by [Claude Code](https://claude.ai/code/session_015Zx8z4DMYBn1PG5jjisjC8)_