### PR TITLE
Show who claimed each invite code

### DIFF
--- a/src/app/account/invite/page.tsx
+++ b/src/app/account/invite/page.tsx
@@ -1,12 +1,13 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
+import { pluck, uniq } from 'ramda'
 
 import { createServiceClient } from '@/utils/supabase/service'
 import { createClient } from '@/utils/supabase/server'
 
 import { DateTime } from '../../DateTime'
 import { isChancellor } from '../chancellor/chancellor'
-import { mainCharacterNameForUser } from '../lib/inviter'
+import { mainCharacterNameForUser, mainCharacterNamesForUsers } from '../lib/inviter'
 import CopyLink from './copyLink'
 import CreateButton from './createButton'
 import { earnedCount, unlockDate, weeksToUnlock } from './schedule'
@@ -53,6 +54,18 @@ const InvitesPage = async () => {
 
   const allCodes = codes ?? []
   const unused = allCodes.filter((c) => !c.redeemed_by)
+
+  // Who claimed each redeemed code, by their main character. The redeemer's
+  // registrations sit behind their own RLS, so this reuses the same service-role
+  // lookup as the inviter line above, batched across every claimed code.
+  const claimedNames = await mainCharacterNamesForUsers(
+    uniq(
+      pluck(
+        'redeemed_by',
+        allCodes.filter((c) => c.redeemed_by)
+      ) as string[]
+    )
+  )
   const earned = earnedCount(firstSsoAt)
   const available = Math.max(0, earned - allCodes.length)
 
@@ -152,6 +165,7 @@ const InvitesPage = async () => {
                 <th>Code</th>
                 <th>Created</th>
                 <th>Status</th>
+                <th>Claimed by</th>
               </tr>
             </thead>
             <tbody>
@@ -172,6 +186,7 @@ const InvitesPage = async () => {
                       'Unclaimed'
                     )}
                   </td>
+                  <td>{(c.redeemed_by && claimedNames.get(c.redeemed_by)) || '—'}</td>
                 </tr>
               ))}
             </tbody>

--- a/src/app/account/lib/inviter.ts
+++ b/src/app/account/lib/inviter.ts
@@ -1,3 +1,5 @@
+import { reduce } from 'ramda'
+
 import { createServiceClient } from '@/utils/supabase/service'
 
 // A user's public-facing name: their main character, falling back to their
@@ -14,4 +16,24 @@ export const mainCharacterNameForUser = async (userId: string): Promise<string |
     .limit(1)
     .maybeSingle()
   return data?.name ?? null
+}
+
+// The same lookup for a set of accounts in one query — for listing who redeemed
+// each of a user's invite codes without a round trip per code. Rows come back in
+// main-first, then oldest-first order, so the first row seen for an account is
+// the one to show; accounts with no linked character are simply absent.
+export const mainCharacterNamesForUsers = async (userIds: string[]): Promise<Map<string, string>> => {
+  if (userIds.length === 0) return new Map()
+  const service = createServiceClient()
+  const { data } = await service
+    .from('registration')
+    .select('user_id, name')
+    .in('user_id', userIds)
+    .order('is_main', { ascending: false })
+    .order('created_at', { ascending: true })
+  return reduce(
+    (acc, r) => (acc.has(r.user_id) ? acc : acc.set(r.user_id, r.name)),
+    new Map<string, string>(),
+    data ?? []
+  )
 }


### PR DESCRIPTION
Closes #810.

The "Codes you've created" table on `/account/invite` said only whether a code was claimed and when. This adds a **Claimed by** column naming the redeemer's main character (falling back to their earliest character), with an em dash where the redeemer hasn't linked a character yet or the code is still unclaimed.

## Changes

- `src/app/account/lib/inviter.ts` — new `mainCharacterNamesForUsers(userIds)` beside the existing `mainCharacterNameForUser`: the same main-first / oldest-next ordering, batched into one query so the page doesn't do a round trip per claimed code. Returns a `Map<userId, name>`; accounts with no linked character are simply absent.
- `src/app/account/invite/page.tsx` — resolve the redeemers of every claimed code once, add the column.

The redeemer's `registration` rows sit behind their own RLS, so this reuses the same service-role path the "Who invited you" line already uses. Scope is unchanged otherwise: RLS still limits the code list itself to codes the signed-in user created.

## Verification

`pnpm run lint` and `pnpm run build` pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARSst7fSLRkesrKdJ7WVx3)_