### PR TITLE
Add volume, group and category columns to the asset table

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -3423,7 +3423,10 @@ select
   g.data -> 'name' ->> 'en' as group_name,
   c.data -> 'name' ->> 'en' as category_name,
   (t.data ->> 'raceID')::bigint as race_id,
-  (t.data ->> 'metaGroupID')::bigint as meta_group_id
+  (t.data ->> 'metaGroupID')::bigint as meta_group_id,
+  -- m³ per unit (migration 20260804000000). Assembled singletons carry their
+  -- assembled volume — the SDE has no packaged figure for them.
+  (t.data ->> 'volume')::double precision as volume
 from public.sde_types t
 left join public.sde_groups g on g._key = (t.data ->> 'groupID')::bigint
 left join public.sde_categories c on c._key = (g.data ->> 'categoryID')::bigint

--- a/src/app/asset/[locationId]/locationAssets.tsx
+++ b/src/app/asset/[locationId]/locationAssets.tsx
@@ -6,7 +6,7 @@ import { ascend, descend, sortWith } from 'ramda'
 
 import { ALL_OWNERS, OwnerSelect, ownerNames, useOwnerFilter, type Owners } from '../../ownerFilter'
 import retro from '../../retro.module.css'
-import { TypeIcon } from '../../typeIcon'
+import { TypeIcon, type IconVariation } from '../../typeIcon'
 import { TypeName } from '../../typeName'
 import styles from '../assets.module.css'
 import { OWNER_STORAGE_KEY } from '../filterKey'
@@ -31,6 +31,16 @@ export type ItemRow = {
   // containers with contents, null for plain stacks (no link). Computed
   // server-side, where the SDE category lookup lives.
   href: string | null
+  // SDE facts about this row's type, resolved server-side for the same reason
+  // (the browser has no SDE access): m³ per unit — the assembled figure for a
+  // ship or other singleton, which is all the SDE carries — plus the group and
+  // category the type belongs to. Null for a type the published-type view
+  // doesn't cover.
+  unitVolume: number | null
+  groupName: string | null
+  categoryName: string | null
+  // Which image CCP holds for this type; blueprints have no "icon" variation.
+  icon: IconVariation
 }
 
 type LocationAssetsProps = {
@@ -45,7 +55,7 @@ type LocationAssetsProps = {
 
 // The sortable columns. Appraisal is deliberately absent: its values only exist
 // once each row's button has been pressed, so there'd be nothing to order by.
-type SortKey = 'quantity' | 'item' | 'owner' | 'hangar' | 'contents'
+type SortKey = 'quantity' | 'item' | 'volume' | 'group' | 'category' | 'owner' | 'hangar' | 'contents'
 type Sort = { key: SortKey; dir: 'asc' | 'desc' }
 
 // A stack of one — what a singleton (a ship, a rig, an assembled container)
@@ -55,6 +65,18 @@ const SINGLE = 1
 // ESI stores the literal string "None" for a singleton with no player-assigned
 // name; TypeName hides it, so sorting ignores it too.
 const givenName = (row: ItemRow): string | null => (row.name && row.name !== 'None' ? row.name : null)
+
+const stackSize = (row: ItemRow): number => (row.isSingleton ? SINGLE : Number(row.quantity ?? SINGLE))
+
+// What the whole stack occupies: the type's per-unit m³ times how many are in
+// it. Null for a type with no volume in the SDE mirror, which renders blank
+// rather than an invented zero.
+const stackVolume = (row: ItemRow): number | null => (row.unitVolume == null ? null : row.unitVolume * stackSize(row))
+
+// Volumes span from 0.01 m³ (a piece of ammo) to eight figures (a freighter's
+// worth of ore), so they're grouped and capped at two decimals rather than
+// printed raw.
+const formatVolume = (m3: number): string => m3.toLocaleString('en-US', { maximumFractionDigits: 2 })
 
 type SortHeaderProps = {
   label: string
@@ -115,9 +137,16 @@ export const LocationAssets = ({ rows, owners, typeNamesPromise, canAppraise }: 
   const sortValue = (row: ItemRow, key: SortKey): number | string => {
     switch (key) {
       case 'quantity':
-        return row.isSingleton ? SINGLE : Number(row.quantity ?? SINGLE)
+        return stackSize(row)
       case 'item':
         return (givenName(row) ?? typeNames[row.typeId] ?? `#${row.typeId}`).toLowerCase()
+      case 'volume':
+        // An unknown volume sorts as nothing rather than jumping to the top.
+        return stackVolume(row) ?? 0
+      case 'group':
+        return (row.groupName ?? '').toLowerCase()
+      case 'category':
+        return (row.categoryName ?? '').toLowerCase()
       case 'owner':
         return (ownerMap.get(row.ownerId) ?? row.ownerId).toLowerCase()
       case 'hangar':
@@ -158,6 +187,9 @@ export const LocationAssets = ({ rows, owners, typeNamesPromise, canAppraise }: 
               <tr>
                 <SortHeader label="Quantity" sortKey="quantity" sort={sort} onSort={toggleSort} numeric />
                 <SortHeader label="Item" sortKey="item" sort={sort} onSort={toggleSort} />
+                <SortHeader label="Volume (m³)" sortKey="volume" sort={sort} onSort={toggleSort} numeric />
+                <SortHeader label="Group" sortKey="group" sort={sort} onSort={toggleSort} />
+                <SortHeader label="Category" sortKey="category" sort={sort} onSort={toggleSort} />
                 <SortHeader label="Owner" sortKey="owner" sort={sort} onSort={toggleSort} />
                 <SortHeader label="Hangar" sortKey="hangar" sort={sort} onSort={toggleSort} />
                 <SortHeader label="Contents" sortKey="contents" sort={sort} onSort={toggleSort} numeric />
@@ -178,7 +210,7 @@ export const LocationAssets = ({ rows, owners, typeNamesPromise, canAppraise }: 
                         outside the link so a click always lands on the name,
                         and it renders immediately (no name lookup). */}
                     <span className={styles.item}>
-                      <TypeIcon id={row.typeId} />
+                      <TypeIcon id={row.typeId} variation={row.icon} />
                       {row.href ? (
                         // Ships open their own /ship page; containers drill into /asset.
                         <Link href={row.href}>
@@ -190,6 +222,16 @@ export const LocationAssets = ({ rows, owners, typeNamesPromise, canAppraise }: 
                       {row.isCurrentShip && <span className={styles.badge}>current ship</span>}
                     </span>
                   </td>
+                  {/* Blank rather than a zero when the SDE has no volume for
+                      the type — nothing is known, not "it takes no space". */}
+                  <td className={retro.num}>
+                    {(() => {
+                      const m3 = stackVolume(row)
+                      return m3 == null ? null : formatVolume(m3)
+                    })()}
+                  </td>
+                  <td>{row.groupName ?? '—'}</td>
+                  <td>{row.categoryName ?? '—'}</td>
                   <td>{ownerMap.get(row.ownerId) ?? row.ownerId}</td>
                   <td>{row.flag ?? '—'}</td>
                   <td className={retro.num}>{row.contents > 0 ? row.contents : '—'}</td>
@@ -204,7 +246,7 @@ export const LocationAssets = ({ rows, owners, typeNamesPromise, canAppraise }: 
               ))}
               {ordered.length === 0 && (
                 <tr>
-                  <td colSpan={canAppraise ? 6 : 5}>No assets here for this owner.</td>
+                  <td colSpan={canAppraise ? 9 : 8}>No assets here for this owner.</td>
                 </tr>
               )}
             </tbody>

--- a/src/app/asset/[locationId]/page.tsx
+++ b/src/app/asset/[locationId]/page.tsx
@@ -5,6 +5,7 @@ import { getSdeTypes } from '@/sdeTypes'
 import { createClient } from '@/utils/supabase/server'
 import { createServiceClient } from '@/utils/supabase/service'
 import { AssetPath, fetchAssetPath, regionSystemCrumbs, type Crumb } from '../../assetPath'
+import { typeFacts } from '../../assetTypeFacts'
 import { fetchOwners } from '../../owners'
 import { resolveLocations, type LocationRef } from '../../resolveLocations'
 import { resolveShareToken } from '../../ship/access'
@@ -42,6 +43,7 @@ type CharacterAsset = {
   location_type: string | null
   quantity: number | string | null
   is_singleton: boolean | null
+  is_blueprint_copy: boolean | null
   name: string | null
 }
 
@@ -98,13 +100,15 @@ const AssetLocationPage = async ({
   let characterQuery = supabase
     .from('character_asset')
     .select(
-      'item_id, registration_id, type_id, location_id, location_flag, location_type, quantity, is_singleton, name'
+      'item_id, registration_id, type_id, location_id, location_flag, location_type, quantity, is_singleton, is_blueprint_copy, name'
     )
     .eq('location_id', locationId)
   if (characterScope) characterQuery = characterQuery.in('registration_id', characterScope)
   let corpQuery = supabase
     .from('corp_asset')
-    .select('item_id, corporation_id, type_id, location_id, location_flag, location_type, quantity, is_singleton')
+    .select(
+      'item_id, corporation_id, type_id, location_id, location_flag, location_type, quantity, is_singleton, is_blueprint_copy'
+    )
     .eq('location_id', locationId)
   if (corpScope) corpQuery = corpQuery.in('corporation_id', corpScope)
   // A character's currently-piloted ship reports its location as wherever it's
@@ -176,14 +180,15 @@ const AssetLocationPage = async ({
   const self = characterSelf ?? (corpSelf ? { ...corpSelf, name: null } : null)
 
   // One bulk SDE lookup for every type in play (this location's root items plus
-  // the location itself, if it's an item) → the set of Ship-category type ids,
-  // so the per-row ship test stays a sync Set.has.
-  const shipTypes = await getSdeTypes([
+  // the location itself, if it's an item). It feeds three things: the set of
+  // Ship-category type ids, so the per-row ship test stays a sync Set.has; each
+  // row's volume/group/category columns; and which image variation its icon has.
+  const itemTypes = await getSdeTypes([
     ...rootItems.map((a) => Number(a.type_id)),
     ...(self ? [Number(self.type_id)] : []),
   ])
   const shipTypeIds = new Set(
-    Object.values(shipTypes)
+    Object.values(itemTypes)
       .filter((t) => t.categoryID === SHIP_CATEGORY_ID)
       .map((t) => t.typeID)
   )
@@ -357,6 +362,7 @@ const AssetLocationPage = async ({
   const rows: ItemRow[] = rootItems
     .map((a) => {
       const contents = contentsByItem.get(String(a.item_id)) ?? 0
+      const type = itemTypes[Number(a.type_id)]
       return {
         itemId: String(a.item_id),
         ownerId: a.owner_id,
@@ -368,6 +374,7 @@ const AssetLocationPage = async ({
         contents,
         isCurrentShip: currentShipItemIds.has(String(a.item_id)),
         href: scope ? null : isShip(a.type_id) ? `/ship/${a.item_id}` : contents > 0 ? `/asset/${a.item_id}` : null,
+        ...typeFacts(type, a.is_blueprint_copy),
       }
     })
     .sort((a, b) => b.contents - a.contents || a.typeId - b.typeId)

--- a/src/app/asset/search/page.tsx
+++ b/src/app/asset/search/page.tsx
@@ -10,7 +10,7 @@ import { createClient } from '@/utils/supabase/server'
 import { fetchOwners } from '../../owners'
 import { resolveLocations, type LocationRef } from '../../resolveLocations'
 import retro from '../../retro.module.css'
-import { TypeIcon } from '../../typeIcon'
+import { TypeIcon, type IconVariation } from '../../typeIcon'
 import { TypeName } from '../../typeName'
 import { AssetSearchForm } from '../assetSearchForm'
 import { Quantity } from '../[locationId]/quantity'
@@ -148,6 +148,12 @@ const AssetSearchPage = async ({ searchParams }: { searchParams: Promise<{ q?: s
   // every matched type's name — no extra SDE lookup needed. TypeName still
   // expects a promise (it also renders each row's player-assigned name, if any).
   const typeNamesPromise = Promise.resolve(Object.fromEntries(typeNameById))
+  // Blueprints have no "icon" on CCP's image server (only bp/bpc — asking for
+  // an icon is a 400, not a fallback), and the search results already carry
+  // each match's category. The asset-search RPCs don't report whether a given
+  // stack is a copy, so every blueprint row shows the original's artwork.
+  const blueprintTypeIds = new Set(matches.filter((m) => m.categoryID === BLUEPRINT_CATEGORY_ID).map((m) => m.typeID))
+  const iconFor = (typeId: number): IconVariation => (blueprintTypeIds.has(typeId) ? 'bp' : 'icon')
 
   const [{ data: characterRows }, { data: corpRows }, owners] = await Promise.all([
     supabase.rpc('character_asset_search', { type_ids: typeIds }),
@@ -266,7 +272,7 @@ const AssetSearchPage = async ({ searchParams }: { searchParams: Promise<{ q?: s
                   {row.root && !floating ? <Link href={`/asset/${row.root.id}`}>{stationName}</Link> : '—'}
                 </td>
                 <td>
-                  <TypeIcon id={row.typeId} />
+                  <TypeIcon id={row.typeId} variation={iconFor(row.typeId)} />
                   {row.contents > 0 ? (
                     <Link href={`/asset/${row.itemId}`}>
                       <TypeName id={row.typeId} name={row.name} promise={typeNamesPromise} />

--- a/src/app/assetTypeFacts.ts
+++ b/src/app/assetTypeFacts.ts
@@ -1,0 +1,26 @@
+// The SDE-derived half of an asset row: what a unit occupies, where the type
+// sits in the taxonomy, and which image CCP holds for it. Every page that
+// builds ItemRows (the asset folder, both ship views) resolves the same facts
+// from one getSdeTypes lookup, so they can't drift from each other.
+import type { SdeType } from '@/sdeTypes'
+import { BLUEPRINT_CATEGORY_ID } from '@/utils/sdeCategories'
+import { blueprintIcon, type IconVariation } from './typeIcon'
+
+export type TypeFacts = {
+  unitVolume: number | null
+  groupName: string | null
+  categoryName: string | null
+  icon: IconVariation
+}
+
+// `type` is undefined for anything the published-type view doesn't cover (an
+// unpublished or brand-new type), which leaves the columns blank rather than
+// guessing. isBlueprintCopy only matters for blueprint-category rows: CCP's
+// image server has no "icon" for those — asking for one is a 400, not a
+// fallback — so they point at bp/bpc instead.
+export const typeFacts = (type: SdeType | undefined, isBlueprintCopy?: boolean | null): TypeFacts => ({
+  unitVolume: type?.volume ?? null,
+  groupName: type?.groupName ?? null,
+  categoryName: type?.categoryName ?? null,
+  icon: type?.categoryID === BLUEPRINT_CATEGORY_ID ? blueprintIcon(isBlueprintCopy) : 'icon',
+})

--- a/src/app/retro.module.css
+++ b/src/app/retro.module.css
@@ -45,3 +45,11 @@
   text-align: right;
   white-space: nowrap;
 }
+
+/* The alignment has to be restated at cell specificity: `.retro td` above is a
+   class plus an element, which outranks a bare `.num` and was quietly winning,
+   leaving every numeric column left-aligned. */
+.retro td.num,
+.retro th.num {
+  text-align: right;
+}

--- a/src/app/ship/[itemId]/page.tsx
+++ b/src/app/ship/[itemId]/page.tsx
@@ -5,6 +5,7 @@ import { getSdeType, getSdeTypes } from '@/sdeTypes'
 import { createClient } from '@/utils/supabase/server'
 import { createServiceClient } from '@/utils/supabase/service'
 import { AssetPath, fetchAssetPath } from '../../assetPath'
+import { typeFacts } from '../../assetTypeFacts'
 import { fetchOwners } from '../../owners'
 import type { Owners } from '../../ownerFilter'
 import { TypeIcon } from '../../typeIcon'
@@ -35,6 +36,7 @@ type ChildRow = {
   location_flag: string | null
   quantity: number | string | null
   is_singleton: boolean | null
+  is_blueprint_copy?: boolean | null
   name?: string | null
   registration_id?: string
   corporation_id?: number | string
@@ -103,11 +105,11 @@ const ShipPage = async ({
   const [{ data: characterChildren }, { data: corpChildren }] = await Promise.all([
     supabase
       .from('character_asset')
-      .select('item_id, registration_id, type_id, location_flag, quantity, is_singleton, name')
+      .select('item_id, registration_id, type_id, location_flag, quantity, is_singleton, is_blueprint_copy, name')
       .eq('location_id', itemId),
     supabase
       .from('corp_asset')
-      .select('item_id, corporation_id, type_id, location_flag, quantity, is_singleton')
+      .select('item_id, corporation_id, type_id, location_flag, quantity, is_singleton, is_blueprint_copy')
       .eq('location_id', itemId),
   ])
   const children = [...((characterChildren ?? []) as ChildRow[]), ...((corpChildren ?? []) as ChildRow[])]
@@ -181,6 +183,7 @@ const ShipPage = async ({
           : contents > 0
             ? `/asset/${c.item_id}`
             : null,
+        ...typeFacts(childTypes[Number(c.type_id)], c.is_blueprint_copy),
       }
     })
   )
@@ -235,12 +238,12 @@ const SharedShipPage = async ({ itemId, token }: { itemId: string; token: string
   const [{ data: characterChildren }, { data: corpChildren }] = await Promise.all([
     supabase
       .from('character_asset')
-      .select('item_id, type_id, location_flag, quantity, is_singleton, name')
+      .select('item_id, type_id, location_flag, quantity, is_singleton, is_blueprint_copy, name')
       .eq('location_id', itemId)
       .in('registration_id', scope.registrationIds),
     supabase
       .from('corp_asset')
-      .select('item_id, type_id, location_flag, quantity, is_singleton')
+      .select('item_id, type_id, location_flag, quantity, is_singleton, is_blueprint_copy')
       .eq('location_id', itemId)
       .in('corporation_id', scope.corporationIds.length > 0 ? scope.corporationIds : [-1]),
   ])
@@ -267,6 +270,10 @@ const SharedShipPage = async ({ itemId, token }: { itemId: string; token: string
   const heading = self.name && self.name !== typeName ? `${self.name} (${typeName})` : typeName
 
   const typeNamesPromise = fetchTypeNames(children.map((c) => Number(c.type_id)))
+  // The same bulk lookup the signed-in view does, for the volume/group/category
+  // columns and each row's icon variation. Pure SDE data — public-read, nothing
+  // owner-specific — so it's as safe on the share path as the type names are.
+  const childTypes = await getSdeTypes(children.map((c) => Number(c.type_id)))
   // Display-only in the shared view: no href (a nested container would need its
   // own share token to open), and contents is unused without drill-down links.
   const rows: ItemRow[] = fittingOrder(
@@ -281,6 +288,7 @@ const SharedShipPage = async ({ itemId, token }: { itemId: string; token: string
       contents: 0,
       isCurrentShip: false,
       href: null,
+      ...typeFacts(childTypes[Number(c.type_id)], c.is_blueprint_copy),
     }))
   )
 

--- a/src/app/typeIcon.tsx
+++ b/src/app/typeIcon.tsx
@@ -1,21 +1,32 @@
 import styles from './typeIcon.module.css'
 
+// Which image CCP's server holds for a type. Most types have "icon"; blueprints
+// have only "bp"/"bpc" (a blueprint request for "icon" is a 400, not a
+// fallback), and ships additionally have the big "render". Callers that know a
+// row is a blueprint pass the matching variation — see blueprintIcon below.
+export type IconVariation = 'icon' | 'bp' | 'bpc' | 'render'
+
 type TypeIconProps = {
   id: number
   // Rendered size in CSS pixels; the image itself is always fetched at 64 so a
   // hi-dpi screen has pixels to spare at the sizes used here.
   size?: number
+  variation?: IconVariation
 }
+
+// The image variation for a blueprint stack: originals and copies have distinct
+// artwork, and neither answers to "icon".
+export const blueprintIcon = (isCopy: boolean | null | undefined): IconVariation => (isCopy ? 'bpc' : 'bp')
 
 // The item icon CCP's image server serves for a type id. Purely decorative —
 // every use sits next to the type's name (TypeName), so it carries an empty alt
 // and is hidden from screen readers rather than repeating that name. Not a
 // next/image: the existing icon/portrait uses across the app are plain <img>
 // tags, which keeps images.evetech.net out of next.config.mjs's remote patterns.
-export const TypeIcon = ({ id, size = 24 }: TypeIconProps) => (
+export const TypeIcon = ({ id, size = 24, variation = 'icon' }: TypeIconProps) => (
   <img
     className={styles.icon}
-    src={`https://images.evetech.net/types/${id}/icon?size=64`}
+    src={`https://images.evetech.net/types/${id}/${variation}?size=64`}
     alt=""
     aria-hidden="true"
     width={size}

--- a/src/sdeTypes.ts
+++ b/src/sdeTypes.ts
@@ -11,19 +11,24 @@
 import { bulkLookup, createByIdCache } from './sdeCache'
 import { sdeSupabase } from './utils/supabase/sde'
 
-// groupName/raceID/metaGroupID ride along from the view (raceID and
-// metaGroupID added by migration 20260728120000_sde_type_race_meta): race is
-// which empire's ship line a hull belongs to, metaGroup its tech/faction tier.
-// Both are null for the many types the SDE doesn't stamp (metaGroupID is
-// absent on plain T1 types). First consumer is the /fitting ship matrix.
+// groupName/categoryName/raceID/metaGroupID/volume ride along from the view
+// (raceID and metaGroupID added by migration 20260728120000_sde_type_race_meta,
+// volume by 20260804000000_sde_type_volume): race is which empire's ship line a
+// hull belongs to, metaGroup its tech/faction tier — both null for the many
+// types the SDE doesn't stamp (metaGroupID is absent on plain T1 types) — and
+// volume is m³ per unit, the assembled figure for ships and other singletons
+// (the SDE carries no packaged volume). The /fitting ship matrix reads race and
+// meta; the asset folder table reads group/category names and volume.
 export type SdeType = {
   typeID: number
   name: string
   groupID: number
   categoryID: number | null
   groupName: string | null
+  categoryName: string | null
   raceID: number | null
   metaGroupID: number | null
+  volume: number | null
 }
 
 type TypeRow = {
@@ -32,8 +37,10 @@ type TypeRow = {
   group_id: number
   category_id: number | null
   group_name: string | null
+  category_name: string | null
   race_id: number | null
   meta_group_id: number | null
+  volume: number | null
 }
 
 const cache = createByIdCache<SdeType>()
@@ -44,11 +51,13 @@ const rowToType = (r: TypeRow): SdeType => ({
   groupID: r.group_id,
   categoryID: r.category_id,
   groupName: r.group_name,
+  categoryName: r.category_name,
   raceID: r.race_id == null ? null : Number(r.race_id),
   metaGroupID: r.meta_group_id == null ? null : Number(r.meta_group_id),
+  volume: r.volume == null ? null : Number(r.volume),
 })
 
-const TYPE_COLUMNS = 'type_id, name, group_id, category_id, group_name, race_id, meta_group_id'
+const TYPE_COLUMNS = 'type_id, name, group_id, category_id, group_name, category_name, race_id, meta_group_id, volume'
 
 export const getSdeTypes = (typeIDs: Iterable<number>): Promise<Record<number, SdeType>> =>
   bulkLookup(cache, typeIDs, async (chunk) => {

--- a/supabase/migrations/20260804000000_sde_type_volume.sql
+++ b/supabase/migrations/20260804000000_sde_type_volume.sql
@@ -1,0 +1,29 @@
+-- Extend sde_published_type with the packaged-item volume the SDE stamps on
+-- every type (m³ per unit). The asset folder table multiplies it by the stack
+-- size to show what a row occupies in a hangar; ships and other assembled
+-- singletons carry their assembled volume here, since the SDE has no packaged
+-- figure for them (that's a group-level rule the client applies, not data).
+--
+-- Same replacement rules as 20260728120000_sde_type_race_meta.sql: the new
+-- column is appended at the END of the select — create-or-replace requires it,
+-- and it keeps existing consumers (the sde_search_type RPC, the sde_name_joins
+-- functions, src/sdeTypes.ts) working unchanged. Access model is inherited from
+-- the existing view (security_invoker over the public-read sde_* tables), so no
+-- new grants are needed.
+create or replace view public.sde_published_type
+with (security_invoker = true) as
+select
+  t._key as type_id,
+  t.data -> 'name' ->> 'en' as name,
+  (t.data ->> 'groupID')::bigint as group_id,
+  (g.data ->> 'categoryID')::bigint as category_id,
+  g.data -> 'name' ->> 'en' as group_name,
+  c.data -> 'name' ->> 'en' as category_name,
+  (t.data ->> 'raceID')::bigint as race_id,
+  (t.data ->> 'metaGroupID')::bigint as meta_group_id,
+  (t.data ->> 'volume')::double precision as volume
+from public.sde_types t
+left join public.sde_groups g on g._key = (t.data ->> 'groupID')::bigint
+left join public.sde_categories c on c._key = (g.data ->> 'categoryID')::bigint
+where (t.data ->> 'published')::boolean
+  and coalesce(trim(t.data -> 'name' ->> 'en'), '') <> '';


### PR DESCRIPTION
Three new columns on the asset folder table — which the ship page's module list also renders, since they share `LocationAssets` — plus two fixes to what was already there.

## New columns

`Quantity · Item · Volume (m³) · Group · Category · Owner · Hangar · Contents · Appraisal`

- **Volume (m³)** — the type's per-unit volume times the stack size, grouped and capped at two decimals. Blank (not zero) when the SDE has no volume for a type.
- **Group** and **Category** — the type's SDE taxonomy.

All three sort from their headers like the existing columns. The item-describing columns sit next to Item and the ownership/location ones after; easy to reshuffle if you'd rather have a different arrangement.

Volume needed a new column on `sde_published_type` (migration `20260804000000_sde_type_volume.sql`, appended at the end of the select like `20260728120000`, plus the same change in `schema.sql`). Group and category names were already in that view but weren't exposed by the loader — `SdeType` now carries `categoryName` and `volume`.

**Caveat worth knowing:** ships and other assembled singletons report their *assembled* volume. The SDE carries no packaged figure — that's a group-level rule the client applies — so a parked frigate reads as its assembled m³, not the 2,500 m³ it would pack into.

## Numeric columns were never actually right-aligned

`retro.module.css` has `.retro td { text-align: left }` (a class plus an element) and `.num { text-align: right }` (a bare class). The first outranks the second on specificity, so every `.num` cell in the app has been silently left-aligned — which is why Quantity looked wrong once it moved to the leftmost column. The alignment is now restated at cell specificity (`.retro td.num`), so Quantity right-aligns — **and so does every other numeric column across the app**, which is what that rule always intended. Flagging it because the blast radius is wider than this page.

## Blueprint icons were 400ing

CCP's image server holds only `bp`/`bpc` for a blueprint type — there is no `icon` variation, and asking for one is an error, not a fallback (`https://images.evetech.net/types/57517/` lists exactly `["bpc","bp"]`). `TypeIcon` now takes a variation, and blueprint-category rows request `bp` — or `bpc` when the asset row is flagged as a copy, which the folder view and ship views can tell from `is_blueprint_copy`.

The shared `typeFacts` helper (`src/app/assetTypeFacts.ts`) resolves the icon variation and the volume/group/category from one `getSdeTypes` lookup, so the folder view, both ship views and `/asset/search` can't drift on it. The search page's RPCs don't report copy status, so blueprint rows there show the original's artwork.

## Testing

- `pnpm run lint` — clean
- `pnpm run build` — compiles
- `pnpm test` — 101/101 pass
- `node .github/scripts/check-migrations.mjs origin/main` — no ordering problems
- Image variations verified against the live service: `bp` and `bpc` return 200 for 57517 where `icon` returns 400

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZoYVxvCtqjGGUL9MGTbHR)_