### PR TITLE
Rename the lens share gate from `shared` to `enabled`

### DIFF
--- a/docs/sharing-layer/07-lens.md
+++ b/docs/sharing-layer/07-lens.md
@@ -8,8 +8,9 @@ save-time validation in `src/app/lens/validate.ts`, CSV flattening in
 `test/lensFlatten.test.ts`, `test/sql/lens.sql`. One deviation from the
 sketch below, found while building: because the lens row IS the share row,
 the Revision 3 "empty audience = public" reading would have made a freshly
-created lens public — the table carries a `shared boolean not null default
-false` that gates the audience-read policy, keeping "not shared yet"
+created lens public — the table carries an `enabled boolean not null default
+false` (shipped as `shared`, renamed by `20260806140000_lens_enabled.sql`)
+that gates the audience-read policy, keeping "not shared yet"
 distinct from "shared with everyone" (the no-row state the sibling share
 tables get for free). The CSV route is `/lens/[id]/csv` (a path segment,
 not `?format=csv`).
@@ -45,7 +46,7 @@ create table public.lens (
   -- As built: the lens row doubles as its share row, so this flag keeps a
   -- freshly created (never-shared) lens out of the empty-audience-is-public
   -- reading. The audience policy requires it.
-  shared boolean not null default false,
+  enabled boolean not null default false,
   corporation_ids bigint[] not null default '{}',
   alliance_ids bigint[] not null default '{}',
   secret text,

--- a/schema.sql
+++ b/schema.sql
@@ -2073,9 +2073,9 @@ create table public.lens (
   variables jsonb not null default '{}',
   -- Unlike the sibling share tables, the lens row IS the share row — so the
   -- Revision 3 "empty audience = public" reading would make a freshly created
-  -- lens public by default. `shared` keeps "not shared yet" (the no-row state
+  -- lens public by default. `enabled` keeps "not shared yet" (the no-row state
   -- the other tables get for free) distinct from "shared with everyone".
-  shared boolean not null default false,
+  enabled boolean not null default false,
   corporation_ids bigint[] not null default '{}',
   alliance_ids bigint[] not null default '{}',
   secret text,
@@ -2102,7 +2102,7 @@ create policy "Audience reads lenses aimed at them"
   on public.lens
   for select
   to anon, authenticated
-  using (shared and public.share_audience_matches(corporation_ids, alliance_ids, secret));
+  using (enabled and public.share_audience_matches(corporation_ids, alliance_ids, secret));
 
 grant select                         on public.lens to anon;
 grant select, insert, update, delete on public.lens to authenticated;

--- a/src/app/lens/access.ts
+++ b/src/app/lens/access.ts
@@ -37,7 +37,7 @@ const resolveSignedLens = async (lensId: string, param: string): Promise<LensRec
 
   const service = createServiceClient()
   const { data: lens } = await service.from('lens').select('*').eq('id', lensId).maybeSingle<LensRecord>()
-  if (!lens || !lens.shared || !lens.secret) return null
+  if (!lens || !lens.enabled || !lens.secret) return null
   return verifyShareToken(lens.id, lens.secret, salt, signature) ? lens : null
 }
 

--- a/src/app/lens/actions.ts
+++ b/src/app/lens/actions.ts
@@ -91,7 +91,7 @@ export const previewLens = async (input: {
 }
 
 // The audience side, driven by the shared ShareDialog. The lens row IS the
-// share row, so save/revoke toggle its `shared` flag and audience columns
+// share row, so save/revoke toggle its `enabled` flag and audience columns
 // rather than upserting a sibling row. Requested audience ids are filtered to
 // ones the caller actually has (the setSharedAlliances defense).
 const ownAudiences = async (supabase: Awaited<ReturnType<typeof createClient>>) => {
@@ -153,7 +153,7 @@ export const saveLensShare = async (lensId: string, input: SaveShareInput): Prom
 
   const { error } = await supabase
     .from('lens')
-    .update({ shared: true, corporation_ids: corporationIds, alliance_ids: allianceIds, secret })
+    .update({ enabled: true, corporation_ids: corporationIds, alliance_ids: allianceIds, secret })
     .eq('id', lensId)
     .eq('user_id', userId)
   if (error) return { error: error.message }
@@ -180,7 +180,7 @@ export const revokeLensShare = async (lensId: string): Promise<{ error?: string 
   // Back to the unshared state — NOT an empty audience, which would be public.
   const { error } = await supabase
     .from('lens')
-    .update({ shared: false, corporation_ids: [], alliance_ids: [], secret: null })
+    .update({ enabled: false, corporation_ids: [], alliance_ids: [], secret: null })
     .eq('id', lensId)
     .eq('user_id', userId)
   if (error) return { error: error.message }

--- a/src/app/lens/page.tsx
+++ b/src/app/lens/page.tsx
@@ -58,7 +58,7 @@ const LensPage = async () => {
               urlPath={`/lens/${lens.id}`}
               hint="Whoever you share with can run this query and see its results — your data, live — until you stop sharing."
               data={{
-                share: lens.shared ? shareRowToState(lens) : null,
+                share: lens.enabled ? shareRowToState(lens) : null,
                 corporations: audiences.corporations,
                 alliances: audiences.alliances,
                 hasLegacyToken: false,

--- a/src/app/lens/run.ts
+++ b/src/app/lens/run.ts
@@ -15,7 +15,7 @@ export type LensRecord = {
   name: string
   query: string
   variables: Record<string, unknown>
-  shared: boolean
+  enabled: boolean
   corporation_ids: number[] | null
   alliance_ids: number[] | null
   secret: string | null

--- a/supabase/migrations/20260806140000_lens_enabled.sql
+++ b/supabase/migrations/20260806140000_lens_enabled.sql
@@ -1,0 +1,14 @@
+-- Rename the lens share gate from `shared` to `enabled`.
+--
+-- The column (added in 20260806130000_lens.sql) is what keeps a never-shared
+-- lens out of the Revision 3 "empty audience = public" reading — the lens row
+-- doubles as its own share row, so a freshly created lens would otherwise
+-- read as shared with everyone. `enabled` says what the flag does without
+-- colliding with the word "shared", which in this layer already means the
+-- audience arrays.
+--
+-- A rename rather than a new column: the flag has no production data worth
+-- preserving semantics around, and Postgres rewrites dependent expressions
+-- (the audience-read policy's qual is a parsed node tree over the attribute,
+-- not the text "shared"), so the policy follows the rename untouched.
+alter table public.lens rename column shared to enabled;

--- a/test/sql/lens.sql
+++ b/test/sql/lens.sql
@@ -1,7 +1,7 @@
 -- SQL-level coverage for the lens migration
 -- (docs/sharing-layer/07-lens.md): owner-only management, the audience-read
 -- policy through share_audience_matches(), and — the lens-specific semantic —
--- the `shared` gate: because the lens row IS the share row, an UNSHARED lens
+-- the `enabled` gate: because the lens row IS the share row, an UNSHARED lens
 -- must be invisible to everyone but its owner even though its default empty
 -- audience would otherwise read as "public".
 --
@@ -74,6 +74,11 @@ as $$
 $$;
 
 \i supabase/migrations/20260806130000_lens.sql
+-- The share gate arrives as `shared` and is renamed by the follow-up; the
+-- assertions below run against the post-rename `enabled`, which also proves
+-- the audience-read policy followed the rename (its qual is a node tree over
+-- the attribute, not the text).
+\i supabase/migrations/20260806140000_lens_enabled.sql
 
 -- Fixtures: alice (corp 98001 / alliance 99001) owns four lenses in different
 -- share states; bob is a corp-mate, carol is unaffiliated.
@@ -86,7 +91,7 @@ insert into public.registration values
   ('00000000-0000-0000-0000-0000000000aa', 'a0000000-0000-0000-0000-000000000000', 98001),
   ('00000000-0000-0000-0000-0000000000bb', 'b0000000-0000-0000-0000-000000000000', 98001),
   ('00000000-0000-0000-0000-0000000000cc', 'c0000000-0000-0000-0000-000000000000', null);
-insert into public.lens (id, user_id, name, query, shared, corporation_ids, alliance_ids, secret) values
+insert into public.lens (id, user_id, name, query, enabled, corporation_ids, alliance_ids, secret) values
   -- Freshly created: never shared. The empty audience must NOT read as public.
   ('11111111-0000-0000-0000-000000000001', 'a0000000-0000-0000-0000-000000000000', 'unshared', '{ x }', false, '{}', '{}', null),
   -- Shared with the corp.
@@ -126,7 +131,7 @@ begin
   select count(*) into n from public.lens;
   assert n = 1, format('anon sees only public, got %s', n);
 
-  -- The unshared lens is invisible to everyone but the owner: the shared
+  -- The unshared lens is invisible to everyone but the owner: the enabled
   -- gate, not the audience, is what held it back.
   select count(*) into n from public.lens where name = 'unshared';
   assert n = 0, 'an unshared lens never leaks through the empty-audience-is-public reading';
@@ -136,9 +141,9 @@ begin
   -- Non-owner writes bounce off RLS: bob's update matches no row.
   set local role authenticated;
   perform set_config('test.uid', 'b0000000-0000-0000-0000-000000000000', true);
-  update public.lens set shared = true where name = 'unshared';
+  update public.lens set enabled = true where name = 'unshared';
   get diagnostics n = row_count;
-  assert n = 0, 'a non-owner cannot flip another user''s lens to shared';
+  assert n = 0, 'a non-owner cannot flip another user''s lens to enabled';
   reset role;
 end $$;
 


### PR DESCRIPTION
Follow-up to #812. The `lens` flag that keeps a never-shared lens out of the Revision 3 "empty audience = public" reading is renamed `shared` → `enabled`: in this layer "shared" already means the audience arrays, so the column read as if it were one of them. `enabled` says what it does.

#812 merged before this landed, so the rename arrives as its **own migration** (`20260806140000_lens_enabled.sql`) rather than an edit to the applied one — the applied file is restored byte-for-byte.

- `alter table public.lens rename column shared to enabled;` — Postgres rewrites dependent expressions through a rename (the audience-read policy's qual is a parsed node tree over the attribute, not the text), so the policy needs no re-creation.
- `schema.sql` (the from-scratch reset) carries `enabled` directly.
- `test/sql/lens.sql` now runs **both** migrations in sequence and asserts against the post-rename column, which is what proves the policy followed the rename: owner sees all four lenses, corp-mate sees corp + public, unaffiliated and anon see public only, the un-enabled lens never leaks, and a non-owner's write still matches no rows.
- Call sites updated: `run.ts` (`LensRecord`), `access.ts` (signed-link gate), `actions.ts` (save/revoke), `page.tsx` (dialog state).

`pnpm run lint`, `pnpm test` (145 pass), `pnpm run build`, the migration ordering guard, and the SQL suite on a throwaway Postgres all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSjBdjGmTZVXJHXkVLtKpf

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSjBdjGmTZVXJHXkVLtKpf)_