### PR TITLE
Document the unified recursive sharing project (Revision 3)

### DIFF
--- a/docs/sharing-layer/01-asset-share-table.md
+++ b/docs/sharing-layer/01-asset-share-table.md
@@ -1,0 +1,146 @@
+# Phase 1: the `character_asset_share` table
+
+**Status: not started.**
+
+Pure additive schema: the share table, its owner and audience policies, the
+audience-match helper, and the token-signing seam. Nothing reads it yet — the
+widening policy on the asset tables is phase 2, the UI phase 3 — so this PR
+has zero blast radius on existing behavior.
+
+## The table
+
+One row per shared thing. Audience lives **on the row** as arrays, not one
+row per audience (this supersedes design.md Revision 2's `audience` enum and
+the fitting share's `level` rows):
+
+```sql
+create table public.character_asset_share (
+  id uuid primary key default gen_random_uuid(),
+  -- Grantor: the registration owning the shared item. Per-character, never
+  -- user_id (the alt-privacy invariant; see design.md).
+  registration_id uuid not null references public.registration(id) on delete cascade,
+  -- Subject: the shared item (a ship, container, or any asset). The share
+  -- covers this item and, recursively, everything inside it (phase 2).
+  item_id bigint not null,
+  -- (a) Viewers with a registration in any of these corporations see the rows.
+  corporation_ids bigint[] not null default '{}',
+  -- (b) Same, matched against the viewer's alliances.
+  alliance_ids bigint[] not null default '{}',
+  -- (c) Link-token mode: a random private key (32 bytes, hex). The URL token
+  -- is an HMAC signature derived from this and TOKEN_SALT — see below. Null
+  -- when the share has no link.
+  secret text,
+  created_at timestamptz not null default now(),
+  unique (registration_id, item_id)
+);
+create index character_asset_share_item_id_idx on public.character_asset_share (item_id);
+
+alter table public.character_asset_share enable row level security;
+```
+
+**(d) Fully public** is the row state `secret is null and corporation_ids =
+'{}' and alliance_ids = '{}'` — a public share is represented as a share
+that names no one. There is no `is_public` flag to drift out of sync.
+
+The audiences compose: a row may carry corporation ids _and_ a secret; each
+grant path is independent.
+
+## Policies
+
+Owner policies mirror `character_mercenary_den_share` exactly (read own,
+insert own, delete own, keyed on `registration_id in (select id from
+registration where user_id = (select auth.uid()))`), **plus update** — unlike
+the den/fitting tables, audience arrays are edited in place rather than
+add/remove rows, so the owner needs `for update` with the same predicate on
+both `using` and `with check` (so a row can't be re-pointed at someone else's
+registration).
+
+The audience-read policy is **load-bearing** (same reasoning as the den
+share: the visibility helper runs as the querying user, so it can only match
+share rows these policies expose):
+
+```sql
+create policy "Audience reads asset shares aimed at them"
+  on public.character_asset_share
+  for select
+  to anon, authenticated
+  using (public.asset_share_matches_caller(corporation_ids, alliance_ids, secret));
+```
+
+`to anon` matters: fully-public shares are visible to signed-out viewers, so
+`grant select on public.character_asset_share to anon` as well (plus the
+usual `select, insert, update, delete` to `authenticated`, `all` to
+`service_role`).
+
+## The audience-match helper
+
+Invoker rights, like every helper in this layer:
+
+```sql
+create or replace function public.asset_share_matches_caller(
+  corporation_ids bigint[], alliance_ids bigint[], secret text
+)
+returns boolean
+language sql
+stable
+as $$
+  select
+    -- (d) public: names no one, visible to everyone
+    (secret is null and corporation_ids = '{}' and alliance_ids = '{}')
+    -- (a)/(b) membership: array overlap with the caller's affiliations
+    or corporation_ids && array(select public.my_corporation_ids())
+    or alliance_ids && array(select public.my_alliance_ids());
+$$;
+```
+
+Note what this deliberately does **not** match: a row whose only grant is a
+`secret`. RLS cannot see a URL token — link shares are resolved at the app
+layer (phase 3) — so to RLS a link-only share is invisible to everyone but
+its owner. That is exactly the (c) semantics.
+
+`my_corporation_ids()`/`my_alliance_ids()` already exist (den sharing) and
+return empty sets for `anon` (their `registration` read comes back empty), so
+the anon path falls through to the public clause only.
+
+## Token signing — `src/shareToken.ts` + `TOKEN_SALT`
+
+New env var `TOKEN_SALT` (add to `.env.example` and Vercel). The URL token
+for a link share is a **signature, not the stored secret**:
+
+```ts
+// src/shareToken.ts
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+// token = HMAC-SHA256(key = secret ‖ TOKEN_SALT, message = shareId), base64url.
+// The DB row alone can't produce a valid link — the salt only exists in the
+// environment — and the URL alone can't be looked up backwards to a row.
+export const signShare = (shareId: string, secret: string): string => ...
+export const verifyShareToken = (shareId: string, secret: string, token: string): boolean => ...
+```
+
+The share URL carries `?share=<shareId>.<signature>`: the id locates the row
+(service-role lookup, phase 3), the signature proves possession. Verification
+recomputes and compares with `timingSafeEqual`. Revoking a link = nulling
+`secret` (or rotating it, which invalidates old URLs); deleting the row
+revokes everything.
+
+`signShare`/`verifyShareToken` are pure given their inputs — unit-test them in
+`test/shareToken.test.ts` with a fixed salt injected as a parameter (read
+`process.env.TOKEN_SALT` only at the callers, so the node test runner needs
+no env plumbing).
+
+## Deliverables
+
+- Migration `supabase/migrations/<ts>_character_asset_share.sql` + the same
+  DDL in `schema.sql` (dual-write).
+- `src/shareToken.ts` + `test/shareToken.test.ts`.
+- `TOKEN_SALT` in `.env.example`; set it on Vercel before phase 3 ships.
+- `pnpm run test:sql` assertions for `asset_share_matches_caller` (public row
+  matches with no membership; corp/alliance overlap matches; link-only row
+  matches no one).
+
+## Verification
+
+`pnpm run lint && pnpm test && pnpm run build`; `supabase db push` applies
+cleanly; a hand-inserted share row is readable by a second account only when
+its affiliation overlaps, and by anon only when the row is fully public.

--- a/docs/sharing-layer/02-recursive-rls.md
+++ b/docs/sharing-layer/02-recursive-rls.md
@@ -1,0 +1,137 @@
+# Phase 2: recursive RLS — the widening policy on assets
+
+**Status: not started.**
+
+The hard phase. A share on a ship or container must open **everything inside
+it**, to any depth, purely through RLS — so `/asset/[locationId]`,
+`/ship/[itemId]`, the MCP tools, and GraphQL all inherit shared visibility by
+querying as the caller, with no parallel service-role path.
+
+## The recursion problem, stated plainly
+
+The natural policy is "this asset row is visible if it, or any ancestor
+container, is the subject of a share matching the caller":
+
+```sql
+create policy "Audience reads shared assets"
+  on public.character_asset_over_time
+  for select
+  to anon, authenticated
+  using (is_current and public.asset_share_covers(item_id));
+```
+
+`asset_share_covers()` must climb the parentage chain — and parentage lives
+in `character_asset_over_time` itself. An invoker-rights helper selecting
+from the table it is a policy on re-enters that policy, and Postgres aborts
+with `infinite recursion detected in policy for relation
+"character_asset_over_time"`. This is the unresolved warning design.md Stage
+E flagged; this phase resolves it.
+
+## The one sanctioned SECURITY DEFINER
+
+`asset_share_covers()` is written `security definer` with a pinned
+`search_path`, as **the single exception** to the no-definer invariant. The
+exception is safe because the function:
+
+- returns a single boolean — it can never leak row data;
+- reads only parentage columns (`item_id`, `location_id`) plus the share
+  table, and matches audiences through `asset_share_matches_caller()`, whose
+  `my_*_ids()` calls still resolve `auth.uid()` to the _caller_ inside a
+  definer context — so it grants exactly what the audience rules say;
+- is `revoke`d from `public` and granted only to `anon, authenticated`.
+
+```sql
+create or replace function public.asset_share_covers(item bigint)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with recursive
+    -- Best-known parent per item, the same distinct-on shape
+    -- character_asset_location_summary() uses (bridges snapshot gaps).
+    parent_of as (
+      select distinct on (item_id) item_id, location_id
+      from character_asset_over_time
+      order by item_id, is_current desc, valid_until desc
+    ),
+    walk (node, depth) as (
+      select item, 0
+      union all
+      select p.location_id, w.depth + 1
+      from walk w
+      join parent_of p on p.item_id = w.node
+      where w.depth < 16
+    )
+  select exists (
+    select 1
+    from character_asset_share s
+    join walk w on w.node = s.item_id
+    where asset_share_matches_caller(s.corporation_ids, s.alliance_ids, s.secret)
+  );
+$$;
+
+revoke execute on function public.asset_share_covers(bigint) from public;
+grant execute on function public.asset_share_covers(bigint) to anon, authenticated;
+```
+
+Depth cap 16 matches `asset_ancestors()`. `is_current` on the policy (not in
+the helper) keeps SCD-2 history closed: a share opens the **current view
+only** — the same rows `character_asset` shows the owner.
+
+## Performance
+
+The policy runs per candidate row, and the naive form climbs per row.
+Mitigations, in order of importance:
+
+1. **Fast-path guard**: `character_asset_share` is small; when the caller
+   matches no share row at all (the overwhelmingly common case), the helper
+   must exit without recursing. Structure the SQL so the planner can start
+   from the share table: first collect the caller-matching share subjects,
+   return false immediately if none, and only then walk — climbing _down_
+   from the handful of shared roots (the seeded-recursion shape
+   `character_asset_search()` uses) beats climbing _up_ from every candidate
+   row. Equivalent semantics, opposite direction; benchmark both under
+   `explain analyze` and keep the winner.
+2. Index `character_asset_share (item_id)` (phase 1) and rely on the existing
+   `character_asset_over_time` item/parent indexes.
+3. The policy is OR'd with the owner policy (permissive policies compose with
+   OR), so the owner's own queries are unaffected when the share check is
+   slow — but grantee page loads are the experience to protect.
+
+`pnpm run test:sql` gets a `blueprint_search`-style script asserting: nested
+item visible through a shared grandparent container; sibling container not
+visible; revoked share closes access; depth cap respected.
+
+## Grantee access to the walk RPCs
+
+`character_asset_location_contents(parent)` /
+`character_asset_subtree_items(parent)` / `asset_ancestors(start_id)` are
+SECURITY INVOKER — once the widening policy exists they **just work** for
+grantees over the shared subtree, because the underlying selects now return
+the shared rows. Verify this rather than assuming it: the
+`/asset/[locationId]` contents counts and the appraisal fold
+(`collectAssetLines.ts`) are the acceptance tests. `asset_ancestors` on a
+shared item ends its climb at the shared root's parent (a row the caller
+can't see just stops the walk) — the breadcrumb for a grantee shows the path
+_within_ the share, which is the right disclosure.
+
+Corp-owned assets (`corp_asset_over_time`) are **out of scope** for this
+phase: shares are granted by a registration over character assets. A
+`corp_asset_share` mirror can follow the same recipe later if wanted; note it
+in Non-goals rather than half-building it.
+
+## Deliverables
+
+- Migration + `schema.sql` (dual-write): the policy, `asset_share_covers()`,
+  grants.
+- `test/sql/asset_share.sql` for `pnpm run test:sql`.
+- No app-code changes — that's the point.
+
+## Verification
+
+Two-account test: B sees a container A shared (and its nested contents, via
+`/asset/[id]` opened as B), and nothing else from A's hangar; anon sees a
+fully-public share without signing in; revoke closes it. `explain analyze` on
+a grantee's `character_asset` select over a large hangar stays interactive.

--- a/docs/sharing-layer/03-share-dialog.md
+++ b/docs/sharing-layer/03-share-dialog.md
@@ -1,0 +1,97 @@
+# Phase 3: the Share dialog
+
+**Status: not started.**
+
+The user-facing surface: a **Share** button in the top right of an asset
+view, opening an HTML `<dialog>` that creates and configures a share of the
+currently displayed thing — an asset/container on `/asset/[locationId]` or a
+ship on `/ship/[itemId]`.
+
+## The dialog
+
+`src/app/asset/shareDialog.tsx` (`'use client'`), rendered by both pages when
+the viewer owns the displayed item (the same ownership check the ship page's
+existing `shareControls.tsx` does). Native `<dialog>` element via
+`showModal()` — no portal library; style with a CSS module on the global
+theme vars (`::backdrop` included).
+
+Contents, mapping 1:1 to the share row:
+
+- **Corporations** — checkbox list of the owner's corporations (from their
+  registrations, the way `shareAlliance.tsx` builds its alliance list) →
+  `corporation_ids`.
+- **Alliances** — same for alliances → `alliance_ids`.
+- **Share link** — a toggle; when on, the row gets a `secret` and the dialog
+  shows the copyable URL `${origin}/ship/${itemId}?share=<shareId>.<sig>`
+  (or `/asset/…`), signed by `signShare()` from phase 1. "Reset link"
+  rotates the secret (old URLs die); toggling off nulls it.
+- **Public** — a toggle explained honestly ("anyone can see this"). On =
+  clear both lists and the secret (the empty row _is_ the public share, per
+  phase 1); the dialog greys the other controls while set.
+- **Stop sharing** — deletes the row.
+
+One share row per item (`unique (registration_id, item_id)`), so the dialog
+is an editor over that single row: create on first save, update in place
+after (the phase-1 UPDATE policy exists for exactly this).
+
+## Server actions
+
+`src/app/asset/shareActions.ts` (`'use server'`), on the **cookie-session
+client** like every share writer (`fitting/actions.ts`,
+`mercenary-dens/actions.ts`) — never the service role:
+
+- `getAssetShare(itemId)` — the owner's existing row, if any.
+- `saveAssetShare(itemId, { corporationIds, allianceIds, link, isPublic })` —
+  proves ownership by reading the item through RLS on `character_asset`
+  (which of the caller's registrations owns it fixes `registration_id`),
+  filters the requested corp/alliance ids to ones the owner actually has (the
+  `setSharedAlliances` defense), mints/rotates/nulls the secret
+  (`randomBytes(32)`), upserts, and returns the signed link when one exists.
+  Signing needs the secret + `TOKEN_SALT`, both server-side — the client only
+  ever sees the finished URL.
+- `revokeAssetShare(itemId)` — delete, RLS-scoped.
+
+## The anonymous link path
+
+For signed-in audiences, phase 2 already did the work — the pages render
+shared content through plain RLS. The link token is the one audience RLS
+can't see, so `?share=` is resolved at the app layer, replacing
+`src/app/ship/access.ts`:
+
+- `resolveSignedShare(param)` → split `<shareId>.<sig>`, service-role lookup
+  of the share row by id, `verifyShareToken()`, then return the same
+  `ShareScope` shape `resolveShareToken()` returns today — **plus** the
+  subject `item_id`, and reject when the URL's item is not the share subject
+  or inside its subtree (walk `asset_ancestors` from the requested id on the
+  service client and require the subject among them; this is what makes the
+  link recursive where the old token was exact-id-only).
+- The pages' existing token branches swap `resolveShareToken` for this; the
+  JS `.in('registration_id', …)` scoping on the service client stays as-is
+  for the anon path.
+
+## Legacy `shared_asset_token`
+
+Old links must not break silently. Keep `resolveShareToken()` working as a
+fallback during a deprecation window (try `?share=` first, then `?token=`);
+stop **minting** old-style tokens (the ship page's share controls are
+replaced by the dialog); list existing rows in the dialog's footer with a
+"migrate" affordance that creates the new row and deletes the old. Drop the
+table in a later cleanup once the window passes — its own tiny migration,
+not part of this PR.
+
+## Deliverables
+
+- `shareDialog.tsx` + CSS module + `shareActions.ts` under `src/app/asset/`
+  (shared by both pages; the ship page drops `shareControls.tsx` /
+  `actions.ts` mint path).
+- `resolveSignedShare` in `src/app/asset/access.ts` (move/rename of
+  `src/app/ship/access.ts`), with the subtree containment check.
+- Share button placement on both pages (top right, `pageHeader` flex slot).
+
+## Verification
+
+Owner: create each audience shape, see the row change; copy link opens the
+ship/asset signed-out; reset link kills the old URL; revoke closes all
+access. Grantee (second account): shared item appears at its `/asset/` and
+`/ship/` URLs without any token. Legacy `?token=` links still resolve.
+`pnpm run lint && pnpm test && pnpm run build`.

--- a/docs/sharing-layer/04-graphql-shared.md
+++ b/docs/sharing-layer/04-graphql-shared.md
@@ -1,0 +1,57 @@
+# Phase 4: shared rows in GraphQL
+
+**Status: not started.**
+
+Let a grantee query what's been shared with them through `/api/graphql`, so
+shared stockpiles are scriptable, not just browsable. **Current views only —
+the `_over_time` SCD tables are never exposed over GraphQL**, shared or
+owned; that invariant predates this phase and survives every future one.
+
+## What phase 2 already gives us, and what blocks it
+
+In **session mode** the GraphQL context queries as the caller, so once the
+widening policy exists, `character_asset` selects would return shared rows —
+except the resolvers deliberately hard-scope every query with
+`.in('registration_id', ctx.registrationIds)` (the leak guard that keeps
+api_token/service mode safe). That guard is correct and stays; shared rows
+therefore need an explicit, opt-in path rather than an accidental one.
+
+## Schema changes
+
+- `assets(..., includeShared: Boolean = false)` — when true **in session
+  mode**, the resolver widens its filter to `registration_id in (own ∪
+grantor registrations)` and lets RLS decide which grantor rows actually
+  come back (the DB is the authority; the widened `.in()` is just no longer
+  the barrier). Grantor registration ids come from the share rows the caller
+  can read (`character_asset_share` audience policy) — one small query in the
+  resolver.
+- `sharedWithMe: [ShareGrant!]!` — discovery: the shares whose audience the
+  caller matches, each `{ shareId, ownerName, itemId, itemTypeName,
+sharedAt }`. Owner name resolves through the world-readable
+  `character_directory` (never `registration`), exactly like `list_fittings`
+  handles foreign owners in the MCP layer.
+- `Asset.ownerName` for a shared row resolves via `character_directory` too;
+  `ownerId` stays the grantor registration uuid.
+
+## api_token mode stays own-data-only
+
+The Bearer path runs on the **service client**, where RLS can't arbitrate a
+widened filter — honoring `includeShared` there would mean re-implementing
+the whole audience+recursion model in JS against the service role. Don't.
+`includeShared` in token mode returns a clear GraphQL error ("shared data
+requires a session; use a Lens"), and phase 7's Lens is the designed answer
+for external tools consuming shared data (the creator's context does the
+authorizing instead).
+
+## Deliverables
+
+- `schema.graphql.ts` + `resolvers.ts` changes; `test/graphqlSchema.test.ts`
+  updated for the new field/args (the drift guard exists for exactly this).
+- No DB changes.
+
+## Verification
+
+Two accounts: B's `assets(includeShared: true)` returns A's shared container
+contents and nothing else of A's; `sharedWithMe` lists the grant; the same
+queries over B's api_token error as specified; `pnpm run lint && pnpm test &&
+pnpm run build`.

--- a/docs/sharing-layer/05-supersede-fittings.md
+++ b/docs/sharing-layer/05-supersede-fittings.md
@@ -1,0 +1,68 @@
+# Phase 5: fold fittings into the unified model
+
+**Status: not started.**
+
+`character_fitting_share` works today (create/revoke UI on the fitting page,
+RLS policies, `fitting_shared_with_caller()`), but it speaks the Revision 2
+dialect: one row per `level` (`corporation`/`alliance`/`public`) with a dead
+`token` placeholder column. This phase migrates it to the Revision 3 row
+shape so every share in the product configures the same way.
+
+## Migration
+
+New table `character_fitting_share` columns — or, preferred, alter in place
+(the name is fine, the shape isn't):
+
+- add `corporation_ids bigint[] not null default '{}'`, `alliance_ids
+bigint[] not null default '{}'`, `secret text`;
+- backfill from the level rows: for each `(registration_id, fitting_id)`
+  group, `level='corporation'` becomes the owner's corporation id at
+  migration time appended to `corporation_ids` (resolved through
+  `character_directory`), `level='alliance'` likewise into `alliance_ids`,
+  `level='public'` becomes the empty-audience row; collapse the group to
+  **one row** (new `unique (registration_id, fitting_id)`);
+- drop `level` and the dead `token` column.
+
+Semantics note the migration must preserve: today's `level='corporation'`
+share means "whoever is _currently_ in my corp" — membership resolves live
+through the owner's directory row. The Revision 3 arrays pin **specific**
+corporation/alliance ids instead. Backfilling the owner's current corp id
+keeps today's audiences intact at cut-over, but the meaning shifts from "my
+corp, wherever I go" to "this corp". That shift is deliberate (it is what the
+asset share does, and what the dialog's checkbox list expresses); call it out
+in the PR description.
+
+- Rewrite `fitting_shared_with_caller(registration_id, fitting_id)` to match
+  on the arrays via `asset_share_matches_caller()`'s logic (or extract a
+  shared `share_audience_matches(corporation_ids, alliance_ids, secret)` and
+  have both call it — do the extraction here, retrofitting phase 1's helper
+  to delegate). The widening policy on `character_fitting_over_time` is
+  untouched — it already just calls the helper.
+- Update the audience-read policy on the share table to the array/anon form
+  from phase 1.
+
+## UI
+
+The fitting page swaps its three toggle buttons (`shareControls.tsx`) for the
+phase-3 share dialog, parameterized by subject kind: the dialog's form is
+identical, only the actions differ (`fitting/actions.ts` gains the same
+save/revoke pair over the new shape; ownership proof stays "read the fit
+through RLS"). Fittings gain the link-token audience for free —
+`/fitting/[characterId]/[fittingId]?share=…` resolves through a fitting
+variant of `resolveSignedShare` (service-role read scoped to the grantor,
+same as the asset path).
+
+## Deliverables
+
+- Migration + `schema.sql` dual-write (table reshape, helper rewrite,
+  policies); the shared `share_audience_matches()` extraction.
+- Dialog reuse on the fitting page; `fitting/actions.ts` rewrite;
+  `shareControls.tsx` deleted.
+- `list_fittings` (MCP) needs no change — it reads through RLS.
+
+## Verification
+
+Existing shares keep working across the migration (corp/alliance mates still
+see the fit; public still public — assert in a `test:sql` script over a
+seeded copy). Dialog edits round-trip. A signed fitting link opens the fit
+signed-out. `pnpm run lint && pnpm test && pnpm run build`.

--- a/docs/sharing-layer/06-supersede-mercenary-dens.md
+++ b/docs/sharing-layer/06-supersede-mercenary-dens.md
@@ -1,0 +1,54 @@
+# Phase 6: fold mercenary dens into the unified model
+
+**Status: not started.**
+
+The den share was the pattern-setter and is the closest to the target
+already; this phase is mostly a reshape. It carries one structural difference
+worth keeping in mind: the den share is **whole-category, not per-item** —
+one row means "share all my dens (and enemy intel) with this alliance", with
+no den-level subject.
+
+## Migration
+
+`character_mercenary_den_share (registration_id, alliance_id)` rows collapse
+to one row per registration in the Revision 3 shape:
+
+- `registration_id uuid`, `alliance_ids bigint[]` (aggregate the existing
+  rows), `corporation_ids bigint[] not null default '{}'` (new capability),
+  `secret text` (new capability), `unique (registration_id)` — the subject
+  stays "all my dens", so there is no `den_id` column; a per-den subject
+  (design.md Stage B's open item) stays out of scope unless someone asks.
+- `mercenary_den_shared_with_caller(reg_id)` rewrites onto the shared
+  `share_audience_matches()` helper (extracted in phase 5). The two widening
+  policies (`character_mercenary_den_over_time`,
+  `mercenary_den_enemy_intel`) are untouched — they call the helper.
+- Audience-read policy on the share table moves to the array/anon form.
+
+Dens gain corp-scoped sharing and (if ever wanted) link/public audiences for
+free, but `/mercenary-dens` renders nothing for anon today — the page itself
+stays signed-in-only; a public den share simply means any signed-in user
+sees the dens. Say so in the dialog copy.
+
+## UI
+
+`shareAlliance.tsx`'s checkbox list becomes the share dialog (subject kind
+"my dens", no item id), or — since the alliance picker is genuinely a better
+fit for "share with usually-just-one alliance" — keep the picker and simply
+rewire `setSharedAlliances` to write the array column. **Decide when
+building**; the data model doesn't care. Either way `actions.ts`'s wholesale
+delete-then-insert becomes a single upsert of the array (fixing the existing
+non-transactional replace, which can currently drop all shares when the
+insert half fails).
+
+## Deliverables
+
+- Migration + `schema.sql` dual-write (reshape, helper rewrite, policies).
+- `mercenary-dens/actions.ts` rewrite; picker or dialog per the decision
+  above.
+
+## Verification
+
+Existing alliance shares survive the migration byte-for-byte in effect
+(`test:sql` over a seeded copy: same rows visible before/after). The
+`/mercenary-dens` topology shows a grantee the same dens as before. `pnpm
+run lint && pnpm test && pnpm run build`.

--- a/docs/sharing-layer/07-lens.md
+++ b/docs/sharing-layer/07-lens.md
@@ -1,0 +1,111 @@
+# Phase 7: Lenses — shared queries in the creator's context
+
+**Status: not started.**
+
+A **Lens** is a saved GraphQL query a user creates, then shares with the
+same audience granularity as any asset share — corporation list, alliance
+list, signed link, or public. The defining property: when a viewer opens a
+Lens, the query runs **under the security context of the creator**, not the
+viewer. The viewer receives results, never access. Every Lens also renders
+to **CSV** in a logical way, positioned to supersede the `api_token` Google
+Sheets endpoints (`/api/character/*`, `/api/corp/*`).
+
+## Why creator-context is the right trust model
+
+The creator authors the query against _their own_ data and decides who may
+run it — a Lens is a window the owner points, exactly like an asset share,
+just expressed as a query instead of a subtree. It also cleanly solves what
+phase 4 declined to do: external tools and spreadsheet pulls of shared data
+go through a Lens (creator authorizes), so the api_token path never needs an
+audience model of its own.
+
+## Data model
+
+```sql
+create table public.lens (
+  id uuid primary key default gen_random_uuid(),
+  -- Creator. user_id-keyed (like shared_asset_token), because a Lens spans
+  -- all the creator's registrations the way their GraphQL context does.
+  user_id uuid not null references auth.users(id) on delete cascade,
+  name text not null,
+  query text not null,
+  variables jsonb not null default '{}',
+  corporation_ids bigint[] not null default '{}',
+  alliance_ids bigint[] not null default '{}',
+  secret text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+```
+
+Owner policies as usual (all four commands, `user_id = auth.uid()`);
+audience-read policy via `share_audience_matches()` so signed-in audience
+members can _discover_ lenses aimed at them. Public = empty lists + null
+secret, same as everywhere.
+
+`variables` are **fixed by the creator** at save time. Viewers cannot supply
+variables in v1 — a variable substituted into `assets(typeName: $x)` doesn't
+widen access (still the creator's rows), but fixed variables keep the output
+exactly what the creator reviewed. Loosen later if wanted, deliberately.
+
+## Execution
+
+`runLens(lensId, viewer)`:
+
+1. Authorize the viewer: session user matching the audience arrays (or
+   owner), a valid `?share=<id>.<sig>` signature, or public.
+2. Build the **creator's** GraphQL context: service client + the creator's
+   `registrationIds`/owner map — exactly what `buildContext` does for
+   api_token mode, minus the token lookup (reuse it; factor a
+   `contextForUser(userId)` out of `src/app/api/graphql/context.ts`).
+3. Execute the stored query in-process against the executable schema
+   (`graphql()` from the `graphql` package with `schema` from
+   `src/app/api/graphql/schema.ts` — no HTTP hop), with the stored
+   variables.
+4. Current views only, by construction: the schema _is_ the phase-4 GraphQL
+   schema, which never exposes `_over_time` tables. `includeShared`-style
+   session-only args are rejected at save time (validate the query against
+   the schema, and against a small denylist of session-only fields, when the
+   creator saves).
+
+Creator-context execution is the sharpest tool in this project — the
+safeguards are that the query text is creator-authored, validated at save,
+frozen at run, and scoped by the same resolvers whose leak guard already
+assumes a service client.
+
+## Surfaces
+
+- **`/lens` — the editor, a new top-level route, dark-launched behind a
+  feature flag** (`LENS_FLAG = 'lens'` in `src/flags.ts`, the same
+  gate-and-redirect shape as `/graphql`): list your lenses, create/edit
+  (query textarea + variables + a Run-as-me preview reusing the `/graphql`
+  editor component), and the share dialog for the audience.
+- **`/lens/[id]`** — the viewer: runs the lens (per Execution above),
+  renders the result as a table, shows the creator's name (via
+  `character_directory`-safe display: lens shares are user-scoped, so show
+  the lens name and nothing about alts).
+- **`/lens/[id].csv`** (or `?format=csv`) — the CSV rendering: find the
+  **primary list** in the result (the single top-level list field; reject
+  saving a lens with more than one when CSV is enabled — "logical" must stay
+  unambiguous), flatten each row's scalar fields to columns via `toCsv()`
+  (`src/utils/csv.ts`), nested objects dot-pathed, lists of scalars joined.
+  Served like `/api/character/assets` (force-dynamic, `text/csv`), and — for
+  link-token lenses — fetchable by Google Sheets `IMPORTDATA` with the
+  signed param, which is what lets Lenses supersede the bespoke Sheets
+  endpoints over time (each existing endpoint becomes "a lens you could
+  save"; the old routes retire only after parity, in their own cleanup).
+
+## Deliverables
+
+- Migration + `schema.sql` (lens table + policies); flag; `/lens` editor,
+  `/lens/[id]` viewer, CSV route; `runLens` + save-time query validation;
+  unit tests for the CSV flattening (pure) and the query validator.
+
+## Verification
+
+Creator saves a lens over their assets; a corp-mate runs it and sees the
+creator's rows (never their own); a non-audience account gets a 403; the
+signed CSV URL imports into a spreadsheet; revoking the share/rotating the
+secret closes access. Attempting to save a query touching a session-only
+arg or a second top-level list fails with a clear message. `pnpm run lint &&
+pnpm test && pnpm run build`.

--- a/docs/sharing-layer/README.md
+++ b/docs/sharing-layer/README.md
@@ -1,0 +1,144 @@
+# Sharing layer: unified, recursive asset shares (Revision 3)
+
+Make asset paths shareable — a container, a ship, or any asset — with the share
+applying **recursively** to everything inside it, and the audience configurable
+per share: a list of corporations, a list of alliances, a signed link token, or
+fully public. The data structure and RLS shape follow the pattern that already
+works for mercenary dens and fittings: a `_share` sibling table plus additional
+**SELECT policies** that widen what the audience can read — never a parallel
+read path, never a copy of the data. Later phases fold the fitting and
+mercenary-den share mechanisms into the same model, and add **Lenses**: shared
+GraphQL queries that run under the _creator's_ security context and render to
+CSV, superseding the `api_token` Google Sheets endpoints.
+
+Each numbered doc below is a self-contained implementation spec; do them as
+**separate PRs, in order**. `design.md` in this directory is Revision 2 of the
+model — still the right read for the identity split, the alt-privacy
+rationale, and the invariants — but where this README and the phase docs
+diverge from it (audience representation, token scheme), **Revision 3 wins**.
+
+## Why
+
+Three-and-a-half sharing mechanisms exist today, each with a different model:
+
+| Mechanism              | Table                           | Audience model                                    | Recursive?       | Anonymous?              |
+| ---------------------- | ------------------------------- | ------------------------------------------------- | ---------------- | ----------------------- |
+| Mercenary dens         | `character_mercenary_den_share` | one row per (registration, alliance)              | n/a              | no                      |
+| Fittings               | `character_fitting_share`       | one row per level (`corporation/alliance/public`) | n/a              | no (`token` col unused) |
+| Ship/asset share links | `shared_asset_token`            | secret URL token, resolved via service role       | one level, in JS | yes                     |
+| (structures)           | hard-coded alliance policy      | —                                                 | n/a              | no                      |
+
+Dens and fittings are on the target _RLS_ shape (share row + widening policy,
+invoker rights, `character_directory` for owner affiliation) but disagree on
+audience representation. The asset token path bypasses RLS entirely: the
+`/asset/[locationId]` and `/ship/[itemId]` pages re-implement scoping in JS on
+the service client, can't use the recursive `*_location_contents` RPCs (which
+are SECURITY INVOKER), and only cover the exact id in the URL. This project
+replaces that with one model that RLS enforces everywhere — pages, MCP tools,
+and GraphQL inherit shared visibility automatically because they all query as
+the caller.
+
+## Target model
+
+One share row per shared thing, on a `_share` sibling table. Audience is
+carried **on the row** (not one row per audience):
+
+- **(a) corporations** — `corporation_ids bigint[]`: a viewer with a
+  registration in any listed corporation sees the rows.
+- **(b) alliances** — `alliance_ids bigint[]`: same, matched against the
+  viewer's alliances (via `my_alliance_ids()`).
+- **(c) link token** — `secret` (random bytes) stored on the row; the URL
+  token is an HMAC **signature** derived from the secret and the `TOKEN_SALT`
+  environment variable (set on Vercel). A database dump alone cannot mint a
+  valid link — the salt lives only in the environment. Resolved at the app
+  layer (an anonymous HTTP request is invisible to RLS).
+- **(d) fully public** — `secret is null and corporation_ids = '{}' and
+alliance_ids = '{}'`. A public share is represented as a share that names
+  no one: the empty audience _is_ the "everyone" audience.
+
+For assets the share subject is an `item_id`, and visibility is **recursive**:
+a share on a ship or container covers every item inside it, to any depth,
+following the same parentage walk `asset_ancestors()` /
+`character_asset_location_contents()` already do.
+
+Exposure is always the **current view** (`is_current` rows) — shares never
+open SCD-2 history, and GraphQL never exposes the `_over_time` tables, shared
+or not.
+
+## Risk model
+
+The ordering runs safest-first:
+
+1. Pure additive schema (share table + helpers) with nothing reading it yet.
+2. The widening policies — the risky part is the **recursive** check under
+   RLS (a policy whose helper reads the same table recurses; see phase 02 for
+   the one sanctioned SECURITY DEFINER boolean that breaks the cycle).
+3. UI on top of a proven substrate.
+4. Read-side surfaces (GraphQL) that only consume what RLS already grants.
+5. Migrations of working mechanisms (fittings, dens) last — they have users.
+6. Lens, which builds on both the share model and the GraphQL API.
+
+## The plan
+
+| Doc                                                              | What                                                                                                                                              | Status / dependency           |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| [01-asset-share-table.md](01-asset-share-table.md)               | `character_asset_share` table, owner + audience policies, `asset_share_matches_caller()`, `TOKEN_SALT` + token signing seam                       | not started                   |
+| [02-recursive-rls.md](02-recursive-rls.md)                       | Recursive widening policy on `character_asset_over_time` via the definer boolean `asset_share_covers()`; grantee RPC access                       | after 01                      |
+| [03-share-dialog.md](03-share-dialog.md)                         | Share button + `<dialog>` on `/asset/[locationId]` and `/ship/[itemId]`; server actions; legacy `shared_asset_token` compat                       | after 02                      |
+| [04-graphql-shared.md](04-graphql-shared.md)                     | Shared rows in GraphQL — session mode only, current views only, opt-in                                                                            | after 02                      |
+| [05-supersede-fittings.md](05-supersede-fittings.md)             | Fold `character_fitting_share` into the unified audience model, keep the fitting page UI                                                          | after 03                      |
+| [06-supersede-mercenary-dens.md](06-supersede-mercenary-dens.md) | Fold `character_mercenary_den_share` into the unified model                                                                                       | after 05                      |
+| [07-lens.md](07-lens.md)                                         | Lenses: shared GraphQL queries under the creator's context, CSV rendering to supersede the Sheets endpoints; `/lens` editor behind a feature flag | after 04 (05/06 not required) |
+
+## What already exists (build on this, don't reinvent it)
+
+- `my_corporation_ids()` / `my_alliance_ids()` — invoker-rights membership
+  helpers (schema.sql; shipped with den sharing). Every audience match goes
+  through these.
+- `character_directory` — the world-readable identity table (no `user_id`,
+  ever). Owner affiliation for audience checks resolves through it, never
+  through `registration`, which is RLS-hidden to non-owners.
+- The den share's **load-bearing audience-read policy**: because the
+  visibility helpers run as the querying user, the audience can only match
+  share rows the share table's own policies expose to them. Every new share
+  table repeats this.
+- `asset_ancestors()` / `character_asset_location_contents()` /
+  `character_asset_subtree_items()` — the depth-capped recursive walks
+  (SECURITY INVOKER). Phase 02's recursion is the same shape.
+- The fitting share UI (`src/app/fitting/shareControls.tsx` + `actions.ts`)
+  and the den picker (`src/app/mercenary-dens/shareAlliance.tsx` +
+  `actions.ts`) — working create/revoke server actions on the cookie-session
+  client. The share dialog copies their approach, not the service role.
+- `src/utils/csv.ts` `toCsv()` and the `/api/*` CSV route shape — what the
+  Lens CSV rendering reuses.
+
+## Invariants (unchanged from Revision 2, plus new ones)
+
+- **Read-only grants.** A share never allows the audience to write anything.
+- **No SECURITY DEFINER** — with exactly one sanctioned exception, the
+  boolean `asset_share_covers()` (phase 02), which exists only to break RLS
+  policy recursion, returns a single boolean, and never returns row data.
+- **`user_id` is never world-readable**; alt correlation stays impossible.
+- **Current rows only.** Widening policies carry `is_current`; shares never
+  expose SCD-2 history. GraphQL exposes only the current views — never the
+  `_over_time` tables (this holds for every phase, including Lens).
+- Shares widen exactly the shared subject; wallets, tokens, settings, and
+  unrelated tables are never touched by any policy in this layer.
+
+## Verification (every PR)
+
+- `pnpm run lint`, `pnpm test`, `pnpm run build`.
+- Schema changes are **dual-write**: edit `schema.sql` _and_ add a
+  `supabase/migrations/` file (never rename an existing migration).
+- The two-account leak test, per phase: account B must see exactly what A
+  shared and nothing else; revoking must close access on the next request.
+- `pnpm run test:sql` gains assertions per phase where the logic is in
+  Postgres (the recursion helper especially) — point `DATABASE_URL` at a
+  throwaway database.
+
+## House rules (from CLAUDE.md — these bite)
+
+- `git fetch origin && git rebase origin/main` immediately before every push.
+- Never rename an existing file under `supabase/migrations/`.
+- ramda over `for`/`while`; tail recursion for unbounded pagination.
+- Prefer distinct migration timestamps; the composite key is a backstop.

--- a/docs/sharing-layer/design.md
+++ b/docs/sharing-layer/design.md
@@ -1,5 +1,11 @@
 # Sharing layer — data architecture
 
+> **Superseded in part by Revision 3** — see [README.md](README.md) and the
+> numbered phase docs beside this file for the current execution plan. This
+> document remains the reference for the identity split, the alt-privacy
+> rationale, and the invariants; where it disagrees with the phase docs
+> (audience representation, token scheme), the phase docs win.
+
 Design for a uniform, table-driven sharing layer: for every core table a
 sibling `<table>_share` table, and RLS of the shape **"read your own rows, or
 rows a matching share row grants you."** Replaces the three ad-hoc mechanisms


### PR DESCRIPTION
Docs only — a seven-phase execution plan under `docs/sharing-layer/`, sitting beside (and partially superseding) the Revision 2 `design.md`. No schema or code changes; each phase is meant to land as its own PR in the README's order.

## The model (Revision 3)

One share row per shared thing, audience **on the row**:

- **(a)** `corporation_ids bigint[]` — a viewer with a registration in any listed corp sees the rows
- **(b)** `alliance_ids bigint[]` — same, by alliance (via the existing `my_alliance_ids()`)
- **(c)** `secret` — link tokens are HMAC **signatures** over the share id, keyed by the row's secret + the new `TOKEN_SALT` env var, so a DB dump alone can't mint valid links; resolved at the app layer since RLS can't see a URL
- **(d)** fully public = `secret is null` + both lists empty — a public share is represented as a share that names no one

Asset shares are **recursive**: a share on a ship/container covers everything inside it, enforced by a widening RLS policy in the mercenary-den pattern. The recursion-under-RLS problem (a policy helper reading its own table recurses) is addressed head-on in phase 2 with the one sanctioned SECURITY DEFINER boolean, `asset_share_covers()`.

## The phases

1. **01-asset-share-table** — `character_asset_share` + policies + `asset_share_matches_caller()` + `src/shareToken.ts`/`TOKEN_SALT`
2. **02-recursive-rls** — the widening policy on `character_asset_over_time` (`is_current` only), grantee access to the invoker-rights walk RPCs, performance notes, `test:sql` coverage
3. **03-share-dialog** — Share button top-right on `/asset/[locationId]` and `/ship/[itemId]`, native HTML `<dialog>`, cookie-client server actions, signed-link path replacing `shared_asset_token` (legacy `?token=` keeps resolving through a deprecation window)
4. **04-graphql-shared** — shared rows over `/api/graphql`, session mode only, current views only (the `_over_time` SCDs are never exposed over GraphQL), `includeShared` opt-in + `sharedWithMe` discovery
5. **05-supersede-fittings** — migrate `character_fitting_share`'s per-level rows onto the array shape, extract the shared `share_audience_matches()` helper, reuse the dialog
6. **06-supersede-mercenary-dens** — same reshape for `character_mercenary_den_share` (subject stays "all my dens")
7. **07-lens** — Lenses: saved GraphQL queries shared with the same granularity, executed under the **creator's** security context, rendered to CSV to supersede the `api_token` Sheets endpoints, with a flag-gated `/lens` editor as a new top-level route

`design.md` gets a header note pointing at the new plan; it remains the reference for the identity split, alt-privacy rationale, and invariants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSjBdjGmTZVXJHXkVLtKpf

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSjBdjGmTZVXJHXkVLtKpf)_