### PR TITLE
docs(discord-bot): rescope for Discord sign-in and structure fuel alerts

### DIFF
--- a/docs/discord-bot/03-account-linking.md
+++ b/docs/discord-bot/03-account-linking.md
@@ -11,13 +11,21 @@ server, (b) prove to the bot which edencom.link account they are, and
 the target channel. After this stage, `/account/settings` shows the linked
 channel(s); nothing posts to them yet.
 
-## Design: link codes, not Discord OAuth
+## Design: linked identity first, link codes as fallback
+
+*(Amended 2026-08-01: this stage originally ruled out Discord OAuth. Stage
+06 now brings Discord sign-in via Supabase Auth, so a growing share of
+accounts carry a Discord identity — `auth.identities` holds the Discord
+user id. When the `/edencom link` invoker's Discord user id matches a
+linked identity (service-role lookup), bind the channel to that account
+directly, no code needed. The link-code flow below stays as the fallback
+for accounts without a Discord identity, and the two flows share the same
+`discord_channel` row shape. If 06 lands first, the implementing PR for
+this stage may make codes a follow-up rather than building both paths.)*
 
 Two identities need joining: the edencom.link account (Supabase `user_id`)
-and a Discord channel. Full Discord OAuth2 sign-in would work but drags in a
-second OAuth client, callback route, and token storage for something we need
-exactly once. Instead, mirror the invite-code pattern the repo already has
-(`invite_code`):
+and a Discord channel. The code-based flow mirrors the invite-code pattern
+the repo already has (`invite_code`):
 
 1. Settings page mints a short-lived, single-use **link code** (server
    action; `randomBytes` like `generateApiToken`), shown with copy button
@@ -97,5 +105,5 @@ Server actions in the existing settings `actions.ts`.
 - Choosing *which* events go to *which* channel (all den reinforcements to
   every linked channel is the MVP; per-den or per-event routing is a
   follow-up).
-- Discord OAuth2 website sign-in.
+- Discord OAuth2 website sign-in (now stage 06).
 - Role-mention configuration.

--- a/docs/discord-bot/06-discord-sign-in.md
+++ b/docs/discord-bot/06-discord-sign-in.md
@@ -1,0 +1,75 @@
+# Stage 06 — Discord as an auth method
+
+**PR size:** medium · **Depends on:** 02 (the Discord application exists) ·
+**Independent of:** 03–05 (no bot, no channels, no outbox involved)
+
+## Goal
+
+- A new user can create an edencom.link account by authenticating with
+  Discord alone — no email/password step.
+- A Discord-only user can add email/password later.
+- An existing email/password user can add Discord to their account.
+
+## Design: Supabase Auth's native Discord provider
+
+No hand-rolled OAuth client. Supabase Auth ships a Discord provider; the
+whole feature is dashboard configuration plus a handful of client calls:
+
+- **Sign in / sign up:** `supabase.auth.signInWithOAuth({ provider:
+  'discord', options: { redirectTo } })` from a "Continue with Discord"
+  button on `/account/login` and `/account/register`. Supabase creates the
+  account on first sign-in (identity in `auth.identities`, carrying the
+  Discord user id, username, avatar).
+- **Add Discord to an email account:** `supabase.auth.linkIdentity({
+  provider: 'discord' })` from a new "Connected accounts" section on
+  `/account/settings`. Requires **manual linking** enabled in the Supabase
+  dashboard (Authentication → Providers). `unlinkIdentity` for removal —
+  Supabase refuses to unlink the last identity, so a Discord-only account
+  can't strand itself.
+- **Add email/password to a Discord-only account:**
+  `supabase.auth.updateUser({ email, password })` from settings; email
+  change confirms via the existing `/account/confirm` OTP route.
+
+## Platform configuration (not code)
+
+- Supabase dashboard: enable the Discord provider with the same
+  `DISCORD_APP_ID` + a client secret (new env var `DISCORD_CLIENT_SECRET`
+  for local parity, though Supabase holds the live value); enable manual
+  linking.
+- Discord developer portal: add Supabase's callback
+  (`https://<project-ref>.supabase.co/auth/v1/callback`) as an OAuth2
+  redirect. Scopes: `identify email` only.
+- An auth-code callback route (`/account/callback` or reuse of the PKCE
+  flow in `@supabase/ssr`) exchanges the code for a session — follow the
+  current `@supabase/ssr` cookie pattern used by `src/utils/supabase/*`.
+
+## Interactions with the rest of the app
+
+- **Invite gating:** registration today is invite-code gated. Decide in the
+  implementing PR whether Discord sign-up must also present an invite code
+  (likely yes: collect/redeem it on a post-OAuth landing step for accounts
+  with no redeemed code, reusing the `invite_code` machinery) — otherwise
+  Discord becomes an open-registration bypass.
+- **Stage 03 linking:** an account's Discord identity (in
+  `auth.identities`) lets the `/edencom link` handler bind a channel by
+  matching the invoking Discord user id — no link code. See the amended
+  design note in 03-account-linking.md.
+- `user_settings` and everything else keys off `auth.uid()` and is
+  unaffected by which identity signed in.
+
+## Milestone / acceptance
+
+- Fresh browser: "Continue with Discord" creates a working account
+  (assets/settings pages behave exactly like an email account's).
+- That account adds an email/password and can then sign in with either.
+- An existing email account links Discord in settings, signs out, and signs
+  back in via Discord to the same account (same `user_id`).
+- Unlinking the sole identity is refused with a clear message.
+- `pnpm run lint` + `pnpm run build` pass.
+
+## Out of scope
+
+- Storing Discord tokens ourselves (Supabase holds the provider tokens; we
+  only ever need the Discord user id from the identity).
+- Using the Discord identity for bot features (stage 03 consumes it).
+- Discord avatar/username display in the header (cheap follow-up).

--- a/docs/discord-bot/07-structure-fuel-alerts.md
+++ b/docs/discord-bot/07-structure-fuel-alerts.md
@@ -1,0 +1,49 @@
+# Stage 07 — Low structure fuel alerts
+
+**PR size:** small · **Depends on:** 04 (outbox table), 05 (sender), 03
+(linked channels)
+
+## Goal
+
+When a structure a user monitors is running low on fuel, post an alert to
+their linked Discord channel(s). First alert source beyond den
+reinforcement, and the proof that the outbox generalizes.
+
+## Detection
+
+`corp_structure.fuel_expires` is already extracted daily by the
+`corp-structures` job (`src/jobs/corpStructures.js`). At the end of each
+run, for each structure whose `fuel_expires` has crossed under a threshold
+(start with 7 days; per-user configurability is a follow-up), enqueue one
+outbox row — mirroring how stage 04 hooks `character-mercenary-dens`.
+
+Dedup: the crossing must fire once, not on every daily run while low. Use
+the same mechanism stage 04 picks (compare against the previous
+observation, or an outbox uniqueness key like
+`(source, structure_id, fuel_expires)` — refueling pushes `fuel_expires`
+forward, naturally re-arming the alert).
+
+Audience: structures are corp-scoped; alert every user with a linked
+channel whose registration is in that corp (same resolution the
+`/structure` page's RLS implies), not just the character whose token pulled
+the extract.
+
+## Message
+
+Structure name, system, and "fuel expires <relative time>" — reusing the
+name resolution the `/structure` page already does. Formatting lives with
+the stage-05 sender's per-source message builders.
+
+## Milestone / acceptance
+
+- A structure with `fuel_expires` inside the threshold produces exactly one
+  outbox row per crossing, and the message arrives in the linked channel.
+- A refuel then a re-drain below threshold re-alerts.
+- `pnpm run lint` + `pnpm run build` pass.
+
+## Out of scope
+
+- Per-user thresholds / muting individual structures.
+- Escalation tiers ("7 days" then "48 hours").
+- In-site notification surface (the website alerts UI is its own future
+  project; this stage is Discord delivery only).

--- a/docs/discord-bot/README.md
+++ b/docs/discord-bot/README.md
@@ -1,12 +1,36 @@
-# Discord bot: reinforced-den notifications
+# Discord integration: sign-in + channel alerts
 
-Scope for making edencom.link double as a Discord application, so that when
-an extract run detects that one of a user's Mercenary Dens has been
-reinforced, a message is posted automatically to a Discord channel the user
-configured. Today this is manual: the `/mercenary-dens` page has a 📋 button
-(`src/app/mercenary-dens/copyDiscordPing.tsx`) that copies a Discord-ready
-ping the user pastes into their corp channel themselves. This project closes
-that loop.
+Scope for making edencom.link double as a Discord application. Two goals
+(rescoped 2026-08-01 — the project began as den-reinforcement pings only):
+
+1. **Discord as an auth method.** New users can create an account by
+   authenticating with Discord alone — no email/password required — and can
+   add email/password later. Existing email/password users can add Discord
+   to their account. (Supabase Auth's native Discord provider:
+   `signInWithOAuth` / `linkIdentity`; no hand-rolled OAuth client.)
+2. **A bot posting alerts to a Discord channel** the user configured, fed by
+   alert sources we build into the website over time. First sources:
+   Mercenary Den reinforcement (the original scope — today manual via the
+   `/mercenary-dens` 📋 button, `copyDiscordPing.tsx`) and low structure
+   fuel (promoted from the follow-ups list to stage 07).
+
+## Status (2026-08-01)
+
+- **Stage 01 — shipped.** `/privacy` and `/terms` are live
+  (`src/app/privacy/`, `src/app/terms/`), linked from the footer.
+- **Stage 02 — shipped.** The signed interactions endpoint is live at
+  `/api/discord/interactions` (`src/app/api/discord/lib.ts` does
+  dependency-free Ed25519 verification via `node:crypto`); PING→PONG works,
+  application commands get a placeholder ephemeral reply.
+  `DISCORD_APP_ID`/`DISCORD_PUBLIC_KEY`/`DISCORD_BOT_TOKEN` are in
+  `.env.example`, and interactions emit `recordDiscordInteraction`
+  observability metrics.
+- **Stage 03 — not started.** No `discord_link_code`/`discord_channel`
+  tables, no command router, no settings UI yet. Its "link codes, not
+  Discord OAuth" design predates goal 1 and is amended below: stage 06's
+  Discord identity becomes the primary account↔Discord binding, with link
+  codes kept as the fallback for users who haven't linked Discord.
+- **Stages 04–07 — not started.**
 
 This is a scoping document set, not an implementation spec. Each stage is
 one PR with its own milestone; do them **in order** (each builds on the
@@ -21,6 +45,12 @@ against the code as it stands then.
 | [03-account-linking.md](03-account-linking.md) | medium | Bot install flow, account↔Discord linking, channel configuration via `/edencom link` | A linked channel row appears in settings after running the slash command |
 | [04-reinforcement-detection.md](04-reinforcement-detection.md) | medium | Detect the unreinforced→reinforced transition at extract time; notification outbox table | A simulated reinforcement produces exactly one pending outbox row |
 | [05-notification-sender.md](05-notification-sender.md) | small | Cron sweep that posts pending notifications to the linked channel | End-to-end: reinforced den → message in the Discord channel |
+| [06-discord-sign-in.md](06-discord-sign-in.md) | medium | Discord as a Supabase Auth provider: sign in / sign up with Discord, link Discord to an email account, add email later | A Discord-only account exists and works; an email account shows a linked Discord identity in settings |
+| [07-structure-fuel-alerts.md](07-structure-fuel-alerts.md) | small | Low-fuel detection on the `corp-structures` extract, riding the stage-04 outbox and stage-05 sender | A structure crossing the fuel threshold produces exactly one channel message |
+
+Stage 06 is independent of 03–05 and can land any time after 02 (it wants
+the same Discord application, plus a second OAuth2 redirect for Supabase).
+Stage 07 depends on 04+05 (outbox + sender).
 
 Follow-ups (out of scope for all five stages) are collected at the bottom of
 this file.
@@ -126,7 +156,8 @@ New secrets (Vercel env vars + `.env.example`), introduced in stage 02:
 - Notifications from the enemy-den intel corkboard (user-submitted
   reinforcements, `enemyDenIntel.tsx`).
 - Other notification sources riding the same outbox: industry-job
-  completion (the ntfy plan), clone-jump cooldown, structure fuel.
+  completion (the ntfy plan), clone-jump cooldown. (Structure fuel was
+  promoted out of this list to stage 07.)
 - Incoming-webhook delivery as an alternative transport for users who don't
   want the bot in their server.
 - Discord App Directory listing / verification.


### PR DESCRIPTION
Updates the Discord integration plan (`docs/discord-bot/`) to match the project's new goals:

- **README**: retitled to "Discord integration: sign-in + channel alerts", added a Status section (stages 01–02 shipped — legal pages and the signed interactions endpoint are live; 03–05 not started), and added two new stage rows.
- **New stage 06 — Discord sign-in** (`06-discord-sign-in.md`): Discord as a Supabase Auth provider — new users create an account with Discord alone, can add email/password later, and email users can `linkIdentity` Discord. Independent of stages 03–05; flags the invite-code-gating question for the implementing PR.
- **New stage 07 — structure fuel alerts** (`07-structure-fuel-alerts.md`): low-fuel detection on the daily `corp-structures` extract (`fuel_expires` threshold crossing), riding the stage-04 outbox and stage-05 sender. Promoted from the follow-ups list.
- **Stage 03 amended**: once stage 06 exists, an account's Discord identity (in `auth.identities`) becomes the primary account↔Discord binding for `/edencom link`; link codes stay as the fallback.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P36APcs93Ut48Xg2bSL9qV

---
_Generated by [Claude Code](https://claude.ai/code/session_01P36APcs93Ut48Xg2bSL9qV)_