### PR TITLE
Serve GraphiQL on /api/graphql, gated on the graphql flag

### DIFF
--- a/src/app/api/graphql/route.ts
+++ b/src/app/api/graphql/route.ts
@@ -1,6 +1,8 @@
 import { createYoga } from 'graphql-yoga'
 import type { NextRequest } from 'next/server'
 
+import { GRAPHQL_FLAG, hasFlag } from '@/flags'
+import { createClient } from '@/utils/supabase/server'
 import { buildContext } from './context'
 import { schema } from './schema'
 
@@ -15,13 +17,31 @@ export const dynamic = 'force-dynamic'
 // /api/character/assets.
 export const maxDuration = 60
 
+// GraphiQL is served on GET, and rendering it never touches a resolver — so
+// without this the IDE shell would answer anonymous requests at a public path.
+// The factory keeps the dark launch honest: only a signed-in account carrying
+// the `graphql` flag gets the IDE, everyone else gets yoga's 404. Queries are
+// still authorized independently by buildContext.
+const graphiqlForRequest = async (): Promise<boolean> => {
+  const supabase = await createClient()
+  const { data, error } = await supabase.auth.getUser()
+  if (error || !data?.user) return false
+  return hasFlag(data.user.id, GRAPHQL_FLAG)
+}
+
 const { handleRequest } = createYoga({
   schema,
   context: ({ request }) => buildContext(request),
   graphqlEndpoint: '/api/graphql',
   fetchAPI: { Response },
-  // The /graphql page is the in-browser UI; no bundled GraphiQL or landing page.
-  graphiql: false,
+  // GraphiQL for schema-aware autocomplete and the docs explorer; the /graphql
+  // page's plain editor stays as the lightweight surface (and is what the Lens
+  // editor reuses). credentials same-origin so the IDE's own requests carry
+  // the Supabase session cookie — the Bearer path is for external tools.
+  graphiql: () =>
+    graphiqlForRequest().then(
+      (allowed) => allowed && { title: 'Edencom Link GraphQL', credentials: 'same-origin' as const }
+    ),
   landingPage: false,
   batching: false,
   // Wildcard origin with credentials OFF is the safe pairing: external UIs

--- a/src/app/graphql/page.tsx
+++ b/src/app/graphql/page.tsx
@@ -34,7 +34,8 @@ const GraphqlPage = async () => {
       <h1>GraphQL</h1>
       <p>
         Query your extracted data — assets, blueprints, orders, industry jobs, wallets — with GraphQL. This page posts
-        to <code>/api/graphql</code> with your session; external tools authenticate with your API token instead.
+        to <code>/api/graphql</code> with your session; external tools authenticate with your API token instead. For
+        autocomplete and a browsable schema, <a href="/api/graphql">open GraphiQL</a>.
       </p>
 
       <QueryEditor />


### PR DESCRIPTION
Turns on yoga's bundled GraphiQL, which was deliberately off (`graphiql: false`) when the endpoint shipped. The plain `/graphql` editor can't offer schema-aware autocomplete, the docs explorer, or as-you-type validation — all of which matter for a surface people are meant to explore, and for authoring lens queries before `validateLensQuery` rejects them at save.

**The gate is the point.** GraphiQL renders on `GET`, and rendering it never touches a resolver — so an ungated GET would put the IDE shell on a public path. The `graphiql` option takes a per-request factory, so it resolves the cookie session and requires the account's `graphql` dark-launch flag; everyone else gets yoga's 404. Query execution is unaffected, still authorized independently by `buildContext` (401 signed-out, 403 unflagged), so the gate is defense in depth rather than the only barrier.

- `credentials: 'same-origin'` so the IDE's own requests carry the Supabase session cookie; the Bearer path remains for external tools.
- CORS is untouched — `methods` stays `POST`/`OPTIONS`, since the IDE is same-origin and needs no preflight.
- `/graphql` gains a link to it.

Note: yoga loads the GraphiQL bundle from unpkg. There's no CSP on this deployment, so it loads as-is; self-hosting the assets would be a follow-up if that's ever unwanted.

`pnpm run lint`, `pnpm test`, and `pnpm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSjBdjGmTZVXJHXkVLtKpf

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSjBdjGmTZVXJHXkVLtKpf)_