### PR TITLE
Discord stage 04: reinforcement detection + notification outbox

### DIFF
--- a/docs/discord-bot/README.md
+++ b/docs/discord-bot/README.md
@@ -34,7 +34,14 @@ Scope for making edencom.link double as a Discord application. Two goals
   amended below (match the invoker's Discord user id against
   `auth.identities`) waits on stage 06 — link codes are the only path
   until then.
-- **Stages 04–07 — not started.**
+- **Stage 04 — shipped.** Detection lives inside the
+  `character-mercenary-dens` extract (`src/jobs/characterMercenaryDens.js`
+  compares each fresh observation against the den's previous one; the pure
+  transition/format seam is `src/jobs/denReinforcement.js`, the enqueue I/O
+  is `src/jobs/mercenaryDenNotification.js`). The generic `notification`
+  outbox table was minted with `transport` + `discord_channel_id` per the
+  amended ntfy design; the extract cadence was bumped to hourly.
+- **Stages 05–07 — not started.**
 
 This is a scoping document set, not an implementation spec. Each stage is
 one PR with its own milestone; do them **in order** (each builds on the

--- a/docs/ntfy-notifications.md
+++ b/docs/ntfy-notifications.md
@@ -65,6 +65,14 @@ add_notification`) change together.
 
 ### New table `notification`
 
+> **Update:** this table was minted by Discord stage 04
+> (`supabase/migrations/20260806120000_notification_outbox.sql`) with two
+> extra columns — `transport text not null` and a nullable
+> `discord_channel_id` FK — and the pending unique index widened to
+> `(user_id, source, discord_channel_id) nulls not distinct`. This project
+> adds `transport = 'ntfy'` rows (null channel) and filters its sweep on its
+> own transport; the DDL below is otherwise as built.
+
 Deliberately generic — nothing industry-specific in the columns — so future
 sources (mercenary den reinforcement timers, clone-jump cooldowns, structure
 fuel) reuse it by minting new `source` prefixes.

--- a/schema.sql
+++ b/schema.sql
@@ -111,6 +111,7 @@ drop table if exists public.user_settings        cascade;
 drop table if exists public.refresh_task         cascade;
 drop table if exists public.shared_asset_token   cascade;
 drop table if exists public.discord_link_code    cascade;
+drop table if exists public.notification         cascade;
 drop table if exists public.discord_channel      cascade;
 drop table if exists public.gice_account         cascade;
 drop table if exists public.heartbeat            cascade;
@@ -3531,6 +3532,60 @@ create policy "Users remove own linked channels"
 
 grant select, delete on public.discord_channel to authenticated;
 grant all            on public.discord_channel to service_role;
+
+-- ── notification ──────────────────────────────────────────────────────────
+-- Notification outbox (Discord stage 04,
+-- docs/discord-bot/04-reinforcement-detection.md). The generic shape from
+-- docs/ntfy-notifications.md §1, plus a transport discriminator and the
+-- Discord delivery target so fan-out is per-message: a user with N linked
+-- channels gets N rows per event, each with its own delivery state. The ntfy
+-- project later adds transport='ntfy' rows (discord_channel_id null) with no
+-- schema change; its sweep filters on its own transport.
+--
+-- Rows are written by detection inside the extract jobs (service role), sit
+-- pending until the stage-05 sender stamps sent_at, and dedupe on the partial
+-- unique index below — detection treats a 23505 as success, so re-observing
+-- the same reinforcement is a no-op while a changed timer (new source) pings
+-- again. `nulls not distinct` so transports with no channel dedupe too.
+create table public.notification (
+  id bigint generated always as identity primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  source text not null,                 -- 'mercenary-den:<den_id>:<end unix>'
+  transport text not null,              -- 'discord' | (future) 'ntfy'
+  discord_channel_id uuid references public.discord_channel(id) on delete cascade,
+  subject text not null,
+  body text not null,
+  scheduled_at timestamptz not null,    -- when it should go out; now() for immediate pings
+  sent_at timestamptz,                  -- when it actually went out; null = pending
+  attempts int not null default 0,      -- failed delivery tries (sender gives up past a cap)
+  created_at timestamptz not null default now()
+);
+
+-- One *pending* row per (user, source, channel); sent history rows don't
+-- block re-notifying the same source later.
+create unique index notification_pending_source_idx
+  on public.notification (user_id, source, discord_channel_id)
+  nulls not distinct
+  where sent_at is null;
+
+-- The sender sweep's working set.
+create index notification_due_idx
+  on public.notification (scheduled_at)
+  where sent_at is null;
+
+create index notification_discord_channel_id_idx
+  on public.notification (discord_channel_id);
+
+alter table public.notification enable row level security;
+create policy "Users manage own notifications"
+  on public.notification
+  for all
+  to authenticated
+  using (user_id = (select auth.uid()))
+  with check (user_id = (select auth.uid()));
+
+grant select, insert, update, delete on public.notification to authenticated;
+grant all                            on public.notification to service_role;
 
 -- ── gice_account ──────────────────────────────────────────────────────────
 -- GICE (Goonfleet SSO) as an auth method (docs/gice-auth.md): one row links a

--- a/src/jobs/characterMercenaryDens.js
+++ b/src/jobs/characterMercenaryDens.js
@@ -1,6 +1,7 @@
 import { characterMercenaryDen, characterMercenaryDens } from '../esi.js'
 import { sudoSupabase } from '../supabase.js'
 import { cli, forEachCharacter, forEachSequential } from './lib.js'
+import { enqueueDenReinforcement, selectUserDiscordChannels } from './mercenaryDenNotification.js'
 
 const TAG = 'character-mercenary-dens'
 export const SCOPE = 'esi-structures.read_character.v1'
@@ -27,7 +28,7 @@ const signature = (d) =>
     d.skyhook_corporation_id == null ? null : Number(d.skyhook_corporation_id),
   ])
 
-export const syncCharacterMercenaryDens = async ({ access_token, characterID, registration_id, name }) => {
+export const syncCharacterMercenaryDens = async ({ access_token, characterID, registration_id, userId, name }) => {
   const { mercenary_dens: listed = [] } = await characterMercenaryDens(access_token, characterID)
 
   // One timestamp for the whole character so valid_from/valid_until line up per run.
@@ -41,6 +42,11 @@ export const syncCharacterMercenaryDens = async ({ access_token, characterID, re
     .eq('is_current', true)
   if (curErr) throw curErr
   const currentByDen = new Map((currentRows ?? []).map((r) => [Number(r.den_id), r]))
+
+  // Reinforcement detection (docs/discord-bot/04-reinforcement-detection.md)
+  // only matters when someone is listening — no linked channels means no
+  // previous-observation selects and no outbox writes.
+  const channels = await selectUserDiscordChannels(userId)
 
   await forEachSequential(listed, async (den) => {
     const detail = await characterMercenaryDen(access_token, characterID, den.id)
@@ -76,6 +82,24 @@ export const syncCharacterMercenaryDens = async ({ access_token, characterID, re
       if (error) throw error
     }
 
+    // The den's previous latest observation, read before inserting the fresh
+    // one — the un→reinforced transition is the comparison between the two.
+    // maybeSingle: a den's first-ever run has no previous row (and per the
+    // first-observation rule, a first sighting already reinforced still pings).
+    let prevObservation = null
+    if (channels.length > 0) {
+      const { data, error } = await sudoSupabase
+        .from('character_mercenary_den_status')
+        .select('reinforcement_end')
+        .eq('registration_id', registration_id)
+        .eq('den_id', den.id)
+        .order('observed_at', { ascending: false })
+        .limit(1)
+        .maybeSingle()
+      if (error) throw error
+      prevObservation = data
+    }
+
     // Observed volatile state — appended as a new history row every run.
     const { error: statusError } = await sudoSupabase.from('character_mercenary_den_status').insert({
       registration_id,
@@ -90,6 +114,18 @@ export const syncCharacterMercenaryDens = async ({ access_token, characterID, re
       observed_at: now,
     })
     if (statusError) throw statusError
+
+    if (channels.length > 0) {
+      await enqueueDenReinforcement({
+        userId,
+        denId: den.id,
+        planetId: den.planet_id,
+        prevObservation,
+        newObservation: { reinforcement_end: detail.reinforcement_timer?.end ?? null },
+        channels,
+        now: new Date(now),
+      })
+    }
   })
 
   // Dens still open but not listed this run have been unanchored/transferred —

--- a/src/jobs/denReinforcement.js
+++ b/src/jobs/denReinforcement.js
@@ -1,0 +1,107 @@
+// Pure decision logic for mercenary-den reinforcement notifications
+// (docs/discord-bot/04-reinforcement-detection.md): given a den's previous and
+// fresh status observations, decide whether it just entered reinforcement and
+// compose the outbox rows. Ramda-only and I/O-free so node --test can exercise
+// it directly (test/denReinforcement.test.ts); the reads/writes live in
+// src/jobs/mercenaryDenNotification.js.
+import { map } from 'ramda'
+
+// Roman numeral for a planet's celestial index (1 → "I", 4 → "IV", …). Local
+// copy of src/sdePlanets.ts's toRoman — that module imports via `@/` and can't
+// load under plain `node src/jobs/<job>.js`.
+export const toRoman = (n) => {
+  if (!Number.isInteger(n) || n <= 0) return String(n)
+  const table = [
+    [1000, 'M'],
+    [900, 'CM'],
+    [500, 'D'],
+    [400, 'CD'],
+    [100, 'C'],
+    [90, 'XC'],
+    [50, 'L'],
+    [40, 'XL'],
+    [10, 'X'],
+    [9, 'IX'],
+    [5, 'V'],
+    [4, 'IV'],
+    [1, 'I'],
+  ]
+  const [, roman] = table.reduce(
+    ([rest, acc], [value, numeral]) =>
+      rest >= value ? [rest % value, acc + numeral.repeat(Math.floor(rest / value))] : [rest, acc],
+    [n, '']
+  )
+  return roman
+}
+
+// A timestamp as epoch millis, or null for missing/unparsable — timers are
+// compared numerically, never as strings (ISO spellings of the same instant
+// differ between ESI and Postgres round-trips).
+const toEpoch = (timestamp) => {
+  if (timestamp == null) return null
+  const ms = new Date(timestamp).getTime()
+  return Number.isNaN(ms) ? null : ms
+}
+
+// The outbox dedupe key: one ping per den per distinct timer. Re-observing the
+// same reinforcement next run re-derives the same source and hits the pending
+// unique index; a changed timer mints a new source and pings again.
+export const denNotificationSource = (denId, reinforcementEnd) =>
+  `mercenary-den:${denId}:${Math.floor(toEpoch(reinforcementEnd) / 1000)}`
+
+// Newly reinforced: the fresh observation carries a future timer the previous
+// one didn't. Previous null (first-ever observation — user links
+// mid-reinforcement and wants the ping), null-end, past-end, or a different
+// timestamp all count; the same future timer seen again does not.
+export const isNewlyReinforced = (prevObservation, newObservation, now = new Date()) => {
+  const next = toEpoch(newObservation?.reinforcement_end)
+  if (next === null || next <= now.getTime()) return false
+  const prev = toEpoch(prevObservation?.reinforcement_end)
+  return prev !== next
+}
+
+// The exact message users already paste by hand — keep in lockstep with
+// src/app/mercenary-dens/copyDiscordPing.tsx (its enemy=false branch). <t:…:s>
+// / <t:…:R> are Discord timestamp markup: viewer-local wall clock + live
+// countdown. `planet` is a raw sde_planet row ({ system_name, celestial_index })
+// or null when the lookup failed — fall back to the raw planet id.
+export const composeDenPing = ({ planet, planetId, reinforcementEnd }) => {
+  const unix = Math.floor(toEpoch(reinforcementEnd) / 1000)
+  const roman = planet?.celestial_index != null ? ` ${toRoman(planet.celestial_index)}` : ''
+  const place = planet?.system_name ? `${planet.system_name}${roman}` : `planet ${planetId}`
+  return {
+    subject: 'Mercenary Den Reinforced',
+    body: `Friendly Den Reinforced - ${place} at <t:${unix}:s> <t:${unix}:R>`,
+  }
+}
+
+// The whole decision: [] unless the den just entered reinforcement, else one
+// insert-ready notification row per linked channel (delivery state is
+// per-message, so detection fans out here rather than in the sender).
+export const planDenNotifications = ({
+  userId,
+  denId,
+  planetId,
+  planet,
+  prevObservation,
+  newObservation,
+  channels,
+  now = new Date(),
+}) => {
+  if (!isNewlyReinforced(prevObservation, newObservation, now)) return []
+  const reinforcementEnd = newObservation.reinforcement_end
+  const { subject, body } = composeDenPing({ planet, planetId, reinforcementEnd })
+  const source = denNotificationSource(denId, reinforcementEnd)
+  return map(
+    (channel) => ({
+      user_id: userId,
+      source,
+      transport: 'discord',
+      discord_channel_id: channel.id,
+      subject,
+      body,
+      scheduled_at: now.toISOString(),
+    }),
+    channels
+  )
+}

--- a/src/jobs/mercenaryDenNotification.js
+++ b/src/jobs/mercenaryDenNotification.js
@@ -1,0 +1,79 @@
+// I/O side of mercenary-den reinforcement notifications
+// (docs/discord-bot/04-reinforcement-detection.md): resolve the den's planet to
+// a display name, plan the rows via the pure seam (denReinforcement.js), and
+// insert them into the notification outbox. Called from
+// characterMercenaryDens.js at extract time, so the cron, queue, and CLI paths
+// all detect for free.
+import { createClient } from '@supabase/supabase-js'
+
+import { sudoSupabase } from '../supabase.js'
+import { isNewlyReinforced, planDenNotifications } from './denReinforcement.js'
+import { forEachSequential } from './lib.js'
+
+// Lazy anon client for the public-read sde_planet view (same env fallbacks as
+// src/buildEsfData.js). Missing env or a failed lookup degrades to the
+// planet-id fallback body rather than failing the extract — a ping with a raw
+// id beats no ping.
+let sdeClient
+const sde = () => {
+  if (sdeClient === undefined) {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL
+    const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? process.env.SUPABASE_KEY
+    sdeClient = url && key ? createClient(url, key, { auth: { persistSession: false, autoRefreshToken: false } }) : null
+  }
+  return sdeClient
+}
+
+const selectPlanet = async (planetId) => {
+  const client = sde()
+  if (!client) return null
+  const { data, error } = await client
+    .from('sde_planet')
+    .select('system_name, celestial_index')
+    .eq('planet_id', planetId)
+    .maybeSingle()
+  return error ? null : data
+}
+
+// The user's linked Discord channels still in good standing — detection
+// consults this before writing anything, so a character with no linked
+// channels produces no outbox rows (and skips the per-den history select).
+export const selectUserDiscordChannels = async (userId) => {
+  if (!userId) return []
+  const { data, error } = await sudoSupabase
+    .from('discord_channel')
+    .select('id')
+    .eq('user_id', userId)
+    .is('disabled_at', null)
+  if (error) throw error
+  return data ?? []
+}
+
+// Compare the previous and fresh observations and enqueue one pending
+// notification per channel if the den just entered reinforcement. Returns the
+// number of rows actually inserted. Per-row inserts so a 23505 (the pending
+// unique index — this timer was already enqueued) is swallowed as success
+// without poisoning the rest of the fan-out.
+export const enqueueDenReinforcement = async ({
+  userId,
+  denId,
+  planetId,
+  prevObservation,
+  newObservation,
+  channels,
+  now = new Date(),
+}) => {
+  // Early-out before the SDE lookup — the common path is "nothing changed."
+  if (channels.length === 0 || !isNewlyReinforced(prevObservation, newObservation, now)) return 0
+
+  const planet = await selectPlanet(planetId)
+  const rows = planDenNotifications({ userId, denId, planetId, planet, prevObservation, newObservation, channels, now })
+
+  let inserted = 0
+  await forEachSequential(rows, async (row) => {
+    const { error } = await sudoSupabase.from('notification').insert(row)
+    if (error && error.code !== '23505') throw error
+    if (!error) inserted += 1
+  })
+  return inserted
+}

--- a/supabase/migrations/20260806120000_notification_outbox.sql
+++ b/supabase/migrations/20260806120000_notification_outbox.sql
@@ -1,0 +1,53 @@
+-- Notification outbox (Discord stage 04,
+-- docs/discord-bot/04-reinforcement-detection.md). The generic shape from
+-- docs/ntfy-notifications.md §1, plus a transport discriminator and the
+-- Discord delivery target so fan-out is per-message: a user with N linked
+-- channels gets N rows per event, each with its own delivery state. The ntfy
+-- project later adds transport='ntfy' rows (discord_channel_id null) with no
+-- schema change; its sweep filters on its own transport.
+--
+-- Rows are written by detection inside the extract jobs (service role), sit
+-- pending until the stage-05 sender stamps sent_at, and dedupe on the partial
+-- unique index below — detection treats a 23505 as success, so re-observing
+-- the same reinforcement is a no-op while a changed timer (new source) pings
+-- again. `nulls not distinct` so transports with no channel dedupe too.
+
+create table public.notification (
+  id bigint generated always as identity primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  source text not null,                 -- 'mercenary-den:<den_id>:<end unix>'
+  transport text not null,              -- 'discord' | (future) 'ntfy'
+  discord_channel_id uuid references public.discord_channel(id) on delete cascade,
+  subject text not null,
+  body text not null,
+  scheduled_at timestamptz not null,    -- when it should go out; now() for immediate pings
+  sent_at timestamptz,                  -- when it actually went out; null = pending
+  attempts int not null default 0,      -- failed delivery tries (sender gives up past a cap)
+  created_at timestamptz not null default now()
+);
+
+-- One *pending* row per (user, source, channel); sent history rows don't
+-- block re-notifying the same source later.
+create unique index notification_pending_source_idx
+  on public.notification (user_id, source, discord_channel_id)
+  nulls not distinct
+  where sent_at is null;
+
+-- The sender sweep's working set.
+create index notification_due_idx
+  on public.notification (scheduled_at)
+  where sent_at is null;
+
+create index notification_discord_channel_id_idx
+  on public.notification (discord_channel_id);
+
+alter table public.notification enable row level security;
+create policy "Users manage own notifications"
+  on public.notification
+  for all
+  to authenticated
+  using (user_id = (select auth.uid()))
+  with check (user_id = (select auth.uid()));
+
+grant select, insert, update, delete on public.notification to authenticated;
+grant all                            on public.notification to service_role;

--- a/test/denReinforcement.test.ts
+++ b/test/denReinforcement.test.ts
@@ -1,0 +1,118 @@
+// Unit coverage for the pure den-reinforcement detection seam
+// (docs/discord-bot/04-reinforcement-detection.md). Everything here is the
+// logic a live reinforced den can't be arranged to exercise on demand: the
+// transition rules, the dedupe source key, and the exact ping format shared
+// with src/app/mercenary-dens/copyDiscordPing.tsx.
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  composeDenPing,
+  denNotificationSource,
+  isNewlyReinforced,
+  planDenNotifications,
+  toRoman,
+} from '../src/jobs/denReinforcement.js'
+
+const now = new Date('2026-08-06T12:00:00Z')
+const future = '2026-08-07T21:27:55Z' // unix 1786138075
+const futureUnix = 1786138075
+const past = '2026-08-01T00:00:00Z'
+
+test('newly reinforced: first-ever observation already carrying a future timer', () => {
+  assert.equal(isNewlyReinforced(null, { reinforcement_end: future }, now), true)
+})
+
+test('newly reinforced: previous observation had no timer', () => {
+  assert.equal(isNewlyReinforced({ reinforcement_end: null }, { reinforcement_end: future }, now), true)
+})
+
+test('newly reinforced: previous timer already in the past', () => {
+  assert.equal(isNewlyReinforced({ reinforcement_end: past }, { reinforcement_end: future }, now), true)
+})
+
+test('newly reinforced: a changed (moved) timer pings again', () => {
+  const moved = '2026-08-08T09:00:00Z'
+  assert.equal(isNewlyReinforced({ reinforcement_end: future }, { reinforcement_end: moved }, now), true)
+})
+
+test('not newly reinforced: the same timer observed again', () => {
+  assert.equal(isNewlyReinforced({ reinforcement_end: future }, { reinforcement_end: future }, now), false)
+})
+
+test('not newly reinforced: same instant in a different ISO spelling', () => {
+  const spelled = '2026-08-07T21:27:55.000+00:00'
+  assert.equal(isNewlyReinforced({ reinforcement_end: spelled }, { reinforcement_end: future }, now), false)
+})
+
+test('not newly reinforced: no timer, or a timer already in the past', () => {
+  assert.equal(isNewlyReinforced(null, { reinforcement_end: null }, now), false)
+  assert.equal(isNewlyReinforced(null, { reinforcement_end: past }, now), false)
+})
+
+test('source key is stable and unix-based', () => {
+  assert.equal(denNotificationSource(42, future), `mercenary-den:42:${futureUnix}`)
+  assert.equal(denNotificationSource(42, '2026-08-07T21:27:55.000Z'), `mercenary-den:42:${futureUnix}`)
+})
+
+test('toRoman matches the sdePlanets algorithm', () => {
+  assert.equal(toRoman(1), 'I')
+  assert.equal(toRoman(4), 'IV')
+  assert.equal(toRoman(5), 'V')
+  assert.equal(toRoman(9), 'IX')
+  assert.equal(toRoman(14), 'XIV')
+})
+
+test('ping body matches the copy-button format', () => {
+  const { subject, body } = composeDenPing({
+    planet: { system_name: 'QQGH-G', celestial_index: 5 },
+    planetId: 40099763,
+    reinforcementEnd: future,
+  })
+  assert.equal(subject, 'Mercenary Den Reinforced')
+  assert.equal(body, `Friendly Den Reinforced - QQGH-G V at <t:${futureUnix}:s> <t:${futureUnix}:R>`)
+})
+
+test('ping body falls back to the raw planet id when the SDE lookup missed', () => {
+  const { body } = composeDenPing({ planet: null, planetId: 40099763, reinforcementEnd: future })
+  assert.equal(body, `Friendly Den Reinforced - planet 40099763 at <t:${futureUnix}:s> <t:${futureUnix}:R>`)
+})
+
+test('plan fans out one row per channel, identical but for the channel id', () => {
+  const rows = planDenNotifications({
+    userId: 'user-1',
+    denId: 42,
+    planetId: 40099763,
+    planet: { system_name: 'QQGH-G', celestial_index: 5 },
+    prevObservation: null,
+    newObservation: { reinforcement_end: future },
+    channels: [{ id: 'chan-a' }, { id: 'chan-b' }],
+    now,
+  })
+  assert.equal(rows.length, 2)
+  assert.deepEqual(
+    rows.map((r) => r.discord_channel_id),
+    ['chan-a', 'chan-b']
+  )
+  rows.forEach((row) => {
+    assert.equal(row.user_id, 'user-1')
+    assert.equal(row.transport, 'discord')
+    assert.equal(row.source, `mercenary-den:42:${futureUnix}`)
+    assert.equal(row.scheduled_at, now.toISOString())
+    assert.equal(row.subject, 'Mercenary Den Reinforced')
+  })
+})
+
+test('plan is empty with no channels or no transition', () => {
+  const base = {
+    userId: 'user-1',
+    denId: 42,
+    planetId: 40099763,
+    planet: null,
+    prevObservation: { reinforcement_end: future },
+    newObservation: { reinforcement_end: future },
+    now,
+  }
+  assert.deepEqual(planDenNotifications({ ...base, channels: [{ id: 'chan-a' }] }), [])
+  assert.deepEqual(planDenNotifications({ ...base, prevObservation: null, channels: [] }), [])
+})

--- a/test/schedule.test.ts
+++ b/test/schedule.test.ts
@@ -24,6 +24,14 @@ test('parses the field syntax vercel.json uses', () => {
   const daily = parseCron('7 9 * * *')
   assert.deepEqual(daily?.minutes, [7])
   assert.deepEqual(daily?.hours, [9])
+
+  // character-mercenary-dens runs hourly (Discord stage 04 detection cadence).
+  const hourly = parseCron('30 * * * *')
+  assert.deepEqual(hourly?.minutes, [30])
+  assert.deepEqual(
+    hourly?.hours,
+    Array.from({ length: 24 }, (_, h) => h)
+  )
 })
 
 test('parses ranges, lists and stepped ranges', () => {

--- a/vercel.json
+++ b/vercel.json
@@ -15,7 +15,7 @@
     },
     {
       "path": "/api/cron/character-mercenary-dens",
-      "schedule": "30 */6 * * *"
+      "schedule": "30 * * * *"
     },
     {
       "path": "/api/cron/character-fittings",


### PR DESCRIPTION
Implements stage 04 of the Discord integration (`docs/discord-bot/04-reinforcement-detection.md`): when the `character-mercenary-dens` extract observes a den entering reinforcement, exactly one pending notification row per linked Discord channel appears in a new generic outbox table. Nothing posts to Discord yet — that's stage 05; the milestone here is verified in the database.

## Outbox table (dual-write: `schema.sql` + `20260806120000_notification_outbox.sql`)

The generic `notification` shape from `docs/ntfy-notifications.md` §1, plus the two columns that stage doc's decision adds: `transport text not null` (`'discord'` now, `'ntfy'` later with no schema change) and a nullable `discord_channel_id` FK (`on delete cascade` — unlinking a channel kills its pending rows). The pending unique index is `(user_id, source, discord_channel_id) nulls not distinct where sent_at is null`, so a null-channel transport still dedupes; detection treats `23505` as success per the ntfy design. The ntfy doc got a short "as built" note pointing here.

## Detection

- Pure seam `src/jobs/denReinforcement.js` (ramda-only, no I/O): `isNewlyReinforced` (prev null / null-end / past-end / moved timer ⇒ enqueue; same future timer re-observed ⇒ not — compared as epoch millis, not strings), `denNotificationSource` (`mercenary-den:<den_id>:<end unix>` — a changed timer mints a new source and pings again), `composeDenPing` (byte-identical to the `/mercenary-dens` copy-button format; the stage doc's older quoted format lost to the live component), `planDenNotifications` (fan-out, one row per channel). Unit-tested in `test/denReinforcement.test.ts`.
- I/O wrapper `src/jobs/mercenaryDenNotification.js`: linked-channel lookup (`disabled_at is null`), planet name from the public-read `sde_planet` view via a lazy anon client (`buildEsfData.js` precedent — `sdePlanets.ts` can't load under plain node), degrading to a `planet <id>` body on any lookup failure; per-row inserts so one duplicate doesn't poison the batch.
- `src/jobs/characterMercenaryDens.js` reads the den's previous latest observation before inserting the fresh one and enqueues after — so the cron, on-demand queue, and CLI paths all detect for free. A character with no linked channels skips both the history select and the enqueue entirely.

## Cadence

`character-mercenary-dens` bumped from every 6h to hourly (`30 * * * *`) per the stage doc's recommendation — a 6h-late ping eats a real chunk of a 1–1.5 day timer, and the pull is one listing + one detail per den at single-digit dens per character. `test/schedule.test.ts` pins the new cron shape.

## Verification

- `pnpm test` (128 pass, incl. the new seam tests), `pnpm run lint`, `pnpm run build` all green.
- First-observation rule covered: a den first seen mid-reinforcement still pings; a vanished den's pending rows are deliberately left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014saqfgmtTJk7SgtkLbi3F7

---
_Generated by [Claude Code](https://claude.ai/code/session_014saqfgmtTJk7SgtkLbi3F7)_