### PR TITLE
Add exact typeIds filters to assets, blueprints and walletTransactions

### DIFF
--- a/src/app/api/graphql/filters.ts
+++ b/src/app/api/graphql/filters.ts
@@ -58,3 +58,26 @@ export const parseIdArg = (raw: string | null | undefined, label: string): IdPar
   if (!/^\d+$/.test(trimmed)) return { ok: false, message: `${label} must be a numeric id, got "${raw}".` }
   return { ok: true, id: trimmed }
 }
+
+// The two ways to name item types, resolved to one filter. They are mutually
+// EXCLUSIVE rather than unioned: typeIds asks an exact question and typeName a
+// fuzzy one (it substring-matches the SDE, so "Fuel Block" also catches the
+// blueprints), and a lens whose stored query silently blends both is a lens
+// nobody can predict a year later. Returns the exact ids when given, `null`
+// for "no id filter" (the caller then applies its fuzzy typeName path), and an
+// error when both or a malformed id arrive.
+export type TypeIdsParse = { ok: true; ids: number[] | null } | { ok: false; message: string }
+
+export const parseTypeIdsArg = (
+  typeIds: readonly string[] | null | undefined,
+  typeName: string | null | undefined
+): TypeIdsParse => {
+  const ids = (typeIds ?? []).map((id) => (id ?? '').trim()).filter((id) => id !== '')
+  if (ids.length === 0) return { ok: true, ids: null }
+  if ((typeName ?? '').trim() !== '') {
+    return { ok: false, message: 'Pass typeIds or typeName, not both — one is exact, the other is a name search.' }
+  }
+  const bad = ids.find((id) => !/^\d+$/.test(id))
+  if (bad !== undefined) return { ok: false, message: `typeIds must be numeric ids, got "${bad}".` }
+  return { ok: true, ids: [...new Set(ids.map(Number))] }
+}

--- a/src/app/api/graphql/resolvers.ts
+++ b/src/app/api/graphql/resolvers.ts
@@ -12,7 +12,7 @@ import { uniq } from 'ramda'
 import { guessLocationRef, resolveTypeFilter } from '@/app/api/mcp/lib'
 import { resolveLocations, type LocationRef, type ResolvedLocations } from '@/app/resolveLocations'
 import { getSdeTypeNames } from '@/sdeTypes'
-import { ASSET_CAP, LIST_CAP, clampLimit, matchOwnerIds, parseIdArg, parseSince } from './filters'
+import { ASSET_CAP, LIST_CAP, clampLimit, matchOwnerIds, parseIdArg, parseSince, parseTypeIdsArg } from './filters'
 import type { GraphqlContext } from './context'
 
 const badRequest = (message: string): never => {
@@ -31,10 +31,17 @@ const scopeIds = (ctx: GraphqlContext, owner: string | null | undefined): string
   return match.ids ?? ctx.registrationIds
 }
 
-// Fuzzy item-name filter → SDE type ids, with the MCP layer's "too many
-// matches" guard; null means no filter.
-const typeIdsFor = async (typeName: string | null | undefined): Promise<number[] | null> => {
-  const filter = await resolveTypeFilter(typeName ?? undefined)
+// The item-type filter → SDE type ids, or null for no filter. Exact `typeIds`
+// win outright; otherwise the fuzzy name search runs, with the MCP layer's
+// "too many matches" guard. parseTypeIdsArg rejects passing both.
+const typeIdsFor = async (args: {
+  typeIds?: readonly string[] | null
+  typeName?: string | null
+}): Promise<number[] | null> => {
+  const exact = parseTypeIdsArg(args.typeIds, args.typeName)
+  if (!exact.ok) return badRequest(exact.message)
+  if (exact.ids !== null) return exact.ids
+  const filter = await resolveTypeFilter(args.typeName ?? undefined)
   if (!filter.ok) return badRequest(filter.message)
   return filter.matches === null ? null : filter.matches.map((m) => m.typeID)
 }
@@ -138,6 +145,7 @@ export const resolvers = {
     assets: async (
       _parent: unknown,
       args: {
+        typeIds?: readonly string[] | null
         typeName?: string | null
         locationId?: string | null
         owner?: string | null
@@ -155,7 +163,7 @@ export const resolvers = {
       const ownerIds = scopeIds(ctx, args.owner)
       const sharedIds = args.includeShared ? await grantorRegistrationIds(ctx) : []
       const scopedIds = [...ownerIds, ...sharedIds]
-      const typeIds = await typeIdsFor(args.typeName)
+      const typeIds = await typeIdsFor(args)
       const location = parseIdArg(args.locationId, 'locationId')
       if (!location.ok) return badRequest(location.message)
       const cap = clampLimit(args.limit, ASSET_CAP)
@@ -267,11 +275,16 @@ export const resolvers = {
 
     blueprints: async (
       _parent: unknown,
-      args: { typeName?: string | null; owner?: string | null; limit?: number | null },
+      args: {
+        typeIds?: readonly string[] | null
+        typeName?: string | null
+        owner?: string | null
+        limit?: number | null
+      },
       ctx: GraphqlContext
     ) => {
       const ownerIds = scopeIds(ctx, args.owner)
-      const typeIds = await typeIdsFor(args.typeName)
+      const typeIds = await typeIdsFor(args)
       const cap = clampLimit(args.limit, LIST_CAP)
 
       type BlueprintRow = {
@@ -497,11 +510,17 @@ export const resolvers = {
 
     walletTransactions: async (
       _parent: unknown,
-      args: { typeName?: string | null; owner?: string | null; since?: string | null; limit?: number | null },
+      args: {
+        typeIds?: readonly string[] | null
+        typeName?: string | null
+        owner?: string | null
+        since?: string | null
+        limit?: number | null
+      },
       ctx: GraphqlContext
     ) => {
       const ownerIds = scopeIds(ctx, args.owner)
-      const typeIds = await typeIdsFor(args.typeName)
+      const typeIds = await typeIdsFor(args)
       const since = parseSince(args.since)
       if (!since.ok) return badRequest(since.message)
       const cap = clampLimit(args.limit, LIST_CAP)

--- a/src/app/api/graphql/schema.graphql.ts
+++ b/src/app/api/graphql/schema.graphql.ts
@@ -14,18 +14,26 @@ export const typeDefs = /* GraphQL */ `
     owners: [Owner!]!
 
     """
-    Current asset rows (live inventory) across your characters. includeShared
-    additionally returns rows other users have shared with you (session auth
-    only — the api_token path is own-data only; a Lens is the way to hand
-    shared data to external tools).
+    Current asset rows (live inventory) across your characters. typeIds filters
+    on exact SDE type ids; typeName is a fuzzy name search — pass one or the
+    other, never both. includeShared additionally returns rows other users have
+    shared with you (session auth only — the api_token path is own-data only; a
+    Lens is the way to hand shared data to external tools).
     """
-    assets(typeName: String, locationId: String, owner: String, limit: Int, includeShared: Boolean = false): AssetPage!
+    assets(
+      typeIds: [String!]
+      typeName: String
+      locationId: String
+      owner: String
+      limit: Int
+      includeShared: Boolean = false
+    ): AssetPage!
 
     "Asset shares other users have aimed at you (corporation/alliance/public). Session auth only."
     sharedWithMe: [ShareGrant!]!
 
-    "Current blueprint rows (BPOs and BPCs) across your characters."
-    blueprints(typeName: String, owner: String, limit: Int): BlueprintPage!
+    "Current blueprint rows (BPOs and BPCs) across your characters. typeIds and typeName are mutually exclusive."
+    blueprints(typeIds: [String!], typeName: String, owner: String, limit: Int): BlueprintPage!
 
     "Open market orders across your characters."
     marketOrders(owner: String): [MarketOrder!]!
@@ -36,8 +44,14 @@ export const typeDefs = /* GraphQL */ `
     "Latest known wallet balance per character."
     walletBalances: [WalletBalance!]!
 
-    "Market transaction history across your characters, newest first."
-    walletTransactions(typeName: String, owner: String, since: String, limit: Int): [WalletTransaction!]!
+    "Market transaction history across your characters, newest first. typeIds and typeName are mutually exclusive."
+    walletTransactions(
+      typeIds: [String!]
+      typeName: String
+      owner: String
+      since: String
+      limit: Int
+    ): [WalletTransaction!]!
   }
 
   "A linked character (id is this site's registration id, not the EVE character id)."

--- a/test/graphqlFilters.test.ts
+++ b/test/graphqlFilters.test.ts
@@ -13,6 +13,7 @@ import {
   matchOwnerIds,
   parseIdArg,
   parseSince,
+  parseTypeIdsArg,
 } from '../src/app/api/graphql/filters.ts'
 
 test('clampLimit defaults to the cap when absent or not a number', () => {
@@ -69,4 +70,26 @@ test('parseIdArg accepts only bare positive integer literals', () => {
   assert.equal(parseIdArg('60003760; drop table', 'locationId').ok, false)
   assert.equal(parseIdArg('-1', 'locationId').ok, false)
   assert.equal(parseIdArg('1e9', 'locationId').ok, false)
+})
+
+test('parseTypeIdsArg returns null when no ids are given', () => {
+  assert.deepEqual(parseTypeIdsArg(undefined, undefined), { ok: true, ids: null })
+  assert.deepEqual(parseTypeIdsArg([], 'Fuel Block'), { ok: true, ids: null })
+  assert.deepEqual(parseTypeIdsArg(['  '], undefined), { ok: true, ids: null })
+})
+
+test('parseTypeIdsArg parses, trims and dedupes exact ids', () => {
+  assert.deepEqual(parseTypeIdsArg([' 4051 ', '4246', '4051'], undefined), { ok: true, ids: [4051, 4246] })
+})
+
+test('parseTypeIdsArg refuses typeIds and typeName together', () => {
+  const both = parseTypeIdsArg(['4051'], 'Fuel Block')
+  assert.equal(both.ok, false)
+  assert.match(!both.ok ? both.message : '', /not both/)
+})
+
+test('parseTypeIdsArg rejects non-numeric ids rather than widening', () => {
+  assert.equal(parseTypeIdsArg(['4051', 'Tritanium'], undefined).ok, false)
+  assert.equal(parseTypeIdsArg(['-4051'], undefined).ok, false)
+  assert.equal(parseTypeIdsArg(['4051; drop table'], undefined).ok, false)
 })

--- a/test/graphqlSchema.test.ts
+++ b/test/graphqlSchema.test.ts
@@ -44,3 +44,15 @@ test('ids stay String — EVE item ids overflow GraphQL Int', () => {
   const order = schema.getType('MarketOrder') as GraphQLObjectType
   assert.equal(String(order.getFields().orderId.type), 'String!')
 })
+
+test('the type-filtered fields all carry typeIds as a String list', () => {
+  const schema = buildSchema(typeDefs)
+  const fields = (schema.getQueryType() as GraphQLObjectType).getFields()
+  for (const name of ['assets', 'blueprints', 'walletTransactions']) {
+    const arg = fields[name].args.find((a) => a.name === 'typeIds')
+    assert.ok(arg, `${name} has a typeIds arg`)
+    // String, not Int: EVE type ids are small today but the schema keeps one
+    // id representation, and Int is 32-bit.
+    assert.equal(String(arg.type), '[String!]')
+  }
+})


### PR DESCRIPTION
The three type-filtered query fields only took `typeName`, which goes through the fuzzy SDE search: "Fuel Block" matches the four fuel blocks *and* their blueprints, and a CCP rename silently changes what a saved lens returns. `typeIds: [String!]` asks the exact question — which is what a lens, pinned once and read for months, actually wants.

```graphql
{
  assets(typeIds: ["4051", "4246", "4247", "4312"], locationId: "1050530810113") {
    totalCount
    rows { typeName quantity locationFlag ownerName }
  }
}
```

**Mutually exclusive, not unioned.** Passing both is an error rather than a merge: exact ids and a name search answer different questions, and a stored query that quietly blends them is one nobody can predict a year later.

- `parseTypeIdsArg` (pure, in `filters.ts`) trims, dedupes, rejects non-numeric ids rather than widening the filter, and rejects `typeIds` + `typeName` together.
- The resolvers share one `typeIdsFor` seam, so the fuzzy path is untouched when no ids are given — `typeIds` simply short-circuits ahead of `resolveTypeFilter`.
- `String`, not `Int`, matching every other id in this schema.
- Tests: 4 new cases in `test/graphqlFilters.test.ts` for the parser, plus a schema drift guard asserting all three fields carry `[String!]` (150 tests pass).

`pnpm run lint` and `pnpm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSjBdjGmTZVXJHXkVLtKpf

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSjBdjGmTZVXJHXkVLtKpf)_