### PR TITLE
Replay the recursive-RLS migration that a version collision skipped

### DIFF
--- a/supabase/migrations/20260805120000_asset_share_recursive_rls_replay.sql
+++ b/supabase/migrations/20260805120000_asset_share_recursive_rls_replay.sql
@@ -1,0 +1,101 @@
+-- Replays 20260805010000_asset_share_recursive_rls.sql, which never applied.
+--
+-- WHAT HAPPENED. Two PRs merged carrying the same migration version:
+-- 20260805010000_gice_account.sql (#802) and
+-- 20260805010000_asset_share_recursive_rls.sql (#801). #802 merged first and
+-- recorded version 20260805010000 in supabase_migrations.schema_migrations;
+-- when #801 merged, `supabase db push` computed its pending set by diffing
+-- local file VERSIONS against the versions already in the history table, saw
+-- 20260805010000 present, and treated the recursive-RLS file as applied. The
+-- Migrate workflow went green having silently skipped it, so production ran
+-- with character_asset_share rows that no policy consulted: every share
+-- resolved to zero visible rows.
+--
+-- WHY THE EXISTING GUARDS DIDN'T CATCH IT. Neither is wrong; the case falls
+-- between them.
+--   * .github/scripts/check-migrations.mjs rejects a version that collides with
+--     one already on main, but #801 and #802 were open simultaneously and each
+--     validated against a main that did not yet contain the other. This is the
+--     exact gap CLAUDE.md names: "two open PRs carrying the same new timestamp
+--     both pass the check against main, then collide on merge."
+--   * 20260727000000_migration_history_composite_key.sql widened the history
+--     key to (version, name) so a colliding INSERT records both rows instead of
+--     aborting every later push. That backstop addresses the loud failure mode.
+--     This was the quiet one — the CLI never attempted the insert, because it
+--     never selected the file as pending in the first place.
+--
+-- WHY THIS IS A NEW FILE. Renaming 20260805010000_asset_share_recursive_rls.sql
+-- to a free timestamp would look like the tidier fix and is the documented trap
+-- (CLAUDE.md, Workflow): a filename is a migration's identity to every database
+-- that may already have applied it, so a rename only relocates the mismatch
+-- between local, CI and remote. The old file keeps its name and its recorded
+-- history entry stays as-is; this file carries the DDL forward.
+--
+-- Everything below is idempotent, so the from-scratch replay path — where the
+-- 20260805010000 file DOES apply, then this one follows — is a no-op rather
+-- than a duplicate-object error. schema.sql already carries this DDL (it landed
+-- with #801) and is unchanged.
+
+-- Identical to the function in 20260805010000_asset_share_recursive_rls.sql;
+-- see that file's header for the SECURITY DEFINER rationale (it is the single
+-- sanctioned definer: an invoker-rights helper selecting from the table it
+-- policies re-enters that policy and Postgres aborts with "infinite recursion
+-- detected in policy"). `create or replace` makes the replay a no-op.
+create or replace function public.asset_share_covers(item bigint, registration uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with recursive
+    matching_shares as (
+      select s.item_id
+      from character_asset_share s
+      where s.registration_id = asset_share_covers.registration
+        and asset_share_matches_caller(s.corporation_ids, s.alliance_ids, s.secret)
+    ),
+    walk (node, depth) as (
+      select asset_share_covers.item, 0
+      union all
+      select parent.location_id, w.depth + 1
+      from walk w
+      cross join lateral (
+        select o.location_id
+        from character_asset_over_time o
+        where o.item_id = w.node
+        order by o.is_current desc, o.valid_until desc
+        limit 1
+      ) parent
+      where w.depth < 16
+        and parent.location_id is not null
+        and exists (select 1 from matching_shares)
+    )
+  select exists (
+    select 1
+    from walk w
+    join matching_shares m on m.item_id = w.node
+  );
+$$;
+
+revoke execute on function public.asset_share_covers(bigint, uuid) from public;
+grant execute on function public.asset_share_covers(bigint, uuid) to anon, authenticated;
+
+-- The widening policy. is_current keeps SCD-2 history closed: a share opens the
+-- CURRENT view only — the same rows character_asset shows the owner.
+-- Permissive, so it ORs with "Users read own assets". `to anon` so a
+-- fully-public share is readable signed-out. The drop-if-exists is what makes
+-- this replayable; create policy has no `or replace`.
+drop policy if exists "Audience reads shared assets" on public.character_asset_over_time;
+
+create policy "Audience reads shared assets"
+  on public.character_asset_over_time
+  for select
+  to anon, authenticated
+  using (is_current and public.asset_share_covers(item_id, registration_id));
+
+-- RLS still scopes anon to rows a public share covers (the owner policy never
+-- matches a null uid). Already true on the remote via the schema-wide default
+-- privileges, but restated so a from-scratch database does not depend on them.
+grant select on public.character_asset_over_time to anon;
+grant select on public.character_asset           to anon;


### PR DESCRIPTION
## What didn't run

`supabase/migrations/20260805010000_asset_share_recursive_rls.sql` (#801) is in the repo but was never applied to production. Verified against the remote's `supabase_migrations.schema_migrations`: 95 migration files, 94 history rows, exactly one gap.

Confirmed by object, not just by bookkeeping:

| object | expected | on remote |
| --- | --- | --- |
| `character_asset_share` table (#800, phase 1) | present | ✅ present |
| `asset_share_matches_caller()` (#800) | present | ✅ present |
| `asset_share_covers()` (#801, phase 2) | present | ❌ **missing** |
| `"Audience reads shared assets"` policy (#801) | present | ❌ **missing** |

## Why

Two PRs merged carrying the same migration version, `20260805010000`:

- `20260805010000_gice_account.sql` (#802) — merged first, recorded the version
- `20260805010000_asset_share_recursive_rls.sql` (#801) — merged second

`supabase db push` computes its pending set by diffing local file **versions** against the versions already in the history table. It saw `20260805010000` present, treated the recursive-RLS file as applied, and never opened it. The Migrate workflow went green having silently skipped it.

Neither existing guard covers this, and neither is wrong — the case falls between them:

- `.github/scripts/check-migrations.mjs` rejects a version colliding with one already on `main`, but #801 and #802 were open simultaneously and each validated against a `main` that lacked the other. This is the gap CLAUDE.md already names: *"two open PRs carrying the same new timestamp both pass the check against main, then collide on merge."*
- `20260727000000_migration_history_composite_key.sql` widened the history key to `(version, name)` so a colliding INSERT records both rows instead of aborting every later push. That addresses the **loud** failure mode. This was the quiet one: the CLI never attempted an insert, because it never selected the file as pending.

## Impact

Production has the share table (#800) and the Share dialog (#801) but no policy consulting them, so every share resolves to zero visible rows. Phase 4 (#803, merged this morning) surfaces shared assets through GraphQL by querying as the caller and inheriting the same policy — so it is shipping broken for the same reason. This unblocks both.

## The fix

A **new** file with a free timestamp, `20260805120000_asset_share_recursive_rls_replay.sql`, carrying the same DDL forward.

The old file keeps its name and its recorded history entry. Renaming it to a free timestamp would look like the tidier fix and is the trap CLAUDE.md documents from the #614/#615/#616 incident: a filename is a migration's identity to every database that may already have applied it, so a rename only relocates the mismatch between local, CI and remote.

The DDL is idempotent — `create or replace function`, and `drop policy if exists` before `create policy` (which has no `or replace`) — so the from-scratch path, where `20260805010000` applies first and this file follows, is a no-op rather than a duplicate-object error.

`schema.sql` already carries this DDL (it landed with #801) and is unchanged, so a fresh reset was always correct; only the incremental rollout was missing.

## Verification

Ran on a throwaway Postgres 16 with stand-in tables whose column types were read off the live schema first, applying the migration **twice**:

- `asset_share_covers()` exists exactly once and is `SECURITY DEFINER`
- `"Audience reads shared assets"` exists exactly once after two applications
- `execute` revoked from `public`, held by `anon`
- recursive walk: a share on a container covers the container and its nested descendants, but **not** its ancestor, **not** an unrelated sibling, and **not** the same item for a different grantor

`node .github/scripts/check-migrations.mjs origin/main` passes. Rebased on `origin/main` (`9bcda09`).

## Follow-up worth considering (not in this PR)

Nothing yet catches this class of failure at the moment it happens. A post-push assertion in `migrate.yml` — every local migration filename must appear in the remote history, else fail — would have turned this silent skip into a red build on the #801 merge. Left out deliberately: it is a separate change to a workflow this PR doesn't otherwise touch, and this area has a history of well-intentioned tooling fixes making things worse. Happy to open it separately if you want it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MffvSFnEGJewJALo9aeqDS)_