### PR TITLE
Add dark-launched GraphQL API and query page

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "@vercel/speed-insights": "2.0.0",
     "eve-industry": "0.1.0",
     "fast-shuffle": "^6.2.0",
+    "graphql": "^17.0.2",
+    "graphql-yoga": "^5.21.2",
     "mcp-handler": "^2.1.0",
     "next": "16.2.12",
     "protobufjs": "^8.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,12 @@ importers:
       fast-shuffle:
         specifier: ^6.2.0
         version: 6.2.1
+      graphql:
+        specifier: ^17.0.2
+        version: 17.0.2
+      graphql-yoga:
+        specifier: ^5.21.2
+        version: 5.21.2(graphql@17.0.2)
       mcp-handler:
         specifier: ^2.1.0
         version: 2.1.0(@modelcontextprotocol/server@2.0.0)(next@16.2.12(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
@@ -123,6 +129,9 @@ packages:
   '@aws-sdk/core@3.977.4':
     resolution: {integrity: sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==}
     engines: {node: '>=20.0.0'}
+    deprecated: |-
+      Deprecated due to Document number parsing bug in JSON, see
+        https://github.com/aws/aws-sdk-js-v3/issues/8246. Newer version available.
 
   '@aws-sdk/credential-provider-web-identity@3.972.49':
     resolution: {integrity: sha512-IYx1lN38MnnPXv+NBLpuATu0cZakbZ321TAfjW+aVkw7HIJF38YnEwdeEO55MSl3pl7hIX1IvvnD6EmnAzmAJw==}
@@ -189,6 +198,18 @@ packages:
 
   '@emnapi/runtime@1.11.3':
     resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
+
+  '@envelop/core@5.5.1':
+    resolution: {integrity: sha512-3DQg8sFskDo386TkL5j12jyRAdip/8yzK3x7YGbZBgobZ4aKXrvDU0GppU0SnmrpQnNaiTUsxBs9LKkwQ/eyvw==}
+    engines: {node: '>=18.0.0'}
+
+  '@envelop/instrumentation@1.0.0':
+    resolution: {integrity: sha512-cxgkB66RQB95H3X27jlnxCRNTmPuSTgmBAq6/4n2Dtv4hsk4yz8FadA1ggmd0uZzvKqWD6CR+WFgTjhDqg7eyw==}
+    engines: {node: '>=18.0.0'}
+
+  '@envelop/types@5.2.1':
+    resolution: {integrity: sha512-CsFmA3u3c2QoLDTfEpGr4t25fjMU31nyvse7IzWTvb0ZycuPjMjb0fjlheh+PbhBYb9YLugnT2uY6Mwcg1o+Zg==}
+    engines: {node: '>=18.0.0'}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -404,6 +425,56 @@ packages:
       '@eveshipfit/dogma-engine': ^7
       react: ^18
       react-dom: ^18
+
+  '@fastify/busboy@3.2.0':
+    resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
+
+  '@graphql-tools/executor@1.5.7':
+    resolution: {integrity: sha512-UcXVClkBml+qyGEsQxfEaAkboqySVGFUd9ivn7pDc9jZSckgF6zL21cNxuRH5ZA2exneV3PTtcc0I0rDOdE0Tg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/merge@9.2.2':
+    resolution: {integrity: sha512-DSLLAztOIQId7QE3m8Ehk5lV+0pjxNSSRDHPzlYQ9E4KJ9AoUMBprC4C+eX3v4srh05S2ujm5/veqAr5yEWFSQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/schema@10.0.38':
+    resolution: {integrity: sha512-Kckk2/vm+rELJ7ijvFaAn9ouWSVUTD0D4SJIvYF4rKeuQHAfCzE/jzMFonZVpTXleqJjPXLZjVbuaMorw7A5Og==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/utils@10.11.0':
+    resolution: {integrity: sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/utils@11.2.2':
+    resolution: {integrity: sha512-Do2A/t6ayqOma8m7PvpYMsCBswL+NB35BQSng4GWSBqafL2/BnfAZy/NSENPwV721Rm2fG0BHETFC0+FJJZmLw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-typed-document-node/core@3.2.0':
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-yoga/logger@2.0.1':
+    resolution: {integrity: sha512-Nv0BoDGLMg9QBKy9cIswQ3/6aKaKjlTh87x3GiBg2Z4RrjyrM48DvOOK0pJh1C1At+b0mUIM67cwZcFTDLN4sA==}
+    engines: {node: '>=18.0.0'}
+
+  '@graphql-yoga/subscription@5.0.5':
+    resolution: {integrity: sha512-oCMWOqFs6QV96/NZRt/ZhTQvzjkGB4YohBOpKM4jH/lDT4qb7Lex/aGCxpi/JD9njw3zBBtMqxbaC22+tFHVvw==}
+    engines: {node: '>=18.0.0'}
+
+  '@graphql-yoga/typed-event-target@3.0.2':
+    resolution: {integrity: sha512-ZpJxMqB+Qfe3rp6uszCQoag4nSw42icURnBRfFYSOmTgEeOe4rD0vYlbA8spvCu2TlCesNTlEN9BLWtQqLxabA==}
+    engines: {node: '>=18.0.0'}
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -839,6 +910,9 @@ packages:
   '@philihp/prettier-config@1.0.0':
     resolution: {integrity: sha512-OZjBpLRyKzSVV++9rQcJeWdleBFn7dVmay44HsZPO6Sc3ecLxXbNn2imxJSiSzHugxc9+d2WIoai3gVeMqFDaA==}
 
+  '@repeaterjs/repeater@3.1.0':
+    resolution: {integrity: sha512-TaoVksZRSx2KWYYpyLQtMQXXeS98VsgZImzW65xmiVgbYhXLk+aEsmzPLirqVuE4/XuUapH2iMtxUzaBNDzdSQ==}
+
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
@@ -1237,6 +1311,30 @@ packages:
         optional: true
       vue-router:
         optional: true
+
+  '@whatwg-node/disposablestack@0.0.6':
+    resolution: {integrity: sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==}
+    engines: {node: '>=18.0.0'}
+
+  '@whatwg-node/events@0.1.2':
+    resolution: {integrity: sha512-ApcWxkrs1WmEMS2CaLLFUEem/49erT3sxIVjpzU5f6zmVcnijtDSrhoK2zVobOIikZJdH63jdAXOrvjf6eOUNQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@whatwg-node/fetch@0.10.13':
+    resolution: {integrity: sha512-b4PhJ+zYj4357zwk4TTuF2nEe0vVtOrwdsrNo5hL+u1ojXNhh1FgJ6pg1jzDlwlT4oBdzfSwaBwMCtFCsIWg8Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@whatwg-node/node-fetch@0.8.6':
+    resolution: {integrity: sha512-BDMdYFcerLQkwA2RTldxOqRCs6ZQD1S7UgP3pUdGUkcbgTrP/V5ko77ZkCww9DHmC4lpoYuwigGfQYj285gMvA==}
+    engines: {node: '>=18.0.0'}
+
+  '@whatwg-node/promise-helpers@1.3.2':
+    resolution: {integrity: sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==}
+    engines: {node: '>=16.0.0'}
+
+  '@whatwg-node/server@0.11.0':
+    resolution: {integrity: sha512-VSdkwnJRr8Yv9UgB2aXB3VUPWwd6Oqnn0hycFwhg9pZgWxJXb7JmhsiXe9tmpMwjHFxli12PGcz9aI63YYloGQ==}
+    engines: {node: '>=18.0.0'}
 
   '@workflow/astro@4.0.15':
     resolution: {integrity: sha512-SI07J10espfpVWlcwEZ8Wnc4D96nkwvKVRC6FshASkBM2iyWc58R+nRRHwuymgXRld3brP5Mt7avW5ta8BWPOQ==}
@@ -1660,6 +1758,10 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  cross-inspect@1.0.1:
+    resolution: {integrity: sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==}
+    engines: {node: '>=16.0.0'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -2047,6 +2149,16 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  graphql-yoga@5.21.2:
+    resolution: {integrity: sha512-IIRF/3xtjj2D6caAWL9177hQ8tV3mWB3hve1GRnz7njPhQ3iY1jFtSp98fNGv0yV9kaPh9kKQ8JWdJZnedVmDw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      graphql: ^15.2.0 || ^16.0.0
+
+  graphql@17.0.2:
+    resolution: {integrity: sha512-FRWbddMxfkjiB7z+aQDWIR+E34xo9I8c9mtK2RPv8PmMzKRvrdsreHL/Ui/TmwHJfhHChEtsFPyMHKI+xuarQQ==}
+    engines: {node: ^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -2349,6 +2461,9 @@ packages:
   lowercase-keys@3.0.0:
     resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
@@ -3064,6 +3179,9 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  urlpattern-polyfill@10.1.0:
+    resolution: {integrity: sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==}
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -3251,6 +3369,23 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@envelop/core@5.5.1':
+    dependencies:
+      '@envelop/instrumentation': 1.0.0
+      '@envelop/types': 5.2.1
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
+
+  '@envelop/instrumentation@1.0.0':
+    dependencies:
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
+
+  '@envelop/types@5.2.1':
+    dependencies:
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
+
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
@@ -3389,6 +3524,67 @@ snapshots:
       jwt-decode: 4.0.0
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
+
+  '@fastify/busboy@3.2.0': {}
+
+  '@graphql-tools/executor@1.5.7(graphql@17.0.2)':
+    dependencies:
+      '@graphql-tools/utils': 11.2.2(graphql@17.0.2)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@17.0.2)
+      '@repeaterjs/repeater': 3.1.0
+      '@whatwg-node/disposablestack': 0.0.6
+      '@whatwg-node/promise-helpers': 1.3.2
+      graphql: 17.0.2
+      tslib: 2.8.1
+
+  '@graphql-tools/merge@9.2.2(graphql@17.0.2)':
+    dependencies:
+      '@graphql-tools/utils': 11.2.2(graphql@17.0.2)
+      graphql: 17.0.2
+      tslib: 2.8.1
+
+  '@graphql-tools/schema@10.0.38(graphql@17.0.2)':
+    dependencies:
+      '@graphql-tools/merge': 9.2.2(graphql@17.0.2)
+      '@graphql-tools/utils': 11.2.2(graphql@17.0.2)
+      graphql: 17.0.2
+      tslib: 2.8.1
+
+  '@graphql-tools/utils@10.11.0(graphql@17.0.2)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@17.0.2)
+      '@whatwg-node/promise-helpers': 1.3.2
+      cross-inspect: 1.0.1
+      graphql: 17.0.2
+      tslib: 2.8.1
+
+  '@graphql-tools/utils@11.2.2(graphql@17.0.2)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@17.0.2)
+      '@whatwg-node/promise-helpers': 1.3.2
+      cross-inspect: 1.0.1
+      graphql: 17.0.2
+      tslib: 2.8.1
+
+  '@graphql-typed-document-node/core@3.2.0(graphql@17.0.2)':
+    dependencies:
+      graphql: 17.0.2
+
+  '@graphql-yoga/logger@2.0.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@graphql-yoga/subscription@5.0.5':
+    dependencies:
+      '@graphql-yoga/typed-event-target': 3.0.2
+      '@repeaterjs/repeater': 3.1.0
+      '@whatwg-node/events': 0.1.2
+      tslib: 2.8.1
+
+  '@graphql-yoga/typed-event-target@3.0.2':
+    dependencies:
+      '@repeaterjs/repeater': 3.1.0
+      tslib: 2.8.1
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -3723,6 +3919,8 @@ snapshots:
       - supports-color
 
   '@philihp/prettier-config@1.0.0': {}
+
+  '@repeaterjs/repeater@3.1.0': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
 
@@ -4079,6 +4277,39 @@ snapshots:
     optionalDependencies:
       next: 16.2.12(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
+
+  '@whatwg-node/disposablestack@0.0.6':
+    dependencies:
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
+
+  '@whatwg-node/events@0.1.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@whatwg-node/fetch@0.10.13':
+    dependencies:
+      '@whatwg-node/node-fetch': 0.8.6
+      urlpattern-polyfill: 10.1.0
+
+  '@whatwg-node/node-fetch@0.8.6':
+    dependencies:
+      '@fastify/busboy': 3.2.0
+      '@whatwg-node/disposablestack': 0.0.6
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
+
+  '@whatwg-node/promise-helpers@1.3.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@whatwg-node/server@0.11.0':
+    dependencies:
+      '@envelop/instrumentation': 1.0.0
+      '@whatwg-node/disposablestack': 0.0.6
+      '@whatwg-node/fetch': 0.10.13
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
 
   '@workflow/astro@4.0.15(supports-color@8.1.1)':
     dependencies:
@@ -4676,6 +4907,10 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  cross-inspect@1.0.1:
+    dependencies:
+      tslib: 2.8.1
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -5146,6 +5381,24 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  graphql-yoga@5.21.2(graphql@17.0.2):
+    dependencies:
+      '@envelop/core': 5.5.1
+      '@envelop/instrumentation': 1.0.0
+      '@graphql-tools/executor': 1.5.7(graphql@17.0.2)
+      '@graphql-tools/schema': 10.0.38(graphql@17.0.2)
+      '@graphql-tools/utils': 10.11.0(graphql@17.0.2)
+      '@graphql-yoga/logger': 2.0.1
+      '@graphql-yoga/subscription': 5.0.5
+      '@whatwg-node/fetch': 0.10.13
+      '@whatwg-node/promise-helpers': 1.3.2
+      '@whatwg-node/server': 0.11.0
+      graphql: 17.0.2
+      lru-cache: 10.4.3
+      tslib: 2.8.1
+
+  graphql@17.0.2: {}
+
   has-flag@4.0.0: {}
 
   has-flag@5.0.1: {}
@@ -5389,6 +5642,8 @@ snapshots:
   long@5.3.2: {}
 
   lowercase-keys@3.0.0: {}
+
+  lru-cache@10.4.3: {}
 
   lru-cache@6.0.0:
     dependencies:
@@ -6101,6 +6356,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  urlpattern-polyfill@10.1.0: {}
 
   vary@1.1.2: {}
 

--- a/src/app/api/graphql/context.ts
+++ b/src/app/api/graphql/context.ts
@@ -1,0 +1,75 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { GraphQLError } from 'graphql'
+
+import { GRAPHQL_FLAG, hasFlag } from '@/flags'
+import { resolvePlayer } from '@/utils/apiToken'
+import { createClient } from '@/utils/supabase/server'
+
+// The per-request context every resolver receives. Two auth modes share it:
+//
+// - token: `Authorization: Bearer <api_token>` (the same per-user token the
+//   Sheets CSV endpoints use) resolves via the SERVICE-ROLE client, which
+//   bypasses RLS — so registrationIds is the only barrier between users.
+// - session: the Supabase auth cookie (the in-browser /graphql page), where
+//   RLS scopes every read anyway.
+//
+// THE LEAK GUARD: every resolver must filter .in('registration_id', ...) from
+// ctx.registrationIds explicitly, in BOTH modes. In session mode that's
+// redundant with RLS (harmless); in token mode it is load-bearing.
+export type GraphqlContext = {
+  supabase: SupabaseClient
+  mode: 'session' | 'token'
+  userId: string
+  registrationIds: string[]
+  // registration uuid → character name, for owner filters and ownerName fields.
+  ownerNameById: Map<string, string>
+}
+
+const deny = (message: string, status: number): never => {
+  throw new GraphQLError(message, { extensions: { http: { status } } })
+}
+
+export const buildContext = async (request: Request): Promise<GraphqlContext> => {
+  const authorization = request.headers.get('authorization') ?? ''
+  const bearer = authorization.startsWith('Bearer ') ? authorization.slice('Bearer '.length).trim() : ''
+
+  let supabase: SupabaseClient
+  let mode: GraphqlContext['mode']
+  let userId: string
+
+  if (bearer !== '') {
+    const player = await resolvePlayer(bearer)
+    if (!player.ok) return deny(player.error, player.status)
+    supabase = player.supabase
+    userId = player.userId
+    mode = 'token'
+  } else {
+    supabase = await createClient()
+    const { data, error } = await supabase.auth.getUser()
+    if (error || !data?.user) return deny('Not signed in. Send Authorization: Bearer <api_token>, or sign in.', 401)
+    userId = data.user.id
+    mode = 'session'
+  }
+
+  if (!(await hasFlag(userId, GRAPHQL_FLAG))) {
+    deny('The GraphQL API is not enabled for this account.', 403)
+  }
+
+  // Owner names come from the user's own registration rows — scoped by user_id
+  // here rather than through fetchOwners, whose unscoped registration select
+  // would return every user's characters under the service client.
+  const { data: registrations, error: registrationError } = await supabase
+    .from('registration')
+    .select('id, name')
+    .eq('user_id', userId)
+  if (registrationError) deny('Lookup failed', 500)
+
+  const rows = (registrations ?? []) as Array<{ id: string; name: string }>
+  return {
+    supabase,
+    mode,
+    userId,
+    registrationIds: rows.map((r) => r.id),
+    ownerNameById: new Map(rows.map((r) => [r.id, r.name])),
+  }
+}

--- a/src/app/api/graphql/filters.ts
+++ b/src/app/api/graphql/filters.ts
@@ -1,0 +1,60 @@
+// Pure argument→filter shaping for the GraphQL resolvers — no I/O imports so
+// test/graphqlFilters.test.ts can exercise it under the node test runner.
+// These mirror the MCP layer's resolveOwnerFilter/limit semantics but can't
+// import src/app/api/mcp/lib.ts, whose transitive imports (next/headers,
+// Supabase) don't load outside Next.
+
+// Hard caps keep a single request bounded regardless of the limit argument;
+// filters, not paging, are how callers narrow further.
+export const ASSET_CAP = 5000
+export const LIST_CAP = 1000
+
+// Clamp a caller-supplied limit into [1, cap]; absent means the cap itself.
+export const clampLimit = (limit: number | null | undefined, cap: number): number => {
+  if (limit == null || !Number.isFinite(limit)) return cap
+  return Math.min(Math.max(1, Math.floor(limit)), cap)
+}
+
+// Case-insensitive substring match of an owner-name filter against the
+// caller's characters. Returns the matching registration ids, or an error
+// listing what's available — same semantics as the MCP resolveOwnerFilter.
+export type OwnerMatch = { ok: true; ids: string[] | null } | { ok: false; message: string }
+
+export const matchOwnerIds = (owner: string | null | undefined, nameById: Map<string, string>): OwnerMatch => {
+  const trimmed = (owner ?? '').trim().toLowerCase()
+  if (trimmed === '') return { ok: true, ids: null }
+  const ids = [...nameById].filter(([, name]) => name.toLowerCase().includes(trimmed)).map(([id]) => id)
+  if (ids.length === 0) {
+    const available = [...nameById.values()].sort((a, b) => a.localeCompare(b))
+    return { ok: false, message: `No character matched "${owner}". Available: ${available.join(', ')}.` }
+  }
+  return { ok: true, ids }
+}
+
+// Parse the `since` argument (full ISO timestamp or a date prefix) into an
+// ISO string usable as a >= bound, or reject with a hint.
+export type SinceParse = { ok: true; iso: string | null } | { ok: false; message: string }
+
+export const parseSince = (since: string | null | undefined): SinceParse => {
+  const trimmed = (since ?? '').trim()
+  if (trimmed === '') return { ok: true, iso: null }
+  const parsed = new Date(trimmed)
+  if (Number.isNaN(parsed.getTime())) {
+    return {
+      ok: false,
+      message: `Could not parse since="${since}" — use an ISO date like 2026-08-01 or a full timestamp.`,
+    }
+  }
+  return { ok: true, iso: parsed.toISOString() }
+}
+
+// A numeric id argument (GraphQL String, since EVE ids overflow Int). Rejects
+// anything that isn't a plain positive integer literal.
+export type IdParse = { ok: true; id: string | null } | { ok: false; message: string }
+
+export const parseIdArg = (raw: string | null | undefined, label: string): IdParse => {
+  const trimmed = (raw ?? '').trim()
+  if (trimmed === '') return { ok: true, id: null }
+  if (!/^\d+$/.test(trimmed)) return { ok: false, message: `${label} must be a numeric id, got "${raw}".` }
+  return { ok: true, id: trimmed }
+}

--- a/src/app/api/graphql/resolvers.ts
+++ b/src/app/api/graphql/resolvers.ts
@@ -1,0 +1,448 @@
+// Root resolvers for /api/graphql. Flat by design: each Query field returns
+// fully-materialized rows with names resolved here, batched once per result
+// set — no nested resolvers, so no N+1 and no deep-query surface.
+//
+// THE LEAK GUARD (see context.ts): every table read filters
+// .in('registration_id', …) from the context. In session mode that's
+// redundant with RLS; in token mode the client is service-role and the filter
+// is the only barrier between users.
+import { GraphQLError } from 'graphql'
+import { uniq } from 'ramda'
+
+import { guessLocationRef, resolveTypeFilter } from '@/app/api/mcp/lib'
+import { resolveLocations, type LocationRef, type ResolvedLocations } from '@/app/resolveLocations'
+import { getSdeTypeNames } from '@/sdeTypes'
+import { ASSET_CAP, LIST_CAP, clampLimit, matchOwnerIds, parseIdArg, parseSince } from './filters'
+import type { GraphqlContext } from './context'
+
+const badRequest = (message: string): never => {
+  throw new GraphQLError(message, { extensions: { http: { status: 400 } } })
+}
+
+const queryFailed = (): never => {
+  throw new GraphQLError('Query failed', { extensions: { http: { status: 500 } } })
+}
+
+// The registration ids a field should read for, after the optional owner-name
+// filter — always a subset of the caller's own registrations.
+const scopeIds = (ctx: GraphqlContext, owner: string | null | undefined): string[] => {
+  const match = matchOwnerIds(owner, ctx.ownerNameById)
+  if (!match.ok) return badRequest(match.message)
+  return match.ids ?? ctx.registrationIds
+}
+
+// Fuzzy item-name filter → SDE type ids, with the MCP layer's "too many
+// matches" guard; null means no filter.
+const typeIdsFor = async (typeName: string | null | undefined): Promise<number[] | null> => {
+  const filter = await resolveTypeFilter(typeName ?? undefined)
+  if (!filter.ok) return badRequest(filter.message)
+  return filter.matches === null ? null : filter.matches.map((m) => m.typeID)
+}
+
+// Page a filtered select up to `cap` rows — PostgREST caps a single request at
+// 1000, so larger caps recurse a page at a time (tail-recursive per house style).
+const PAGE_SIZE = 1000
+
+const fetchCapped = async <T>(
+  build: (from: number, to: number) => PromiseLike<{ data: T[] | null; error: unknown }>,
+  cap: number,
+  from = 0,
+  acc: T[] = []
+): Promise<T[]> => {
+  const to = Math.min(from + PAGE_SIZE, cap) - 1
+  const { data, error } = await build(from, to)
+  if (error) return queryFailed()
+  const rows = data ?? []
+  acc.push(...rows)
+  return acc.length >= cap || rows.length < to - from + 1 ? acc : fetchCapped(build, cap, from + PAGE_SIZE, acc)
+}
+
+const typeNamesFor = async (typeIds: Array<number | string | null | undefined>): Promise<Record<number, string>> =>
+  getSdeTypeNames(uniq(typeIds.filter((id): id is number | string => id != null).map(Number)))
+
+// Batch-resolve display names for a set of location refs (station, structure,
+// solar system, or a container/ship item id that falls back to a raw label).
+const locationNamesFor = async (ctx: GraphqlContext, refs: Array<LocationRef | null>): Promise<ResolvedLocations> => {
+  const byId = new Map((refs.filter(Boolean) as LocationRef[]).map((r) => [r.id, r]))
+  return resolveLocations([...byId.values()], ctx.supabase)
+}
+
+const str = (v: number | string | null | undefined): string | null => (v == null ? null : String(v))
+
+type AssetRow = {
+  item_id: number
+  registration_id: string
+  type_id: number
+  location_id: number | null
+  location_flag: string | null
+  location_type: string | null
+  quantity: number | null
+  is_singleton: boolean | null
+  is_blueprint_copy: boolean | null
+  name: string | null
+}
+
+const assetLocationRef = (row: AssetRow): LocationRef | null =>
+  row.location_id == null
+    ? null
+    : {
+        id: String(row.location_id),
+        type: row.location_type === 'station' || row.location_type === 'solar_system' ? row.location_type : null,
+      }
+
+export const resolvers = {
+  Query: {
+    owners: (_parent: unknown, _args: unknown, ctx: GraphqlContext) =>
+      [...ctx.ownerNameById].map(([id, name]) => ({ id, name })).sort((a, b) => a.name.localeCompare(b.name)),
+
+    assets: async (
+      _parent: unknown,
+      args: { typeName?: string | null; locationId?: string | null; owner?: string | null; limit?: number | null },
+      ctx: GraphqlContext
+    ) => {
+      const ownerIds = scopeIds(ctx, args.owner)
+      const typeIds = await typeIdsFor(args.typeName)
+      const location = parseIdArg(args.locationId, 'locationId')
+      if (!location.ok) return badRequest(location.message)
+      const cap = clampLimit(args.limit, ASSET_CAP)
+
+      // The same filter set applies to the head-only count and the row pages.
+      // The builder is untyped (no generated DB types in this repo), so `any`.
+      const filtered = (query: any): any => {
+        let q = query.in('registration_id', ownerIds)
+        if (typeIds !== null) q = q.in('type_id', typeIds)
+        if (location.id !== null) q = q.eq('location_id', location.id)
+        return q
+      }
+
+      const { count, error: countError } = await filtered(
+        ctx.supabase.from('character_asset').select('item_id', { count: 'exact', head: true })
+      )
+      if (countError) return queryFailed()
+      const totalCount = count ?? 0
+
+      const rows = await fetchCapped<AssetRow>(
+        (from, to) => filtered(ctx.supabase.from('character_asset').select('*')).order('item_id').range(from, to),
+        cap
+      )
+
+      const [typeNames, locations] = await Promise.all([
+        typeNamesFor(rows.map((r) => r.type_id)),
+        locationNamesFor(ctx, rows.map(assetLocationRef)),
+      ])
+
+      return {
+        totalCount,
+        truncated: totalCount > rows.length,
+        rows: rows.map((r) => {
+          const ref = assetLocationRef(r)
+          return {
+            itemId: String(r.item_id),
+            typeId: String(r.type_id),
+            typeName: typeNames[r.type_id] ?? null,
+            quantity: String(r.quantity ?? 1),
+            locationId: str(r.location_id),
+            locationFlag: r.location_flag,
+            locationType: r.location_type,
+            locationName: ref ? locations.nameFor(ref) : null,
+            isSingleton: r.is_singleton,
+            isBlueprintCopy: r.is_blueprint_copy,
+            name: r.name,
+            ownerId: r.registration_id,
+            ownerName: ctx.ownerNameById.get(r.registration_id) ?? r.registration_id,
+          }
+        }),
+      }
+    },
+
+    blueprints: async (
+      _parent: unknown,
+      args: { typeName?: string | null; owner?: string | null; limit?: number | null },
+      ctx: GraphqlContext
+    ) => {
+      const ownerIds = scopeIds(ctx, args.owner)
+      const typeIds = await typeIdsFor(args.typeName)
+      const cap = clampLimit(args.limit, LIST_CAP)
+
+      type BlueprintRow = {
+        item_id: number
+        registration_id: string
+        type_id: number
+        location_id: number | null
+        location_flag: string | null
+        quantity: number | null
+        material_efficiency: number | null
+        time_efficiency: number | null
+        runs: number | null
+      }
+
+      const filtered = (query: any): any => {
+        const q = query.in('registration_id', ownerIds)
+        return typeIds !== null ? q.in('type_id', typeIds) : q
+      }
+
+      const { count, error: countError } = await filtered(
+        ctx.supabase.from('character_blueprint').select('item_id', { count: 'exact', head: true })
+      )
+      if (countError) return queryFailed()
+      const totalCount = count ?? 0
+
+      const rows = await fetchCapped<BlueprintRow>(
+        (from, to) => filtered(ctx.supabase.from('character_blueprint').select('*')).order('item_id').range(from, to),
+        cap
+      )
+
+      const [typeNames, locations] = await Promise.all([
+        typeNamesFor(rows.map((r) => r.type_id)),
+        locationNamesFor(
+          ctx,
+          rows.map((r) => guessLocationRef(r.location_id))
+        ),
+      ])
+
+      return {
+        totalCount,
+        truncated: totalCount > rows.length,
+        rows: rows.map((r) => {
+          const ref = guessLocationRef(r.location_id)
+          return {
+            itemId: String(r.item_id),
+            typeId: String(r.type_id),
+            typeName: typeNames[r.type_id] ?? null,
+            quantity: String(r.quantity ?? 1),
+            locationId: str(r.location_id),
+            locationFlag: r.location_flag,
+            locationName: ref ? locations.nameFor(ref) : null,
+            materialEfficiency: r.material_efficiency,
+            timeEfficiency: r.time_efficiency,
+            runs: r.runs,
+            ownerId: r.registration_id,
+            ownerName: ctx.ownerNameById.get(r.registration_id) ?? r.registration_id,
+          }
+        }),
+      }
+    },
+
+    marketOrders: async (_parent: unknown, args: { owner?: string | null }, ctx: GraphqlContext) => {
+      const ownerIds = scopeIds(ctx, args.owner)
+
+      type OrderRow = {
+        order_id: number
+        registration_id: string
+        type_id: number
+        region_id: number
+        location_id: number
+        range: string
+        is_buy: boolean
+        price: number
+        volume_total: number
+        volume_remain: number
+        min_volume: number | null
+        escrow: number | null
+        duration: number
+        issued: string
+      }
+
+      const rows = await fetchCapped<OrderRow>(
+        (from, to) =>
+          ctx.supabase
+            .from('character_order')
+            .select('*')
+            .in('registration_id', ownerIds)
+            .order('issued', { ascending: false })
+            .range(from, to),
+        LIST_CAP
+      )
+
+      const [typeNames, locations] = await Promise.all([
+        typeNamesFor(rows.map((r) => r.type_id)),
+        locationNamesFor(
+          ctx,
+          rows.map((r) => guessLocationRef(r.location_id))
+        ),
+      ])
+
+      return rows.map((r) => {
+        const ref = guessLocationRef(r.location_id)
+        return {
+          orderId: String(r.order_id),
+          typeId: String(r.type_id),
+          typeName: typeNames[r.type_id] ?? null,
+          locationId: String(r.location_id),
+          locationName: ref ? locations.nameFor(ref) : null,
+          regionId: String(r.region_id),
+          isBuy: r.is_buy,
+          price: Number(r.price),
+          volumeTotal: String(r.volume_total),
+          volumeRemain: String(r.volume_remain),
+          minVolume: str(r.min_volume),
+          escrow: r.escrow == null ? null : Number(r.escrow),
+          range: r.range,
+          duration: r.duration,
+          issued: r.issued,
+          ownerId: r.registration_id,
+          ownerName: ctx.ownerNameById.get(r.registration_id) ?? r.registration_id,
+        }
+      })
+    },
+
+    industryJobs: async (
+      _parent: unknown,
+      args: { owner?: string | null; includeDelivered?: boolean | null },
+      ctx: GraphqlContext
+    ) => {
+      const ownerIds = scopeIds(ctx, args.owner)
+
+      type JobRow = {
+        job_id: number
+        registration_id: string
+        activity_id: number
+        blueprint_type_id: number
+        product_type_id: number | null
+        runs: number
+        licensed_runs: number | null
+        probability: number | null
+        successful_runs: number | null
+        status: string
+        cost: number | null
+        duration: number
+        start_date: string
+        end_date: string
+        completed_date: string | null
+        station_id: number | null
+        facility_id: number
+      }
+
+      const rows = await fetchCapped<JobRow>((from, to) => {
+        const q = ctx.supabase
+          .from('character_industry_job')
+          .select('*')
+          .in('registration_id', ownerIds)
+          .order('start_date', { ascending: false })
+          .range(from, to)
+        return args.includeDelivered ? q : q.neq('status', 'delivered')
+      }, LIST_CAP)
+
+      const jobLocationRef = (r: JobRow): LocationRef | null => guessLocationRef(r.station_id ?? r.facility_id)
+
+      const [typeNames, locations] = await Promise.all([
+        typeNamesFor(rows.flatMap((r) => [r.blueprint_type_id, r.product_type_id])),
+        locationNamesFor(ctx, rows.map(jobLocationRef)),
+      ])
+
+      return rows.map((r) => {
+        const ref = jobLocationRef(r)
+        return {
+          jobId: String(r.job_id),
+          activityId: r.activity_id,
+          blueprintTypeId: String(r.blueprint_type_id),
+          blueprintTypeName: typeNames[r.blueprint_type_id] ?? null,
+          productTypeId: str(r.product_type_id),
+          productTypeName: r.product_type_id == null ? null : (typeNames[r.product_type_id] ?? null),
+          runs: r.runs,
+          licensedRuns: r.licensed_runs,
+          probability: r.probability,
+          successfulRuns: r.successful_runs,
+          status: r.status,
+          cost: r.cost == null ? null : Number(r.cost),
+          duration: r.duration,
+          startDate: r.start_date,
+          endDate: r.end_date,
+          completedDate: r.completed_date,
+          stationId: str(r.station_id),
+          locationName: ref ? locations.nameFor(ref) : null,
+          ownerId: r.registration_id,
+          ownerName: ctx.ownerNameById.get(r.registration_id) ?? r.registration_id,
+        }
+      })
+    },
+
+    walletBalances: async (_parent: unknown, _args: unknown, ctx: GraphqlContext) => {
+      // character_wallet is an append-only balance history; one small query per
+      // registration (a user links a handful of characters) grabs each latest row.
+      const latest = await Promise.all(
+        ctx.registrationIds.map(async (registrationId) => {
+          const { data, error } = await ctx.supabase
+            .from('character_wallet')
+            .select('registration_id, balance, recorded_at')
+            .eq('registration_id', registrationId)
+            .order('recorded_at', { ascending: false })
+            .limit(1)
+            .maybeSingle()
+          if (error) return queryFailed()
+          return data as { registration_id: string; balance: number; recorded_at: string } | null
+        })
+      )
+
+      return latest
+        .filter((r): r is NonNullable<typeof r> => r != null)
+        .map((r) => ({
+          ownerId: r.registration_id,
+          ownerName: ctx.ownerNameById.get(r.registration_id) ?? r.registration_id,
+          balance: Number(r.balance),
+          recordedAt: r.recorded_at,
+        }))
+        .sort((a, b) => a.ownerName.localeCompare(b.ownerName))
+    },
+
+    walletTransactions: async (
+      _parent: unknown,
+      args: { typeName?: string | null; owner?: string | null; since?: string | null; limit?: number | null },
+      ctx: GraphqlContext
+    ) => {
+      const ownerIds = scopeIds(ctx, args.owner)
+      const typeIds = await typeIdsFor(args.typeName)
+      const since = parseSince(args.since)
+      if (!since.ok) return badRequest(since.message)
+      const cap = clampLimit(args.limit, LIST_CAP)
+
+      type TransactionRow = {
+        transaction_id: number
+        registration_id: string
+        date: string
+        type_id: number
+        quantity: number
+        unit_price: number
+        is_buy: boolean
+        location_id: number
+      }
+
+      const rows = await fetchCapped<TransactionRow>((from, to) => {
+        let q = ctx.supabase
+          .from('character_wallet_transaction')
+          .select('*')
+          .in('registration_id', ownerIds)
+          .order('date', { ascending: false })
+          .range(from, to)
+        if (typeIds !== null) q = q.in('type_id', typeIds)
+        if (since.iso !== null) q = q.gte('date', since.iso)
+        return q
+      }, cap)
+
+      const [typeNames, locations] = await Promise.all([
+        typeNamesFor(rows.map((r) => r.type_id)),
+        locationNamesFor(
+          ctx,
+          rows.map((r) => guessLocationRef(r.location_id))
+        ),
+      ])
+
+      return rows.map((r) => {
+        const ref = guessLocationRef(r.location_id)
+        return {
+          transactionId: String(r.transaction_id),
+          date: r.date,
+          typeId: String(r.type_id),
+          typeName: typeNames[r.type_id] ?? null,
+          quantity: String(r.quantity),
+          unitPrice: Number(r.unit_price),
+          isBuy: r.is_buy,
+          locationId: String(r.location_id),
+          locationName: ref ? locations.nameFor(ref) : null,
+          ownerId: r.registration_id,
+          ownerName: ctx.ownerNameById.get(r.registration_id) ?? r.registration_id,
+        }
+      })
+    },
+  },
+}

--- a/src/app/api/graphql/route.ts
+++ b/src/app/api/graphql/route.ts
@@ -1,0 +1,42 @@
+import { createYoga } from 'graphql-yoga'
+import type { NextRequest } from 'next/server'
+
+import { buildContext } from './context'
+import { schema } from './schema'
+
+// The dark-launched GraphQL endpoint (see /graphql for the in-browser editor).
+// Auth is either the Supabase session cookie (same-origin, the editor page) or
+// `Authorization: Bearer <api_token>` (external stockpile UIs — the same
+// per-user token the Sheets CSV endpoints use); both are additionally gated on
+// the account's `graphql` dark-launch flag (src/flags.ts). buildContext throws
+// GraphQLErrors carrying extensions.http.status, which yoga maps to 401/403.
+export const dynamic = 'force-dynamic'
+// Headroom over Vercel's default function timeout for a large hangar, matching
+// /api/character/assets.
+export const maxDuration = 60
+
+const { handleRequest } = createYoga({
+  schema,
+  context: ({ request }) => buildContext(request),
+  graphqlEndpoint: '/api/graphql',
+  fetchAPI: { Response },
+  // The /graphql page is the in-browser UI; no bundled GraphiQL or landing page.
+  graphiql: false,
+  landingPage: false,
+  batching: false,
+  // Wildcard origin with credentials OFF is the safe pairing: external UIs
+  // authenticate with the Bearer token, and the session cookie only ever rides
+  // same-origin requests (which need no CORS at all).
+  cors: {
+    origin: '*',
+    credentials: false,
+    methods: ['POST', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
+  },
+})
+
+// Thin wrapper only to satisfy Next's route-handler signature (yoga's second
+// parameter is its own server context, not Next's { params }).
+const handler = (request: NextRequest): Promise<Response> => Promise.resolve(handleRequest(request, {}))
+
+export { handler as GET, handler as POST, handler as OPTIONS }

--- a/src/app/api/graphql/schema.graphql.ts
+++ b/src/app/api/graphql/schema.graphql.ts
@@ -1,0 +1,150 @@
+// The GraphQL SDL for /api/graphql, kept in a module with no I/O imports so
+// the node test runner can assert its shape (test/graphqlSchema.test.ts)
+// without dragging in Next or Supabase.
+//
+// Design stance: a flat schema — every list is a root Query field returning
+// fully-materialized rows, with names (typeName/locationName/ownerName)
+// resolved in the root resolver, batched once per result set. There are no
+// nested resolvers, so N+1 fan-out and deep-query abuse are impossible by
+// construction. Ids are String: EVE item ids exceed 2^53, and GraphQL Int is
+// 32-bit. Timestamps are ISO 8601 strings.
+export const typeDefs = /* GraphQL */ `
+  type Query {
+    "Your linked characters. ownerId on every row below is one of these ids."
+    owners: [Owner!]!
+
+    "Current asset rows (live inventory) across your characters."
+    assets(typeName: String, locationId: String, owner: String, limit: Int): AssetPage!
+
+    "Current blueprint rows (BPOs and BPCs) across your characters."
+    blueprints(typeName: String, owner: String, limit: Int): BlueprintPage!
+
+    "Open market orders across your characters."
+    marketOrders(owner: String): [MarketOrder!]!
+
+    "Industry jobs across your characters. Delivered jobs are excluded unless includeDelivered."
+    industryJobs(owner: String, includeDelivered: Boolean = false): [IndustryJob!]!
+
+    "Latest known wallet balance per character."
+    walletBalances: [WalletBalance!]!
+
+    "Market transaction history across your characters, newest first."
+    walletTransactions(typeName: String, owner: String, since: String, limit: Int): [WalletTransaction!]!
+  }
+
+  "A linked character (id is this site's registration id, not the EVE character id)."
+  type Owner {
+    id: String!
+    name: String!
+  }
+
+  type Asset {
+    itemId: String!
+    typeId: String!
+    typeName: String
+    quantity: String!
+    locationId: String
+    locationFlag: String
+    locationType: String
+    locationName: String
+    isSingleton: Boolean
+    isBlueprintCopy: Boolean
+    "Player-assigned name (ship/container custom name), if any."
+    name: String
+    ownerId: String!
+    ownerName: String!
+  }
+
+  type AssetPage {
+    rows: [Asset!]!
+    "Rows matching the filters, before the limit."
+    totalCount: Int!
+    truncated: Boolean!
+  }
+
+  type Blueprint {
+    itemId: String!
+    typeId: String!
+    typeName: String
+    quantity: String!
+    locationId: String
+    locationFlag: String
+    locationName: String
+    materialEfficiency: Int
+    timeEfficiency: Int
+    "-1 for an original, remaining licensed runs for a copy."
+    runs: Int
+    ownerId: String!
+    ownerName: String!
+  }
+
+  type BlueprintPage {
+    rows: [Blueprint!]!
+    totalCount: Int!
+    truncated: Boolean!
+  }
+
+  type MarketOrder {
+    orderId: String!
+    typeId: String!
+    typeName: String
+    locationId: String!
+    locationName: String
+    regionId: String!
+    isBuy: Boolean!
+    price: Float!
+    volumeTotal: String!
+    volumeRemain: String!
+    minVolume: String
+    escrow: Float
+    range: String!
+    duration: Int!
+    issued: String!
+    ownerId: String!
+    ownerName: String!
+  }
+
+  type IndustryJob {
+    jobId: String!
+    activityId: Int!
+    blueprintTypeId: String!
+    blueprintTypeName: String
+    productTypeId: String
+    productTypeName: String
+    runs: Int!
+    licensedRuns: Int
+    probability: Float
+    successfulRuns: Int
+    status: String!
+    cost: Float
+    duration: Int!
+    startDate: String!
+    endDate: String!
+    completedDate: String
+    stationId: String
+    locationName: String
+    ownerId: String!
+    ownerName: String!
+  }
+
+  type WalletBalance {
+    ownerId: String!
+    ownerName: String!
+    balance: Float!
+    recordedAt: String!
+  }
+
+  type WalletTransaction {
+    transactionId: String!
+    date: String!
+    typeId: String!
+    typeName: String
+    quantity: String!
+    unitPrice: Float!
+    isBuy: Boolean!
+    locationId: String!
+    locationName: String
+    ownerId: String!
+    ownerName: String!
+  }
+`

--- a/src/app/api/graphql/schema.ts
+++ b/src/app/api/graphql/schema.ts
@@ -1,0 +1,6 @@
+import { createSchema } from 'graphql-yoga'
+
+import { resolvers } from './resolvers'
+import { typeDefs } from './schema.graphql'
+
+export const schema = createSchema({ typeDefs, resolvers })

--- a/src/app/graphql/graphql.module.css
+++ b/src/app/graphql/graphql.module.css
@@ -1,0 +1,54 @@
+.editor {
+  display: flex;
+  flex-direction: column;
+  gap: 8pt;
+  margin-top: 8pt;
+}
+
+.examples {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6pt;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 2pt;
+  font-size: 9pt;
+  color: var(--ink-soft);
+}
+
+.query,
+.variables {
+  font-family: var(--mono);
+  font-size: 10pt;
+  color: var(--ink);
+  background: var(--paper-raised);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 6pt 8pt;
+  resize: vertical;
+}
+
+.result,
+.docs {
+  font-family: var(--mono);
+  font-size: 9pt;
+  background: var(--paper-raised);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 6pt 8pt;
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.result {
+  max-height: 32em;
+  overflow-y: auto;
+}
+
+.docsNote {
+  font-size: 9pt;
+  color: var(--ink-soft);
+}

--- a/src/app/graphql/page.tsx
+++ b/src/app/graphql/page.tsx
@@ -1,0 +1,67 @@
+import { redirect } from 'next/navigation'
+
+import { GRAPHQL_FLAG, hasFlag } from '@/flags'
+import { createClient } from '@/utils/supabase/server'
+import { QueryEditor } from './queryEditor'
+import styles from './graphql.module.css'
+
+// Dark-launched GraphQL explorer (no nav link): query your own extracted data
+// and build external stockpile interfaces against /api/graphql. Gated on the
+// per-account `graphql` flag in user_settings.flags.
+export const dynamic = 'force-dynamic'
+
+const GraphqlPage = async () => {
+  const supabase = await createClient()
+
+  const { data, error } = await supabase.auth.getUser()
+  if (error || !data?.user) {
+    redirect('/account/login')
+  }
+  if (!(await hasFlag(data.user.id, GRAPHQL_FLAG))) {
+    redirect('/')
+  }
+
+  // The user's own api_token (RLS-scoped read), for the external-usage docs.
+  const { data: settings } = await supabase
+    .from('user_settings')
+    .select('api_token')
+    .eq('user_id', data.user.id)
+    .maybeSingle()
+  const apiToken = settings?.api_token ?? null
+
+  return (
+    <>
+      <h1>GraphQL</h1>
+      <p>
+        Query your extracted data — assets, blueprints, orders, industry jobs, wallets — with GraphQL. This page posts
+        to <code>/api/graphql</code> with your session; external tools authenticate with your API token instead.
+      </p>
+
+      <QueryEditor />
+
+      <h2>Use it from your own tools</h2>
+      <p>
+        Send a POST to <code>/api/graphql</code> with your API token
+        {apiToken === null && (
+          <>
+            {' '}
+            (generate one under <a href="/account/settings">account settings</a>)
+          </>
+        )}
+        :
+      </p>
+      <pre className={styles.docs}>
+        {`curl -X POST https://edencom.link/api/graphql \\
+  -H 'Content-Type: application/json' \\
+  -H 'Authorization: Bearer ${apiToken ?? '<your api token>'}' \\
+  -d '{"query": "{ walletBalances { ownerName balance } }"}'`}
+      </pre>
+      <p className={styles.docsNote}>
+        The endpoint answers cross-origin requests, so a static page on your own host can fetch it directly. Keep the
+        token secret — it reads everything your account can see.
+      </p>
+    </>
+  )
+}
+
+export default GraphqlPage

--- a/src/app/graphql/queryEditor.tsx
+++ b/src/app/graphql/queryEditor.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import { useState } from 'react'
+
+import styles from './graphql.module.css'
+
+// Deliberately simple in-browser editor (no GraphiQL dependency): a query
+// textarea, an optional variables JSON textarea, and the raw JSON response.
+// Posts same-origin, so the Supabase session cookie authenticates it.
+
+const EXAMPLES: Array<{ label: string; query: string }> = [
+  {
+    label: 'Wallet balances',
+    query: `{
+  walletBalances {
+    ownerName
+    balance
+    recordedAt
+  }
+}`,
+  },
+  {
+    label: 'Stockpile by item',
+    query: `query Stockpile($item: String!) {
+  assets(typeName: $item) {
+    totalCount
+    truncated
+    rows {
+      typeName
+      quantity
+      locationName
+      ownerName
+    }
+  }
+}`,
+  },
+  {
+    label: 'Open orders',
+    query: `{
+  marketOrders {
+    typeName
+    isBuy
+    price
+    volumeRemain
+    locationName
+    ownerName
+  }
+}`,
+  },
+  {
+    label: 'Industry jobs',
+    query: `{
+  industryJobs {
+    blueprintTypeName
+    productTypeName
+    activityId
+    runs
+    status
+    endDate
+    locationName
+    ownerName
+  }
+}`,
+  },
+]
+
+const EXAMPLE_VARIABLES: Record<string, string> = {
+  'Stockpile by item': `{ "item": "Tritanium" }`,
+}
+
+export const QueryEditor = () => {
+  const [query, setQuery] = useState(EXAMPLES[0].query)
+  const [variables, setVariables] = useState('')
+  const [result, setResult] = useState('')
+  const [running, setRunning] = useState(false)
+
+  const run = async () => {
+    let parsedVariables: unknown
+    const trimmed = variables.trim()
+    if (trimmed !== '') {
+      try {
+        parsedVariables = JSON.parse(trimmed)
+      } catch {
+        setResult('Variables must be a JSON object, e.g. { "item": "Tritanium" }')
+        return
+      }
+    }
+    setRunning(true)
+    try {
+      const response = await fetch('/api/graphql', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query, variables: parsedVariables }),
+      })
+      const json = await response.json()
+      setResult(JSON.stringify(json, null, 2))
+    } catch (e) {
+      setResult(`Request failed: ${e instanceof Error ? e.message : String(e)}`)
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  const loadExample = (label: string) => {
+    const example = EXAMPLES.find((e) => e.label === label)
+    if (!example) return
+    setQuery(example.query)
+    setVariables(EXAMPLE_VARIABLES[label] ?? '')
+  }
+
+  return (
+    <div className={styles.editor}>
+      <div className={styles.examples}>
+        {EXAMPLES.map((e) => (
+          <button key={e.label} type="button" onClick={() => loadExample(e.label)}>
+            {e.label}
+          </button>
+        ))}
+      </div>
+      <label className={styles.field}>
+        Query
+        <textarea
+          className={styles.query}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          rows={14}
+          spellCheck={false}
+        />
+      </label>
+      <label className={styles.field}>
+        Variables (JSON, optional)
+        <textarea
+          className={styles.variables}
+          value={variables}
+          onChange={(e) => setVariables(e.target.value)}
+          rows={3}
+          spellCheck={false}
+        />
+      </label>
+      <div>
+        <button type="button" onClick={run} disabled={running || query.trim() === ''}>
+          {running ? 'Running…' : 'Run query'}
+        </button>
+      </div>
+      {result !== '' && <pre className={styles.result}>{result}</pre>}
+    </div>
+  )
+}

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,0 +1,15 @@
+import { createServiceClient } from '@/utils/supabase/service'
+
+// Dark-launch flag names live here so callers can't typo them apart.
+export const GRAPHQL_FLAG = 'graphql'
+
+// user_settings.flags is the per-user dark-launch flag list (see the
+// add_user_settings_flags migration, whose comment points at this module).
+// Read with the service role, mirroring isChancellor: callable from api_token
+// contexts that carry no Supabase session. A missing user_settings row means
+// no flags. Flags are set by hand for now (SQL array_append); no admin UI.
+export const hasFlag = async (userId: string, flag: string): Promise<boolean> => {
+  const service = createServiceClient()
+  const { data } = await service.from('user_settings').select('flags').eq('user_id', userId).maybeSingle()
+  return ((data?.flags ?? []) as string[]).includes(flag)
+}

--- a/src/utils/apiToken.ts
+++ b/src/utils/apiToken.ts
@@ -1,7 +1,7 @@
 import { createServiceClient } from '@/utils/supabase/service'
 
 type Resolved =
-  | { ok: true; supabase: ReturnType<typeof createServiceClient>; registrationIds: string[] }
+  | { ok: true; supabase: ReturnType<typeof createServiceClient>; userId: string; registrationIds: string[] }
   | { ok: false; status: number; error: string }
 
 // Resolve a per-user api_token (from the IMPORTDATA query string) to the owner's
@@ -35,5 +35,5 @@ export const resolvePlayer = async (token: string | undefined): Promise<Resolved
     return { ok: false, status: 500, error: 'Lookup failed' }
   }
 
-  return { ok: true, supabase, registrationIds: (characters ?? []).map((c) => c.id) }
+  return { ok: true, supabase, userId: settings.user_id, registrationIds: (characters ?? []).map((c) => c.id) }
 }

--- a/test/graphqlFilters.test.ts
+++ b/test/graphqlFilters.test.ts
@@ -1,0 +1,72 @@
+// Unit coverage for the GraphQL resolvers' pure argument shaping
+// (src/app/api/graphql/filters.ts). What matters here is what the resolvers
+// can't get wrong quietly: limit clamping against the hard caps (the request
+// bound), owner matching (the same substring semantics as the MCP layer), and
+// the argument parsers rejecting rather than silently widening a filter.
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  ASSET_CAP,
+  LIST_CAP,
+  clampLimit,
+  matchOwnerIds,
+  parseIdArg,
+  parseSince,
+} from '../src/app/api/graphql/filters.ts'
+
+test('clampLimit defaults to the cap when absent or not a number', () => {
+  assert.equal(clampLimit(undefined, LIST_CAP), LIST_CAP)
+  assert.equal(clampLimit(null, ASSET_CAP), ASSET_CAP)
+  assert.equal(clampLimit(Number.NaN, LIST_CAP), LIST_CAP)
+})
+
+test('clampLimit bounds into [1, cap] and floors fractions', () => {
+  assert.equal(clampLimit(0, LIST_CAP), 1)
+  assert.equal(clampLimit(-5, LIST_CAP), 1)
+  assert.equal(clampLimit(2.9, LIST_CAP), 2)
+  assert.equal(clampLimit(250, LIST_CAP), 250)
+  assert.equal(clampLimit(999999, ASSET_CAP), ASSET_CAP)
+})
+
+const OWNERS = new Map([
+  ['reg-a', 'Philihp Busby'],
+  ['reg-b', 'Philihp Alt'],
+  ['reg-c', 'Someone Else'],
+])
+
+test('matchOwnerIds passes null through as no filter', () => {
+  assert.deepEqual(matchOwnerIds(undefined, OWNERS), { ok: true, ids: null })
+  assert.deepEqual(matchOwnerIds('   ', OWNERS), { ok: true, ids: null })
+})
+
+test('matchOwnerIds matches case-insensitive substrings, possibly several', () => {
+  const match = matchOwnerIds('philihp', OWNERS)
+  assert.ok(match.ok)
+  assert.deepEqual(match.ok && match.ids, ['reg-a', 'reg-b'])
+  const exact = matchOwnerIds('someone else', OWNERS)
+  assert.deepEqual(exact.ok && exact.ids, ['reg-c'])
+})
+
+test('matchOwnerIds rejects an unknown owner, listing what exists', () => {
+  const match = matchOwnerIds('nobody', OWNERS)
+  assert.equal(match.ok, false)
+  assert.match(!match.ok ? match.message : '', /Philihp Alt, Philihp Busby, Someone Else/)
+})
+
+test('parseSince accepts ISO timestamps and date prefixes, rejects junk', () => {
+  assert.deepEqual(parseSince(undefined), { ok: true, iso: null })
+  const day = parseSince('2026-08-01')
+  assert.ok(day.ok && day.iso === '2026-08-01T00:00:00.000Z')
+  const stamp = parseSince('2026-08-01T12:30:00Z')
+  assert.ok(stamp.ok && stamp.iso === '2026-08-01T12:30:00.000Z')
+  assert.equal(parseSince('yesterday-ish').ok, false)
+})
+
+test('parseIdArg accepts only bare positive integer literals', () => {
+  assert.deepEqual(parseIdArg(undefined, 'locationId'), { ok: true, id: null })
+  assert.deepEqual(parseIdArg(' 60003760 ', 'locationId'), { ok: true, id: '60003760' })
+  assert.equal(parseIdArg('60003760; drop table', 'locationId').ok, false)
+  assert.equal(parseIdArg('-1', 'locationId').ok, false)
+  assert.equal(parseIdArg('1e9', 'locationId').ok, false)
+})

--- a/test/graphqlSchema.test.ts
+++ b/test/graphqlSchema.test.ts
@@ -1,0 +1,34 @@
+// Drift guard for the GraphQL SDL (src/app/api/graphql/schema.graphql.ts):
+// the SDL lives in an I/O-free module precisely so this can build it with the
+// plain `graphql` reference implementation and pin the query surface — a field
+// someone renames or drops shows up here before an external stockpile UI
+// breaks on it.
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { buildSchema, type GraphQLObjectType } from 'graphql'
+
+import { typeDefs } from '../src/app/api/graphql/schema.graphql.ts'
+
+test('the SDL parses and exposes the expected query fields', () => {
+  const schema = buildSchema(typeDefs)
+  const query = schema.getQueryType() as GraphQLObjectType
+  assert.deepEqual(Object.keys(query.getFields()).sort(), [
+    'assets',
+    'blueprints',
+    'industryJobs',
+    'marketOrders',
+    'owners',
+    'walletBalances',
+    'walletTransactions',
+  ])
+})
+
+test('ids stay String — EVE item ids overflow GraphQL Int', () => {
+  const schema = buildSchema(typeDefs)
+  const asset = schema.getType('Asset') as GraphQLObjectType
+  assert.equal(String(asset.getFields().itemId.type), 'String!')
+  assert.equal(String(asset.getFields().quantity.type), 'String!')
+  const order = schema.getType('MarketOrder') as GraphQLObjectType
+  assert.equal(String(order.getFields().orderId.type), 'String!')
+})


### PR DESCRIPTION
A curated GraphQL endpoint at `/api/graphql` plus a dark-launched in-browser editor at `/graphql`, so users can query their extracted data and build their own stockpile interfaces against this site.

## What's queryable (v1, character-scoped)

`owners`, `assets`, `blueprints`, `marketOrders`, `industryJobs`, `walletBalances`, `walletTransactions` — with `typeName` fuzzy filters (through the MCP layer's `resolveTypeFilter`, same too-many-matches guard), owner substring filters, and resolved `typeName`/`locationName`/`ownerName` on every row. Corp-scoped data is deferred to a v2.

## Design

- **Flat schema, no nested resolvers.** Every list is a root Query field; names are batch-resolved once per result set (`getSdeTypeNames`, `resolveLocations`). No N+1, and query depth is bounded by construction. Ids serialize as `String` — EVE item ids overflow GraphQL Int.
- **Hard caps** (5000 asset rows, 1000 elsewhere) with `totalCount`/`truncated` on the paged fields; PostgREST's 1000-row cap is paged past tail-recursively.
- **Dual auth.** The editor page posts same-origin with the Supabase session cookie; external tools send `Authorization: Bearer <api_token>` — the same per-user token the Sheets CSV endpoints use, resolved by `resolvePlayer` (which now additionally returns `userId`, an additive change).
- **The leak guard.** The token path runs on the service client, so every resolver explicitly filters `.in('registration_id', …)` in both modes — redundant under RLS, load-bearing under the service role. `buildContext` builds owner names from `registration` scoped by `user_id` itself rather than through `fetchOwners`, whose unscoped select would return every user's rows on the service client.
- **CORS**: wildcard origin with credentials off — external UIs use the token; cookies never ride cross-origin.
- **Dark launch**: both the page and the endpoint gate on a `graphql` entry in `user_settings.flags` via the new `src/flags.ts` (the reader the flags migration's comment always pointed at), mirroring `isChancellor`. No nav link. Nobody is flagged by default; enable per user with `update user_settings set flags = array_append(flags,'graphql') where user_id = '…';`

New dependencies: `graphql`, `graphql-yoga` (fetch-native, mounts as a route handler, handles CORS/OPTIONS; no GraphiQL bundled — the editor is a plain textarea pair styled like the rest of the site).

## Testing

- `test/graphqlFilters.test.ts` — the pure arg→filter shaping (limit clamping, owner matching, `since`/id parsing).
- `test/graphqlSchema.test.ts` — builds the SDL with the `graphql` reference implementation and pins the query surface + String-id fields, as a drift guard for external consumers.
- `pnpm run lint`, `pnpm test` (110 pass), `pnpm run build` all green.
- Not covered here: a live two-account leak smoke test (needs real tokens) — worth doing once deployed, before flagging anyone beyond your own account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSjBdjGmTZVXJHXkVLtKpf

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSjBdjGmTZVXJHXkVLtKpf)_