### PR TITLE
Shareable invite links, with the inviter shown on the register form

### DIFF
--- a/src/app/account/invite/copyLink.tsx
+++ b/src/app/account/invite/copyLink.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useState } from 'react'
+
+// An unused invite code rendered as its shareable sign-up link. The copy
+// button builds the absolute URL from window.location.origin so it's correct
+// on any deployment (previews included) without env plumbing; the visible
+// href stays relative so the server-rendered markup is stable.
+const CopyLink = ({ code }: { code: string }) => {
+  const [copied, setCopied] = useState(false)
+  const path = `/account/register?invite=${code}`
+
+  const copy = async () => {
+    await navigator.clipboard.writeText(`${window.location.origin}${path}`)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <>
+      <a href={path}>
+        <code>{code}</code>
+      </a>{' '}
+      <button type="button" onClick={copy}>
+        {copied ? 'Copied!' : 'Copy link'}
+      </button>
+    </>
+  )
+}
+
+export default CopyLink

--- a/src/app/account/invite/createButton.tsx
+++ b/src/app/account/invite/createButton.tsx
@@ -4,23 +4,24 @@ import { useState } from 'react'
 
 import Dot from '../settings/dot'
 import { createInviteCode } from './actions'
+import CopyLink from './copyLink'
 
 // `available` is how many slots the schedule has granted but the user hasn't
 // minted yet; the button is hidden by the parent when it's zero. Chancellors
 // pass `unlimited` instead, which drops the count and is always shown.
 const CreateButton = ({ available, unlimited = false }: { available?: number; unlimited?: boolean }) => {
-  const [response, setResponse] = useState('')
-  const [color, setColor] = useState('#000000')
+  const [error, setError] = useState('')
+  const [created, setCreated] = useState('')
 
   const create = async () => {
     const result = await createInviteCode()
     if (result.error) {
-      setColor('#FF0000')
-      setResponse(result.error)
+      setError(result.error)
+      setCreated('')
       return
     }
-    setColor('#00AF00')
-    setResponse(`Created invite code ${result.code}`)
+    setError('')
+    setCreated(result.code ?? '')
   }
 
   return (
@@ -30,7 +31,15 @@ const CreateButton = ({ available, unlimited = false }: { available?: number; un
           {unlimited ? 'Create invite code' : `Create invite code (${available} available)`}
         </button>
       </form>
-      <p>{response && <Dot color={color} response={response} />}</p>
+      <p>
+        {error && <Dot color="#FF0000" response={error} />}
+        {created && (
+          <>
+            <Dot color="#00AF00" response="Created " />
+            <CopyLink code={created} />
+          </>
+        )}
+      </p>
     </>
   )
 }

--- a/src/app/account/invite/page.tsx
+++ b/src/app/account/invite/page.tsx
@@ -6,6 +6,8 @@ import { createClient } from '@/utils/supabase/server'
 
 import { DateTime } from '../../DateTime'
 import { isChancellor } from '../chancellor/chancellor'
+import { mainCharacterNameForUser } from '../lib/inviter'
+import CopyLink from './copyLink'
 import CreateButton from './createButton'
 import { earnedCount, unlockDate, weeksToUnlock } from './schedule'
 
@@ -47,18 +49,7 @@ const InvitesPage = async () => {
     .select('created_by')
     .eq('redeemed_by', data.user.id)
     .maybeSingle()
-  let inviterName: string | null = null
-  if (redeemedCode?.created_by) {
-    const { data: inviter } = await service
-      .from('registration')
-      .select('name')
-      .eq('user_id', redeemedCode.created_by)
-      .order('is_main', { ascending: false })
-      .order('created_at', { ascending: true })
-      .limit(1)
-      .maybeSingle()
-    inviterName = inviter?.name ?? null
-  }
+  const inviterName = redeemedCode?.created_by ? await mainCharacterNameForUser(redeemedCode.created_by) : null
 
   const allCodes = codes ?? []
   const unused = allCodes.filter((c) => !c.redeemed_by)
@@ -72,8 +63,8 @@ const InvitesPage = async () => {
     <>
       <h1>Invite codes</h1>
       <p>
-        Edencom Link is invite-only. Share an unused code below with someone to let them register an account — each code
-        works once.
+        Edencom Link is invite-only. Copy an unused code&rsquo;s link below and send it to someone to let them register
+        an account — each code works once.
       </p>
 
       {!firstSsoAt && (
@@ -88,7 +79,7 @@ const InvitesPage = async () => {
         <ul>
           {unused.map((c) => (
             <li key={c.code}>
-              <code>{c.code}</code>
+              <CopyLink code={c.code} />
             </li>
           ))}
         </ul>
@@ -166,9 +157,7 @@ const InvitesPage = async () => {
             <tbody>
               {allCodes.map((c) => (
                 <tr key={c.code}>
-                  <td>
-                    <code>{c.code}</code>
-                  </td>
+                  <td>{c.redeemed_by ? <code>{c.code}</code> : <CopyLink code={c.code} />}</td>
                   <td>{c.created_at ? <DateTime value={new Date(c.created_at)} /> : '—'}</td>
                   <td>
                     {c.redeemed_by ? (

--- a/src/app/account/lib/inviter.ts
+++ b/src/app/account/lib/inviter.ts
@@ -1,0 +1,17 @@
+import { createServiceClient } from '@/utils/supabase/service'
+
+// A user's public-facing name: their main character, falling back to their
+// earliest one. Service role, since the inviter's registrations sit behind
+// their own RLS and the caller may not even have a session yet.
+export const mainCharacterNameForUser = async (userId: string): Promise<string | null> => {
+  const service = createServiceClient()
+  const { data } = await service
+    .from('registration')
+    .select('name')
+    .eq('user_id', userId)
+    .order('is_main', { ascending: false })
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .maybeSingle()
+  return data?.name ?? null
+}

--- a/src/app/account/register/actions.ts
+++ b/src/app/account/register/actions.ts
@@ -5,6 +5,36 @@ import { setTimeout as delay } from 'node:timers/promises'
 import { createServiceClient } from '@/utils/supabase/service'
 import { createClient } from '@/utils/supabase/server'
 
+import { mainCharacterNameForUser } from '../lib/inviter'
+import { INVITE_CODE_PATTERN } from './inviteCode'
+
+export type InviteLookup =
+  | { status: 'valid'; inviterName: string | null } // null inviter = a founding/seed code
+  | { status: 'redeemed' }
+  | { status: 'unknown' }
+
+// Resolve who an unredeemed invite code came from, so the register form can
+// show "Invited by <main character>" beside the field. Unauthenticated by
+// nature (the registrant has no session), so it reveals nothing beyond the
+// status for redeemed codes, and only ever names the inviter of a code the
+// caller already holds in full.
+export const lookupInvite = async (rawCode: string): Promise<InviteLookup> => {
+  const code = `${rawCode ?? ''}`.trim()
+  if (!INVITE_CODE_PATTERN.test(code)) return { status: 'unknown' }
+
+  const service = createServiceClient()
+  const { data: invite } = await service
+    .from('invite_code')
+    .select('created_by, redeemed_by')
+    .eq('code', code)
+    .maybeSingle()
+  if (!invite) return { status: 'unknown' }
+  if (invite.redeemed_by) return { status: 'redeemed' }
+
+  const inviterName = invite.created_by ? await mainCharacterNameForUser(invite.created_by) : null
+  return { status: 'valid', inviterName }
+}
+
 // Registration is invite-only: the form must carry an unused invite code. We
 // validate and redeem it with the service role, since the registrant has no
 // Supabase session yet and so can't see invite_code rows under RLS.

--- a/src/app/account/register/inviteCode.ts
+++ b/src/app/account/register/inviteCode.ts
@@ -1,0 +1,5 @@
+// Codes are minted as randomBytes(8).toString('hex') — exactly 16 hex chars.
+// Shared by the register form (to gate the live inviter lookup on complete
+// input) and the lookup action itself. Lives outside actions.ts because a
+// 'use server' module may only export async functions.
+export const INVITE_CODE_PATTERN = /^[0-9a-f]{16}$/i

--- a/src/app/account/register/page.tsx
+++ b/src/app/account/register/page.tsx
@@ -1,65 +1,12 @@
-'use client'
+import { Suspense } from 'react'
 
-import { useState } from 'react'
+import RegisterForm from './registerForm'
 
-import { register } from './actions'
-
-const RegisterPage = () => {
-  const [disabled, setDisabled] = useState(false)
-  const [color, setColor] = useState('#000000')
-  const [response, setResponse] = useState('')
-
-  const signupAndReturn = async (formData: FormData) => {
-    const { error } = await register(formData)
-    if (error?.message) {
-      setDisabled(false)
-      setResponse(error?.message)
-      setColor('#FF0000')
-      return
-    }
-
-    setResponse('A perfect time to check your email inbox.')
-    setColor('#00AF00')
-  }
-
-  const handleEmailChange = () => {
-    setDisabled(false)
-  }
-
-  return (
-    <form
-      onSubmit={() => {
-        setResponse('')
-        setDisabled(true)
-      }}
-    >
-      <h1>Register</h1>
-      <p>Create an account to manage your hangars. Registration is invite-only.</p>
-      <label htmlFor="invite">Invite code:</label>
-      <br />
-      <input id="invite" name="invite" type="text" required onChange={handleEmailChange} />
-      <br />
-      <label htmlFor="email">Email:</label>
-      <br />
-      <input id="email" name="email" type="email" required onChange={handleEmailChange} />
-      <br />
-      <label htmlFor="password">Password:</label>
-      <br />
-      <input id="password" name="password" type="password" required />
-      <br />
-      <button formAction={signupAndReturn} disabled={disabled}>
-        Register
-      </button>
-      {response && (
-        <>
-          <svg height="10" width="20">
-            <circle cx="10" cy="5" r="5" fill={color} />
-          </svg>
-          {response}
-        </>
-      )}
-    </form>
-  )
-}
+// useSearchParams() in the form requires a Suspense boundary for prerender.
+const RegisterPage = () => (
+  <Suspense>
+    <RegisterForm />
+  </Suspense>
+)
 
 export default RegisterPage

--- a/src/app/account/register/registerForm.tsx
+++ b/src/app/account/register/registerForm.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
+
+import Dot from '../settings/dot'
+import { lookupInvite, register, type InviteLookup } from './actions'
+import { INVITE_CODE_PATTERN } from './inviteCode'
+
+const RegisterForm = () => {
+  const urlInvite = useSearchParams().get('invite')?.trim() ?? ''
+
+  const [invite, setInvite] = useState(urlInvite)
+  // A code arriving via the URL renders read-only; "use a different code"
+  // unlocks it (needed when a shared link's code turns out to be spent).
+  const [locked, setLocked] = useState(urlInvite !== '')
+  const [lookup, setLookup] = useState<InviteLookup | null>(null)
+  const lookupSeq = useRef(0)
+
+  const [disabled, setDisabled] = useState(false)
+  const [color, setColor] = useState('#000000')
+  const [response, setResponse] = useState('')
+
+  // Resolve the inviter as soon as the field holds a complete code — instantly
+  // for the URL-provided one, debounced while typing. The sequence counter
+  // makes the latest lookup win over a slower earlier one.
+  useEffect(() => {
+    const seq = ++lookupSeq.current
+    if (!INVITE_CODE_PATTERN.test(invite)) {
+      setLookup(null)
+      return undefined
+    }
+    const timer = setTimeout(
+      async () => {
+        const result = await lookupInvite(invite)
+        if (seq === lookupSeq.current) setLookup(result)
+      },
+      invite === urlInvite ? 0 : 500
+    )
+    return () => clearTimeout(timer)
+  }, [invite, urlInvite])
+
+  const signupAndReturn = async (formData: FormData) => {
+    const { error } = await register(formData)
+    if (error?.message) {
+      setDisabled(false)
+      setResponse(error?.message)
+      setColor('#FF0000')
+      return
+    }
+
+    setResponse('A perfect time to check your email inbox.')
+    setColor('#00AF00')
+  }
+
+  const handleEmailChange = () => {
+    setDisabled(false)
+  }
+
+  return (
+    <form
+      onSubmit={() => {
+        setResponse('')
+        setDisabled(true)
+      }}
+    >
+      <h1>Register</h1>
+      <p>Create an account to manage your hangars. Registration is invite-only.</p>
+      <label htmlFor="invite">Invite code:</label>
+      <br />
+      {/* readOnly, not disabled — a disabled input is dropped from FormData on submit */}
+      <input
+        id="invite"
+        name="invite"
+        type="text"
+        required
+        readOnly={locked}
+        value={invite}
+        style={locked ? { backgroundColor: '#eeeeee' } : undefined}
+        onChange={(e) => {
+          setInvite(e.target.value)
+          handleEmailChange()
+        }}
+      />{' '}
+      {lookup?.status === 'valid' && (
+        <Dot
+          color="#00AF00"
+          response={lookup.inviterName ? `Invited by ${lookup.inviterName}` : 'A founding invite code'}
+        />
+      )}
+      {lookup?.status === 'redeemed' && <Dot color="#FF0000" response="This invite code has already been used." />}
+      {lookup?.status === 'unknown' && <Dot color="#FF0000" response="This invite code isn’t recognized." />}
+      {locked && (
+        <>
+          {' '}
+          <button type="button" onClick={() => setLocked(false)}>
+            use a different code
+          </button>
+        </>
+      )}
+      <br />
+      <label htmlFor="email">Email:</label>
+      <br />
+      <input id="email" name="email" type="email" required onChange={handleEmailChange} />
+      <br />
+      <label htmlFor="password">Password:</label>
+      <br />
+      <input id="password" name="password" type="password" required />
+      <br />
+      <button formAction={signupAndReturn} disabled={disabled}>
+        Register
+      </button>
+      {response && <Dot color={color} response={response} />}
+    </form>
+  )
+}
+
+export default RegisterForm


### PR DESCRIPTION
Invite codes now travel as links instead of bare strings.

## Register form (`/account/register?invite=<code>`)

- A code in the URL pre-fills the invite field **read-only** (`readOnly`, not `disabled` — a disabled input is dropped from `FormData` on submit, so the server action would never see the code). A "use a different code" button unlocks the field, for when a shared link's code turns out to be spent.
- Whether the code came from the URL or was typed, once the field holds a complete code the form shows who it came from next to the input: **"Invited by \<main character\>"** (green), "A founding invite code" for seed codes with no creator, or a red "already been used" / "isn't recognized" status. URL codes resolve immediately; typed input is debounced 500 ms with a latest-lookup-wins guard, and nothing is queried until the input matches the minted code shape (16 hex chars, `INVITE_CODE_PATTERN` in `inviteCode.ts`).
- The lookup is a new `lookupInvite` server action (service role — the registrant has no session). It reveals nothing beyond a status for redeemed/unknown codes; the inviter is only named for a valid unredeemed code the caller already holds in full, the same information the existing register action's error paths already gate on.
- The form moved to `registerForm.tsx` (client) with `page.tsx` as a `<Suspense>` wrapper, required for `useSearchParams()` to prerender.

## Invite page

- Each unused code (the "Codes to give out" list, unclaimed rows of the created-codes table, and the just-minted code in `CreateButton`) renders via a new `CopyLink` component: the code links to its sign-up URL, and a **Copy link** button puts the absolute `${origin}/account/register?invite=<code>` URL on the clipboard — origin from `window.location`, so preview deployments produce correct links with no env plumbing.
- The inviter-name resolution the page already did for "Who invited you" is extracted to `account/lib/inviter.ts` (`mainCharacterNameForUser`) and shared with the new lookup action.

No schema or migration changes; the `invite_code` table and redemption flow are untouched.

## Verification

- `pnpm run build`, `pnpm run lint`, and `pnpm test` (101 passing) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NA1GQAxJzS9npG9X774ZNc

---
_Generated by [Claude Code](https://claude.ai/code/session_01NA1GQAxJzS9npG9X774ZNc)_