### PR TITLE
Redirect signed-in users away from login/register/reset pages

### DIFF
--- a/src/app/account/login/page.tsx
+++ b/src/app/account/login/page.tsx
@@ -1,3 +1,7 @@
+import { redirect } from 'next/navigation'
+
+import { createClient } from '@/utils/supabase/server'
+
 import { LoginForm } from './loginForm'
 
 // Only same-site absolute paths are honored (no scheme-relative `//host` or
@@ -7,7 +11,17 @@ const sanitizeNext = (next: string | undefined): string | undefined =>
 
 const Login = async ({ searchParams }: { searchParams: Promise<{ next?: string }> }) => {
   const { next } = await searchParams
-  return <LoginForm next={sanitizeNext(next)} />
+  const sanitizedNext = sanitizeNext(next)
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (user) {
+    redirect(sanitizedNext ?? '/')
+  }
+
+  return <LoginForm next={sanitizedNext} />
 }
 
 export default Login

--- a/src/app/account/register/page.tsx
+++ b/src/app/account/register/page.tsx
@@ -1,12 +1,25 @@
 import { Suspense } from 'react'
+import { redirect } from 'next/navigation'
+
+import { createClient } from '@/utils/supabase/server'
 
 import RegisterForm from './registerForm'
 
 // useSearchParams() in the form requires a Suspense boundary for prerender.
-const RegisterPage = () => (
-  <Suspense>
-    <RegisterForm />
-  </Suspense>
-)
+const RegisterPage = async () => {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (user) {
+    redirect('/')
+  }
+
+  return (
+    <Suspense>
+      <RegisterForm />
+    </Suspense>
+  )
+}
 
 export default RegisterPage

--- a/src/app/account/reset/page.tsx
+++ b/src/app/account/reset/page.tsx
@@ -1,48 +1,19 @@
-'use client'
+import { redirect } from 'next/navigation'
 
-import { useState } from 'react'
+import { createClient } from '@/utils/supabase/server'
 
-import { reset } from './actions'
+import { ResetForm } from './resetForm'
 
-const ResetPage = () => {
-  const [disabled, setDisabled] = useState(false)
-  const [emailSent, setEmailSent] = useState(false)
-
-  const resetAndReturn = async (formData: FormData) => {
-    await reset(formData)
-    setEmailSent(true)
+const ResetPage = async () => {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (user) {
+    redirect('/account/settings')
   }
 
-  const handleEmailChange = () => {
-    setDisabled(false)
-  }
-
-  return (
-    <form
-      onSubmit={() => {
-        setDisabled(true)
-        setEmailSent(false)
-      }}
-    >
-      <h1>Reset Password</h1>
-      <p>Forgot your password? Let&apos;s confirm your email to reset it.</p>
-      <label htmlFor="email">Email:</label>
-      <br />
-      <input id="email" name="email" type="email" required onChange={handleEmailChange} />
-      <br />
-      <button formAction={resetAndReturn} disabled={disabled}>
-        Send Email
-      </button>
-      {emailSent && (
-        <>
-          <svg height="10" width="20">
-            <circle cx="10" cy="5" r="5" fill="#00AF00" />
-          </svg>
-          Check your email for a link.
-        </>
-      )}
-    </form>
-  )
+  return <ResetForm />
 }
 
 export default ResetPage

--- a/src/app/account/reset/resetForm.tsx
+++ b/src/app/account/reset/resetForm.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useState } from 'react'
+
+import { reset } from './actions'
+
+export const ResetForm = () => {
+  const [disabled, setDisabled] = useState(false)
+  const [emailSent, setEmailSent] = useState(false)
+
+  const resetAndReturn = async (formData: FormData) => {
+    await reset(formData)
+    setEmailSent(true)
+  }
+
+  const handleEmailChange = () => {
+    setDisabled(false)
+  }
+
+  return (
+    <form
+      onSubmit={() => {
+        setDisabled(true)
+        setEmailSent(false)
+      }}
+    >
+      <h1>Reset Password</h1>
+      <p>Forgot your password? Let&apos;s confirm your email to reset it.</p>
+      <label htmlFor="email">Email:</label>
+      <br />
+      <input id="email" name="email" type="email" required onChange={handleEmailChange} />
+      <br />
+      <button formAction={resetAndReturn} disabled={disabled}>
+        Send Email
+      </button>
+      {emailSent && (
+        <>
+          <svg height="10" width="20">
+            <circle cx="10" cy="5" r="5" fill="#00AF00" />
+          </svg>
+          Check your email for a link.
+        </>
+      )}
+    </form>
+  )
+}


### PR DESCRIPTION
## Summary

- `/account/login`, `/account/register`, and `/account/reset` now check for an existing session server-side and redirect signed-in users away instead of rendering the auth form.
- Login honors the sanitized `next=` param when redirecting (falls back to `/`), matching where the login form itself sends you post-auth.
- Register redirects to `/`; reset redirects to `/account/settings`, where `ChangePassword` already lives for a signed-in user who wants to change their password.
- `/account/reset`'s form markup moved out of `page.tsx` into a new client component (`resetForm.tsx`) so the page itself could become an async server component that performs the auth check, mirroring the existing `login`/`loginForm` split.

## Test plan

- [x] `pnpm run lint`
- [x] `pnpm run build`
- [ ] Manually verify in a browser: visiting `/account/login`, `/account/register`, `/account/reset` while signed in redirects away; while signed out, all three still render normally.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WoxiEoaAPjiyqruRjkZnkA)_