### PR TITLE
Scale the fit viewer's panels with the wheel and lead with the hull

### DIFF
--- a/src/app/ship/[itemId]/fitPlaceholder.tsx
+++ b/src/app/ship/[itemId]/fitPlaceholder.tsx
@@ -5,15 +5,14 @@ import styles from './shipFit.module.css'
 // The fit viewer's reserved footprint, standing in from first paint until the
 // real thing can draw: the next/dynamic chunk, then the type/dogma protobufs
 // (which EveDataProvider renders nothing without), all load client-side, so
-// the viewer arrives seconds after the page. Same geometry as the live layout
-// — wheel box, stats column, the collapsed simulate line — so the swap fills
-// the space in place instead of pushing the module table down.
+// the viewer arrives seconds after the page. Same three columns as the live
+// layout — the wheel box, the stats column and the simulate line holding the
+// hardware browser's column — so the swap fills the space in place instead of
+// pushing the module table down.
 export const FitPlaceholder = () => (
-  <div aria-busy="true">
-    <div className={styles.layout}>
-      <div className={`${styles.wheel} ${styles.wheelPending}`}>Loading fit viewer…</div>
-      <div className={styles.stats} />
-    </div>
+  <div className={styles.layout} aria-busy="true">
+    <div className={`${styles.wheel} ${styles.wheelPending}`}>Loading fit viewer…</div>
+    <div className={styles.stats} />
     <p className={styles.hardwareGhost} aria-hidden="true">
       Load modules &amp; ammo (simulate)
     </p>

--- a/src/app/ship/[itemId]/page.tsx
+++ b/src/app/ship/[itemId]/page.tsx
@@ -8,15 +8,14 @@ import { AssetPath, fetchAssetPath } from '../../assetPath'
 import { typeFacts } from '../../assetTypeFacts'
 import { fetchOwners } from '../../owners'
 import type { Owners } from '../../ownerFilter'
-import { TypeIcon } from '../../typeIcon'
 import { fetchTypeNames } from '../../typeNames'
 import { flagSortKey } from '../../fitting/fit'
 import { LocationAssets, type ItemRow } from '../../asset/[locationId]/locationAssets'
 import { resolveShareParams } from '../../asset/access'
 import { fetchShareDialogData } from '../../asset/shareData'
 import { ShareDialog } from '../../asset/shareDialog'
-import assetStyles from '../../asset/assets.module.css'
 import { toEsiFit } from './esfFit'
+import { characterPortrait, corporationLogo, ShipHeading, type ShipOwner } from './shipHeading'
 import { ShipFitViewDynamic } from './shipFitViewDynamic'
 
 // invGroups.categoryID for the Ship category in CCP's SDE.
@@ -130,24 +129,31 @@ const ShipPage = async ({
     ).map((r) => [String(r.item_id), Number(r.contents)])
   )
 
-  // Owner: the holding character's name, or the corporation's cached name.
-  let ownerName: string
+  // Owner: the holding character's name and portrait, or the corporation's
+  // cached name and logo. `character_id` here is the EVE numeric id (what the
+  // image server serves portraits for), not the registration uuid its
+  // sibling asset columns misname.
+  let owner: ShipOwner
   if (characterSelf?.registration_id) {
     const { data: registration } = await supabase
       .from('registration')
-      .select('name')
+      .select('name, character_id')
       .eq('id', characterSelf.registration_id)
-      .maybeSingle<{ name: string }>()
+      .maybeSingle<{ name: string; character_id: number | string | null }>()
     // A shared ship's owner is outside the caller's registration view (RLS);
     // their public name resolves through the world-readable directory.
     const { data: directory } = registration
       ? { data: null }
       : await supabase
           .from('character_directory')
-          .select('name')
+          .select('name, character_id')
           .eq('registration_id', characterSelf.registration_id)
-          .maybeSingle<{ name: string | null }>()
-    ownerName = registration?.name ?? directory?.name ?? 'Unknown character'
+          .maybeSingle<{ name: string | null; character_id: number | string | null }>()
+    const eveCharacterId = registration?.character_id ?? directory?.character_id ?? null
+    owner = {
+      name: registration?.name ?? directory?.name ?? 'Unknown character',
+      portrait: eveCharacterId == null ? null : characterPortrait(eveCharacterId),
+    }
   } else {
     const corporationId = Number(corpSelf?.corporation_id)
     const { data: corpName } = await supabase
@@ -155,7 +161,7 @@ const ShipPage = async ({
       .select('name')
       .eq('id', corporationId)
       .maybeSingle<{ name: string }>()
-    ownerName = corpName?.name ?? `Corporation #${corporationId}`
+    owner = { name: corpName?.name ?? `Corporation #${corporationId}`, portrait: corporationLogo(corporationId) }
   }
 
   // Where the ship lives: the full container chain up to its station /
@@ -207,16 +213,12 @@ const ShipPage = async ({
   return (
     <>
       <AssetPath crumbs={crumbs} current={heading} />
-      <div className={assetStyles.header}>
-        <h1 className="serif">
-          <TypeIcon id={Number(self.type_id)} size={32} />
-          {heading}
-        </h1>
-        {shareData ? <ShareDialog itemId={itemId} path="ship" data={shareData} /> : null}
-      </div>
-      <p>
-        Owner: <span className="serif">{ownerName}</span>
-      </p>
+      <ShipHeading
+        typeId={Number(self.type_id)}
+        heading={heading}
+        owner={owner}
+        actions={shareData ? <ShareDialog itemId={itemId} path="ship" data={shareData} /> : null}
+      />
       <ShipFitViewDynamic esiFit={toEsiFit(Number(self.type_id), self.name ?? null, rows)} />
       <LocationAssets rows={rows} owners={owners} typeNamesPromise={typeNamesPromise} canAppraise />
     </>
@@ -273,9 +275,20 @@ const SharedShipPage = async ({
   // Everything inside a ship belongs to whoever owns the ship, so the whole
   // cargo view carries a single owner.
   const ownerId = characterSelf?.registration_id ?? String(corpSelf?.corporation_id)
-  let ownerName: string
+  let owner: ShipOwner
   if (characterSelf?.registration_id) {
-    ownerName = scope.characterNames.get(characterSelf.registration_id) ?? 'Unknown character'
+    // The share scope carries the sharer's name but not their EVE id, which is
+    // what the portrait is keyed on — one lookup on the registration the scope
+    // already vouched for.
+    const { data: registration } = await supabase
+      .from('registration')
+      .select('character_id')
+      .eq('id', characterSelf.registration_id)
+      .maybeSingle<{ character_id: number | string | null }>()
+    owner = {
+      name: scope.characterNames.get(characterSelf.registration_id) ?? 'Unknown character',
+      portrait: registration?.character_id == null ? null : characterPortrait(registration.character_id),
+    }
   } else {
     const corporationId = Number(corpSelf?.corporation_id)
     const { data: corpName } = await supabase
@@ -283,7 +296,7 @@ const SharedShipPage = async ({
       .select('name')
       .eq('id', corporationId)
       .maybeSingle<{ name: string }>()
-    ownerName = corpName?.name ?? `Corporation #${corporationId}`
+    owner = { name: corpName?.name ?? `Corporation #${corporationId}`, portrait: corporationLogo(corporationId) }
   }
 
   const typeNames = await fetchTypeNames([Number(self.type_id)])
@@ -316,18 +329,12 @@ const SharedShipPage = async ({
   // The table's owner column/filter only ever sees the sharing owner — the
   // anonymous viewer has no owner context of their own to offer.
   const owners: Owners = characterSelf?.registration_id
-    ? { characters: [{ id: characterSelf.registration_id, name: ownerName }], corporations: [] }
-    : { characters: [], corporations: [{ id: String(corpSelf?.corporation_id), name: ownerName }] }
+    ? { characters: [{ id: characterSelf.registration_id, name: owner.name }], corporations: [] }
+    : { characters: [], corporations: [{ id: String(corpSelf?.corporation_id), name: owner.name }] }
 
   return (
     <>
-      <h1 className="serif">
-        <TypeIcon id={Number(self.type_id)} size={32} />
-        {heading}
-      </h1>
-      <p>
-        Owner: <span className="serif">{ownerName}</span>
-      </p>
+      <ShipHeading typeId={Number(self.type_id)} heading={heading} owner={owner} />
       <ShipFitViewDynamic esiFit={toEsiFit(Number(self.type_id), self.name ?? null, rows)} />
       <LocationAssets rows={rows} owners={owners} typeNamesPromise={typeNamesPromise} canAppraise={false} />
     </>

--- a/src/app/ship/[itemId]/shipFit.module.css
+++ b/src/app/ship/[itemId]/shipFit.module.css
@@ -16,7 +16,19 @@
   grid-area: 1 / 1;
 }
 
+/*
+ * The viewer's three columns in EVE's fitting-window order: the hardware
+ * browser you drag modules and ammo from on the left, the wheel in the
+ * middle, the statistics readout on the right. Narrower than all three
+ * together, they wrap into one column (see the .hardware order rule below).
+ */
 .layout {
+  /* The viewer's single sizing knob. eveship.fit draws the wheel at a 42rem
+     diameter and authors every panel beside it in fixed px off the same 15px
+     baseline, so shrinking the wheel on its own leaves the numbers and the
+     module browser oversized next to it — everything scales by this one
+     factor instead. */
+  --fit-scale: 0.667;
   display: flex;
   flex-wrap: wrap;
   gap: 1.5rem;
@@ -24,12 +36,13 @@
 }
 
 .wheel {
+  /* 42rem × --fit-scale. */
   width: min(90vw, 28rem);
   aspect-ratio: 1;
   flex: 0 0 auto;
   /* eveship.fit's wheel internals are percentage-sized, so the diameter alone
-     scales them; the font baseline (15px at the 42rem this page used to draw
-     it at) is kept in ratio for anything that inherits it. */
+     scales them; the font baseline (15px at the 42rem the library draws it at)
+     is kept in ratio for anything that inherits it. */
   font-size: 10px;
 }
 
@@ -60,29 +73,49 @@
   font-size: 12px;
 }
 
+/*
+ * The panels flanking the wheel don't follow a font-size or a container width
+ * the way the wheel does: ShipStatistics is a hard `width: 350px` and both it
+ * and HardwareListing lay their rows out in fixed px. `zoom` is what scales
+ * them — it shrinks the used layout box along with the contents, so the
+ * column really is the width it looks (a transform would leave a full-size
+ * hole in the flex row). Modules move onto the wheel by native HTML5
+ * drag-and-drop through dataTransfer, with no coordinate math, so zooming a
+ * drag source doesn't disturb dropping.
+ */
 .stats {
-  flex: 1 1 18rem;
-  min-width: 16rem;
+  flex: 0 0 auto;
+  zoom: var(--fit-scale);
 }
 
-/* Interactive (owner-only) hardware browser used to drag modules/ammo onto the
- * wheel. Collapsed by default so the big listing doesn't dominate the page. */
+/* Left column: the hardware browser, beside the wheel rather than under it,
+ * the way EVE's fitting window puts it. Still collapsible, but on a reserved
+ * column width so toggling it never moves the wheel. */
 .hardware {
-  margin-top: 1.5rem;
-  max-width: min(90vw, 42rem);
+  flex: 0 0 min(90vw, 16rem);
 }
 .hardware > summary {
   cursor: pointer;
   font-weight: 600;
 }
 
-/* Stand-in for the collapsed simulate <summary> line while the viewer loads,
- * matching its geometry so content below doesn't nudge when the real one
- * mounts. */
+/* Stand-in for the simulate <summary> line while the viewer loads, holding
+ * the same column so the wheel and stats don't slide left and back. */
 .hardwareGhost {
-  margin: 1.5rem 0 0;
+  flex: 0 0 min(90vw, 16rem);
+  margin: 0;
   font-weight: 600;
   color: var(--ink-faint);
+}
+
+/* Wide enough for all three columns: the browser to the left of the wheel.
+ * Below it they're stacked, and the browser — the optional tool of the three
+ * — goes last, which is also the DOM order (wheel, stats, browser). */
+@media (min-width: 68rem) {
+  .hardware,
+  .hardwareGhost {
+    order: -1;
+  }
 }
 
 .hardwareHint {
@@ -91,10 +124,13 @@
   margin: 0.5rem 0;
 }
 .hardwareListing {
-  height: 28rem;
+  /* In the listing's own pre-zoom units: 42rem × --fit-scale renders it
+     exactly as tall as the wheel beside it is wide. */
+  height: 42rem;
   overflow: auto;
   border: 1px solid var(--rule, #cbb8a0);
   border-radius: 6px;
+  zoom: var(--fit-scale);
 }
 /* Same global-img override the wheel needs: keep the listing's icons at their
  * intended size instead of the app-wide max-width: 100% clamp. */

--- a/src/app/ship/[itemId]/shipFitView.tsx
+++ b/src/app/ship/[itemId]/shipFitView.tsx
@@ -137,17 +137,20 @@ export const ShipFitView = ({ esiFit }: ShipFitViewProps) => {
                         <div className={styles.stats}>
                           <ShipStatistics />
                         </div>
+                        {/* Last in the DOM, first in the row: CSS `order` moves
+                            it left of the wheel once there's room for three
+                            columns, and leaves it at the bottom when stacked. */}
+                        <details className={styles.hardware} open>
+                          <summary>Load modules &amp; ammo (simulate)</summary>
+                          <p className={styles.hardwareHint}>
+                            Drag a charge onto a weapon slot to load ammo and see damage update. Changes here are a
+                            local simulation and are never saved back to the game.
+                          </p>
+                          <div className={styles.hardwareListing}>
+                            <HardwareListing />
+                          </div>
+                        </details>
                       </div>
-                      <details className={styles.hardware}>
-                        <summary>Load modules &amp; ammo (simulate)</summary>
-                        <p className={styles.hardwareHint}>
-                          Drag a charge onto a weapon slot to load ammo and see damage update. Changes here are a local
-                          simulation and are never saved back to the game.
-                        </p>
-                        <div className={styles.hardwareListing}>
-                          <HardwareListing />
-                        </div>
-                      </details>
                     </FitManagerProvider>
                   </StatisticsProvider>
                 </FitFromEsi>

--- a/src/app/ship/[itemId]/shipHeading.module.css
+++ b/src/app/ship/[itemId]/shipHeading.module.css
@@ -1,0 +1,63 @@
+/* The ship page's identity block: hull render, name, owner. */
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 12pt;
+  margin-bottom: 12pt;
+}
+
+/* The hull render, flanking the whole identity block rather than sitting
+ * inside the <h1> — it labels the ship, not just its name, and the owner line
+ * below reads as part of the same subject. */
+.render {
+  flex: none;
+  /* The flex gap does the spacing here, not the inline icon's own margin. */
+  margin-right: 0;
+  border-radius: var(--radius-sm);
+  background: var(--line-soft);
+}
+
+.identity {
+  display: flex;
+  flex-direction: column;
+  gap: 4pt;
+  min-width: 0;
+}
+
+.identity h1 {
+  margin: 0;
+}
+
+/* Pushes the share dialog (when there is one) to the far end of the row. */
+.actions {
+  margin-left: auto;
+}
+
+.owner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  /* Between the body text it used to be set in and the 22px heading above. */
+  font-size: 17px;
+}
+
+.ownerLabel {
+  font-size: 12px;
+  color: var(--ink-soft);
+}
+
+.ownerAvatar {
+  width: 32px;
+  height: 32px;
+  flex: none;
+  /* Round for a pilot portrait, square-ish for a corporation logo — CCP draws
+     the two that way, so match the shape to what the image is. */
+  border-radius: 50%;
+  background: var(--line-soft);
+}
+
+.ownerAvatarCorporation {
+  border-radius: var(--radius-sm);
+}

--- a/src/app/ship/[itemId]/shipHeading.tsx
+++ b/src/app/ship/[itemId]/shipHeading.tsx
@@ -1,0 +1,63 @@
+import type { ReactNode } from 'react'
+
+import { TypeIcon } from '../../typeIcon'
+import styles from './shipHeading.module.css'
+
+// Who holds the ship, as the heading draws them: a name plus the portrait or
+// logo CCP's image server serves for them. `portrait` is null when the id
+// behind the name couldn't be resolved (a shared ship whose owner is outside
+// the caller's registration view and missing from the public directory), in
+// which case the name stands alone.
+export type ShipOwner = {
+  name: string
+  portrait: { url: string; kind: 'character' | 'corporation' } | null
+}
+
+export const characterPortrait = (characterId: number | string): ShipOwner['portrait'] => ({
+  url: `https://images.evetech.net/characters/${characterId}/portrait?size=64`,
+  kind: 'character',
+})
+
+export const corporationLogo = (corporationId: number | string): ShipOwner['portrait'] => ({
+  url: `https://images.evetech.net/corporations/${corporationId}/logo?size=64`,
+  kind: 'corporation',
+})
+
+type ShipHeadingProps = {
+  typeId: number
+  heading: string
+  owner: ShipOwner
+  // The share dialog on the owner's own view; the shared view passes nothing.
+  actions?: ReactNode
+}
+
+// The ship page's identity block: the hull's render to the left of the name
+// and its owner, the way the in-game ship info window leads with the render.
+// Shared by the signed-in and share-link views so the two can't drift.
+export const ShipHeading = ({ typeId, heading, owner, actions }: ShipHeadingProps) => (
+  <div className={styles.header}>
+    {/* "render" is the big 3D hull art — every Ship-category type has one, and
+        both callers have already gated on that category. */}
+    <TypeIcon id={typeId} size={64} variation="render" className={styles.render} />
+    <div className={styles.identity}>
+      <h1 className="serif">{heading}</h1>
+      <p className={styles.owner}>
+        <span className={styles.ownerLabel}>Owner</span>
+        {owner.portrait ? (
+          <img
+            className={`${styles.ownerAvatar} ${
+              owner.portrait.kind === 'corporation' ? styles.ownerAvatarCorporation : ''
+            }`}
+            src={owner.portrait.url}
+            alt=""
+            aria-hidden="true"
+            width={32}
+            height={32}
+          />
+        ) : null}
+        <span className="serif">{owner.name}</span>
+      </p>
+    </div>
+    {actions ? <div className={styles.actions}>{actions}</div> : null}
+  </div>
+)

--- a/src/app/typeIcon.tsx
+++ b/src/app/typeIcon.tsx
@@ -8,25 +8,32 @@ export type IconVariation = 'icon' | 'bp' | 'bpc' | 'render'
 
 type TypeIconProps = {
   id: number
-  // Rendered size in CSS pixels; the image itself is always fetched at 64 so a
-  // hi-dpi screen has pixels to spare at the sizes used here.
+  // Rendered size in CSS pixels; the image is fetched at the power-of-two
+  // above it (see fetchSize) so a hi-dpi screen has pixels to spare.
   size?: number
   variation?: IconVariation
+  // Extra class, for the few icons that aren't the inline-beside-a-name shape
+  // the module's own class assumes (the ship page's big hull render).
+  className?: string
 }
 
 // The image variation for a blueprint stack: originals and copies have distinct
 // artwork, and neither answers to "icon".
 export const blueprintIcon = (isCopy: boolean | null | undefined): IconVariation => (isCopy ? 'bpc' : 'bp')
 
+// CCP's image server serves fixed power-of-two sizes; ask for the one that
+// still has pixels to spare at 2× the rendered size.
+const fetchSize = (size: number) => (size <= 32 ? 64 : size <= 64 ? 128 : size <= 128 ? 256 : 512)
+
 // The item icon CCP's image server serves for a type id. Purely decorative —
 // every use sits next to the type's name (TypeName), so it carries an empty alt
 // and is hidden from screen readers rather than repeating that name. Not a
 // next/image: the existing icon/portrait uses across the app are plain <img>
 // tags, which keeps images.evetech.net out of next.config.mjs's remote patterns.
-export const TypeIcon = ({ id, size = 24, variation = 'icon' }: TypeIconProps) => (
+export const TypeIcon = ({ id, size = 24, variation = 'icon', className }: TypeIconProps) => (
   <img
-    className={styles.icon}
-    src={`https://images.evetech.net/types/${id}/${variation}?size=64`}
+    className={className ? `${styles.icon} ${className}` : styles.icon}
+    src={`https://images.evetech.net/types/${id}/${variation}?size=${fetchSize(size)}`}
     alt=""
     aria-hidden="true"
     width={size}


### PR DESCRIPTION
The wheel shrank from 42rem to 28rem in #791, but the panels beside it didn't follow. eveship.fit authors `ShipStatistics` and `HardwareListing` in fixed px — the stats panel is a hard `width: 350px` — so unlike the wheel they follow neither a font-size nor a container width, and the capacitor/EHP/DPS numbers stayed full size next to a two-thirds wheel.

Both now shrink by the same factor. `.layout` declares one `--fit-scale` knob and the panels apply it with `zoom`, which scales the used layout box along with the contents, so the column beside the wheel really is the width it looks (a transform would leave a full-size hole in the flex row). Modules move onto the wheel by native HTML5 drag-and-drop through `dataTransfer` with no coordinate math, so zooming a drag source doesn't disturb dropping.

The "Load modules & ammo" browser moves out from under the wheel into a column to its **left**, the way EVE's fitting window arranges it, scaled to match and open by default now that it no longer dominates the page. It's last in the DOM and ordered left by CSS, so below the width where three columns fit it stacks at the bottom rather than above the ship. Its listing is sized so it renders exactly as tall as the wheel is wide. `fitPlaceholder.tsx` holds all three columns so the viewer's arrival still fills a reserved box.

The heading is now a shared `ShipHeading` (used by both the signed-in and share-link views): the hull's 64px `render` to the left of the name, with the owner under it at 17px carrying the pilot's portrait or the corporation's logo. `TypeIcon` grew a fetch-size ladder so a 64px icon isn't a 64px image stretched, and takes a `className` for icons that aren't its inline-beside-a-name default.

## Testing

- `pnpm run lint`, `pnpm run build`, `pnpm test` (115 pass) all clean.
- Layout geometry checked in headless Chromium against a harness replicating the copied CSS with px stand-ins for the eveship.fit components: at 1280px the browser is 256px wide on the left, the wheel 448px, the stats panel 233px (350 × 0.667) on the right, and the listing renders 448px tall — matching the wheel. At 700px the wheel takes the first row and the two panels wrap below it.
- Not exercised against live data (no Supabase credentials in this environment), so the wheel and stats were stood in for rather than rendered.

Note the fit viewer is shared with `/fitting/[characterId]/[fittingId]`, which picks up the same three-column layout; the heading changes are the ship page only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxingdqVC5nht5JjwZyZBR)_