### PR TITLE
Discord stage 03: bot install, account linking, channel configuration

### DIFF
--- a/docs/discord-bot/README.md
+++ b/docs/discord-bot/README.md
@@ -25,11 +25,15 @@ Scope for making edencom.link double as a Discord application. Two goals
   `DISCORD_APP_ID`/`DISCORD_PUBLIC_KEY`/`DISCORD_BOT_TOKEN` are in
   `.env.example`, and interactions emit `recordDiscordInteraction`
   observability metrics.
-- **Stage 03 — not started.** No `discord_link_code`/`discord_channel`
-  tables, no command router, no settings UI yet. Its "link codes, not
-  Discord OAuth" design predates goal 1 and is amended below: stage 06's
-  Discord identity becomes the primary account↔Discord binding, with link
-  codes kept as the fallback for users who haven't linked Discord.
+- **Stage 03 — shipped (link-code flow).** `discord_link_code`/
+  `discord_channel` tables, the `/edencom link|unlink` command router
+  (`src/app/api/discord/commands.ts`), the registration script
+  (`pnpm run discord-register-commands`, `--guild <id>` for instant test
+  registration), and the settings Discord section (install link, code
+  minting with countdown, linked-channel list). The identity-first binding
+  amended below (match the invoker's Discord user id against
+  `auth.identities`) waits on stage 06 — link codes are the only path
+  until then.
 - **Stages 04–07 — not started.**
 
 This is a scoping document set, not an implementation spec. Each stage is

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "sheet-csv": "node src/jobs/sheetCsv.js",
     "connect": "node src/connect.js",
     "db:new": "supabase migration new",
+    "discord-register-commands": "node src/discordRegisterCommands.js",
     "db:push": "supabase db push",
     "dev": "next dev",
     "heartbeat": "node src/heartbeat.js",

--- a/schema.sql
+++ b/schema.sql
@@ -110,6 +110,8 @@ drop table if exists public.watched_system       cascade;
 drop table if exists public.user_settings        cascade;
 drop table if exists public.refresh_task         cascade;
 drop table if exists public.shared_asset_token   cascade;
+drop table if exists public.discord_link_code    cascade;
+drop table if exists public.discord_channel      cascade;
 drop table if exists public.heartbeat            cascade;
 drop table if exists public.esi_etag             cascade;
 drop table if exists public.innominate_throttle  cascade;
@@ -3266,6 +3268,77 @@ create policy "Users manage own share tokens"
 
 grant select, insert, update, delete on public.shared_asset_token to authenticated;
 grant all    on public.shared_asset_token to service_role;
+
+-- ── discord_link_code ─────────────────────────────────────────────────────
+-- Discord integration stage 03 (docs/discord-bot/03-account-linking.md):
+-- short-lived (~10 min), single-use codes minted from /account/settings and
+-- redeemed by `/edencom link <code>` in Discord — the proof joining a
+-- Supabase account to the invoking Discord interaction. Minted by the owner
+-- (authenticated insert), redeemed by the interactions route (service role
+-- stamps redeemed_at).
+create table public.discord_link_code (
+  id uuid primary key default gen_random_uuid(),
+  code text not null unique,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  expires_at timestamptz not null,
+  redeemed_at timestamptz
+);
+create index discord_link_code_user_id_idx on public.discord_link_code (user_id);
+
+alter table public.discord_link_code enable row level security;
+create policy "Users read own link codes"
+  on public.discord_link_code
+  for select
+  to authenticated
+  using (user_id = (select auth.uid()));
+create policy "Users mint own link codes"
+  on public.discord_link_code
+  for insert
+  to authenticated
+  with check (user_id = (select auth.uid()));
+
+grant select, insert on public.discord_link_code to authenticated;
+grant all           on public.discord_link_code to service_role;
+
+-- ── discord_channel ───────────────────────────────────────────────────────
+-- One row = "this user's alerts go to this Discord channel." Written only by
+-- the service role (the interactions route is the sole writer); owners read
+-- and delete their own rows from settings. guild_name / channel_name are
+-- display-only, denormalized from the interaction payload at link time
+-- (nullable — Discord doesn't always include them). disabled_at is stamped by
+-- the stage-05 sender when Discord reports the channel gone. Snowflake ids
+-- are text: Discord delivers them as strings and they overflow JS number
+-- precision.
+create table public.discord_channel (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  guild_id text not null,
+  channel_id text not null,
+  guild_name text,
+  channel_name text,
+  linked_by_discord_user_id text not null,
+  created_at timestamptz not null default now(),
+  disabled_at timestamptz,
+  unique (user_id, channel_id)
+);
+create index discord_channel_user_id_idx on public.discord_channel (user_id);
+create index discord_channel_channel_id_idx on public.discord_channel (channel_id);
+
+alter table public.discord_channel enable row level security;
+create policy "Users read own linked channels"
+  on public.discord_channel
+  for select
+  to authenticated
+  using (user_id = (select auth.uid()));
+create policy "Users remove own linked channels"
+  on public.discord_channel
+  for delete
+  to authenticated
+  using (user_id = (select auth.uid()));
+
+grant select, delete on public.discord_channel to authenticated;
+grant all            on public.discord_channel to service_role;
 
 -- ── SDE mirror ───────────────────────────────────────────────────────────────────
 -- Nightly-refreshed mirror of CCP's official Static Data Export, populated by

--- a/src/app/account/settings/actions.ts
+++ b/src/app/account/settings/actions.ts
@@ -60,6 +60,44 @@ export const generateApiToken = async (): Promise<{ token?: string; error?: stri
   return { token }
 }
 
+// Mint a short-lived, single-use Discord link code, redeemed by running
+// `/edencom link <code>` in the Discord channel that should receive alerts
+// (docs/discord-bot/03-account-linking.md). Old codes aren't revoked — they
+// expire on their own within 10 minutes.
+export const generateDiscordLinkCode = async (): Promise<{ code?: string; expiresAt?: string; error?: string }> => {
+  const supabase = await createClient()
+
+  const { data, error: userError } = await supabase.auth.getUser()
+  if (userError || !data?.user) {
+    return { error: 'Not signed in' }
+  }
+
+  const code = randomBytes(8).toString('hex')
+  const expiresAt = new Date(Date.now() + 10 * 60 * 1000).toISOString()
+  const { error } = await supabase
+    .from('discord_link_code')
+    .insert({ code, user_id: data.user.id, expires_at: expiresAt })
+  if (error) {
+    return { error: error.message }
+  }
+
+  return { code, expiresAt }
+}
+
+// Remove a linked Discord channel. RLS's owner delete policy scopes the row to
+// the caller, so a foreign id matches nothing.
+export const removeDiscordChannel = async (id: string): Promise<{ error?: string }> => {
+  const supabase = await createClient()
+
+  const { error } = await supabase.from('discord_channel').delete().eq('id', id)
+  if (error) {
+    return { error: error.message }
+  }
+
+  revalidatePath('/account/settings')
+  return {}
+}
+
 // Mark the selected registration as the player's main character, clearing any
 // previous main. RLS scopes both writes to the caller's own registrations, so a
 // foreign id simply matches nothing. Returns { error } on failure.

--- a/src/app/account/settings/discord.tsx
+++ b/src/app/account/settings/discord.tsx
@@ -73,10 +73,10 @@ const Discord = ({ appId, channels }: { appId: string | null; channels: DiscordC
         <li>
           {installUrl ? (
             <a href={installUrl} target="_blank" rel="noreferrer">
-              Add the Edencom Link bot to your Discord server
+              Add the Edencom.link bot to your Discord server
             </a>
           ) : (
-            'Add the Edencom Link bot to your Discord server (bot not configured on this deployment)'
+            'Add the Edencom.link bot to your Discord server (bot not configured on this deployment)'
           )}
         </li>
         <li>Generate a link code below</li>

--- a/src/app/account/settings/discord.tsx
+++ b/src/app/account/settings/discord.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { generateDiscordLinkCode, removeDiscordChannel } from './actions'
+import Dot from './dot'
+
+export type DiscordChannel = {
+  id: string
+  guild_id: string
+  channel_id: string
+  guild_name: string | null
+  channel_name: string | null
+  created_at: string
+  disabled_at: string | null
+}
+
+// Send Messages (1<<11) + Embed Links (1<<14) — the bot asks for nothing else.
+const BOT_PERMISSIONS = 2048 + 16384
+
+// The Discord section of settings: install the bot, mint a link code for
+// /edencom link, and review/remove linked channels. Codes live 10 minutes; the
+// countdown mirrors that client-side so a stale code isn't copied in vain.
+const Discord = ({ appId, channels }: { appId: string | null; channels: DiscordChannel[] }) => {
+  const [code, setCode] = useState<string | null>(null)
+  const [expiresAt, setExpiresAt] = useState<number | null>(null)
+  const [secondsLeft, setSecondsLeft] = useState(0)
+  const [response, setResponse] = useState('')
+  const [color, setColor] = useState('#000000')
+
+  useEffect(() => {
+    if (expiresAt === null) return undefined
+    const tick = () => setSecondsLeft(Math.max(0, Math.floor((expiresAt - Date.now()) / 1000)))
+    tick()
+    const interval = setInterval(tick, 1000)
+    return () => clearInterval(interval)
+  }, [expiresAt])
+
+  const generate = async () => {
+    const result = await generateDiscordLinkCode()
+    if (result.error || !result.code || !result.expiresAt) {
+      setColor('#FF0000')
+      setResponse(result.error ?? 'Could not generate a code')
+      return
+    }
+    setCode(result.code)
+    setExpiresAt(new Date(result.expiresAt).getTime())
+    setResponse('')
+  }
+
+  const remove = async (id: string) => {
+    const result = await removeDiscordChannel(id)
+    if (result.error) {
+      setColor('#FF0000')
+      setResponse(result.error)
+      return
+    }
+    setColor('#00AF00')
+    setResponse('Channel unlinked')
+  }
+
+  const installUrl = appId
+    ? `https://discord.com/oauth2/authorize?client_id=${appId}&scope=bot+applications.commands&permissions=${BOT_PERMISSIONS}`
+    : null
+
+  const countdown = `${Math.floor(secondsLeft / 60)}:${String(secondsLeft % 60).padStart(2, '0')}`
+
+  return (
+    <>
+      <h2>Discord</h2>
+      <p>Get alerts (Mercenary Den reinforcements first) in a Discord channel of your choosing:</p>
+      <ol>
+        <li>
+          {installUrl ? (
+            <a href={installUrl} target="_blank" rel="noreferrer">
+              Add the Edencom Link bot to your Discord server
+            </a>
+          ) : (
+            'Add the Edencom Link bot to your Discord server (bot not configured on this deployment)'
+          )}
+        </li>
+        <li>Generate a link code below</li>
+        <li>
+          In the channel that should get alerts, run <code>/edencom link &lt;code&gt;</code>
+        </li>
+      </ol>
+      <form>
+        <button formAction={generate}>Generate link code</button>
+      </form>
+      {code &&
+        (secondsLeft > 0 ? (
+          <p>
+            Your code: <code>{code}</code> — expires in {countdown}
+          </p>
+        ) : (
+          <p>That code expired — generate another.</p>
+        ))}
+
+      {channels.length > 0 && (
+        <>
+          <h3>Linked channels</h3>
+          <ul>
+            {channels.map((channel) => (
+              <li key={channel.id}>
+                {channel.guild_name ?? `server ${channel.guild_id}`} /{' '}
+                {channel.channel_name ? `#${channel.channel_name}` : `channel ${channel.channel_id}`} — linked{' '}
+                {channel.created_at.slice(0, 10)}
+                {channel.disabled_at && ' — bot lost access; remove and re-link'}{' '}
+                <button onClick={() => remove(channel.id)}>Remove</button>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+      <p>{response && <Dot color={color} response={response} />}</p>
+    </>
+  )
+}
+
+export default Discord

--- a/src/app/account/settings/page.tsx
+++ b/src/app/account/settings/page.tsx
@@ -6,6 +6,7 @@ import { createClient } from '@/utils/supabase/server'
 import { isChancellor } from '../chancellor/chancellor'
 import ApiToken from './apiToken'
 import ChangePassword from './changePassword'
+import Discord from './discord'
 import { LogoffButton } from './logoffButton'
 import MainCharacter from './mainCharacter'
 
@@ -25,6 +26,10 @@ const SettingsPage = async () => {
     .order('name', { ascending: true })
   const mainId = characters?.find((c) => c.is_main)?.id ?? null
   const chancellor = await isChancellor(data.user.id)
+  const { data: discordChannels } = await supabase
+    .from('discord_channel')
+    .select('id, guild_id, channel_id, guild_name, channel_name, created_at, disabled_at')
+    .order('created_at', { ascending: true })
 
   return (
     <>
@@ -41,6 +46,8 @@ const SettingsPage = async () => {
       <h2>Invite codes</h2>
       <p>Edencom Link is invite-only. See the codes you can give out and when you earn more.</p>
       <Link href="/account/invite">Manage invite codes</Link>
+
+      <Discord appId={process.env.DISCORD_APP_ID ?? null} channels={discordChannels ?? []} />
 
       <ApiToken initialToken={settings?.api_token ?? null} />
 

--- a/src/app/api/discord/commands.ts
+++ b/src/app/api/discord/commands.ts
@@ -42,7 +42,7 @@ const describeChannel = (interaction: CommandInteraction): string => {
 }
 
 const link = async (interaction: CommandInteraction, code: string | undefined): Promise<CommandResponse> => {
-  if (!code) return reply('Provide the link code from your edencom.link account settings.')
+  if (!code) return reply('Provide the link code from your Edencom.link account settings.')
 
   const invokerId = interaction.member?.user?.id ?? interaction.user?.id
   if (!invokerId) return reply('Could not tell who ran this command — try again.')
@@ -54,7 +54,7 @@ const link = async (interaction: CommandInteraction, code: string | undefined): 
     .eq('code', code)
     .maybeSingle()
   if (codeError) return reply('Something went wrong looking up that code — try again.')
-  if (!codeRow) return reply('That code is not recognized — generate one from your edencom.link account settings.')
+  if (!codeRow) return reply('That code is not recognized — generate one from your Edencom.link account settings.')
   if (codeRow.redeemed_at) return reply('That code was already used — generate a fresh one from your settings.')
   if (new Date(codeRow.expires_at).getTime() < Date.now())
     return reply('That code has expired (codes last 10 minutes) — generate a fresh one from your settings.')
@@ -70,13 +70,13 @@ const link = async (interaction: CommandInteraction, code: string | undefined): 
   // 23505 = unique (user_id, channel_id): this account already targets this
   // channel. Burn the code anyway? No — leave it usable elsewhere; the state
   // the user wanted already exists, so just say so.
-  if (insertError?.code === '23505') return reply(`This channel is already linked to that edencom.link account.`)
+  if (insertError?.code === '23505') return reply(`This channel is already linked to that Edencom.link account.`)
   if (insertError) return reply('Something went wrong linking the channel — try again.')
 
   await supabase.from('discord_link_code').update({ redeemed_at: new Date().toISOString() }).eq('id', codeRow.id)
 
   return reply(
-    `Linked! Alerts for that edencom.link account will post to ${describeChannel(interaction)}. Run /edencom unlink here to stop.`
+    `Linked! Alerts for that Edencom.link account will post to ${describeChannel(interaction)}. Run /edencom unlink here to stop.`
   )
 }
 
@@ -96,7 +96,7 @@ const unlink = async (interaction: CommandInteraction): Promise<CommandResponse>
     .select('id')
   if (error) return reply('Something went wrong unlinking — try again.')
   if (!removed?.length)
-    return reply('No link of yours found for this channel. Links can also be removed from edencom.link settings.')
+    return reply('No link of yours found for this channel. Links can also be removed from Edencom.link settings.')
 
   return reply(`Unlinked — ${describeChannel(interaction)} will no longer receive alerts you set up.`)
 }

--- a/src/app/api/discord/commands.ts
+++ b/src/app/api/discord/commands.ts
@@ -1,0 +1,119 @@
+// The /edencom slash-command router, called by the interactions endpoint after
+// signature verification. Runs on the service-role client: the invoker is a
+// Discord user, not a signed-in Supabase session, and the link code is what
+// proves which account they are — every query here must therefore be scoped
+// explicitly (by code, channel, and invoking Discord user), never broadly.
+import { createServiceClient } from '@/utils/supabase/service'
+
+import { EPHEMERAL, InteractionResponseType } from './lib'
+
+// The slices of Discord's interaction payload the router reads.
+// https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object
+type CommandOption = {
+  name: string
+  value?: string
+  options?: CommandOption[]
+}
+export type CommandInteraction = {
+  data?: { name?: string; options?: CommandOption[] }
+  guild_id?: string
+  channel_id?: string
+  guild?: { id?: string; name?: string }
+  channel?: { id?: string; name?: string }
+  member?: { user?: { id?: string } }
+  user?: { id?: string }
+}
+
+type CommandResponse = {
+  type: number
+  data: { flags: number; content: string }
+}
+
+const reply = (content: string): CommandResponse => ({
+  type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+  data: { flags: EPHEMERAL, content },
+})
+
+// "#channel-name in Server" when the payload carries names, ids otherwise.
+const describeChannel = (interaction: CommandInteraction): string => {
+  const channel = interaction.channel?.name ? `#${interaction.channel.name}` : `channel ${interaction.channel_id}`
+  const guild = interaction.guild?.name ?? null
+  return guild ? `${channel} in ${guild}` : channel
+}
+
+const link = async (interaction: CommandInteraction, code: string | undefined): Promise<CommandResponse> => {
+  if (!code) return reply('Provide the link code from your edencom.link account settings.')
+
+  const invokerId = interaction.member?.user?.id ?? interaction.user?.id
+  if (!invokerId) return reply('Could not tell who ran this command — try again.')
+
+  const supabase = createServiceClient()
+  const { data: codeRow, error: codeError } = await supabase
+    .from('discord_link_code')
+    .select('id, user_id, expires_at, redeemed_at')
+    .eq('code', code)
+    .maybeSingle()
+  if (codeError) return reply('Something went wrong looking up that code — try again.')
+  if (!codeRow) return reply('That code is not recognized — generate one from your edencom.link account settings.')
+  if (codeRow.redeemed_at) return reply('That code was already used — generate a fresh one from your settings.')
+  if (new Date(codeRow.expires_at).getTime() < Date.now())
+    return reply('That code has expired (codes last 10 minutes) — generate a fresh one from your settings.')
+
+  const { error: insertError } = await supabase.from('discord_channel').insert({
+    user_id: codeRow.user_id,
+    guild_id: interaction.guild_id,
+    channel_id: interaction.channel_id,
+    guild_name: interaction.guild?.name ?? null,
+    channel_name: interaction.channel?.name ?? null,
+    linked_by_discord_user_id: invokerId,
+  })
+  // 23505 = unique (user_id, channel_id): this account already targets this
+  // channel. Burn the code anyway? No — leave it usable elsewhere; the state
+  // the user wanted already exists, so just say so.
+  if (insertError?.code === '23505') return reply(`This channel is already linked to that edencom.link account.`)
+  if (insertError) return reply('Something went wrong linking the channel — try again.')
+
+  await supabase.from('discord_link_code').update({ redeemed_at: new Date().toISOString() }).eq('id', codeRow.id)
+
+  return reply(
+    `Linked! Alerts for that edencom.link account will post to ${describeChannel(interaction)}. Run /edencom unlink here to stop.`
+  )
+}
+
+const unlink = async (interaction: CommandInteraction): Promise<CommandResponse> => {
+  const invokerId = interaction.member?.user?.id ?? interaction.user?.id
+  if (!invokerId) return reply('Could not tell who ran this command — try again.')
+
+  // Scope: this channel, links made by this Discord user. Someone else's link
+  // to the same channel survives — they (or the account owner via settings)
+  // remove their own.
+  const supabase = createServiceClient()
+  const { data: removed, error } = await supabase
+    .from('discord_channel')
+    .delete()
+    .eq('channel_id', interaction.channel_id)
+    .eq('linked_by_discord_user_id', invokerId)
+    .select('id')
+  if (error) return reply('Something went wrong unlinking — try again.')
+  if (!removed?.length)
+    return reply('No link of yours found for this channel. Links can also be removed from edencom.link settings.')
+
+  return reply(`Unlinked — ${describeChannel(interaction)} will no longer receive alerts you set up.`)
+}
+
+// Route a verified APPLICATION_COMMAND interaction. Unknown commands and
+// subcommands get a plain ephemeral note rather than an error, since Discord
+// only offers what the registration script registered.
+export const handleCommand = async (interaction: CommandInteraction): Promise<CommandResponse> => {
+  if (interaction.data?.name !== 'edencom') return reply('Unknown command.')
+  if (!interaction.guild_id || !interaction.channel_id)
+    return reply('Run this in a server channel that should receive alerts.')
+
+  const subcommand = interaction.data.options?.[0]
+  if (subcommand?.name === 'link') {
+    const code = subcommand.options?.find((option) => option.name === 'code')?.value
+    return link(interaction, code)
+  }
+  if (subcommand?.name === 'unlink') return unlink(interaction)
+  return reply('Unknown subcommand — use /edencom link or /edencom unlink.')
+}

--- a/src/app/api/discord/interactions/route.ts
+++ b/src/app/api/discord/interactions/route.ts
@@ -1,15 +1,15 @@
 // The one route Discord calls into us. Discord signs every interaction with
 // Ed25519; we verify the signature (over the raw body, before parsing) and
-// answer by interaction type. Stage 2 only handles PING (what the developer
-// portal's endpoint validation exercises) — application commands get a
-// placeholder ephemeral reply until the command router lands in a later stage.
+// answer by interaction type: PING→PONG (the developer portal's endpoint
+// validation), application commands via the /edencom router in ../commands.
 //
-// Node runtime: node:crypto Ed25519 verification (and, later, the service-role
-// Supabase client) aren't available on the edge runtime.
+// Node runtime: node:crypto Ed25519 verification and the service-role
+// Supabase client aren't available on the edge runtime.
 import { NextResponse } from 'next/server'
 
 import { recordDiscordInteraction } from '@/observability'
 
+import { handleCommand, type CommandInteraction } from '../commands'
 import { EPHEMERAL, InteractionResponseType, InteractionType, verifyDiscordSignature } from '../lib'
 
 export const runtime = 'nodejs'
@@ -32,7 +32,7 @@ export async function POST(request: Request) {
 
   // A verified body came from Discord and is always valid JSON; guard anyway so
   // a malformed one is a clean 400 rather than a logged 500.
-  let interaction: { type?: number }
+  let interaction: CommandInteraction & { type?: number }
   try {
     interaction = JSON.parse(rawBody)
   } catch {
@@ -44,15 +44,11 @@ export async function POST(request: Request) {
       recordDiscordInteraction({ type: interaction.type, outcome: 'pong' })
       return NextResponse.json({ type: InteractionResponseType.PONG })
 
-    case InteractionType.APPLICATION_COMMAND:
-      recordDiscordInteraction({ type: interaction.type, outcome: 'unimplemented' })
-      return NextResponse.json({
-        type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
-        data: {
-          flags: EPHEMERAL,
-          content: 'Edencom Link is still setting up — commands are not available yet.',
-        },
-      })
+    case InteractionType.APPLICATION_COMMAND: {
+      const response = await handleCommand(interaction)
+      recordDiscordInteraction({ type: interaction.type, outcome: 'command' })
+      return NextResponse.json(response)
+    }
 
     default:
       recordDiscordInteraction({ type: interaction.type ?? null, outcome: 'unhandled' })

--- a/src/discordRegisterCommands.js
+++ b/src/discordRegisterCommands.js
@@ -1,0 +1,78 @@
+// One-off utility (DB/token-utilities family, like connect/ping/refresh):
+// registers the /edencom slash command with Discord. Commands are data held by
+// Discord, not code — run this once after changing the command shape below.
+//
+//   node src/discordRegisterCommands.js               # global (~1h to propagate)
+//   node src/discordRegisterCommands.js --guild <id>  # instant, one test server
+//
+// Needs DISCORD_APP_ID and DISCORD_BOT_TOKEN in the environment. The handler
+// answering these commands is src/app/api/discord/interactions/route.ts.
+import { indexOf } from 'ramda'
+
+// https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type
+const SUB_COMMAND = 1
+const STRING = 3
+
+const commands = [
+  {
+    name: 'edencom',
+    description: 'edencom.link hangar tracker',
+    options: [
+      {
+        type: SUB_COMMAND,
+        name: 'link',
+        description: 'Send den alerts to this channel (get a code from edencom.link settings)',
+        options: [
+          {
+            type: STRING,
+            name: 'code',
+            description: 'Link code from your edencom.link account settings',
+            required: true,
+          },
+        ],
+      },
+      {
+        type: SUB_COMMAND,
+        name: 'unlink',
+        description: 'Stop sending edencom.link alerts to this channel',
+      },
+    ],
+  },
+]
+
+const appId = process.env.DISCORD_APP_ID
+const botToken = process.env.DISCORD_BOT_TOKEN
+if (!appId || !botToken) {
+  console.error('DISCORD_APP_ID and DISCORD_BOT_TOKEN must be set')
+  process.exit(1)
+}
+
+const guildFlag = indexOf('--guild', process.argv)
+const guildId = guildFlag === -1 ? undefined : process.argv[guildFlag + 1]
+if (guildFlag !== -1 && !guildId) {
+  console.error('--guild needs a guild id')
+  process.exit(1)
+}
+
+const url = guildId
+  ? `https://discord.com/api/v10/applications/${appId}/guilds/${guildId}/commands`
+  : `https://discord.com/api/v10/applications/${appId}/commands`
+
+// PUT replaces the full command list, so removals propagate too.
+const response = await fetch(url, {
+  method: 'PUT',
+  headers: {
+    Authorization: `Bot ${botToken}`,
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify(commands),
+})
+
+const body = await response.json()
+if (!response.ok) {
+  console.error(`Discord rejected the command list (${response.status}):`, JSON.stringify(body, null, 2))
+  process.exit(1)
+}
+console.log(
+  `Registered ${body.length} command(s) ${guildId ? `on guild ${guildId} (instant)` : 'globally (may take ~1h to propagate)'}`
+)

--- a/src/discordRegisterCommands.js
+++ b/src/discordRegisterCommands.js
@@ -16,17 +16,17 @@ const STRING = 3
 const commands = [
   {
     name: 'edencom',
-    description: 'edencom.link hangar tracker',
+    description: 'Edencom.link — query the SDE and your EVE Online ESI data',
     options: [
       {
         type: SUB_COMMAND,
         name: 'link',
-        description: 'Send den alerts to this channel (get a code from edencom.link settings)',
+        description: 'Send den alerts to this channel (get a code from Edencom.link settings)',
         options: [
           {
             type: STRING,
             name: 'code',
-            description: 'Link code from your edencom.link account settings',
+            description: 'Link code from your Edencom.link account settings',
             required: true,
           },
         ],
@@ -34,7 +34,7 @@ const commands = [
       {
         type: SUB_COMMAND,
         name: 'unlink',
-        description: 'Stop sending edencom.link alerts to this channel',
+        description: 'Stop sending Edencom.link alerts to this channel',
       },
     ],
   },

--- a/supabase/migrations/20260804120000_discord_link.sql
+++ b/supabase/migrations/20260804120000_discord_link.sql
@@ -1,0 +1,72 @@
+-- Discord integration stage 03 (docs/discord-bot/03-account-linking.md):
+-- account↔channel linking via the /edencom slash command.
+--
+-- discord_link_code: short-lived (~10 min), single-use codes minted from
+-- /account/settings and redeemed by `/edencom link <code>` in Discord — the
+-- proof joining a Supabase account to the invoking Discord interaction.
+-- Minted by the owner (authenticated insert), redeemed by the interactions
+-- route (service role stamps redeemed_at).
+--
+-- discord_channel: one row = "this user's alerts go to this Discord channel."
+-- Written only by the service role (the interactions route is the sole
+-- writer); owners read and delete their own rows from settings. guild_name /
+-- channel_name are display-only, denormalized from the interaction payload at
+-- link time (nullable — Discord doesn't always include them). disabled_at is
+-- stamped by the stage-05 sender when Discord reports the channel gone.
+-- Snowflake ids are text: Discord delivers them as strings and they overflow
+-- JS number precision.
+
+create table public.discord_link_code (
+  id uuid primary key default gen_random_uuid(),
+  code text not null unique,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  expires_at timestamptz not null,
+  redeemed_at timestamptz
+);
+create index discord_link_code_user_id_idx on public.discord_link_code (user_id);
+
+alter table public.discord_link_code enable row level security;
+create policy "Users read own link codes"
+  on public.discord_link_code
+  for select
+  to authenticated
+  using (user_id = (select auth.uid()));
+create policy "Users mint own link codes"
+  on public.discord_link_code
+  for insert
+  to authenticated
+  with check (user_id = (select auth.uid()));
+
+grant select, insert on public.discord_link_code to authenticated;
+grant all           on public.discord_link_code to service_role;
+
+create table public.discord_channel (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  guild_id text not null,
+  channel_id text not null,
+  guild_name text,
+  channel_name text,
+  linked_by_discord_user_id text not null,
+  created_at timestamptz not null default now(),
+  disabled_at timestamptz,
+  unique (user_id, channel_id)
+);
+create index discord_channel_user_id_idx on public.discord_channel (user_id);
+create index discord_channel_channel_id_idx on public.discord_channel (channel_id);
+
+alter table public.discord_channel enable row level security;
+create policy "Users read own linked channels"
+  on public.discord_channel
+  for select
+  to authenticated
+  using (user_id = (select auth.uid()));
+create policy "Users remove own linked channels"
+  on public.discord_channel
+  for delete
+  to authenticated
+  using (user_id = (select auth.uid()));
+
+grant select, delete on public.discord_channel to authenticated;
+grant all            on public.discord_channel to service_role;


### PR DESCRIPTION
Implements stage 03 of the Discord integration (`docs/discord-bot/03-account-linking.md`): a signed-in user can invite the bot to their server, prove which edencom.link account they are with a short-lived link code, and pick the channel that gets alerts — all via `/edencom link` run in the target channel. Nothing posts to channels yet (that's stages 04–05).

## Schema (dual-write)

- `discord_link_code` — 16-hex-char single-use codes, 10-minute expiry. Minted by the owner from settings (authenticated insert policy), redeemed by the interactions route (service role stamps `redeemed_at`).
- `discord_channel` — one row per (account, channel) binding, unique on `(user_id, channel_id)`. Service-role writes only; owners read/delete their own. Snowflake ids stored as text (they overflow JS number precision). `disabled_at` reserved for the stage-05 sender.
- Same DDL in `schema.sql` and `supabase/migrations/20260804120000_discord_link.sql`.

## Command router

`src/app/api/discord/commands.ts`, dispatched from the verified `APPLICATION_COMMAND` arm of the interactions route (replacing the stage-02 placeholder reply):

- `/edencom link <code>` — validates the code (unknown / already used / expired each get a distinct ephemeral reply), inserts the channel row (denormalizing `guild_name`/`channel_name` from the payload when present), burns the code. A duplicate link replies "already linked" without burning the code.
- `/edencom unlink` — deletes rows for this channel made by the invoking Discord user; someone else's binding to the same channel survives.
- Both refuse DMs (no `guild_id`) with a pointer to run it in a server channel.

## Command registration

`pnpm run discord-register-commands` (`src/discordRegisterCommands.js`) PUTs the global command list; `--guild <id>` registers on one server instantly for testing. Uses `DISCORD_APP_ID` + `DISCORD_BOT_TOKEN`.

## Settings UI

New Discord section on `/account/settings` (`discord.tsx`, following the `apiToken.tsx` pattern): install-bot link (Send Messages + Embed Links only), generate-code button with a live countdown, linked-channel list with per-row remove and a disabled-state note.

## Notes

- The identity-first binding amended into the stage doc (matching the invoker's Discord user id against `auth.identities`) waits on stage 06 — link codes are the only path until then, as the doc allows.
- `pnpm run lint` and `pnpm run build` pass. Migration timestamp `20260804120000` sorts after the latest on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014saqfgmtTJk7SgtkLbi3F7

---
_Generated by [Claude Code](https://claude.ai/code/session_014saqfgmtTJk7SgtkLbi3F7)_