### PR TITLE
Drain the appraisal queue every 2s, and show the wait

### DIFF
--- a/docs/appraisals/README.md
+++ b/docs/appraisals/README.md
@@ -103,8 +103,20 @@ whole deployment.** Consequences baked into the designs:
 several lambda instances from bursting past 200/hour together, so on Vercel
 every `appraise()` call is funnelled through a Vercel queue (topic
 `innominate`, consumer at `/api/queue/innominate`) that drains at most **one
-request every 18 seconds** (= 200/hour) via an atomic Postgres leaky bucket
-(`innominate_try_acquire()`). `appraise()` keeps its synchronous contract: it
+request every 2 seconds** via an atomic Postgres leaky bucket
+(`innominate_try_acquire()`).
+
+That drain rate is deliberately **faster than the provider's 200/hour** (which
+is one per 18s, what it originally was). At 18s the throttle became the
+dominant cost of the feature once the asset viewer put an appraise button on
+every row: a handful of clicks queued for over a minute, and the later ones
+exhausted the poll budget without ever being sent. 2s serves a normal burst in
+a few seconds. The trade is that it permits up to 1800/hour, so sustained heavy
+use can spend the real budget in ~7 minutes and collect genuine 429s from
+innomin.at (surfaced to the user, never retried). Accepted at this
+deployment's traffic. If it starts biting, the answer isn't a slower drip but
+an hourly token bucket — burst freely, refuse once 200 have gone out in the
+trailing hour. `appraise()` keeps its synchronous contract: it
 upserts a `pending` row in `innominate_appraisal`, enqueues one message, and
 blocks polling that row (up to ~50s, under the MCP function's 60s limit) until
 the consumer fills in the result — which also serves as a shared 5-minute price

--- a/src/app/api/appraisal/route.ts
+++ b/src/app/api/appraisal/route.ts
@@ -17,6 +17,13 @@ import { getSdeTypes } from '@/sdeTypes'
 import { createClient } from '@/utils/supabase/server'
 import { BLUEPRINT_CATEGORY_ID } from '../mcp/lib'
 
+// appraise() blocks polling the shared row for up to 50s while the throttled
+// queue drains (POLL_BUDGET_MS in src/innominate.ts, which is sized against a
+// 60s function limit). Declare that limit rather than inheriting the platform
+// default, which every other long-running route here does too: without it, a
+// lowered default would silently truncate queued appraisals mid-poll.
+export const maxDuration = 60
+
 // One appraisal is always exactly one upstream request — the 200/hour budget is
 // deployment-wide, so looping per item is never an option. A hangar with more
 // distinct types than a single batch can carry is therefore refused outright

--- a/src/app/api/queue/innominate/route.ts
+++ b/src/app/api/queue/innominate/route.ts
@@ -1,8 +1,8 @@
 // Queue consumer for the innomin.at appraisal throttle (topic "innominate", wired
 // up in vercel.json via experimentalTriggers). Every appraisal request is
-// enqueued here so the whole deployment sends at most one request every 18
-// seconds (the provider's 200/hour budget) — see the throttle explanation in
-// src/innominate.ts. This route is the ONLY thing that drains the topic; the
+// enqueued here so the whole deployment sends at most one request every 2
+// seconds — deliberately above the provider's 200/hour, see the throttle
+// explanation in src/innominate.ts. This route is the ONLY thing that drains the topic; the
 // producer (appraise()) enqueues and blocks polling the shared DB row this
 // consumer fills in.
 import { handleCallback } from '@/utils/queue'

--- a/src/app/asset/[locationId]/appraiseButton.tsx
+++ b/src/app/asset/[locationId]/appraiseButton.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { formatBisk, formatIsk, formatKisk } from '../../isk'
 import styles from './appraiseButton.module.css'
@@ -39,13 +39,27 @@ const describe = (value: Appraised): string =>
     ...(value.cached ? ['cached'] : []),
   ].join(' · ')
 
+// Appraisals drain from one global queue, so a click can genuinely be waiting
+// its turn rather than working. Past a couple of seconds the wait is named and
+// counted — an ellipsis that sits there for half a minute reads as broken.
+const QUIET_SECONDS = 2
+
 // Appraise one target on demand: an item id (a stack, or a ship/container and
 // everything inside it) or a location id for the whole hangar. Deliberately
 // lazy and per-mount — pricing every row of a station on load would blow the
-// shared 200/hour budget in a single page view, and navigating away is meant to
+// shared hourly budget in a single page view, and navigating away is meant to
 // discard the answer rather than cache it client-side.
 export const AppraiseButton = ({ target, label = 'appraise' }: { target: string; label?: string }) => {
   const [state, setState] = useState<State>({ phase: 'idle' })
+  const [waited, setWaited] = useState(0)
+
+  useEffect(() => {
+    if (state.phase !== 'loading') return
+    const startedAt = Date.now()
+    setWaited(0)
+    const tick = setInterval(() => setWaited(Math.round((Date.now() - startedAt) / 1000)), 1000)
+    return () => clearInterval(tick)
+  }, [state.phase])
 
   const run = async () => {
     setState({ phase: 'loading' })
@@ -57,10 +71,12 @@ export const AppraiseButton = ({ target, label = 'appraise' }: { target: string;
       })
       const body = await response.json().catch(() => null)
       if (!response.ok || !body?.ok) {
-        // The route's own message is the useful one (it knows whether this was a
-        // rate limit, a blueprint-only container, or an upstream failure).
         const retry = typeof body?.retry_after_seconds === 'number' ? ` — retry in ${body.retry_after_seconds}s` : ''
-        setState({ phase: 'error', message: `${body?.error ?? 'appraisal unavailable'}${retry}` })
+        // A rate limit gets the short form: the route's sentence is written for
+        // the MCP tool and is far too long for a table cell. Everything else
+        // keeps the route's own message, which knows what actually went wrong.
+        const message = response.status === 429 ? `rate limited${retry}` : `${body?.error ?? 'appraisal unavailable'}`
+        setState({ phase: 'error', message })
         return
       }
       setState({ phase: 'done', value: body as Appraised })
@@ -69,7 +85,16 @@ export const AppraiseButton = ({ target, label = 'appraise' }: { target: string;
     }
   }
 
-  if (state.phase === 'loading') return <span className={styles.pending}>…</span>
+  if (state.phase === 'loading') {
+    return (
+      <span
+        className={styles.pending}
+        title="Appraisals share one queue across the whole site, so a burst of clicks waits its turn."
+      >
+        {waited <= QUIET_SECONDS ? '…' : `queued ${waited}s…`}
+      </span>
+    )
+  }
   if (state.phase === 'error') return <span className={styles.error}>{state.message}</span>
   if (state.phase === 'done') {
     return (

--- a/src/innominate.ts
+++ b/src/innominate.ts
@@ -65,8 +65,23 @@ const ENDPOINT = 'https://innomin.at/api/v1/appraise/'
 const USER_AGENT = 'edencom-link (philihp@gmail.com)'
 const TIMEOUT_MS = 10_000
 
-// The global rate: one request per 18 seconds = 200/hour, the provider's budget.
-const THROTTLE_SECONDS = 18
+// The global drain rate: one request every 2 seconds.
+//
+// Deliberately faster than the provider's documented 200/hour (which works out
+// to one per 18s, what this used to be). At 18s the throttle was the dominant
+// cost of using the feature: the asset viewer puts an appraise button on every
+// row, so a handful of clicks queued for a minute or more and the later ones
+// timed out against the poll budget having never been sent at all. Draining at
+// 2s serves a normal burst of clicks in a few seconds.
+//
+// The trade: this permits up to 1800/hour, so sustained heavy use can spend the
+// real 200/hour budget in ~7 minutes and start collecting genuine 429s from
+// innomin.at. That's an accepted risk at this deployment's traffic — a handful
+// of players clicking occasionally, with the 5-minute result cache absorbing
+// repeats — and a real 429 is surfaced to the user rather than retried. If it
+// starts biting, the fix isn't a slower drip but an hourly token bucket: burst
+// freely, then refuse once 200 have gone out in the trailing hour.
+const THROTTLE_SECONDS = 2
 // How long appraise() blocks polling the shared row before giving up — kept
 // under the MCP route's 60s function limit (src/app/api/mcp/route.ts).
 const POLL_BUDGET_MS = 50_000


### PR DESCRIPTION
Appraisals sometimes appeared to hang. They weren't hanging.

## What was happening

The global throttle drained **one request every 18 seconds**, and the asset viewer puts an appraise button on *every row*. A burst of clicks queues behind itself, and past the third concurrent click the wait exceeds the 50s poll budget by construction — 4 × 18s = 72s. So it sat spinning for the better part of a minute and then reported a rate limit. Next to the ones that answered instantly, that reads as "never came back."

Production showed the shape plainly — a dozen requests inside fifteen seconds:

```
02:05:23 POST /api/appraisal 429
02:05:15 POST /api/appraisal 200
02:04:53 POST /api/appraisal 429
02:04:53 POST /api/appraisal 429
02:04:51 POST /api/appraisal 200
02:04:50 POST /api/appraisal 429
```

No 504s anywhere, so nothing was being killed — the requests were returning, just slowly. (The 502s from #773 are gone, so that fix held.)

## The change

Drop the drain interval to **2 seconds**, which serves a normal burst in a few seconds instead of a few minutes.

⚠️ **This is deliberately above the provider's documented budget.** innomin.at publishes `x-ratelimit-limit: 200/hour`, which is one per 18s — that's where the old value came from. One per 2s permits up to **1800/hour**, so sustained heavy use can spend the real budget in ~7 minutes and start collecting genuine 429s from the provider. Those surface to the user and are never auto-retried, and the 5-minute result cache absorbs repeats, so it's an accepted trade at this deployment's traffic — requested explicitly, and recorded in `docs/appraisals/README.md` rather than left as a surprising constant.

The doc also records the better answer if it ever bites: an hourly token bucket that bursts freely and refuses once 200 have gone out in the trailing hour. That fixes the burst case *without* going over budget; it's just more machinery than this needed today.

## Two supporting fixes

**Declare `maxDuration = 60` on `/api/appraisal`.** `appraise()` blocks polling for up to 50s, and `innominate.ts` sizes that budget against "the MCP route's 60s function limit" — but this route never declared one, inheriting the platform default. Nothing has timed out yet, so the default is currently above 50s, but all fourteen other long-running routes here pin 60 rather than trusting that. One lowered default away from silently truncating every queued appraisal.

**Make the waiting state honest.** Past two seconds the button reads `queued 12s…` instead of a motionless ellipsis, with a tooltip explaining the shared queue. A 429 now renders as the terse `rate limited — retry in Ns` the design asked for, instead of the long sentence written for the MCP tool, which was far too wide for a table cell.

## Verification

- `pnpm test` — 95 pass, 0 fail.
- `pnpm run lint` — clean.
- `pnpm run build` — passes.
- Diagnosis grounded in production logs (status distribution and timing above) rather than inference.

Worth a burst of clicks on a busy station after this deploys — that's the case that was failing, and it's the one the 2s drain is meant to fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_015Zx8z4DMYBn1PG5jjisjC8)_