### PR TITLE
Polish the sign-on UI

### DIFF
--- a/src/app/account/auth.module.css
+++ b/src/app/account/auth.module.css
@@ -1,0 +1,206 @@
+/*
+ * Shared chrome for the sign-on surfaces: /account/login, /account/register,
+ * /account/reset and the GICE registration step at /account/gice/complete.
+ *
+ * One centered card at a readable measure, so the steps of a single flow look
+ * like one flow rather than four bare <br/>-separated forms. Built entirely
+ * from the globals.css custom properties, so these pages inherit dark mode and
+ * the warm palette along with the rest of the app.
+ */
+
+.wrap {
+  max-width: 26rem;
+  margin: 32px auto 0;
+}
+
+.card {
+  padding: 28px 28px 24px;
+  border: 1px solid var(--line);
+  border-radius: calc(var(--radius) * 2);
+  background: var(--paper-raised);
+}
+
+.title {
+  margin: 0;
+  font-family: var(--serif);
+  font-size: 26px;
+  font-weight: 500;
+  letter-spacing: -0.015em;
+}
+
+.intro {
+  margin: 10px 0 0;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--ink-soft);
+}
+
+/* Field stack ------------------------------------------------------------- */
+
+.fields {
+  display: grid;
+  gap: 14px;
+  margin-top: 22px;
+}
+
+.field {
+  display: grid;
+  gap: 5px;
+}
+
+.label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ink-soft);
+}
+
+.input {
+  width: 100%;
+  padding: 9px 12px;
+  font-size: 14px;
+}
+
+/* An invite code arriving via a shared link renders read-only until unlocked. */
+.input[readonly] {
+  background: var(--line-soft);
+  color: var(--ink-soft);
+}
+
+/* The "use a different code" affordance beside a locked invite field: a button
+ * for the semantics (it changes state, it doesn't navigate), a link for looks. */
+.linkButton {
+  justify-self: start;
+  margin: 0;
+  padding: 0;
+  background: none;
+  border: none;
+  color: var(--link);
+  font-family: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.linkButton:hover {
+  background: none;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.submit {
+  width: 100%;
+  margin: 20px 0 0;
+  padding: 10px 16px;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+/* Status lines ------------------------------------------------------------ */
+
+.status {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin: 14px 0 0;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+/* Inline under a field (the invite-code lookup) rather than under the form. */
+.statusInline {
+  margin: 1px 0 0;
+  font-size: 12px;
+}
+
+.ok {
+  color: var(--ok);
+}
+
+.error {
+  color: var(--danger);
+}
+
+.dot {
+  flex: none;
+  align-self: center;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+/* Alternate sign-on (GICE) ------------------------------------------------ */
+
+.divider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 22px 0 16px;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+.divider::before,
+.divider::after {
+  content: '';
+  flex: 1;
+  border-top: 1px solid var(--line);
+}
+
+.alt,
+.alt:visited {
+  display: block;
+  padding: 9px 16px;
+  text-align: center;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  transition:
+    border-color 0.12s ease,
+    transform 0.04s ease;
+}
+
+.alt:hover {
+  border-color: var(--accent);
+  text-decoration: none;
+}
+
+.alt:active {
+  transform: translateY(1px);
+}
+
+.altNote {
+  margin: 8px 0 0;
+  font-size: 12px;
+  line-height: 1.5;
+  text-align: center;
+  color: var(--ink-faint);
+}
+
+.footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 20px 0 0;
+  padding-top: 16px;
+  border-top: 1px solid var(--line-soft);
+  font-size: 12px;
+}
+
+@media (max-width: 480px) {
+  .wrap {
+    margin-top: 20px;
+  }
+
+  .card {
+    padding: 22px 18px 20px;
+  }
+
+  .title {
+    font-size: 22px;
+  }
+}

--- a/src/app/account/gice/complete/completeForm.tsx
+++ b/src/app/account/gice/complete/completeForm.tsx
@@ -3,9 +3,11 @@
 import { useEffect, useRef, useState } from 'react'
 import { redirect } from 'next/navigation'
 
+import styles from '../../auth.module.css'
+import Status from '../../status'
+import SubmitButton from '../../submitButton'
 import { lookupInvite, type InviteLookup } from '../../register/actions'
 import { INVITE_CODE_PATTERN } from '../../register/inviteCode'
-import Dot from '../../settings/dot'
 import { completeGiceRegistration } from './actions'
 
 // Invite code entry for a freshly verified GICE identity. Mirrors the live
@@ -15,8 +17,8 @@ const CompleteForm = ({ name }: { name: string | null }) => {
   const [lookup, setLookup] = useState<InviteLookup | null>(null)
   const lookupSeq = useRef(0)
 
-  const [disabled, setDisabled] = useState(false)
-  const [response, setResponse] = useState('')
+  const [submitted, setSubmitted] = useState(false)
+  const [error, setError] = useState('')
 
   useEffect(() => {
     const seq = ++lookupSeq.current
@@ -32,53 +34,77 @@ const CompleteForm = ({ name }: { name: string | null }) => {
   }, [invite])
 
   const completeAndReturn = async (formData: FormData) => {
-    const error = await completeGiceRegistration(formData)
-    if (error) {
-      setDisabled(false)
-      setResponse(error)
+    const message = await completeGiceRegistration(formData)
+    if (message) {
+      setSubmitted(false)
+      setError(message)
       return
     }
     redirect('/')
   }
 
   return (
-    <form
-      onSubmit={() => {
-        setResponse('')
-        setDisabled(true)
-      }}
-    >
-      <h1>Almost there{name ? `, ${name}` : ''}</h1>
-      <p>
-        Your GICE login checks out. Edencom Link is invite-only, so one last thing: an invite code creates your account.
-      </p>
-      <label htmlFor="invite">Invite code:</label>
-      <br />
-      <input
-        id="invite"
-        name="invite"
-        type="text"
-        required
-        value={invite}
-        onChange={(e) => {
-          setInvite(e.target.value)
-          setDisabled(false)
-        }}
-      />{' '}
-      {lookup?.status === 'valid' && (
-        <Dot
-          color="#00AF00"
-          response={lookup.inviterName ? `Invited by ${lookup.inviterName}` : 'A founding invite code'}
-        />
-      )}
-      {lookup?.status === 'redeemed' && <Dot color="#FF0000" response="This invite code has already been used." />}
-      {lookup?.status === 'unknown' && <Dot color="#FF0000" response="This invite code isn’t recognized." />}
-      <br />
-      <button formAction={completeAndReturn} disabled={disabled}>
-        Create account
-      </button>
-      {response && <Dot color="#FF0000" response={response} />}
-    </form>
+    <main className={styles.wrap}>
+      <div className={styles.card}>
+        <h1 className={styles.title}>Almost there{name ? `, ${name}` : ''}</h1>
+        <p className={styles.intro}>
+          Your GICE login checks out. Edencom Link is invite-only, so one last thing: an invite code creates your
+          account.
+        </p>
+
+        <form
+          onSubmit={() => {
+            setError('')
+            setSubmitted(true)
+          }}
+        >
+          <div className={styles.fields}>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="invite">
+                Invite code
+              </label>
+              <input
+                className={styles.input}
+                id="invite"
+                name="invite"
+                type="text"
+                autoComplete="off"
+                autoFocus
+                required
+                value={invite}
+                onChange={(e) => {
+                  setInvite(e.target.value)
+                  setSubmitted(false)
+                }}
+              />
+              <div aria-live="polite">
+                {lookup?.status === 'valid' && (
+                  <Status kind="ok" inline>
+                    {lookup.inviterName ? `Invited by ${lookup.inviterName}` : 'A founding invite code'}
+                  </Status>
+                )}
+                {lookup?.status === 'redeemed' && (
+                  <Status kind="error" inline>
+                    This invite code has already been used.
+                  </Status>
+                )}
+                {lookup?.status === 'unknown' && (
+                  <Status kind="error" inline>
+                    This invite code isn&rsquo;t recognized.
+                  </Status>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <SubmitButton formAction={completeAndReturn} disabled={submitted} pendingLabel="Creating account…">
+            Create account
+          </SubmitButton>
+
+          <div aria-live="polite">{error && <Status kind="error">{error}</Status>}</div>
+        </form>
+      </div>
+    </main>
   )
 }
 

--- a/src/app/account/login/loginForm.tsx
+++ b/src/app/account/login/loginForm.tsx
@@ -1,54 +1,94 @@
 'use client'
 
 import { useState } from 'react'
+import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
+import styles from '../auth.module.css'
+import Status from '../status'
+import SubmitButton from '../submitButton'
 import { login } from './actions'
 
 // The login form proper; the page (a server component) passes a sanitized
 // same-site `next` path so flows like the OAuth consent page can bounce a
 // logged-out user through login and back.
 export const LoginForm = ({ next }: { next?: string }) => {
-  const [response, setResponse] = useState<string>('')
+  const [error, setError] = useState('')
+  // Controlled so a rejected sign-in doesn't cost the address too: React resets
+  // the form's uncontrolled fields once the action settles. The password is
+  // left to clear, which is the conventional behaviour after a failure.
+  const [email, setEmail] = useState('')
 
   const loginAndReturn = async (formData: FormData) => {
-    const error = await login(formData)
-    if (error) {
-      setResponse(error)
+    const message = await login(formData)
+    if (message) {
+      setError(message)
       return
     }
     redirect(next ?? '/')
   }
 
   return (
-    <>
-      <h1>Login</h1>
-      <p>Login to access your hangar.</p>
-      <form onSubmit={() => setResponse('')}>
-        <label htmlFor="email">Email:</label>
-        <br />
-        <input id="email" name="email" type="email" required />
-        <br />
-        <label htmlFor="password">Password:</label>
-        <br />
-        <input id="password" name="password" type="password" required />
-        <br />
-        <button formAction={loginAndReturn}>Log in</button>
-        {response && (
-          <>
-            <svg height="10" width="20">
-              <circle cx="10" cy="5" r="5" fill="#FF0000" />
-            </svg>
-            {response}
-          </>
-        )}
-        <div>
-          <a href="reset">Forgot Password</a>
+    <main className={styles.wrap}>
+      <div className={styles.card}>
+        <h1 className={styles.title}>Log in</h1>
+        <p className={styles.intro}>Pick up where you left off — your hangars, wallets and industry jobs.</p>
+
+        <form onSubmit={() => setError('')}>
+          <div className={styles.fields}>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="email">
+                Email
+              </label>
+              <input
+                className={styles.input}
+                id="email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                autoFocus
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+            </div>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="password">
+                Password
+              </label>
+              <input
+                className={styles.input}
+                id="password"
+                name="password"
+                type="password"
+                autoComplete="current-password"
+                required
+              />
+            </div>
+          </div>
+
+          <SubmitButton formAction={loginAndReturn} pendingLabel="Logging in…">
+            Log in
+          </SubmitButton>
+
+          {/* Present on every render so a screen reader announces the failure
+              when it appears, rather than only on the next focus move. */}
+          <div aria-live="polite">{error && <Status kind="error">{error}</Status>}</div>
+        </form>
+
+        <div className={styles.divider}>or</div>
+        {/* A plain anchor, not next/link: /account/gice is a route handler that
+            redirects out to the SSO, so it wants a real navigation. */}
+        <a className={styles.alt} href="/account/gice">
+          Log in with GICE
+        </a>
+        <p className={styles.altNote}>In The Imperium? Use your Goonfleet SSO account.</p>
+
+        <div className={styles.footer}>
+          <Link href="/account/register">Need an account?</Link>
+          <Link href="/account/reset">Forgot password?</Link>
         </div>
-      </form>
-      <p>
-        In The Imperium? <a href="/account/gice">Log in with GICE</a> instead.
-      </p>
-    </>
+      </div>
+    </main>
   )
 }

--- a/src/app/account/register/registerForm.tsx
+++ b/src/app/account/register/registerForm.tsx
@@ -1,25 +1,35 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
+import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 
-import Dot from '../settings/dot'
+import styles from '../auth.module.css'
+import Status from '../status'
+import SubmitButton from '../submitButton'
 import { lookupInvite, register, type InviteLookup } from './actions'
 import { INVITE_CODE_PATTERN } from './inviteCode'
+
+type Result = { kind: 'ok' | 'error'; message: string }
 
 const RegisterForm = () => {
   const urlInvite = useSearchParams().get('invite')?.trim() ?? ''
 
   const [invite, setInvite] = useState(urlInvite)
+  // Controlled for the same reason the invite code is: React resets the form's
+  // uncontrolled fields once the action settles, and a rejected sign-up
+  // shouldn't cost the address as well. The password is left to clear.
+  const [email, setEmail] = useState('')
   // A code arriving via the URL renders read-only; "use a different code"
   // unlocks it (needed when a shared link's code turns out to be spent).
   const [locked, setLocked] = useState(urlInvite !== '')
   const [lookup, setLookup] = useState<InviteLookup | null>(null)
   const lookupSeq = useRef(0)
 
-  const [disabled, setDisabled] = useState(false)
-  const [color, setColor] = useState('#000000')
-  const [response, setResponse] = useState('')
+  // Stays true after a successful sign-up so the button can't be hit twice;
+  // editing any field clears it, which is how a rejected email gets retried.
+  const [submitted, setSubmitted] = useState(false)
+  const [result, setResult] = useState<Result | null>(null)
 
   // Resolve the inviter as soon as the field holds a complete code — instantly
   // for the URL-provided one, debounced while typing. The sequence counter
@@ -43,79 +53,130 @@ const RegisterForm = () => {
   const signupAndReturn = async (formData: FormData) => {
     const { error } = await register(formData)
     if (error?.message) {
-      setDisabled(false)
-      setResponse(error?.message)
-      setColor('#FF0000')
+      setSubmitted(false)
+      setResult({ kind: 'error', message: error.message })
       return
     }
-
-    setResponse('A perfect time to check your email inbox.')
-    setColor('#00AF00')
-  }
-
-  const handleEmailChange = () => {
-    setDisabled(false)
+    setResult({ kind: 'ok', message: 'A perfect time to check your email inbox.' })
   }
 
   return (
-    <form
-      onSubmit={() => {
-        setResponse('')
-        setDisabled(true)
-      }}
-    >
-      <h1>Register</h1>
-      <p>Create an account to manage your hangars. Registration is invite-only.</p>
-      <p>
-        In The Imperium? <a href="/account/gice">Register with your GICE account</a> instead — no email needed, though
-        you&rsquo;ll still enter an invite code.
-      </p>
-      <label htmlFor="invite">Invite code:</label>
-      <br />
-      {/* readOnly, not disabled — a disabled input is dropped from FormData on submit */}
-      <input
-        id="invite"
-        name="invite"
-        type="text"
-        required
-        readOnly={locked}
-        value={invite}
-        style={locked ? { backgroundColor: '#eeeeee' } : undefined}
-        onChange={(e) => {
-          setInvite(e.target.value)
-          handleEmailChange()
-        }}
-      />{' '}
-      {lookup?.status === 'valid' && (
-        <Dot
-          color="#00AF00"
-          response={lookup.inviterName ? `Invited by ${lookup.inviterName}` : 'A founding invite code'}
-        />
-      )}
-      {lookup?.status === 'redeemed' && <Dot color="#FF0000" response="This invite code has already been used." />}
-      {lookup?.status === 'unknown' && <Dot color="#FF0000" response="This invite code isn’t recognized." />}
-      {locked && (
-        <>
-          {' '}
-          <button type="button" onClick={() => setLocked(false)}>
-            use a different code
-          </button>
-        </>
-      )}
-      <br />
-      <label htmlFor="email">Email:</label>
-      <br />
-      <input id="email" name="email" type="email" required onChange={handleEmailChange} />
-      <br />
-      <label htmlFor="password">Password:</label>
-      <br />
-      <input id="password" name="password" type="password" required />
-      <br />
-      <button formAction={signupAndReturn} disabled={disabled}>
-        Register
-      </button>
-      {response && <Dot color={color} response={response} />}
-    </form>
+    <main className={styles.wrap}>
+      <div className={styles.card}>
+        <h1 className={styles.title}>Register</h1>
+        <p className={styles.intro}>
+          Create an account to manage your hangars. Registration is invite-only — you&rsquo;ll need a code from someone
+          already here.
+        </p>
+
+        <form
+          onSubmit={() => {
+            setResult(null)
+            setSubmitted(true)
+          }}
+        >
+          <div className={styles.fields}>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="invite">
+                Invite code
+              </label>
+              {/* readOnly, not disabled — a disabled input is dropped from FormData on submit */}
+              <input
+                className={styles.input}
+                id="invite"
+                name="invite"
+                type="text"
+                autoComplete="off"
+                autoFocus={urlInvite === ''}
+                required
+                readOnly={locked}
+                value={invite}
+                onChange={(e) => {
+                  setInvite(e.target.value)
+                  setSubmitted(false)
+                }}
+              />
+              <div aria-live="polite">
+                {lookup?.status === 'valid' && (
+                  <Status kind="ok" inline>
+                    {lookup.inviterName ? `Invited by ${lookup.inviterName}` : 'A founding invite code'}
+                  </Status>
+                )}
+                {lookup?.status === 'redeemed' && (
+                  <Status kind="error" inline>
+                    This invite code has already been used.
+                  </Status>
+                )}
+                {lookup?.status === 'unknown' && (
+                  <Status kind="error" inline>
+                    This invite code isn&rsquo;t recognized.
+                  </Status>
+                )}
+              </div>
+              {locked && (
+                <button type="button" className={styles.linkButton} onClick={() => setLocked(false)}>
+                  use a different code
+                </button>
+              )}
+            </div>
+
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="email">
+                Email
+              </label>
+              <input
+                className={styles.input}
+                id="email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                autoFocus={urlInvite !== ''}
+                required
+                value={email}
+                onChange={(e) => {
+                  setEmail(e.target.value)
+                  setSubmitted(false)
+                }}
+              />
+            </div>
+
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="password">
+                Password
+              </label>
+              <input
+                className={styles.input}
+                id="password"
+                name="password"
+                type="password"
+                autoComplete="new-password"
+                required
+              />
+            </div>
+          </div>
+
+          <SubmitButton formAction={signupAndReturn} disabled={submitted} pendingLabel="Creating account…">
+            Register
+          </SubmitButton>
+
+          <div aria-live="polite">{result && <Status kind={result.kind}>{result.message}</Status>}</div>
+        </form>
+
+        <div className={styles.divider}>or</div>
+        {/* A plain anchor, not next/link: /account/gice is a route handler that
+            redirects out to the SSO, so it wants a real navigation. */}
+        <a className={styles.alt} href="/account/gice">
+          Register with GICE
+        </a>
+        <p className={styles.altNote}>
+          In The Imperium? No email needed — though you&rsquo;ll still enter an invite code.
+        </p>
+
+        <div className={styles.footer}>
+          <Link href="/account/login">Already have an account?</Link>
+        </div>
+      </div>
+    </main>
   )
 }
 

--- a/src/app/account/reset/resetForm.tsx
+++ b/src/app/account/reset/resetForm.tsx
@@ -1,46 +1,68 @@
 'use client'
 
 import { useState } from 'react'
+import Link from 'next/link'
 
+import styles from '../auth.module.css'
+import Status from '../status'
+import SubmitButton from '../submitButton'
 import { reset } from './actions'
 
 export const ResetForm = () => {
-  const [disabled, setDisabled] = useState(false)
-  const [emailSent, setEmailSent] = useState(false)
+  // Doubles as the resubmit gate: the button stays off while the "check your
+  // email" line is up, and editing the address clears both.
+  const [sent, setSent] = useState(false)
+  // Controlled so the address survives React's post-action form reset — it's
+  // the confirmation line's subject, so it should still be on screen.
+  const [email, setEmail] = useState('')
 
   const resetAndReturn = async (formData: FormData) => {
     await reset(formData)
-    setEmailSent(true)
-  }
-
-  const handleEmailChange = () => {
-    setDisabled(false)
+    setSent(true)
   }
 
   return (
-    <form
-      onSubmit={() => {
-        setDisabled(true)
-        setEmailSent(false)
-      }}
-    >
-      <h1>Reset Password</h1>
-      <p>Forgot your password? Let&apos;s confirm your email to reset it.</p>
-      <label htmlFor="email">Email:</label>
-      <br />
-      <input id="email" name="email" type="email" required onChange={handleEmailChange} />
-      <br />
-      <button formAction={resetAndReturn} disabled={disabled}>
-        Send Email
-      </button>
-      {emailSent && (
-        <>
-          <svg height="10" width="20">
-            <circle cx="10" cy="5" r="5" fill="#00AF00" />
-          </svg>
-          Check your email for a link.
-        </>
-      )}
-    </form>
+    <main className={styles.wrap}>
+      <div className={styles.card}>
+        <h1 className={styles.title}>Reset password</h1>
+        <p className={styles.intro}>
+          Forgot your password? Confirm your email address and we&rsquo;ll send you a link to set a new one.
+        </p>
+
+        <form onSubmit={() => setSent(false)}>
+          <div className={styles.fields}>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="email">
+                Email
+              </label>
+              <input
+                className={styles.input}
+                id="email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                autoFocus
+                required
+                value={email}
+                onChange={(e) => {
+                  setEmail(e.target.value)
+                  setSent(false)
+                }}
+              />
+            </div>
+          </div>
+
+          <SubmitButton formAction={resetAndReturn} disabled={sent} pendingLabel="Sending…">
+            Send email
+          </SubmitButton>
+
+          <div aria-live="polite">{sent && <Status kind="ok">Check your email for a link.</Status>}</div>
+        </form>
+
+        <div className={styles.footer}>
+          <Link href="/account/login">Back to log in</Link>
+        </div>
+      </div>
+    </main>
   )
 }

--- a/src/app/account/status.tsx
+++ b/src/app/account/status.tsx
@@ -1,0 +1,17 @@
+import styles from './auth.module.css'
+
+// A result line on a sign-on form: a dot in the status color plus the message,
+// both taking their color from `kind` so the two stay in step. The sign-on
+// equivalent of the account area's <Dot color="#FF0000">, but themed — see the
+// --ok / --danger custom properties in globals.css.
+//
+// `inline` tightens the spacing for a line that sits under its own field (the
+// invite-code lookup) rather than under the whole form.
+const Status = ({ kind, inline, children }: { kind: 'ok' | 'error'; inline?: boolean; children: React.ReactNode }) => (
+  <p className={`${styles.status} ${inline ? styles.statusInline : ''} ${styles[kind]}`}>
+    <span className={styles.dot} />
+    <span>{children}</span>
+  </p>
+)
+
+export default Status

--- a/src/app/account/submitButton.tsx
+++ b/src/app/account/submitButton.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useFormStatus } from 'react-dom'
+
+import styles from './auth.module.css'
+
+// The submit control for the sign-on forms. `useFormStatus` reports the pending
+// state of the enclosing form's own action, so the label flips while the server
+// action is in flight without each form tracking a second piece of state. The
+// sign-on actions deliberately take a beat (login sleeps 1s, register 5s) —
+// long enough that a static label reads as a dead button.
+//
+// `disabled` is for the caller's own gating (register keeps the button off after
+// a successful sign-up until a field changes); pending is OR'd in on top.
+const SubmitButton = ({
+  children,
+  pendingLabel,
+  disabled,
+  formAction,
+}: {
+  children: React.ReactNode
+  pendingLabel: string
+  disabled?: boolean
+  formAction: (formData: FormData) => void | Promise<void>
+}) => {
+  const { pending } = useFormStatus()
+
+  return (
+    <button className={styles.submit} formAction={formAction} disabled={pending || disabled}>
+      {pending ? pendingLabel : children}
+    </button>
+  )
+}
+
+export default SubmitButton

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,6 +27,15 @@
   --link: #0000ee;
   --link-visited: #551a8b;
 
+  /*
+   * Status colors, theme-aware. The account forms have long hardcoded a
+   * #00AF00 / #FF0000 pair straight into <Dot color=…>, which reads the same in
+   * both themes and is too hot against the dark paper; these are the
+   * successors, adopted by the sign-on surfaces first.
+   */
+  --ok: #15803d;
+  --danger: #b3261e;
+
   --radius: 10px;
   --radius-sm: 7px;
 
@@ -57,6 +66,8 @@
     --accent-tint: #25244a;
     --link: #6ea8fe;
     --link-visited: #c699f7;
+    --ok: #4ade80;
+    --danger: #fca5a5;
   }
 }
 


### PR DESCRIPTION
The sign-on forms were the least-finished surface in the app: bare `<br/>`-separated fields sprawling the full viewport width, while the landing page next door is a proper card layout. This brings the four steps of one flow — login, register, password reset, and the GICE invite-code step — onto shared chrome so they read as one flow.

## What changed

**Layout.** New `src/app/account/auth.module.css`: a centered card at a 26rem measure, a grid field stack (no `<br/>`), an "or" divider ahead of the GICE path, and a footer link row. Built entirely from the `globals.css` custom properties, so it inherits dark mode along with the rest of the app.

**Cross-links that were missing.** Login now offers "Need an account?", register "Already have an account?", reset "Back to log in". A signed-out user could previously only cross between these pages via the header nav.

**Pending state.** New `submitButton.tsx` flips the label while the action is in flight ("Logging in…", "Creating account…") off `useFormStatus`. The sign-on actions deliberately sleep — 1s for login, 5s for register — long enough that the old static label read as a dead button. Login had no double-submit guard at all.

**Email fields are controlled now**, so a rejected sign-in no longer clears the address along with the password: React resets a form's uncontrolled fields once the action settles. The password is still left to clear, which is conventional after a failure.

**Status lines.** New `status.tsx` replaces the inline `<svg><circle>` and the hardcoded `#00AF00`/`#FF0000` `<Dot color>` pair on these pages, taking its color from new `--ok`/`--danger` custom properties that differ per theme (the old pure red is hot against the dark paper). Result lines sit in an `aria-live` region so a screen reader announces a failure when it appears. The rest of the account area keeps `<Dot>` for now — those call sites are unchanged.

**Forms plumbing.** `autoComplete` on every field (`email` / `current-password` / `new-password`) so password managers fill and offer to save; `autoFocus` lands on the first field the user actually has to fill — the email, when an invite link already filled the code. The locked invite field's `#eeeeee` background becomes `--line-soft`; it was a light-gray box under light-gray text in dark mode.

## Scope note

The ask was login and sign-up. `/account/reset` and `/account/gice/complete` are included because they're reached directly from those two — a polished login that bounces to an unstyled reset page looks broken. Their changes are limited to adopting the shared card; no behavior beyond the pending/controlled-field fixes above.

No server actions, auth logic, or routes were touched.

## Verification

`pnpm run lint`, `pnpm run build`, and `pnpm test` (115 pass) all clean. Rendered all four pages against a dev server in both themes at desktop width and 380px, and exercised the login pending → error transition and the invite-code lookup status line.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DT3oEuZbhx1eAze9VvmeQP)_