### PR TITLE
Show item icons throughout the assets pages

### DIFF
--- a/src/app/asset/[locationId]/locationAssets.tsx
+++ b/src/app/asset/[locationId]/locationAssets.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 
 import { ALL_OWNERS, OwnerSelect, ownerNames, useOwnerFilter, type Owners } from '../../ownerFilter'
 import retro from '../../retro.module.css'
+import { TypeIcon } from '../../typeIcon'
 import { TypeName } from '../../typeName'
 import styles from '../assets.module.css'
 import { OWNER_STORAGE_KEY } from '../filterKey'
@@ -70,6 +71,9 @@ export const LocationAssets = ({ rows, owners, typeNamesPromise, canAppraise }: 
               <tr key={`item-${row.itemId}`}>
                 <td>{ownerMap.get(row.ownerId) ?? row.ownerId}</td>
                 <td>
+                  {/* The icon sits outside the link so a click always lands on
+                      the name, and it renders immediately (no name lookup). */}
+                  <TypeIcon id={row.typeId} />
                   {row.href ? (
                     // Ships open their own /ship page; containers drill into /asset.
                     <Link href={row.href}>

--- a/src/app/asset/[locationId]/page.tsx
+++ b/src/app/asset/[locationId]/page.tsx
@@ -10,6 +10,7 @@ import { resolveLocations, type LocationRef } from '../../resolveLocations'
 import { resolveShareToken } from '../../ship/access'
 import { fetchStationNames, fetchStationSystems } from '../../stationNames'
 import { fetchSystemNames } from '../../systemNames'
+import { TypeIcon } from '../../typeIcon'
 import { fetchTypeNames } from '../../typeNames'
 import type { Owners } from '../../ownerFilter'
 import styles from '../assets.module.css'
@@ -375,7 +376,12 @@ const AssetLocationPage = async ({
     <>
       {!scope ? <AssetPath crumbs={crumbs} current={heading} /> : null}
       <div className={styles.header}>
-        <h1 className="serif">{heading}</h1>
+        <h1 className="serif">
+          {/* A container drilled into is an item like any other, so it wears its
+              own icon; a station/structure/system has no type id to draw one from. */}
+          {self ? <TypeIcon id={Number(self.type_id)} size={32} /> : null}
+          {heading}
+        </h1>
         {/* Prices this whole place in one request — the same endpoint each row
             uses, just aimed at the location instead of an item. */}
         {!scope ? <AppraiseButton target={locationId} label="Appraise everything here" /> : null}

--- a/src/app/asset/search/page.tsx
+++ b/src/app/asset/search/page.tsx
@@ -9,6 +9,7 @@ import { createClient } from '@/utils/supabase/server'
 import { fetchOwners } from '../../owners'
 import { resolveLocations, type LocationRef } from '../../resolveLocations'
 import retro from '../../retro.module.css'
+import { TypeIcon } from '../../typeIcon'
 import { TypeName } from '../../typeName'
 import { AssetSearchForm } from '../assetSearchForm'
 import { Quantity } from '../[locationId]/quantity'
@@ -266,6 +267,7 @@ const AssetSearchPage = async ({ searchParams }: { searchParams: Promise<{ q?: s
                   {row.root && !floating ? <Link href={`/asset/${row.root.id}`}>{stationName}</Link> : '—'}
                 </td>
                 <td>
+                  <TypeIcon id={row.typeId} />
                   {row.contents > 0 ? (
                     <Link href={`/asset/${row.itemId}`}>
                       <TypeName id={row.typeId} name={row.name} promise={typeNamesPromise} />
@@ -281,6 +283,9 @@ const AssetSearchPage = async ({ searchParams }: { searchParams: Promise<{ q?: s
                     if (shipLabel && row.parentId) {
                       return (
                         <>
+                          {/* The containing ship is an item too, so it gets its
+                              own hull icon rather than only the match's. */}
+                          {row.parentTypeId != null && <TypeIcon id={row.parentTypeId} />}
                           <Link className="serif" href={`/ship/${row.parentId}`}>
                             {shipLabel}
                           </Link>

--- a/src/app/ship/[itemId]/page.tsx
+++ b/src/app/ship/[itemId]/page.tsx
@@ -4,6 +4,7 @@ import { getSdeType, getSdeTypes } from '@/sdeTypes'
 import { createClient } from '@/utils/supabase/server'
 import { createServiceClient } from '@/utils/supabase/service'
 import { AssetPath, fetchAssetPath } from '../../assetPath'
+import { TypeIcon } from '../../typeIcon'
 import { fetchTypeNames } from '../../typeNames'
 import { type ItemRow } from '../../asset/[locationId]/locationAssets'
 import { resolveShareToken } from '../access'
@@ -177,7 +178,10 @@ const ShipPage = async ({
   return (
     <>
       <AssetPath crumbs={crumbs} current={heading} />
-      <h1 className="serif">{heading}</h1>
+      <h1 className="serif">
+        <TypeIcon id={Number(self.type_id)} size={32} />
+        {heading}
+      </h1>
       <p>
         Owner: <span className="serif">{ownerName}</span>
       </p>
@@ -267,7 +271,10 @@ const SharedShipPage = async ({ itemId, token }: { itemId: string; token: string
 
   return (
     <>
-      <h1 className="serif">{heading}</h1>
+      <h1 className="serif">
+        <TypeIcon id={Number(self.type_id)} size={32} />
+        {heading}
+      </h1>
       <p>
         Owner: <span className="serif">{ownerName}</span>
       </p>

--- a/src/app/typeIcon.module.css
+++ b/src/app/typeIcon.module.css
@@ -1,0 +1,8 @@
+/* Inline item icon, sitting immediately before a type name. CCP's image server
+   returns square images, so the size comes from the element's width/height
+   attributes and only alignment/spacing lives here. */
+.icon {
+  vertical-align: middle;
+  margin-right: 6px;
+  flex: none;
+}

--- a/src/app/typeIcon.tsx
+++ b/src/app/typeIcon.tsx
@@ -1,0 +1,25 @@
+import styles from './typeIcon.module.css'
+
+type TypeIconProps = {
+  id: number
+  // Rendered size in CSS pixels; the image itself is always fetched at 64 so a
+  // hi-dpi screen has pixels to spare at the sizes used here.
+  size?: number
+}
+
+// The item icon CCP's image server serves for a type id. Purely decorative —
+// every use sits next to the type's name (TypeName), so it carries an empty alt
+// and is hidden from screen readers rather than repeating that name. Not a
+// next/image: the existing icon/portrait uses across the app are plain <img>
+// tags, which keeps images.evetech.net out of next.config.mjs's remote patterns.
+export const TypeIcon = ({ id, size = 24 }: TypeIconProps) => (
+  <img
+    className={styles.icon}
+    src={`https://images.evetech.net/types/${id}/icon?size=64`}
+    alt=""
+    aria-hidden="true"
+    width={size}
+    height={size}
+    loading="lazy"
+  />
+)


### PR DESCRIPTION
Every item listed under the assets pages now renders CCP's type icon before its name, so a hangar reads at a glance instead of as a wall of text.

## What changed

- **`src/app/typeIcon.tsx` (new)** — `TypeIcon`, a small shared `<img>` onto `images.evetech.net/types/<id>/icon`. Always fetches at `size=64` and renders at 24px (32px in headings) so hi-dpi screens have pixels to spare. Plain `<img>` rather than `next/image`, matching the portrait/icon uses already in `character/`, `corpses/` and `shipCargo` — that keeps `images.evetech.net` out of `next.config.mjs`'s remote patterns.
- **`/asset/[locationId]`** — an icon before each row's item name in `locationAssets.tsx`, and the hull/container icon beside the heading when the id being browsed is an item that was drilled into.
- **`/asset/search`** — an icon in the Item column, plus the containing ship's hull icon in the Hangar column (that ship is an item too, and its icon identifies the hull faster than the name does).
- **`/ship/[itemId]`** — the hull icon beside the heading, on both the signed-in and share-token views. The cargo grid below already had per-item icons.

The icon sits outside the item's link so a click always lands on the name, and it renders immediately — it needs only the type id, not the streamed name lookup, so it doesn't wait on `TypeName`'s Suspense boundary.

## Accessibility

Each icon is decorative: it sits next to a name `TypeName` already renders, so it carries an empty `alt` and `aria-hidden` rather than repeating that name to a screen reader.

## Not covered

Location rows on the assets index (and the per-system station list) stay text-only — those are places rather than items. Player structures do carry a `type_id`, but NPC stations have none in the `sde_station` mirror view, so icons there would appear on some rows and not others; extending that view is its own change.

## Testing

- `pnpm run lint` — clean
- `pnpm run build` — succeeds
- `pnpm test` — 96/96 pass (no new pure-logic seam here; the change is markup)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZoYVxvCtqjGGUL9MGTbHR)_