### PR TITLE
Add Lenses: shared GraphQL queries in the creator's context (sharing phase 7)

### DIFF
--- a/docs/sharing-layer/07-lens.md
+++ b/docs/sharing-layer/07-lens.md
@@ -1,6 +1,18 @@
 # Phase 7: Lenses — shared queries in the creator's context
 
-**Status: not started.**
+**Status: ✅ done** — migration `20260806130000_lens.sql`, `/lens` editor
+(flag `lens`), `/lens/[id]` viewer, `/lens/[id]/csv`, `runLens` over
+`contextForUser()` (factored out of `src/app/api/graphql/context.ts`),
+save-time validation in `src/app/lens/validate.ts`, CSV flattening in
+`src/app/lens/flatten.ts`; covered by `test/lensValidate.test.ts`,
+`test/lensFlatten.test.ts`, `test/sql/lens.sql`. One deviation from the
+sketch below, found while building: because the lens row IS the share row,
+the Revision 3 "empty audience = public" reading would have made a freshly
+created lens public — the table carries a `shared boolean not null default
+false` that gates the audience-read policy, keeping "not shared yet"
+distinct from "shared with everyone" (the no-row state the sibling share
+tables get for free). The CSV route is `/lens/[id]/csv` (a path segment,
+not `?format=csv`).
 
 A **Lens** is a saved GraphQL query a user creates, then shares with the
 same audience granularity as any asset share — corporation list, alliance
@@ -30,6 +42,10 @@ create table public.lens (
   name text not null,
   query text not null,
   variables jsonb not null default '{}',
+  -- As built: the lens row doubles as its share row, so this flag keeps a
+  -- freshly created (never-shared) lens out of the empty-audience-is-public
+  -- reading. The audience policy requires it.
+  shared boolean not null default false,
   corporation_ids bigint[] not null default '{}',
   alliance_ids bigint[] not null default '{}',
   secret text,

--- a/docs/sharing-layer/README.md
+++ b/docs/sharing-layer/README.md
@@ -88,7 +88,7 @@ The ordering runs safest-first:
 | [04-graphql-shared.md](04-graphql-shared.md)                     | Shared rows in GraphQL — session mode only, current views only, opt-in                                                                            | ✅ **Done** — `assets(includeShared:)` + `sharedWithMe`                                   |
 | [05-supersede-fittings.md](05-supersede-fittings.md)             | Fold `character_fitting_share` into the unified audience model, keep the fitting page UI                                                          | ✅ **Done** — migration `20260805130000`, `test/sql/fitting_share.sql`                    |
 | [06-supersede-mercenary-dens.md](06-supersede-mercenary-dens.md) | Fold `character_mercenary_den_share` into the unified model                                                                                       | ✅ **Done** — migration `20260806000000`, `test/sql/den_share.sql`                        |
-| [07-lens.md](07-lens.md)                                         | Lenses: shared GraphQL queries under the creator's context, CSV rendering to supersede the Sheets endpoints; `/lens` editor behind a feature flag | after 04 (05/06 not required)                                                             |
+| [07-lens.md](07-lens.md)                                         | Lenses: shared GraphQL queries under the creator's context, CSV rendering to supersede the Sheets endpoints; `/lens` editor behind a feature flag | ✅ **Done** — migration `20260806130000`, `test/sql/lens.sql`                            |
 
 ## What already exists (build on this, don't reinvent it)
 

--- a/schema.sql
+++ b/schema.sql
@@ -110,6 +110,7 @@ drop table if exists public.watched_system       cascade;
 drop table if exists public.user_settings        cascade;
 drop table if exists public.refresh_task         cascade;
 drop table if exists public.shared_asset_token   cascade;
+drop table if exists public.lens                 cascade;
 drop table if exists public.discord_link_code    cascade;
 drop table if exists public.notification         cascade;
 drop table if exists public.discord_channel      cascade;
@@ -2050,6 +2051,62 @@ create policy "Audience reads shared assets"
 -- rows a public share covers (the owner policy never matches a null uid).
 grant select on public.character_asset_over_time to anon;
 grant select on public.character_asset           to anon;
+
+-- ── lens ───────────────────────────────────────────────────────────────────
+-- Sharing layer Revision 3, phase 7 (docs/sharing-layer/07-lens.md). A Lens is
+-- a saved GraphQL query that runs under the CREATOR's security context when a
+-- viewer opens it — the viewer receives results, never access. Shared with the
+-- standard Revision 3 audience row (corporation_ids / alliance_ids / secret;
+-- fully public = the row that names no one), and user_id-keyed rather than
+-- registration-keyed because a Lens spans all the creator's registrations the
+-- way their GraphQL context does.
+--
+-- The audience-read policy exposes the row — including the query text — to the
+-- audience: discovery is the point, and the query IS what they may run. The
+-- secret rides along like on every share table; harmless by design, since a
+-- URL token is an HMAC keyed by secret AND the env-only TOKEN_SALT.
+create table public.lens (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  name text not null,
+  query text not null,
+  variables jsonb not null default '{}',
+  -- Unlike the sibling share tables, the lens row IS the share row — so the
+  -- Revision 3 "empty audience = public" reading would make a freshly created
+  -- lens public by default. `shared` keeps "not shared yet" (the no-row state
+  -- the other tables get for free) distinct from "shared with everyone".
+  shared boolean not null default false,
+  corporation_ids bigint[] not null default '{}',
+  alliance_ids bigint[] not null default '{}',
+  secret text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index lens_user_id_idx on public.lens (user_id);
+
+alter table public.lens enable row level security;
+
+-- Owner manages their lenses outright (the shared_asset_token FOR ALL shape —
+-- the owner is a user, not a registration, so the predicate is direct).
+create policy "Users manage own lenses"
+  on public.lens
+  for all
+  to authenticated
+  using (user_id = (select auth.uid()))
+  with check (user_id = (select auth.uid()));
+
+-- Audience discovery, the load-bearing array/anon policy every Revision 3
+-- share table carries. Link-only lenses match no one under RLS — the signed
+-- ?share= link is resolved at the app layer.
+create policy "Audience reads lenses aimed at them"
+  on public.lens
+  for select
+  to anon, authenticated
+  using (shared and public.share_audience_matches(corporation_ids, alliance_ids, secret));
+
+grant select                         on public.lens to anon;
+grant select, insert, update, delete on public.lens to authenticated;
+grant all                            on public.lens to service_role;
 
 -- ── character_clone_state ──────────────────────────────────────────────────
 -- Character-level fields from ESI /characters/{id}/clones/, written by the

--- a/src/app/api/graphql/context.ts
+++ b/src/app/api/graphql/context.ts
@@ -4,6 +4,7 @@ import { GraphQLError } from 'graphql'
 import { GRAPHQL_FLAG, hasFlag } from '@/flags'
 import { resolvePlayer } from '@/utils/apiToken'
 import { createClient } from '@/utils/supabase/server'
+import { createServiceClient } from '@/utils/supabase/service'
 
 // The per-request context every resolver receives. Two auth modes share it:
 //
@@ -28,6 +29,39 @@ export type GraphqlContext = {
 const deny = (message: string, status: number): never => {
   throw new GraphQLError(message, { extensions: { http: { status } } })
 }
+
+// The context for a given user on a given client — the tail every entry point
+// shares once auth has produced a (client, userId) pair. Owner names come from
+// the user's own registration rows, scoped by user_id here rather than through
+// fetchOwners, whose unscoped registration select would return every user's
+// characters under the service client.
+const contextFor = async (
+  supabase: SupabaseClient,
+  mode: GraphqlContext['mode'],
+  userId: string
+): Promise<GraphqlContext> => {
+  const { data: registrations, error } = await supabase.from('registration').select('id, name').eq('user_id', userId)
+  if (error) deny('Lookup failed', 500)
+
+  const rows = (registrations ?? []) as Array<{ id: string; name: string }>
+  return {
+    supabase,
+    mode,
+    userId,
+    registrationIds: rows.map((r) => r.id),
+    ownerNameById: new Map(rows.map((r) => [r.id, r.name])),
+  }
+}
+
+// A user's GraphQL context outside any request auth: the service client plus
+// their registrations — what api_token mode builds, minus the token lookup.
+// This is how a Lens (docs/sharing-layer/07-lens.md) runs a stored query
+// under its CREATOR's security context: mode 'token' means the session-only
+// surfaces (includeShared/sharedWithMe) reject exactly as they do for Bearer
+// callers, and the resolvers' leak-guard .in('registration_id', …) is the
+// barrier. Callers must have authorized the viewer BEFORE building this.
+export const contextForUser = (userId: string): Promise<GraphqlContext> =>
+  contextFor(createServiceClient(), 'token', userId)
 
 export const buildContext = async (request: Request): Promise<GraphqlContext> => {
   const authorization = request.headers.get('authorization') ?? ''
@@ -55,21 +89,5 @@ export const buildContext = async (request: Request): Promise<GraphqlContext> =>
     deny('The GraphQL API is not enabled for this account.', 403)
   }
 
-  // Owner names come from the user's own registration rows — scoped by user_id
-  // here rather than through fetchOwners, whose unscoped registration select
-  // would return every user's characters under the service client.
-  const { data: registrations, error: registrationError } = await supabase
-    .from('registration')
-    .select('id, name')
-    .eq('user_id', userId)
-  if (registrationError) deny('Lookup failed', 500)
-
-  const rows = (registrations ?? []) as Array<{ id: string; name: string }>
-  return {
-    supabase,
-    mode,
-    userId,
-    registrationIds: rows.map((r) => r.id),
-    ownerNameById: new Map(rows.map((r) => [r.id, r.name])),
-  }
+  return contextFor(supabase, mode, userId)
 }

--- a/src/app/asset/shareDialog.tsx
+++ b/src/app/asset/shareDialog.tsx
@@ -18,6 +18,9 @@ type ShareDialogProps = {
   // dialog drive asset AND fitting shares.
   save: (input: SaveShareInput) => Promise<SaveShareResult>
   revoke: () => Promise<{ error?: string }>
+  // Overrides the what-sharing-means line for subjects that aren't a
+  // container of items (a lens shares query results, not an item tree).
+  hint?: string
 }
 
 // The Share button + native <dialog> editor over a subject's single share row
@@ -30,6 +33,7 @@ export const ShareDialog = ({
   data,
   save: saveAction,
   revoke: revokeAction,
+  hint,
 }: ShareDialogProps) => {
   const ref = useRef<HTMLDialogElement>(null)
   const [share, setShare] = useState<ShareState | null>(data.share)
@@ -99,7 +103,7 @@ export const ShareDialog = ({
       <dialog ref={ref} className={styles.dialog}>
         <h2>Share this {subjectLabel}</h2>
         <p className={styles.hint}>
-          Whoever you share with can see this item and everything inside it, live, until you stop sharing.
+          {hint ?? 'Whoever you share with can see this item and everything inside it, live, until you stop sharing.'}
         </p>
 
         <label className={styles.publicRow}>

--- a/src/app/lens/[id]/csv/route.ts
+++ b/src/app/lens/[id]/csv/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { toCsv } from '@/utils/csv'
+import { resolveLens } from '../../access'
+import { lensRows } from '../../flatten'
+import { runLens } from '../../run'
+
+// The Lens CSV rendering (docs/sharing-layer/07-lens.md): the lens's single
+// top-level field flattened to rows for Google Sheets =IMPORTDATA(). Same
+// authorization as the viewer page — the session cookie when there is one,
+// otherwise the signed ?share= param, which is what Sheets uses (it carries
+// no cookie). This is the surface positioned to supersede the bespoke
+// api_token CSV endpoints once lenses reach parity.
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+export const GET = async (
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> => {
+  const { id } = await params
+  const { searchParams } = new URL(request.url)
+  const share = searchParams.get('share')?.trim() || undefined
+
+  const resolved = await resolveLens(id, share)
+  if (!resolved) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  const result = await runLens(resolved.lens)
+  if (result.errors.length > 0 && result.data == null) {
+    return NextResponse.json({ error: result.errors.join(' — ') }, { status: 500 })
+  }
+
+  return new NextResponse(toCsv(lensRows(result.data)), {
+    headers: { 'content-type': 'text/csv; charset=utf-8' },
+  })
+}

--- a/src/app/lens/[id]/page.tsx
+++ b/src/app/lens/[id]/page.tsx
@@ -1,0 +1,81 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+import { resolveLens } from '../access'
+import { lensRows } from '../flatten'
+import { runLens } from '../run'
+import styles from '../lens.module.css'
+
+// The Lens viewer (docs/sharing-layer/07-lens.md): runs the stored query
+// under its CREATOR's security context and shows the result to anyone the
+// lens is shared with — RLS decides for signed-in audiences (corporation/
+// alliance/public), a signed ?share= link for everyone else, including
+// signed-out. The viewer receives results, never access.
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+const LensViewerPage = async ({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>
+  searchParams: Promise<{ share?: string }>
+}) => {
+  const { id } = await params
+  const { share } = await searchParams
+
+  const resolved = await resolveLens(id, share)
+  if (!resolved) notFound()
+  const { lens, viewerIsOwner } = resolved
+
+  const result = await runLens(lens)
+  const rows = lensRows(result.data)
+  const headers = rows.length > 0 ? Object.keys(rows[0]) : []
+  const csvHref = `/lens/${lens.id}/csv${share ? `?share=${encodeURIComponent(share)}` : ''}`
+
+  return (
+    <>
+      <div className={styles.lensHeading}>
+        <h1>{lens.name}</h1>
+        <div className={styles.buttons}>
+          <a href={csvHref}>CSV</a>
+          {viewerIsOwner && <Link href="/lens">Edit</Link>}
+        </div>
+      </div>
+
+      {result.errors.length > 0 && <p className={styles.error}>{result.errors.join(' — ')}</p>}
+
+      {rows.length === 0 ? (
+        <p className={styles.note}>No rows.</p>
+      ) : (
+        <div className={styles.tableWrap}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                {headers.map((h) => (
+                  <th key={h}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, i) => (
+                <tr key={i}>
+                  {headers.map((h) => (
+                    <td key={h}>{row[h] == null ? '' : String(row[h])}</td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <details>
+        <summary className={styles.note}>Raw result</summary>
+        <pre className={styles.result}>{JSON.stringify({ data: result.data }, null, 2)}</pre>
+      </details>
+    </>
+  )
+}
+
+export default LensViewerPage

--- a/src/app/lens/access.ts
+++ b/src/app/lens/access.ts
@@ -1,0 +1,59 @@
+// Viewer authorization for /lens/[id] and its CSV route. Two doors, same as
+// every Revision 3 share subject:
+//
+// - RLS: the caller's cookie client reads the lens row directly — the owner
+//   policy or the audience policy (corporation/alliance membership, or a
+//   fully-public shared lens) decides. Works signed-out too: the anon role
+//   reaches only shared-and-public rows.
+// - Signed link: ?share=<lensId>.<signature> verified against the row's
+//   secret + TOKEN_SALT via the service client (an anonymous HTTP request is
+//   invisible to RLS — link-only lenses match no one there by design).
+//
+// Either way the run is gated on the CREATOR still holding the lens flag —
+// un-flagging an account turns its shared lenses off, the dark-launch lever.
+import { LENS_FLAG, hasFlag } from '@/flags'
+import { tokenSalt, verifyShareToken } from '@/shareToken'
+import { createClient } from '@/utils/supabase/server'
+import { createServiceClient } from '@/utils/supabase/service'
+import type { LensRecord } from './run'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export type ResolvedLens = { lens: LensRecord; viewerIsOwner: boolean }
+
+const resolveSignedLens = async (lensId: string, param: string): Promise<LensRecord | null> => {
+  const dot = param.indexOf('.')
+  if (dot <= 0) return null
+  const shareId = param.slice(0, dot)
+  const signature = param.slice(dot + 1)
+  if (shareId !== lensId || signature === '') return null
+
+  let salt: string
+  try {
+    salt = tokenSalt()
+  } catch {
+    return null
+  }
+
+  const service = createServiceClient()
+  const { data: lens } = await service.from('lens').select('*').eq('id', lensId).maybeSingle<LensRecord>()
+  if (!lens || !lens.shared || !lens.secret) return null
+  return verifyShareToken(lens.id, lens.secret, salt, signature) ? lens : null
+}
+
+export const resolveLens = async (lensId: string, shareParam?: string): Promise<ResolvedLens | null> => {
+  if (!UUID_RE.test(lensId)) return null
+
+  const supabase = await createClient()
+  const { data: auth } = await supabase.auth.getUser()
+  const viewerId = auth?.user?.id ?? null
+
+  // RLS is the authority for the membership/public/owner doors.
+  const { data: rlsLens } = await supabase.from('lens').select('*').eq('id', lensId).maybeSingle<LensRecord>()
+
+  const lens = rlsLens ?? (shareParam ? await resolveSignedLens(lensId, shareParam) : null)
+  if (!lens) return null
+  if (!(await hasFlag(lens.user_id, LENS_FLAG))) return null
+
+  return { lens, viewerIsOwner: viewerId !== null && viewerId === lens.user_id }
+}

--- a/src/app/lens/actions.ts
+++ b/src/app/lens/actions.ts
@@ -1,0 +1,191 @@
+'use server'
+
+import { graphql } from 'graphql'
+import { revalidatePath } from 'next/cache'
+
+import { contextForUser } from '@/app/api/graphql/context'
+import { schema } from '@/app/api/graphql/schema'
+import type { SaveShareInput, SaveShareResult } from '@/app/asset/shareActions'
+import { LENS_FLAG, hasFlag } from '@/flags'
+import { mintShareSecret, signShare, tokenSalt } from '@/shareToken'
+import { createClient } from '@/utils/supabase/server'
+import { parseLensVariables, validateLensQuery } from './validate'
+
+// Server actions behind the /lens editor (docs/sharing-layer/07-lens.md).
+// Cookie-session client throughout, like every share writer: RLS pins lens
+// rows to their owner. Everything here is additionally gated on the caller's
+// own lens flag — the editor is dark-launched.
+
+const flaggedUser = async (supabase: Awaited<ReturnType<typeof createClient>>): Promise<string | null> => {
+  const { data: auth, error } = await supabase.auth.getUser()
+  if (error || !auth?.user) return null
+  return (await hasFlag(auth.user.id, LENS_FLAG)) ? auth.user.id : null
+}
+
+export type SaveLensInput = { name: string; query: string; variables: string }
+export type SaveLensResult = { error?: string; id?: string }
+
+export const saveLens = async (lensId: string | null, input: SaveLensInput): Promise<SaveLensResult> => {
+  const supabase = await createClient()
+  const userId = await flaggedUser(supabase)
+  if (!userId) return { error: 'Not available' }
+
+  const name = input.name.trim()
+  if (name === '') return { error: 'Give the lens a name.' }
+
+  const validation = validateLensQuery(input.query)
+  if (!validation.ok) return { error: validation.message }
+  const variables = parseLensVariables(input.variables)
+  if (!variables.ok) return { error: variables.message }
+
+  // RLS pins both branches to the caller: with check on insert, using on the
+  // update's row match (a foreign id simply updates nothing).
+  const row = { name, query: input.query, variables: variables.variables, updated_at: new Date().toISOString() }
+  const { data: saved, error } = lensId
+    ? await supabase.from('lens').update(row).eq('id', lensId).eq('user_id', userId).select('id').maybeSingle()
+    : await supabase
+        .from('lens')
+        .insert({ ...row, user_id: userId })
+        .select('id')
+        .maybeSingle()
+  if (error || !saved) return { error: error?.message ?? 'Save failed' }
+
+  revalidatePath('/lens')
+  revalidatePath(`/lens/${saved.id}`)
+  return { id: saved.id as string }
+}
+
+export const deleteLens = async (lensId: string): Promise<{ error?: string }> => {
+  const supabase = await createClient()
+  const userId = await flaggedUser(supabase)
+  if (!userId) return { error: 'Not available' }
+
+  const { error } = await supabase.from('lens').delete().eq('id', lensId).eq('user_id', userId)
+  if (error) return { error: error.message }
+  revalidatePath('/lens')
+  return {}
+}
+
+// Run-as-me preview for the editor: validates, then executes under the
+// CALLER's own context — the same result the audience will see, since the
+// caller is the creator. Doesn't require the graphql flag: the lens flag is
+// the editor's gate.
+export const previewLens = async (input: {
+  query: string
+  variables: string
+}): Promise<{ error?: string; result?: string }> => {
+  const supabase = await createClient()
+  const userId = await flaggedUser(supabase)
+  if (!userId) return { error: 'Not available' }
+
+  const validation = validateLensQuery(input.query)
+  if (!validation.ok) return { error: validation.message }
+  const variables = parseLensVariables(input.variables)
+  if (!variables.ok) return { error: variables.message }
+
+  const contextValue = await contextForUser(userId)
+  const result = await graphql({ schema, source: input.query, variableValues: variables.variables, contextValue })
+  return {
+    result: JSON.stringify({ data: result.data ?? null, errors: result.errors?.map((e) => e.message) }, null, 2),
+  }
+}
+
+// The audience side, driven by the shared ShareDialog. The lens row IS the
+// share row, so save/revoke toggle its `shared` flag and audience columns
+// rather than upserting a sibling row. Requested audience ids are filtered to
+// ones the caller actually has (the setSharedAlliances defense).
+const ownAudiences = async (supabase: Awaited<ReturnType<typeof createClient>>) => {
+  const { data: regs } = await supabase.from('registration').select('corporation_id')
+  const corpIds = [
+    ...new Set(
+      ((regs ?? []) as Array<{ corporation_id: number | string | null }>)
+        .map((r) => r.corporation_id)
+        .filter((c): c is number => c != null)
+        .map(Number)
+    ),
+  ]
+  const { data: corps } = corpIds.length
+    ? await supabase.from('corporation').select('corporation_id, alliance_id').in('corporation_id', corpIds)
+    : { data: [] }
+  const allianceIds = [
+    ...new Set(
+      ((corps ?? []) as Array<{ alliance_id: number | string | null }>)
+        .map((c) => c.alliance_id)
+        .filter((a): a is number => a != null)
+        .map(Number)
+    ),
+  ]
+  return { ownCorpIds: new Set(corpIds), ownAllianceIds: new Set(allianceIds) }
+}
+
+export const saveLensShare = async (lensId: string, input: SaveShareInput): Promise<SaveShareResult> => {
+  const supabase = await createClient()
+  const userId = await flaggedUser(supabase)
+  if (!userId) return { error: 'Not available' }
+
+  const { data: existing } = await supabase
+    .from('lens')
+    .select('id, secret')
+    .eq('id', lensId)
+    .eq('user_id', userId)
+    .maybeSingle<{ id: string; secret: string | null }>()
+  if (!existing) return { error: 'Not your lens' }
+
+  const own = await ownAudiences(supabase)
+  const corporationIds = input.isPublic
+    ? []
+    : [...new Set(input.corporationIds.map(Number))].filter((id) => own.ownCorpIds.has(id))
+  const allianceIds = input.isPublic
+    ? []
+    : [...new Set(input.allianceIds.map(Number))].filter((id) => own.ownAllianceIds.has(id))
+  const link = input.isPublic ? false : input.link
+
+  let salt: string | null = null
+  if (link) {
+    try {
+      salt = tokenSalt()
+    } catch {
+      return { error: 'Share links are unavailable: TOKEN_SALT is not configured.' }
+    }
+  }
+
+  const secret = link ? (input.rotateLink || !existing.secret ? mintShareSecret() : existing.secret) : null
+
+  const { error } = await supabase
+    .from('lens')
+    .update({ shared: true, corporation_ids: corporationIds, alliance_ids: allianceIds, secret })
+    .eq('id', lensId)
+    .eq('user_id', userId)
+  if (error) return { error: error.message }
+
+  revalidatePath('/lens')
+  revalidatePath(`/lens/${lensId}`)
+
+  return {
+    share: {
+      corporationIds,
+      allianceIds,
+      hasLink: secret != null,
+      shareParam: secret != null && salt != null ? `${lensId}.${signShare(lensId, secret, salt)}` : null,
+      isPublic: secret == null && corporationIds.length === 0 && allianceIds.length === 0,
+    },
+  }
+}
+
+export const revokeLensShare = async (lensId: string): Promise<{ error?: string }> => {
+  const supabase = await createClient()
+  const userId = await flaggedUser(supabase)
+  if (!userId) return { error: 'Not available' }
+
+  // Back to the unshared state — NOT an empty audience, which would be public.
+  const { error } = await supabase
+    .from('lens')
+    .update({ shared: false, corporation_ids: [], alliance_ids: [], secret: null })
+    .eq('id', lensId)
+    .eq('user_id', userId)
+  if (error) return { error: error.message }
+
+  revalidatePath('/lens')
+  revalidatePath(`/lens/${lensId}`)
+  return {}
+}

--- a/src/app/lens/flatten.ts
+++ b/src/app/lens/flatten.ts
@@ -1,0 +1,43 @@
+// Flatten a Lens result to CSV-ready rows (docs/sharing-layer/07-lens.md).
+// The validator guarantees exactly one top-level field, so the "primary list"
+// is unambiguous: the root value itself when it's a list (marketOrders,
+// walletBalances, …), its `rows` list when it's a page object (assets,
+// blueprints), or the object itself as a single row otherwise. Each row is
+// flattened to one level: scalars kept, nested objects dot-pathed, lists of
+// scalars joined — anything deeper is left for toCsv's JSON fallback.
+//
+// Pure module (ramda only) so `node --test` covers it: test/lensFlatten.test.ts.
+import { chain, toPairs } from 'ramda'
+
+type Row = Record<string, unknown>
+
+const isPlainObject = (value: unknown): value is Row =>
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+
+// The rows behind the single root field's value.
+export const primaryRows = (data: unknown): Row[] => {
+  if (data == null) return []
+  const values = isPlainObject(data) ? Object.values(data) : []
+  if (values.length !== 1) return []
+  const [value] = values
+  if (Array.isArray(value)) return value.filter(isPlainObject)
+  if (isPlainObject(value)) {
+    if (Array.isArray(value.rows)) return (value.rows as unknown[]).filter(isPlainObject)
+    return [value]
+  }
+  return []
+}
+
+const flattenEntry = ([key, value]: [string, unknown]): Array<[string, unknown]> => {
+  if (isPlainObject(value)) {
+    return toPairs(value).map(([nested, nestedValue]): [string, unknown] => [`${key}.${nested}`, nestedValue])
+  }
+  if (Array.isArray(value) && value.every((v) => v === null || typeof v !== 'object')) {
+    return [[key, value.map((v) => (v == null ? '' : String(v))).join(', ')]]
+  }
+  return [[key, value]]
+}
+
+export const flattenRow = (row: Row): Row => Object.fromEntries(chain(flattenEntry, toPairs(row)))
+
+export const lensRows = (data: unknown): Row[] => primaryRows(data).map(flattenRow)

--- a/src/app/lens/lens.module.css
+++ b/src/app/lens/lens.module.css
@@ -1,0 +1,97 @@
+.editor {
+  display: flex;
+  flex-direction: column;
+  gap: 8pt;
+  margin-top: 8pt;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 2pt;
+  font-size: 9pt;
+  color: var(--ink-soft);
+}
+
+.name {
+  font-size: 10pt;
+  color: var(--ink);
+  background: var(--paper-raised);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 4pt 8pt;
+  max-width: 24em;
+}
+
+.query,
+.variables {
+  font-family: var(--mono);
+  font-size: 10pt;
+  color: var(--ink);
+  background: var(--paper-raised);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 6pt 8pt;
+  resize: vertical;
+}
+
+.result {
+  font-family: var(--mono);
+  font-size: 9pt;
+  background: var(--paper-raised);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 6pt 8pt;
+  overflow-x: auto;
+  white-space: pre;
+  max-height: 32em;
+  overflow-y: auto;
+}
+
+.buttons {
+  display: flex;
+  gap: 6pt;
+  align-items: center;
+}
+
+.error {
+  color: var(--danger, #c33);
+  font-size: 9pt;
+}
+
+.lens {
+  margin-top: 16pt;
+  padding-top: 8pt;
+  border-top: 1px solid var(--line);
+}
+
+.lensHeading {
+  display: flex;
+  gap: 8pt;
+  align-items: baseline;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.note {
+  font-size: 9pt;
+  color: var(--ink-soft);
+}
+
+.table {
+  border-collapse: collapse;
+  font-size: 9pt;
+}
+
+.table th,
+.table td {
+  border: 1px solid var(--line);
+  padding: 3pt 6pt;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.tableWrap {
+  overflow-x: auto;
+  margin-top: 8pt;
+}

--- a/src/app/lens/lensEditor.tsx
+++ b/src/app/lens/lensEditor.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useState, useTransition } from 'react'
+
+import { deleteLens, previewLens, saveLens } from './actions'
+import styles from './lens.module.css'
+
+const DEFAULT_QUERY = `{
+  assets(typeName: "Tritanium") {
+    totalCount
+    rows {
+      typeName
+      quantity
+      locationName
+      ownerName
+    }
+  }
+}`
+
+type LensEditorProps = {
+  // null = the create-new editor; otherwise the lens being edited.
+  lens: { id: string; name: string; query: string; variables: string } | null
+}
+
+// Create/edit form for one lens: name, query, fixed variables, a run-as-me
+// preview (server action under the caller's own context — the same result the
+// audience will see), save, and delete. Sharing lives in the ShareDialog the
+// server component renders beside this.
+export const LensEditor = ({ lens }: LensEditorProps) => {
+  const router = useRouter()
+  const [open, setOpen] = useState(lens === null)
+  const [name, setName] = useState(lens?.name ?? '')
+  const [query, setQuery] = useState(lens?.query ?? DEFAULT_QUERY)
+  const [variables, setVariables] = useState(lens?.variables ?? '')
+  const [result, setResult] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [pending, startTransition] = useTransition()
+
+  const save = () =>
+    startTransition(async () => {
+      setError(null)
+      const saved = await saveLens(lens?.id ?? null, { name, query, variables })
+      if (saved.error) setError(saved.error)
+      else {
+        if (lens === null) {
+          setName('')
+          setQuery(DEFAULT_QUERY)
+          setVariables('')
+          setResult('')
+          setOpen(false)
+        }
+        router.refresh()
+      }
+    })
+
+  const preview = () =>
+    startTransition(async () => {
+      setError(null)
+      const ran = await previewLens({ query, variables })
+      if (ran.error) setError(ran.error)
+      else setResult(ran.result ?? '')
+    })
+
+  const remove = () =>
+    startTransition(async () => {
+      setError(null)
+      const removed = await deleteLens(lens!.id)
+      if (removed.error) setError(removed.error)
+      else router.refresh()
+    })
+
+  if (!open) {
+    return (
+      <button type="button" onClick={() => setOpen(true)}>
+        {lens === null ? 'New lens' : 'Edit'}
+      </button>
+    )
+  }
+
+  return (
+    <div className={styles.editor}>
+      <label className={styles.field}>
+        Name
+        <input className={styles.name} value={name} onChange={(e) => setName(e.target.value)} />
+      </label>
+      <label className={styles.field}>
+        Query (one top-level field)
+        <textarea
+          className={styles.query}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          rows={12}
+          spellCheck={false}
+        />
+      </label>
+      <label className={styles.field}>
+        Variables (JSON, fixed — viewers can&apos;t change them)
+        <textarea
+          className={styles.variables}
+          value={variables}
+          onChange={(e) => setVariables(e.target.value)}
+          rows={2}
+          spellCheck={false}
+        />
+      </label>
+      <div className={styles.buttons}>
+        <button type="button" onClick={save} disabled={pending || name.trim() === '' || query.trim() === ''}>
+          {pending ? 'Working…' : 'Save'}
+        </button>
+        <button type="button" onClick={preview} disabled={pending || query.trim() === ''}>
+          Preview
+        </button>
+        {lens !== null && (
+          <>
+            <button type="button" onClick={remove} disabled={pending}>
+              Delete
+            </button>
+            <button type="button" onClick={() => setOpen(false)} disabled={pending}>
+              Close
+            </button>
+          </>
+        )}
+      </div>
+      {error && <p className={styles.error}>{error}</p>}
+      {result !== '' && <pre className={styles.result}>{result}</pre>}
+    </div>
+  )
+}

--- a/src/app/lens/page.tsx
+++ b/src/app/lens/page.tsx
@@ -1,0 +1,85 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+
+import { ShareDialog } from '@/app/asset/shareDialog'
+import { fetchShareAudiences, shareRowToState, type OwnRegistration } from '@/app/asset/shareData'
+import { LENS_FLAG, hasFlag } from '@/flags'
+import { createClient } from '@/utils/supabase/server'
+import { revokeLensShare, saveLensShare } from './actions'
+import { LensEditor } from './lensEditor'
+import type { LensRecord } from './run'
+import styles from './lens.module.css'
+
+// Dark-launched Lens editor (docs/sharing-layer/07-lens.md; no nav link):
+// saved GraphQL queries that run under YOUR context when someone you shared
+// them with opens them. Gated on the per-account `lens` flag, the same
+// gate-and-redirect shape as /graphql.
+export const dynamic = 'force-dynamic'
+
+const LensPage = async () => {
+  const supabase = await createClient()
+
+  const { data: auth, error } = await supabase.auth.getUser()
+  if (error || !auth?.user) {
+    redirect('/account/login')
+  }
+  if (!(await hasFlag(auth.user.id, LENS_FLAG))) {
+    redirect('/')
+  }
+
+  // RLS also shows lenses others shared with the caller; the editor lists
+  // only their own.
+  const [{ data: lensRows }, { data: regs }] = await Promise.all([
+    supabase.from('lens').select('*').eq('user_id', auth.user.id).order('created_at'),
+    supabase.from('registration').select('id, corporation_id'),
+  ])
+  const lenses = (lensRows ?? []) as LensRecord[]
+  const audiences = await fetchShareAudiences(supabase, (regs ?? []) as OwnRegistration[])
+
+  return (
+    <>
+      <h1>Lenses</h1>
+      <p>
+        A lens is a saved GraphQL query over your data that you can share like any other share — with corporations,
+        alliances, a link, or publicly. Whoever opens it sees <em>your</em> results (they never gain access beyond the
+        query), and every lens also renders as CSV for spreadsheets.
+      </p>
+
+      <LensEditor lens={null} />
+
+      {lenses.map((lens) => (
+        <section key={lens.id} className={styles.lens}>
+          <div className={styles.lensHeading}>
+            <h2>
+              <Link href={`/lens/${lens.id}`}>{lens.name}</Link>
+            </h2>
+            <ShareDialog
+              subjectLabel="lens"
+              urlPath={`/lens/${lens.id}`}
+              hint="Whoever you share with can run this query and see its results — your data, live — until you stop sharing."
+              data={{
+                share: lens.shared ? shareRowToState(lens) : null,
+                corporations: audiences.corporations,
+                alliances: audiences.alliances,
+                hasLegacyToken: false,
+              }}
+              save={saveLensShare.bind(null, lens.id)}
+              revoke={revokeLensShare.bind(null, lens.id)}
+            />
+          </div>
+          <LensEditor
+            lens={{
+              id: lens.id,
+              name: lens.name,
+              query: lens.query,
+              variables:
+                lens.variables && Object.keys(lens.variables).length > 0 ? JSON.stringify(lens.variables, null, 2) : '',
+            }}
+          />
+        </section>
+      ))}
+    </>
+  )
+}
+
+export default LensPage

--- a/src/app/lens/run.ts
+++ b/src/app/lens/run.ts
@@ -1,0 +1,36 @@
+// Execute a Lens: the stored query, in-process against the /api/graphql
+// executable schema, under the CREATOR's context (docs/sharing-layer/07-lens.md).
+// No HTTP hop and no flag check here — callers authorize the viewer (see
+// access.ts) before running. Mode 'token' on the creator context means the
+// session-only surfaces reject exactly as they do for Bearer callers, and the
+// resolvers' leak-guard .in('registration_id', …) is the barrier.
+import { graphql } from 'graphql'
+
+import { contextForUser } from '@/app/api/graphql/context'
+import { schema } from '@/app/api/graphql/schema'
+
+export type LensRecord = {
+  id: string
+  user_id: string
+  name: string
+  query: string
+  variables: Record<string, unknown>
+  shared: boolean
+  corporation_ids: number[] | null
+  alliance_ids: number[] | null
+  secret: string | null
+  updated_at: string
+}
+
+export type LensResult = { data: unknown; errors: string[] }
+
+export const runLens = async (lens: Pick<LensRecord, 'user_id' | 'query' | 'variables'>): Promise<LensResult> => {
+  const contextValue = await contextForUser(lens.user_id)
+  const result = await graphql({
+    schema,
+    source: lens.query,
+    variableValues: lens.variables ?? {},
+    contextValue,
+  })
+  return { data: result.data ?? null, errors: (result.errors ?? []).map((e) => e.message) }
+}

--- a/src/app/lens/validate.ts
+++ b/src/app/lens/validate.ts
@@ -1,0 +1,104 @@
+// Save-time validation for a Lens query (docs/sharing-layer/07-lens.md). A
+// Lens runs its stored query under the CREATOR's context whenever a viewer
+// opens it, so everything that can be rejected is rejected when the creator
+// saves, not when a viewer runs:
+//
+// - it must parse and validate against the /api/graphql schema (built here
+//   from the SDL with the plain `graphql` reference implementation — never
+//   the executable schema, whose resolvers drag in Next/Supabase and would
+//   sink the node test runner);
+// - it must be a single query operation with exactly ONE top-level field, so
+//   the CSV rendering's "primary list" is unambiguous;
+// - it must not touch the session-only surfaces (`sharedWithMe`,
+//   `includeShared:`): a Lens executes in token mode where those reject at
+//   run time anyway, but failing at save time is a clear message instead of a
+//   broken share.
+//
+// Pure module: `graphql` + the SDL only (relative .ts import so `node --test`
+// can load it — see test/lensValidate.test.ts).
+import { buildSchema, parse, validate, visit, Kind, type DocumentNode } from 'graphql'
+
+import { typeDefs } from '../api/graphql/schema.graphql.ts'
+
+// Root fields and argument names that only make sense on a cookie session.
+// Extend in lockstep with requireSession call sites in resolvers.ts.
+export const SESSION_ONLY_FIELDS = ['sharedWithMe']
+export const SESSION_ONLY_ARGUMENTS = ['includeShared']
+
+export type LensValidation = { ok: true } | { ok: false; message: string }
+
+const invalid = (message: string): LensValidation => ({ ok: false, message })
+
+const schema = buildSchema(typeDefs)
+
+const sessionOnlyUse = (document: DocumentNode): string | null => {
+  let found: string | null = null
+  visit(document, {
+    [Kind.FIELD]: (node) => {
+      if (found === null && SESSION_ONLY_FIELDS.includes(node.name.value)) {
+        found = `the "${node.name.value}" field`
+      }
+    },
+    [Kind.ARGUMENT]: (node) => {
+      if (found === null && SESSION_ONLY_ARGUMENTS.includes(node.name.value)) {
+        found = `the "${node.name.value}" argument`
+      }
+    },
+  })
+  return found
+}
+
+export const validateLensQuery = (query: string): LensValidation => {
+  let document: DocumentNode
+  try {
+    document = parse(query)
+  } catch (e) {
+    return invalid(`The query does not parse: ${e instanceof Error ? e.message : String(e)}`)
+  }
+
+  const operations = document.definitions.filter((d) => d.kind === Kind.OPERATION_DEFINITION)
+  if (operations.length !== 1) {
+    return invalid('A lens holds exactly one operation.')
+  }
+  const [operation] = operations
+  if (operation.operation !== 'query') {
+    return invalid('A lens must be a query operation.')
+  }
+
+  const errors = validate(schema, document)
+  if (errors.length > 0) {
+    return invalid(`The query is not valid against the schema: ${errors[0].message}`)
+  }
+
+  const topLevel = operation.selectionSet.selections.filter((s) => s.kind === Kind.FIELD)
+  if (operation.selectionSet.selections.length !== topLevel.length || topLevel.length !== 1) {
+    return invalid('A lens selects exactly one top-level field, so its CSV rendering is unambiguous.')
+  }
+
+  const sessionOnly = sessionOnlyUse(document)
+  if (sessionOnly !== null) {
+    return invalid(
+      `A lens cannot use ${sessionOnly} — that surface is session-only. A lens already runs in its creator's context.`
+    )
+  }
+
+  return { ok: true }
+}
+
+// The stored variables must be a JSON object (fixed by the creator at save
+// time; viewers never supply variables).
+export const parseLensVariables = (
+  raw: string
+): { ok: true; variables: Record<string, unknown> } | { ok: false; message: string } => {
+  const trimmed = raw.trim()
+  if (trimmed === '') return { ok: true, variables: {} }
+  try {
+    const parsed = JSON.parse(trimmed)
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return { ok: false, message: 'Variables must be a JSON object, e.g. { "item": "Tritanium" }' }
+    }
+    return { ok: true, variables: parsed as Record<string, unknown> }
+  } catch {
+    return { ok: false, message: 'Variables must be a JSON object, e.g. { "item": "Tritanium" }' }
+  }
+}

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -2,6 +2,7 @@ import { createServiceClient } from '@/utils/supabase/service'
 
 // Dark-launch flag names live here so callers can't typo them apart.
 export const GRAPHQL_FLAG = 'graphql'
+export const LENS_FLAG = 'lens'
 
 // user_settings.flags is the per-user dark-launch flag list (see the
 // add_user_settings_flags migration, whose comment points at this module).

--- a/supabase/migrations/20260806130000_lens.sql
+++ b/supabase/migrations/20260806130000_lens.sql
@@ -1,0 +1,54 @@
+-- Phase 7 of the sharing layer's Revision 3 (docs/sharing-layer/07-lens.md):
+-- the lens table. A Lens is a saved GraphQL query that runs under the
+-- CREATOR's security context when a viewer opens it — the viewer receives
+-- results, never access. Shared with the standard Revision 3 audience row
+-- (corporation_ids / alliance_ids / secret; fully public = the row that names
+-- no one), and user_id-keyed rather than registration-keyed because a Lens
+-- spans all the creator's registrations the way their GraphQL context does.
+--
+-- The audience-read policy exposes the row — including the query text — to
+-- the audience: discovery is the point, and the query IS what they may run.
+-- The secret rides along like on every share table; harmless by design, since
+-- a URL token is an HMAC keyed by secret AND the env-only TOKEN_SALT.
+create table public.lens (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  name text not null,
+  query text not null,
+  variables jsonb not null default '{}',
+  -- Unlike the sibling share tables, the lens row IS the share row — so the
+  -- Revision 3 "empty audience = public" reading would make a freshly created
+  -- lens public by default. `shared` keeps "not shared yet" (the no-row state
+  -- the other tables get for free) distinct from "shared with everyone".
+  shared boolean not null default false,
+  corporation_ids bigint[] not null default '{}',
+  alliance_ids bigint[] not null default '{}',
+  secret text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index lens_user_id_idx on public.lens (user_id);
+
+alter table public.lens enable row level security;
+
+-- Owner manages their lenses outright (the shared_asset_token FOR ALL shape —
+-- the owner is a user, not a registration, so the predicate is direct).
+create policy "Users manage own lenses"
+  on public.lens
+  for all
+  to authenticated
+  using (user_id = (select auth.uid()))
+  with check (user_id = (select auth.uid()));
+
+-- Audience discovery, the load-bearing array/anon policy every Revision 3
+-- share table carries. Link-only lenses match no one under RLS — the signed
+-- ?share= link is resolved at the app layer.
+create policy "Audience reads lenses aimed at them"
+  on public.lens
+  for select
+  to anon, authenticated
+  using (shared and public.share_audience_matches(corporation_ids, alliance_ids, secret));
+
+grant select                         on public.lens to anon;
+grant select, insert, update, delete on public.lens to authenticated;
+grant all                            on public.lens to service_role;

--- a/test/lensFlatten.test.ts
+++ b/test/lensFlatten.test.ts
@@ -1,0 +1,56 @@
+// CSV flattening for Lens results (src/app/lens/flatten.ts): primary-list
+// discovery under the one-top-level-field guarantee, and one-level row
+// flattening (dot-pathed nested objects, joined scalar lists).
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { flattenRow, lensRows, primaryRows } from '../src/app/lens/flatten.ts'
+
+test('a root list field is the primary list', () => {
+  const data = {
+    walletBalances: [
+      { ownerName: 'A', balance: 1 },
+      { ownerName: 'B', balance: 2 },
+    ],
+  }
+  assert.deepEqual(primaryRows(data), data.walletBalances)
+})
+
+test('a page object yields its rows list', () => {
+  const data = { assets: { totalCount: 2, truncated: false, rows: [{ typeName: 'Tritanium', quantity: '5' }] } }
+  assert.deepEqual(primaryRows(data), [{ typeName: 'Tritanium', quantity: '5' }])
+})
+
+test('a plain object without rows is a single row', () => {
+  const data = { thing: { a: 1, b: 'x' } }
+  assert.deepEqual(primaryRows(data), [{ a: 1, b: 'x' }])
+})
+
+test('null data and multi-key data yield no rows', () => {
+  assert.deepEqual(primaryRows(null), [])
+  assert.deepEqual(primaryRows({ a: [], b: [] }), [])
+})
+
+test('flattenRow keeps scalars, dot-paths nested objects, joins scalar lists', () => {
+  assert.deepEqual(flattenRow({ a: 1, b: { c: 'x', d: 2 }, e: ['p', 'q', null] }), {
+    a: 1,
+    'b.c': 'x',
+    'b.d': 2,
+    e: 'p, q, ',
+  })
+})
+
+test('lists of objects are left for the CSV JSON fallback', () => {
+  const flat = flattenRow({ items: [{ typeId: 1 }] })
+  assert.deepEqual(flat, { items: [{ typeId: 1 }] })
+})
+
+test('lensRows flattens the primary list end to end', () => {
+  const data = {
+    assets: {
+      totalCount: 1,
+      rows: [{ typeName: 'Tritanium', quantity: '5', owner: { name: 'A' } }],
+    },
+  }
+  assert.deepEqual(lensRows(data), [{ typeName: 'Tritanium', quantity: '5', 'owner.name': 'A' }])
+})

--- a/test/lensValidate.test.ts
+++ b/test/lensValidate.test.ts
@@ -1,0 +1,69 @@
+// Save-time validation for Lens queries (src/app/lens/validate.ts): parse +
+// schema validation, the single-top-level-field rule that keeps the CSV
+// rendering unambiguous, and the session-only denylist.
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { parseLensVariables, validateLensQuery } from '../src/app/lens/validate.ts'
+
+test('a plain single-field query passes', () => {
+  const result = validateLensQuery(`{ walletBalances { ownerName balance } }`)
+  assert.deepEqual(result, { ok: true })
+})
+
+test('a named query with variables passes', () => {
+  const result = validateLensQuery(`query Stockpile($item: String!) {
+    assets(typeName: $item) { totalCount rows { typeName quantity } }
+  }`)
+  assert.deepEqual(result, { ok: true })
+})
+
+test('syntax errors are rejected with a parse message', () => {
+  const result = validateLensQuery(`{ walletBalances {`)
+  assert.equal(result.ok, false)
+  assert.match((result as { message: string }).message, /does not parse/)
+})
+
+test('unknown fields fail schema validation', () => {
+  const result = validateLensQuery(`{ walletHistory { balance } }`)
+  assert.equal(result.ok, false)
+  assert.match((result as { message: string }).message, /not valid against the schema/)
+})
+
+test('two top-level fields are rejected', () => {
+  const result = validateLensQuery(`{
+    walletBalances { balance }
+    marketOrders { price }
+  }`)
+  assert.equal(result.ok, false)
+  assert.match((result as { message: string }).message, /exactly one top-level field/)
+})
+
+test('multiple operations are rejected', () => {
+  const result = validateLensQuery(`query A { walletBalances { balance } } query B { marketOrders { price } }`)
+  assert.equal(result.ok, false)
+  assert.match((result as { message: string }).message, /exactly one operation/)
+})
+
+test('the session-only sharedWithMe field is rejected', () => {
+  const result = validateLensQuery(`{ sharedWithMe { itemId ownerName } }`)
+  assert.equal(result.ok, false)
+  assert.match((result as { message: string }).message, /session-only/)
+})
+
+test('the session-only includeShared argument is rejected', () => {
+  const result = validateLensQuery(`{ assets(includeShared: true) { rows { typeName } } }`)
+  assert.equal(result.ok, false)
+  assert.match((result as { message: string }).message, /session-only/)
+})
+
+test('variables parse to an object, empty string to {}', () => {
+  assert.deepEqual(parseLensVariables(''), { ok: true, variables: {} })
+  assert.deepEqual(parseLensVariables('  { "item": "Tritanium" } '), { ok: true, variables: { item: 'Tritanium' } })
+})
+
+test('non-object variables are rejected', () => {
+  assert.equal(parseLensVariables('[1, 2]').ok, false)
+  assert.equal(parseLensVariables('"x"').ok, false)
+  assert.equal(parseLensVariables('not json').ok, false)
+})

--- a/test/sql/lens.sql
+++ b/test/sql/lens.sql
@@ -1,0 +1,145 @@
+-- SQL-level coverage for the lens migration
+-- (docs/sharing-layer/07-lens.md): owner-only management, the audience-read
+-- policy through share_audience_matches(), and — the lens-specific semantic —
+-- the `shared` gate: because the lens row IS the share row, an UNSHARED lens
+-- must be invisible to everyone but its owner even though its default empty
+-- audience would otherwise read as "public".
+--
+-- Run against a THROWAWAY database from the repo root (same harness as
+-- asset_share.sql): DATABASE_URL='postgresql://…/throwaway' pnpm run test:sql
+begin;
+
+do $$ begin create role anon nologin; exception when duplicate_object then null; end $$;
+do $$ begin create role authenticated nologin; exception when duplicate_object then null; end $$;
+do $$ begin create role service_role nologin; exception when duplicate_object then null; end $$;
+
+create schema if not exists auth;
+create or replace function auth.uid() returns uuid
+language sql stable
+as $$ select nullif(current_setting('test.uid', true), '')::uuid $$;
+
+-- Stand-in for auth.users (the lens FK target) and the membership helpers'
+-- inputs.
+create table if not exists auth.users (
+  id uuid primary key
+);
+create table public.registration (
+  id uuid primary key,
+  user_id uuid,
+  corporation_id bigint
+);
+create table public.corporation (
+  corporation_id bigint primary key,
+  alliance_id bigint
+);
+grant select on public.registration to anon, authenticated;
+grant select on public.corporation to anon, authenticated;
+grant usage on schema auth to anon, authenticated;
+grant usage on schema public to anon, authenticated;
+
+create or replace function public.my_corporation_ids()
+returns setof bigint
+language sql
+stable
+as $$
+  select r.corporation_id
+  from public.registration r
+  where r.user_id = (select auth.uid()) and r.corporation_id is not null;
+$$;
+
+create or replace function public.my_alliance_ids()
+returns setof bigint
+language sql
+stable
+as $$
+  select c.alliance_id
+  from public.registration r
+  join public.corporation c on c.corporation_id = r.corporation_id
+  where r.user_id = (select auth.uid()) and c.alliance_id is not null;
+$$;
+
+-- The shared matcher the audience policy calls (created by the
+-- fitting_share_unified migration in prod).
+create or replace function public.share_audience_matches(
+  corporation_ids bigint[], alliance_ids bigint[], secret text
+)
+returns boolean
+language sql
+stable
+as $$
+  select
+    (secret is null and corporation_ids = '{}' and alliance_ids = '{}')
+    or corporation_ids && array(select public.my_corporation_ids())
+    or alliance_ids && array(select public.my_alliance_ids());
+$$;
+
+\i supabase/migrations/20260806130000_lens.sql
+
+-- Fixtures: alice (corp 98001 / alliance 99001) owns four lenses in different
+-- share states; bob is a corp-mate, carol is unaffiliated.
+insert into auth.users values
+  ('a0000000-0000-0000-0000-000000000000'),
+  ('b0000000-0000-0000-0000-000000000000'),
+  ('c0000000-0000-0000-0000-000000000000');
+insert into public.corporation values (98001, 99001);
+insert into public.registration values
+  ('00000000-0000-0000-0000-0000000000aa', 'a0000000-0000-0000-0000-000000000000', 98001),
+  ('00000000-0000-0000-0000-0000000000bb', 'b0000000-0000-0000-0000-000000000000', 98001),
+  ('00000000-0000-0000-0000-0000000000cc', 'c0000000-0000-0000-0000-000000000000', null);
+insert into public.lens (id, user_id, name, query, shared, corporation_ids, alliance_ids, secret) values
+  -- Freshly created: never shared. The empty audience must NOT read as public.
+  ('11111111-0000-0000-0000-000000000001', 'a0000000-0000-0000-0000-000000000000', 'unshared', '{ x }', false, '{}', '{}', null),
+  -- Shared with the corp.
+  ('11111111-0000-0000-0000-000000000002', 'a0000000-0000-0000-0000-000000000000', 'corp', '{ x }', true, '{98001}', '{}', null),
+  -- Fully public: shared with an audience that names no one.
+  ('11111111-0000-0000-0000-000000000003', 'a0000000-0000-0000-0000-000000000000', 'public', '{ x }', true, '{}', '{}', null),
+  -- Link-only: a secret and nobody else. Invisible to RLS by design.
+  ('11111111-0000-0000-0000-000000000004', 'a0000000-0000-0000-0000-000000000000', 'link', '{ x }', true, '{}', '{}', 'deadbeef');
+
+do $$
+declare
+  n int;
+begin
+  -- Owner sees all four.
+  set local role authenticated;
+  perform set_config('test.uid', 'a0000000-0000-0000-0000-000000000000', true);
+  select count(*) into n from public.lens;
+  assert n = 4, format('owner sees all their lenses, got %s', n);
+
+  -- Corp-mate bob: the corp-shared and public lenses — never the unshared or
+  -- link-only ones.
+  perform set_config('test.uid', 'b0000000-0000-0000-0000-000000000000', true);
+  select count(*) into n from public.lens;
+  assert n = 2, format('corp-mate sees corp + public, got %s', n);
+  select count(*) into n from public.lens where name in ('corp', 'public');
+  assert n = 2, 'corp-mate sees exactly the corp and public lenses';
+
+  -- Unaffiliated carol: only the public lens.
+  perform set_config('test.uid', 'c0000000-0000-0000-0000-000000000000', true);
+  select count(*) into n from public.lens;
+  assert n = 1, format('unaffiliated caller sees only public, got %s', n);
+
+  -- Signed-out anon: only the public lens.
+  reset role;
+  set local role anon;
+  perform set_config('test.uid', '', true);
+  select count(*) into n from public.lens;
+  assert n = 1, format('anon sees only public, got %s', n);
+
+  -- The unshared lens is invisible to everyone but the owner: the shared
+  -- gate, not the audience, is what held it back.
+  select count(*) into n from public.lens where name = 'unshared';
+  assert n = 0, 'an unshared lens never leaks through the empty-audience-is-public reading';
+
+  reset role;
+
+  -- Non-owner writes bounce off RLS: bob's update matches no row.
+  set local role authenticated;
+  perform set_config('test.uid', 'b0000000-0000-0000-0000-000000000000', true);
+  update public.lens set shared = true where name = 'unshared';
+  get diagnostics n = row_count;
+  assert n = 0, 'a non-owner cannot flip another user''s lens to shared';
+  reset role;
+end $$;
+
+rollback;


### PR DESCRIPTION
The final phase of the sharing layer (docs/sharing-layer/07-lens.md). A **Lens** is a saved GraphQL query a user shares with the standard Revision 3 audience — corporations, alliances, a signed link, or public — and when a viewer opens it, the query runs **under the creator's security context**: the viewer receives results, never access. Every lens also renders to CSV, positioned to supersede the `api_token` Google Sheets endpoints once lenses reach parity.

## Schema

- `lens` table (migration `20260806130000_lens.sql`, dual-written into `schema.sql`): user_id-keyed (a lens spans all the creator's registrations, like their GraphQL context), with the audience carried on the row (`corporation_ids` / `alliance_ids` / `secret`).
- **One deviation from the phase doc's sketch, found while building:** the lens row *is* its share row, so the Revision 3 "empty audience = public" reading would have made a freshly created lens public. A `shared boolean not null default false` gates the audience-read policy, keeping "not shared yet" (the no-row state the sibling share tables get for free) distinct from "shared with everyone". The doc records this.
- Owner FOR ALL policy; audience-read policy via `share_audience_matches()` to `anon` + `authenticated` (link-only lenses match no one under RLS, resolved at the app layer, as everywhere).

## Execution

- `contextForUser(userId)` factored out of the GraphQL context builder: service client + the user's registrations in **token mode**, so the session-only surfaces (`includeShared` / `sharedWithMe`) reject in lens runs exactly as they do for Bearer callers, and the resolvers' existing leak-guard `.in('registration_id', …)` is the barrier.
- `runLens` executes the stored query in-process against the executable schema — no HTTP hop; variables are fixed by the creator at save time.
- Save-time validation (`src/app/lens/validate.ts`, pure): parse + schema validation, single query operation, **exactly one top-level field** (keeps the CSV rendering unambiguous), and a session-only denylist so a broken share fails at save with a clear message.

## Surfaces

- **`/lens`** — the editor, dark-launched behind the `lens` flag (same gate-and-redirect shape as `/graphql`): list, create/edit, run-as-me preview (a server action under the caller's own context — the same result the audience will see), and the shared ShareDialog per lens (with a lens-appropriate hint via a new optional prop).
- **`/lens/[id]`** — the viewer: RLS decides for signed-in audiences (corp/alliance/public, incl. signed-out anon on public lenses), a signed `?share=<id>.<sig>` link for everyone else. Runs are additionally gated on the creator still holding the `lens` flag — un-flagging an account turns its shared lenses off (the dark-launch lever). Renders a flattened table + raw JSON.
- **`/lens/[id]/csv`** — the CSV rendering via `toCsv()`: primary list discovered from the single root field (a page object yields its `rows`), one-level flattening (nested objects dot-pathed, scalar lists joined). Fetchable by Sheets `=IMPORTDATA()` with the signed param.

## Tests

- `test/lensValidate.test.ts`, `test/lensFlatten.test.ts` (145 unit tests pass).
- `test/sql/lens.sql` on the throwaway-Postgres harness: owner sees all, corp-mate sees corp+public only, unaffiliated/anon see public only, **an unshared lens never leaks through the empty-audience-is-public reading**, link-only lenses invisible to RLS, non-owner writes match no rows.
- `pnpm run lint` / `pnpm run build` clean; migration ordering guard passes (renumbered above main's `20260806120000` after rebase).

Deploy note (standing): `TOKEN_SALT` must be set on Vercel for share links; the `lens` flag is set per user by SQL (`array_append`), same as `graphql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSjBdjGmTZVXJHXkVLtKpf

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSjBdjGmTZVXJHXkVLtKpf)_