### PR TITLE
Add an arrow to open a priced row as a saved appraisal

### DIFF
--- a/docs/appraisals/README.md
+++ b/docs/appraisals/README.md
@@ -42,10 +42,19 @@ our key.
     itself and echoes the resolved `item_id` back.
   - `market` — default `jita`. Available: `jita`, `amarr`, `rens`, `dodi`,
     `hek`, `ualx`, `cj6mt` (the last two are player nullsec markets).
-  - `save` — **always send `false`.** This is a hard requirement from the
-    repo owner: `save: false` makes the call side-effect free on the
-    provider's server (nothing stored, no appraisal id minted). Never expose
-    it as a parameter; hard-code it in the client.
+  - `save` — **`false` for every automatic appraisal**, which is the default
+    everywhere and what all but one code path sends. `save: false` keeps the
+    call side-effect free on the provider's server: nothing stored, no
+    appraisal id minted.
+
+    The single exception, added later at the repo owner's request, is the
+    asset viewer's "open this appraisal" arrow (doc 03): an explicit user
+    click that re-runs the same batch with `save: true` so the provider stores
+    it and mints an id to link to. It is opt-in per call, never a default,
+    and never set by the MCP tool or by merely displaying a price. Note this
+    is a change from the original hard rule of "always false, hard-code it" —
+    if the API-key terms ever require otherwise, this is the one call site to
+    revoke.
   - `comment` — irrelevant when not saving; omit.
 
 - **Response 200** (`AppraisalResponse`): `appraisals[]` (one entry per
@@ -78,6 +87,11 @@ our key.
     suggested names. Totals cover only the priced items.
   - `current_count` is the key's lifetime request counter (undocumented;
     don't rely on it).
+  - `appraisal_id` is present only when `save: true` — a short slug (e.g.
+    `2GeAakV`). A human opens it at **`https://innomin.at/a/<id>`** (the
+    provider's SPA route, not in the OpenAPI schema, confirmed against a real
+    saved appraisal); `GET /api/v1/appraisal/<id>/` returns it as JSON but
+    requires the API key, so it's no use as a shareable link.
 
 - **Errors:** `400` invalid request, `401` bad/missing key, `429` rate
   limited — all `{ "error": "…" }` JSON bodies.

--- a/schema.sql
+++ b/schema.sql
@@ -710,7 +710,7 @@ grant all on public.esi_etag to service_role;
 -- Global throttle for the innomin.at appraisal API (see src/innominate.ts). The
 -- provider allows 200 requests/hour for the whole deployment, so appraisals are
 -- funnelled through a Vercel queue (topic "innominate", consumer at
--- /api/queue/innominate) draining at most one request every 18 seconds across
+-- /api/queue/innominate) draining at most one request every 2 seconds across
 -- ALL lambda instances. Separate instances don't share memory, so the throttle
 -- timestamp and the pending/finished results live here. Internal service-role
 -- bookkeeping only: RLS on with no policy, so only the service role (the queue
@@ -724,15 +724,23 @@ insert into public.innominate_throttle (id) values (true) on conflict (id) do no
 alter table public.innominate_throttle enable row level security;
 grant all on public.innominate_throttle to service_role;
 
--- One row per distinct (market + sorted item list) request, keyed by request_key
--- (the same hash the in-process cache uses). The producer upserts a 'pending'
--- row and blocks polling it; the consumer flips it to 'done' (mapped Appraisal
--- in `result`) or 'error' ({ kind, message, retryAfterSeconds } in `error`). A
--- fresh 'done' row (< 5 min) doubles as the global price cache.
+-- One row per distinct (market + save + sorted item list) request, keyed by
+-- request_key (the hash the in-process cache uses — see src/innominateKey.ts).
+-- The producer upserts a 'pending' row and blocks polling it; the consumer
+-- flips it to 'done' (mapped Appraisal in `result`) or 'error' ({ kind,
+-- message, retryAfterSeconds } in `error`). A fresh 'done' row (< 5 min)
+-- doubles as the global price cache.
+--
+-- `save` is what the consumer passes to the provider. It is false for every
+-- automatic appraisal and true only for an explicit user-initiated save, which
+-- mints a shareable appraisal id on the provider's side. It's part of the
+-- request key too, so a cached unsaved result (which carries no id) can never
+-- satisfy a save request.
 create table public.innominate_appraisal (
   request_key  text primary key,
   market       text not null,
   items        jsonb not null,
+  save         boolean not null default false,
   status       text not null default 'pending' check (status in ('pending', 'done', 'error')),
   result       jsonb,
   error        jsonb,

--- a/src/app/api/appraisal/route.ts
+++ b/src/app/api/appraisal/route.ts
@@ -12,7 +12,7 @@
 import { forEach } from 'ramda'
 import { NextResponse } from 'next/server'
 
-import { appraise, MARKETS, type AppraisalItemInput, type Market } from '@/innominate'
+import { appraise, appraisalUrl, MARKETS, type AppraisalItemInput, type Market } from '@/innominate'
 import { getSdeTypes } from '@/sdeTypes'
 import { createClient } from '@/utils/supabase/server'
 import { BLUEPRINT_CATEGORY_ID } from '../mcp/lib'
@@ -42,13 +42,21 @@ export async function POST(request: Request) {
   const { data: auth, error: authError } = await supabase.auth.getUser()
   if (authError || !auth?.user) return fail(401, 'Sign in to appraise items.')
 
-  const body = (await request.json().catch(() => null)) as { target?: unknown; market?: unknown } | null
+  const body = (await request.json().catch(() => null)) as {
+    target?: unknown
+    market?: unknown
+    save?: unknown
+  } | null
   const target = typeof body?.target === 'string' ? body.target.trim() : ''
   // Ids are bigints kept as strings end to end; anything else can't be one.
   if (!/^\d+$/.test(target)) return fail(400, 'A numeric target id is required.')
   // Validated rather than passed through, so the UI can grow a market picker
   // later without this route changing.
   const market: Market = MARKETS.includes(body?.market as Market) ? (body?.market as Market) : 'jita'
+  // Opt-in, and only ever set by the viewer's explicit "open this appraisal"
+  // arrow. A saved appraisal is stored on the provider's side and gets an id we
+  // can link to; everything else here stays side-effect free over there.
+  const save = body?.save === true
 
   // The target is either one of the caller's own items (ship, container or plain
   // stack) or a bare place id — a station, structure or solar system. RLS
@@ -118,7 +126,7 @@ export async function POST(request: Request) {
     return fail(422, `Too many distinct item types here to appraise at once (${lines.size}, limit ${MAX_LINES}).`)
   }
 
-  const result = await appraise([...lines.values()], market)
+  const result = await appraise([...lines.values()], market, save)
   if (!result.ok) {
     if (result.kind === 'unconfigured') return fail(503, "Appraisals aren't configured on this deployment.")
     if (result.kind === 'rate_limited') {
@@ -141,6 +149,9 @@ export async function POST(request: Request) {
     price_split: appraisal.priceSplit,
     total_volume_m3: appraisal.totalVol,
     line_count: lines.size,
+    // Only a saved appraisal has somewhere to link to. Absent otherwise rather
+    // than null, so the client can just test for it.
+    ...(appraisal.appraisalId && { appraisal_url: appraisalUrl(appraisal.appraisalId) }),
     ...(skippedBlueprints > 0 && { skipped_blueprints: skippedBlueprints }),
     ...(unpriced.length > 0 && { unpriced }),
     ...(appraisal.cached && { cached: true }),

--- a/src/app/asset/[locationId]/appraiseButton.module.css
+++ b/src/app/asset/[locationId]/appraiseButton.module.css
@@ -25,12 +25,42 @@
   color: var(--ink-faint);
 }
 
-/* The answer. Tabular figures so stacked rows line up on the decimal. */
+/* The answer, plus the control that opens it on innomin.at. */
+.result {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6pt;
+  white-space: nowrap;
+}
+
+/* The figures. Tabular so stacked rows line up on the decimal. */
 .value {
   font-family: var(--mono);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
   cursor: help;
+}
+
+/* Opens the saved appraisal. Quiet until hovered — it sits on every priced row,
+   so it shouldn't compete with the number it belongs to. */
+.open {
+  font: inherit;
+  font-size: 11pt;
+  line-height: 1;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--ink-faint);
+  cursor: pointer;
+}
+
+.open:hover {
+  color: var(--ink);
+}
+
+.open:disabled {
+  cursor: default;
+  opacity: 0.5;
 }
 
 /* Errors stay quiet and inline — no toast, no retry, per the design. */

--- a/src/app/asset/[locationId]/appraiseButton.tsx
+++ b/src/app/asset/[locationId]/appraiseButton.tsx
@@ -52,6 +52,7 @@ const QUIET_SECONDS = 2
 export const AppraiseButton = ({ target, label = 'appraise' }: { target: string; label?: string }) => {
   const [state, setState] = useState<State>({ phase: 'idle' })
   const [waited, setWaited] = useState(0)
+  const [opening, setOpening] = useState<'idle' | 'saving' | 'failed'>('idle')
 
   useEffect(() => {
     if (state.phase !== 'loading') return
@@ -85,6 +86,43 @@ export const AppraiseButton = ({ target, label = 'appraise' }: { target: string;
     }
   }
 
+  // Re-run the same target with save: true, which makes innomin.at store the
+  // appraisal and hand back an id, then send the user to it. Unlike the price
+  // itself this leaves a record on their side, so it only ever happens on this
+  // explicit click — never as part of showing a number.
+  const openSaved = async () => {
+    // The tab has to be opened synchronously inside the click, or the browser
+    // treats the post-fetch navigation as an unsolicited pop-up and blocks it.
+    // It's parked on about:blank and pointed at the real URL once we have one.
+    // No 'noopener' here — that makes window.open return null, which would
+    // defeat the whole trick — so the opener reference is severed by hand.
+    const tab = window.open('about:blank', '_blank')
+    if (tab) tab.opener = null
+    setOpening('saving')
+    try {
+      const response = await fetch('/api/appraisal', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ target, save: true }),
+      })
+      const body = await response.json().catch(() => null)
+      const url = typeof body?.appraisal_url === 'string' ? body.appraisal_url : null
+      if (!response.ok || !body?.ok || !url) {
+        tab?.close()
+        setOpening('failed')
+        return
+      }
+      // If the placeholder was blocked, try once more now that there's a real
+      // URL — some browsers allow it, and a blocked pop-up beats losing the save.
+      if (tab) tab.location.href = url
+      else window.open(url, '_blank', 'noopener,noreferrer')
+      setOpening('idle')
+    } catch {
+      tab?.close()
+      setOpening('failed')
+    }
+  }
+
   if (state.phase === 'loading') {
     return (
       <span
@@ -98,10 +136,28 @@ export const AppraiseButton = ({ target, label = 'appraise' }: { target: string;
   if (state.phase === 'error') return <span className={styles.error}>{state.message}</span>
   if (state.phase === 'done') {
     return (
-      <span className={styles.value} title={describe(state.value)}>
-        {formatPair(state.value.total_sell_value, state.value.total_buy_value)}
-        {/* Cheap honesty about staleness: this came from the 5-minute cache. */}
-        {state.value.cached ? '*' : ''}
+      <span className={styles.result}>
+        <span className={styles.value} title={describe(state.value)}>
+          {formatPair(state.value.total_sell_value, state.value.total_buy_value)}
+          {/* Cheap honesty about staleness: this came from the 5-minute cache. */}
+          {state.value.cached ? '*' : ''}
+        </span>
+        <button
+          type="button"
+          className={styles.open}
+          // Distinct from the price's own tooltip: this one costs a request and
+          // leaves a record on innomin.at, so say so before it's clicked.
+          title={
+            opening === 'failed'
+              ? 'Could not open the appraisal — allow pop-ups for this site, or try again.'
+              : 'Save this appraisal on innomin.at and open it in a new tab'
+          }
+          disabled={opening === 'saving'}
+          onClick={openSaved}
+          aria-label="Open this appraisal on innomin.at"
+        >
+          {opening === 'saving' ? '…' : '↗'}
+        </button>
       </span>
     )
   }

--- a/src/innominate.ts
+++ b/src/innominate.ts
@@ -1,7 +1,7 @@
 // The single module in the repo that talks to the Innominate Appraisal API
 // (https://innomin.at/api/docs/) — an Evepraisal-style ISK price service. Both
 // consumers (the appraise_items MCP tool now, the asset viewer in doc 03) go
-// through here so the save:false invariant, auth header, in-process cache, and
+// through here so the save default, auth header, in-process cache, and
 // rate-limit handling live in exactly one place. This is a deliberate, narrow
 // exception to the "UI/MCP read the DB, never call a third-party" rule: market
 // prices aren't in our DB at all, so we call innomin.at server-side at request
@@ -12,8 +12,8 @@
 // deployment, not per user or per lambda. In-process state can't enforce that —
 // separate serverless instances don't share memory — so on Vercel every call is
 // funnelled through a Vercel queue (topic "innominate", consumer at
-// /api/queue/innominate) that drains at most one request every 18 seconds
-// (= 200/hour) via an atomic Postgres leaky bucket. The MCP tool stays
+// /api/queue/innominate) that drains at most one request every 2 seconds via an
+// atomic Postgres leaky bucket (see THROTTLE_SECONDS). The MCP tool stays
 // synchronous: appraise() enqueues the request and BLOCKS polling a shared
 // Supabase row until the consumer fills it in (or a ~50s budget elapses). Local
 // dev (no VERCEL) skips the queue and calls directly — a single developer isn't
@@ -48,6 +48,10 @@ export type Appraisal = {
   marketStatus: string
   rateLimitRemaining: number | null // from x-ratelimit-remaining
   cached: boolean // true when served from the TTL cache
+  // Set only for a saved appraisal (save: true) — the id the provider minted,
+  // which appraisalUrl() turns into a shareable link. Null for the ordinary
+  // side-effect-free path, which stores nothing and mints nothing.
+  appraisalId: string | null
 }
 
 export type AppraisalError =
@@ -109,6 +113,7 @@ type RawAppraisal = {
   price_split?: number
   market?: string
   market_status?: string
+  appraisal_id?: string | null
 }
 
 const num = (v: number | null | undefined): number | null => (typeof v === 'number' ? v : null)
@@ -168,7 +173,7 @@ const cacheSet = (key: string, appraisal: Appraisal): void => {
 //
 // Actually hits innomin.at. Only ever called by the queue consumer (one call at
 // a time, throttled) — or directly by appraise() in local dev. Never throws.
-const callInnominate = async (items: AppraisalItemInput[], market: Market): Promise<AppraisalResult> => {
+const callInnominate = async (items: AppraisalItemInput[], market: Market, save: boolean): Promise<AppraisalResult> => {
   const apiKey = process.env.INNOMINATE_API_KEY
   if (!apiKey) {
     return { ok: false, kind: 'unconfigured', message: 'INNOMINATE_API_KEY is not set on this deployment.' }
@@ -183,10 +188,13 @@ const callInnominate = async (items: AppraisalItemInput[], market: Market): Prom
         'Content-Type': 'application/json',
         'User-Agent': USER_AGENT,
       },
-      // save: false is HARD-CODED (never a parameter, never configurable):
-      // it keeps the call side-effect-free on the provider's server — nothing
-      // stored, no appraisal id minted — per the API-key agreement.
-      body: JSON.stringify({ items, market, save: false }),
+      // `save` defaults to false everywhere and is only ever true for an
+      // explicit, user-initiated "save and open this appraisal" click. Every
+      // automatic appraisal — every row of the asset viewer, every MCP call —
+      // stays side-effect free on the provider's server: nothing stored, no id
+      // minted. Saving is the one case where the user is asking for a record to
+      // exist, so it is passed in rather than assumed.
+      body: JSON.stringify({ items, market, save }),
       signal: AbortSignal.timeout(TIMEOUT_MS),
     })
   } catch {
@@ -230,9 +238,16 @@ const callInnominate = async (items: AppraisalItemInput[], market: Market): Prom
     marketStatus: raw.market_status ?? '',
     rateLimitRemaining,
     cached: false,
+    // Present only when save was true; the provider mints nothing otherwise.
+    appraisalId: raw.appraisal_id ?? null,
   }
   return { ok: true, appraisal }
 }
+
+// Where a saved appraisal lives for a human. Not in the OpenAPI schema (which
+// only documents the key-authenticated GET /api/v1/appraisal/{id}/); this is the
+// provider's own SPA route, confirmed against a real saved appraisal.
+export const appraisalUrl = (appraisalId: string): string => `https://innomin.at/a/${appraisalId}`
 
 // ---- Shared DB row (throttle coordination + global cache) -----------------
 
@@ -241,6 +256,7 @@ type AppraisalRow = {
   request_key: string
   market: string
   items: AppraisalItemInput[]
+  save: boolean
   status: 'pending' | 'done' | 'error'
   result: Appraisal | null
   error: AppraisalError | null
@@ -250,7 +266,7 @@ type AppraisalRow = {
 const readAppraisalRow = async (supabase: ServiceClient, requestKey: string): Promise<AppraisalRow | null> => {
   const { data } = await supabase
     .from('innominate_appraisal')
-    .select('request_key, market, items, status, result, error, updated_at')
+    .select('request_key, market, items, save, status, result, error, updated_at')
     .eq('request_key', requestKey)
     .maybeSingle()
   return (data as AppraisalRow | null) ?? null
@@ -285,7 +301,12 @@ const pollForResult = async (supabase: ServiceClient, key: string, deadline: num
   return pollForResult(supabase, key, deadline)
 }
 
-const appraiseViaQueue = async (items: AppraisalItemInput[], market: Market, key: string): Promise<AppraisalResult> => {
+const appraiseViaQueue = async (
+  items: AppraisalItemInput[],
+  market: Market,
+  save: boolean,
+  key: string
+): Promise<AppraisalResult> => {
   // appraise() must never throw (the MCP tool relies on that), so a DB or queue
   // outage becomes a clean upstream error rather than a rejection.
   try {
@@ -310,6 +331,7 @@ const appraiseViaQueue = async (items: AppraisalItemInput[], market: Market, key
         request_key: key,
         market,
         items,
+        save,
         status: 'pending',
         result: null,
         error: null,
@@ -336,14 +358,22 @@ const appraiseViaQueue = async (items: AppraisalItemInput[], market: Market, key
 
 // ---- Public entry point ---------------------------------------------------
 
-export const appraise = async (items: AppraisalItemInput[], market: Market = 'jita'): Promise<AppraisalResult> => {
+// `save` is opt-in and only ever set by an explicit user action (the asset
+// viewer's "open this appraisal" arrow). It is part of the cache key, so a
+// previously cached unsaved result — which carries no appraisal id — can never
+// satisfy a save request.
+export const appraise = async (
+  items: AppraisalItemInput[],
+  market: Market = 'jita',
+  save = false
+): Promise<AppraisalResult> => {
   if (!process.env.INNOMINATE_API_KEY) {
     // No key → answer without any network/queue work, so local dev without the
     // key still works and the tool degrades gracefully in prod if it's unset.
     return { ok: false, kind: 'unconfigured', message: 'INNOMINATE_API_KEY is not set on this deployment.' }
   }
 
-  const key = cacheKey(items, market)
+  const key = cacheKey(items, market, save)
   const hit = cacheGet(key)
   if (hit) return { ok: true, appraisal: { ...hit, cached: true } }
 
@@ -351,12 +381,12 @@ export const appraise = async (items: AppraisalItemInput[], market: Market = 'ji
   // it calls directly (bypassing the shared-budget throttle); production routes
   // every call through the throttled queue.
   if (process.env.VERCEL !== '1') {
-    const result = await callInnominate(items, market)
+    const result = await callInnominate(items, market, save)
     if (result.ok) cacheSet(key, result.appraisal)
     return result
   }
 
-  return appraiseViaQueue(items, market, key)
+  return appraiseViaQueue(items, market, save, key)
 }
 
 // ---- Queue consumer entry point -------------------------------------------
@@ -392,7 +422,7 @@ export const runInnominateQueueMessage = async ({ requestKey }: InnominateQueueM
     throw new InnominateThrottleRetry(Math.max(1, Math.ceil(gate?.wait_seconds ?? THROTTLE_SECONDS)))
   }
 
-  const result = await callInnominate(row.items, row.market as Market)
+  const result = await callInnominate(row.items, row.market as Market, row.save ?? false)
   await supabase
     .from('innominate_appraisal')
     .update(

--- a/src/innominateKey.ts
+++ b/src/innominateKey.ts
@@ -26,8 +26,21 @@ export type KeyItem = { name: string; quantity: number }
 // The canonical form the digest is taken over. Sorted by name so batches that
 // differ only in order share a key (and therefore a cache entry); quantities
 // included so a different amount is genuinely a different request.
-export const canonicalRequest = (items: KeyItem[], market: string): string =>
-  JSON.stringify({ market, items: sortBy((i: KeyItem) => i.name, items).map((i) => [i.name, i.quantity]) })
+//
+// `save` is part of the identity, not a modifier on it. A saved appraisal is
+// stored on the provider's side and comes back with an id to link to, so an
+// unsaved result — which has no id — must never satisfy a save request from the
+// cache. Two saves of the same items within the TTL do legitimately share an
+// entry, and returning the same stored appraisal is the wanted behaviour: one
+// upstream call, one stored record, one link.
+export const canonicalRequest = (items: KeyItem[], market: string, save = false): string =>
+  JSON.stringify({
+    market,
+    save,
+    items: sortBy((i: KeyItem) => i.name, items).map((i) => [i.name, i.quantity]),
+  })
 
-export const requestKeyFor = (items: KeyItem[], market: string): string =>
-  createHash('sha256').update(canonicalRequest(items, market)).digest('hex')
+export const requestKeyFor = (items: KeyItem[], market: string, save = false): string =>
+  createHash('sha256')
+    .update(canonicalRequest(items, market, save))
+    .digest('hex')

--- a/supabase/migrations/20260801170000_innominate_appraisal_save.sql
+++ b/supabase/migrations/20260801170000_innominate_appraisal_save.sql
@@ -1,0 +1,13 @@
+-- The asset viewer grows a "save and open this appraisal" arrow next to a
+-- returned price: it re-runs the same batch with save: true, which makes
+-- innomin.at store the appraisal and mint an id we can link a player to
+-- (https://innomin.at/a/<id>). Every other appraisal in the app stays
+-- side-effect free on the provider's side, as before.
+--
+-- The queue consumer is what actually calls the provider, so it needs to know
+-- whether this request was a save — hence a column rather than something
+-- derived. It's also part of the request key (src/innominateKey.ts), so a
+-- cached unsaved result, which carries no appraisal id, can never satisfy a
+-- save request; existing rows are all unsaved, which is what the default says.
+alter table public.innominate_appraisal
+  add column if not exists save boolean not null default false;

--- a/test/innominateKey.test.ts
+++ b/test/innominateKey.test.ts
@@ -50,3 +50,15 @@ test('market and quantity are part of the identity', () => {
 test('the same request keys identically across calls', () => {
   assert.equal(requestKeyFor(items(40), 'jita'), requestKeyFor(items(40), 'jita'))
 })
+
+test('saving is part of the identity, so a cached unsaved result cannot satisfy a save', () => {
+  const base = items(5)
+  // The point: an unsaved appraisal carries no provider id to link to, so if it
+  // shared a key with a save request the arrow would have nothing to open.
+  assert.notEqual(requestKeyFor(base, 'jita', false), requestKeyFor(base, 'jita', true))
+  // Two saves of the same batch do share one entry — one upstream call, one
+  // stored record, one link — which is the wanted behaviour, not a collision.
+  assert.equal(requestKeyFor(base, 'jita', true), requestKeyFor(base, 'jita', true))
+  // Unsaved stays the default, so existing callers key exactly as before.
+  assert.equal(requestKeyFor(base, 'jita'), requestKeyFor(base, 'jita', false))
+})


### PR DESCRIPTION
Next to a returned price, a small **↗** re-runs that same batch with `save: true` and opens the result on innomin.at, so a player can share or keep a breakdown rather than just reading a total.

## ⚠️ This is an exception to the `save: false` rule

The rule was emphatic — *"always send `false` … Never expose it as a parameter; hard-code it in the client"* — so it's worth being explicit about what did and didn't change:

- **Everything that prices something automatically still sends `save: false`.** Every row of the asset viewer, every MCP call. Nothing is stored on the provider's side, no id minted.
- **Saving happens only on this click.** Opt-in per call, never a default, never a side effect of displaying a number.

The README now records the exception *and* that this is the one call site to revoke if the API-key terms ever require it — the old text asserted the opposite, which would have misled the next reader.

## How the pieces fit

**`save` is part of the request identity, not a modifier on it.** An unsaved result carries no appraisal id, so if it shared a cache key with a save request the arrow would have nothing to open. Two saves of the same batch *do* share an entry, which is what we want: one upstream call, one stored record, one link. The queue consumer is what actually calls the provider, so the flag rides on the `innominate_appraisal` row — new column, defaulted false, which is what every existing row already is.

**The tab is opened synchronously inside the click** and parked on `about:blank`, then pointed at the URL once the save returns. Open it *after* the await and the browser blocks it as an unsolicited pop-up. `noopener` can't be used there — it makes `window.open` return `null` and defeats the trick — so the opener reference is severed by hand instead.

## Verified against the live API, not guessed

Neither the response field nor the link format is in the docs, so I checked both:

```
POST /api/v1/appraise/  {"save":true}   → 200, appraisal_id: "2GeAakV"
GET  /api/v1/appraisal/2GeAakV/          → 200, round-trips
GET  https://innomin.at/a/2GeAakV        → 200, real page
```

The key-authenticated `GET /api/v1/appraisal/<id>/` is no use as a *shareable* link, which is why the SPA route (`/a/<id>`, found in the provider's JS bundle) is what we open. Both are now written down in the README.

Cost: 1 appraisal request against the budget, plus a couple of plain GETs.

## Verification

- `pnpm test` — 96 pass, 0 fail (1 new, pinning that save changes the key while unsaved stays the default).
- `pnpm run lint` — clean.
- `pnpm run build` — passes.
- Migration-order guard — clean. Schema dual-written to `schema.sql` + a new migration.
- Also fixed two stale `18 seconds` comments in `schema.sql` and `innominate.ts` left over from #776.

Not clicked in a browser — needs a session. Worth checking the pop-up behaviour on the deployed preview, since that's the part most likely to differ by browser.

---
_Generated by [Claude Code](https://claude.ai/code/session_015Zx8z4DMYBn1PG5jjisjC8)_