### PR TITLE
Reorder and sort the asset folder table

### DIFF
--- a/src/app/asset/[locationId]/locationAssets.tsx
+++ b/src/app/asset/[locationId]/locationAssets.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { ascend, descend, sortWith } from 'ramda'
 
 import { ALL_OWNERS, OwnerSelect, ownerNames, useOwnerFilter, type Owners } from '../../ownerFilter'
 import retro from '../../retro.module.css'
@@ -41,70 +43,172 @@ type LocationAssetsProps = {
   canAppraise: boolean
 }
 
+// The sortable columns. Appraisal is deliberately absent: its values only exist
+// once each row's button has been pressed, so there'd be nothing to order by.
+type SortKey = 'quantity' | 'item' | 'owner' | 'hangar' | 'contents'
+type Sort = { key: SortKey; dir: 'asc' | 'desc' }
+
+// A stack of one — what a singleton (a ship, a rig, an assembled container)
+// holds — so an unlabelled quantity cell still sorts where it belongs.
+const SINGLE = 1
+
+// ESI stores the literal string "None" for a singleton with no player-assigned
+// name; TypeName hides it, so sorting ignores it too.
+const givenName = (row: ItemRow): string | null => (row.name && row.name !== 'None' ? row.name : null)
+
+type SortHeaderProps = {
+  label: string
+  sortKey: SortKey
+  sort: Sort | null
+  onSort: (key: SortKey) => void
+  numeric?: boolean
+}
+
+// A column header that sorts on click. Declared at module scope rather than
+// inside LocationAssets: a component defined during render is a new type on
+// every render, so React would remount these buttons and drop keyboard focus
+// the moment one of them was used.
+const SortHeader = ({ label, sortKey, sort, onSort, numeric }: SortHeaderProps) => {
+  const active = sort?.key === sortKey
+  return (
+    <th
+      className={numeric ? retro.num : undefined}
+      aria-sort={active ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}
+    >
+      <button type="button" className={styles.sortButton} onClick={() => onSort(sortKey)}>
+        {label}
+        {/* Fixed-width so the header doesn't shift as the marker moves. */}
+        <span className={styles.sortMarker} aria-hidden="true">
+          {active ? (sort.dir === 'asc' ? '▲' : '▼') : ''}
+        </span>
+      </button>
+    </th>
+  )
+}
+
 export const LocationAssets = ({ rows, owners, typeNamesPromise, canAppraise }: LocationAssetsProps) => {
   const [ownerId, setOwnerId] = useOwnerFilter(OWNER_STORAGE_KEY, owners)
+  const [sort, setSort] = useState<Sort | null>(null)
+  // Type names stream in (the server hands us a promise so a big hangar doesn't
+  // block the page), and each cell renders its own through Suspense. Sorting by
+  // item needs them all at once, so they're mirrored into state as they land
+  // rather than awaited here — reading the promise with use() would suspend the
+  // whole table, which is exactly what the streaming avoids. Until they arrive,
+  // an item sorts by whatever its cell is showing (given name, else "#id").
+  const [typeNames, setTypeNames] = useState<Record<number, string>>({})
+  useEffect(() => {
+    let live = true
+    typeNamesPromise.then((names) => {
+      if (live) setTypeNames(names)
+    })
+    return () => {
+      live = false
+    }
+  }, [typeNamesPromise])
 
-  const filtered = rows.filter((r) => ownerId === ALL_OWNERS || r.ownerId === ownerId)
   const ownerMap = ownerNames(owners)
+  const filtered = rows.filter((r) => ownerId === ALL_OWNERS || r.ownerId === ownerId)
+
+  // What each sortable column compares on — the cell's own displayed value, so
+  // the order always matches what's on screen. Strings are lower-cased so a
+  // capitalized name doesn't sort into its own block ahead of everything else.
+  const sortValue = (row: ItemRow, key: SortKey): number | string => {
+    switch (key) {
+      case 'quantity':
+        return row.isSingleton ? SINGLE : Number(row.quantity ?? SINGLE)
+      case 'item':
+        return (givenName(row) ?? typeNames[row.typeId] ?? `#${row.typeId}`).toLowerCase()
+      case 'owner':
+        return (ownerMap.get(row.ownerId) ?? row.ownerId).toLowerCase()
+      case 'hangar':
+        return (row.flag ?? '').toLowerCase()
+      case 'contents':
+        return row.contents
+    }
+  }
+
+  // Unsorted keeps the server's order (containers first, then type id). Sorting
+  // is stable, so rows that tie hold that order within their group.
+  const ordered = sort
+    ? sortWith<ItemRow>([(sort.dir === 'asc' ? ascend : descend)((row) => sortValue(row, sort.key))], filtered)
+    : filtered
+
+  // Same column again flips direction; a new column starts ascending.
+  const toggleSort = (key: SortKey) =>
+    setSort((current) =>
+      current?.key === key ? { key, dir: current.dir === 'asc' ? 'desc' : 'asc' } : { key, dir: 'asc' }
+    )
 
   return (
     <section>
       {rows.length > 0 ? (
-        <table className={retro.retro}>
-          <thead>
-            <tr>
-              <th>
-                <label className={styles.filter}>
-                  Owner:&nbsp;
-                  <OwnerSelect owners={owners} value={ownerId} onChange={setOwnerId} />
-                </label>
-              </th>
-              <th>Item</th>
-              <th className={retro.num}>Quantity</th>
-              <th>Hangar</th>
-              <th className={retro.num}>Contents</th>
-              {canAppraise && <th className={retro.num}>Value</th>}
-            </tr>
-          </thead>
-          <tbody>
-            {filtered.map((row) => (
-              <tr key={`item-${row.itemId}`}>
-                <td>{ownerMap.get(row.ownerId) ?? row.ownerId}</td>
-                <td>
-                  {/* The icon sits outside the link so a click always lands on
-                      the name, and it renders immediately (no name lookup). */}
-                  <TypeIcon id={row.typeId} />
-                  {row.href ? (
-                    // Ships open their own /ship page; containers drill into /asset.
-                    <Link href={row.href}>
-                      <TypeName id={row.typeId} name={row.name} promise={typeNamesPromise} />
-                    </Link>
-                  ) : (
-                    <TypeName id={row.typeId} name={row.name} promise={typeNamesPromise} />
-                  )}
-                  {row.isCurrentShip && <span className={styles.badge}>current ship</span>}
-                </td>
-                <td className={retro.num}>{row.isSingleton ? '—' : <Quantity value={row.quantity} />}</td>
-                <td>{row.flag ?? '—'}</td>
-                <td className={retro.num}>{row.contents > 0 ? row.contents : '—'}</td>
-                {canAppraise && (
-                  // A container or ship prices itself plus everything nested
-                  // inside it; a plain stack prices just itself.
-                  <td className={retro.num}>
-                    <AppraiseButton target={row.itemId} />
-                  </td>
-                )}
-              </tr>
-            ))}
-            {filtered.length === 0 && (
-              // Keep the table (and the owner dropdown in its header) rendered
-              // so the filter can be changed back when an owner has nothing here.
+        <>
+          {/* The owner filter lives above the table rather than inside a header
+              cell: the headers are sort controls now, and this stays reachable
+              even when the chosen owner has nothing here. */}
+          <div className={styles.filters}>
+            <label className={styles.filter}>
+              Owner:&nbsp;
+              <OwnerSelect owners={owners} value={ownerId} onChange={setOwnerId} />
+            </label>
+          </div>
+          <table className={retro.retro}>
+            <thead>
               <tr>
-                <td colSpan={canAppraise ? 6 : 5}>No assets here for this owner.</td>
+                <SortHeader label="Quantity" sortKey="quantity" sort={sort} onSort={toggleSort} numeric />
+                <SortHeader label="Item" sortKey="item" sort={sort} onSort={toggleSort} />
+                <SortHeader label="Owner" sortKey="owner" sort={sort} onSort={toggleSort} />
+                <SortHeader label="Hangar" sortKey="hangar" sort={sort} onSort={toggleSort} />
+                <SortHeader label="Contents" sortKey="contents" sort={sort} onSort={toggleSort} numeric />
+                {canAppraise && <th className={retro.num}>Appraisal</th>}
               </tr>
-            )}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {ordered.map((row) => (
+                <tr key={`item-${row.itemId}`}>
+                  {/* A singleton has no stack size to speak of — left blank
+                      rather than filled with a placeholder dash. */}
+                  <td className={retro.num}>
+                    {row.isSingleton || row.quantity == null ? null : <Quantity value={row.quantity} />}
+                  </td>
+                  <td>
+                    {/* Icon first, then the name — one line, the icon never
+                        wrapping away from the text it belongs to. It sits
+                        outside the link so a click always lands on the name,
+                        and it renders immediately (no name lookup). */}
+                    <span className={styles.item}>
+                      <TypeIcon id={row.typeId} />
+                      {row.href ? (
+                        // Ships open their own /ship page; containers drill into /asset.
+                        <Link href={row.href}>
+                          <TypeName id={row.typeId} name={row.name} promise={typeNamesPromise} />
+                        </Link>
+                      ) : (
+                        <TypeName id={row.typeId} name={row.name} promise={typeNamesPromise} />
+                      )}
+                      {row.isCurrentShip && <span className={styles.badge}>current ship</span>}
+                    </span>
+                  </td>
+                  <td>{ownerMap.get(row.ownerId) ?? row.ownerId}</td>
+                  <td>{row.flag ?? '—'}</td>
+                  <td className={retro.num}>{row.contents > 0 ? row.contents : '—'}</td>
+                  {canAppraise && (
+                    // A container or ship prices itself plus everything nested
+                    // inside it; a plain stack prices just itself.
+                    <td className={retro.num}>
+                      <AppraiseButton target={row.itemId} />
+                    </td>
+                  )}
+                </tr>
+              ))}
+              {ordered.length === 0 && (
+                <tr>
+                  <td colSpan={canAppraise ? 6 : 5}>No assets here for this owner.</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </>
       ) : (
         <p>No assets known at this location.</p>
       )}

--- a/src/app/asset/assets.module.css
+++ b/src/app/asset/assets.module.css
@@ -98,6 +98,37 @@
   white-space: nowrap;
 }
 
+/* Item cell: the type icon and the name share one line, so a long name wraps
+   within itself rather than pushing the icon onto a line of its own. */
+.item {
+  display: flex;
+  align-items: center;
+}
+
+/* Column header doubling as a sort control. Inline-flex so the cell's own
+   text-align still places it (right, in the numeric columns). */
+.sortButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0;
+  border: 0;
+  background: none;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+.sortButton:hover {
+  color: var(--ink);
+}
+
+.sortMarker {
+  display: inline-block;
+  width: 8px;
+  font-size: 8px;
+}
+
 .badge {
   margin-left: 8pt;
   padding: 1pt 6pt;


### PR DESCRIPTION
Restructures the per-location asset listing (`/asset/[locationId]`, the "folder" view) — column order, sorting, and a couple of cell-level fixes.

## Column order

`Quantity · Item · Owner · Hangar · Contents · Appraisal` — previously `Owner · Item · Quantity · Hangar · Contents · Value`. The last column is now labelled **Appraisal**.

## Sorting

Every column but Appraisal sorts from its header: click to sort ascending, click again to flip. Unsorted (the initial state) keeps the server's order — containers first, then type id — and the sort is stable, so ties hold that order within their group. Appraisal has nothing to order by until each row's button has been pressed, so it stays a plain header.

Each column sorts on what its cell actually displays: the resolved item name, the owner's display name, the hangar flag, the numeric quantity/contents. `aria-sort` is set on the active header.

Two details worth flagging:

- **Item names arrive asynchronously.** The server hands the table a promise so a large hangar streams rather than blocking, and each cell resolves its own name through Suspense. Sorting needs them all at once, but reading the promise with `use()` here would suspend the entire table — exactly what the streaming avoids. So the names are mirrored into state as they land; until they do, an item sorts by whatever its cell is showing (given name, else `#id`).
- **`SortHeader` is declared at module scope**, not inside the component. A component defined during render is a new type on every render, so React would remount the header buttons and drop keyboard focus the moment one was used.

## Cells

- A singleton's quantity cell is now **blank** instead of an em dash — a ship or an assembled container has no stack size to report. It still sorts as the one item it is.
- The Item cell is a flex line, so the icon and the name stay on one line and a long name wraps within itself rather than pushing the icon onto a line of its own. `TypeName`'s existing `<given name> (<type>)` rendering is unchanged.
- The owner filter moved out of the first header cell (now a sort control) into a filter row above the table, where it stays reachable when the chosen owner has nothing at this location.

Scoped to the folder view as asked; `/asset/search` and the assets index table are untouched.

## Testing

- `pnpm run lint` — clean
- `pnpm run build` — compiles
- `pnpm test` — 101/101 pass (this change is markup + client state; no pure-logic seam added)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZoYVxvCtqjGGUL9MGTbHR)_