### PR TITLE
Discord stage 05: sender sweep posts outbox rows to linked channels

### DIFF
--- a/docs/discord-bot/README.md
+++ b/docs/discord-bot/README.md
@@ -41,7 +41,17 @@ Scope for making edencom.link double as a Discord application. Two goals
   is `src/jobs/mercenaryDenNotification.js`). The generic `notification`
   outbox table was minted with `transport` + `discord_channel_id` per the
   amended ntfy design; the extract cadence was bumped to hourly.
-- **Stages 05–07 — not started.**
+- **Stage 05 — shipped; the MVP loop is closed.** The
+  `discord-notification-send` sweep (`src/jobs/discordNotificationSend.js`,
+  pure outcome seam in `src/jobs/discordDelivery.js`) posts pending outbox
+  rows to their channels every 5 minutes, stamping `sent_at` on success,
+  `discord_channel.disabled_at` on 403/404, and bumping `attempts` otherwise
+  (cap 10). Runs as a single-step Vercel Workflow like every other scheduled
+  job — the stage doc's `runDirectCronJob` suggestion predates the completed
+  cron → Workflows migration. Settings grew a per-channel "Send test
+  message" button. Sending needs `DISCORD_BOT_TOKEN` set in Vercel; without
+  it the sweep is a logged no-op.
+- **Stages 06–07 — not started.**
 
 This is a scoping document set, not an implementation spec. Each stage is
 one PR with its own milestone; do them **in order** (each builds on the

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "sheet-csv": "node src/jobs/sheetCsv.js",
     "connect": "node src/connect.js",
     "db:new": "supabase migration new",
+    "discord-notification-send": "node src/jobs/discordNotificationSend.js",
     "discord-register-commands": "node src/discordRegisterCommands.js",
     "db:push": "supabase db push",
     "dev": "next dev",

--- a/src/app/account/settings/actions.ts
+++ b/src/app/account/settings/actions.ts
@@ -84,6 +84,50 @@ export const generateDiscordLinkCode = async (): Promise<{ code?: string; expire
   return { code, expiresAt }
 }
 
+// Post a test message straight to a linked channel (not via the outbox), so a
+// user can verify the pipe before trusting it with real alerts
+// (docs/discord-bot/05-notification-sender.md). The channel is read through the
+// caller's RLS-scoped client, so only their own links resolve; a 403/404 marks
+// the channel disabled exactly as the sender sweep would.
+export const sendDiscordTestMessage = async (id: string): Promise<{ error?: string }> => {
+  const supabase = await createClient()
+
+  const { data: channel, error } = await supabase
+    .from('discord_channel')
+    .select('id, channel_id')
+    .eq('id', id)
+    .maybeSingle()
+  if (error) return { error: error.message }
+  if (!channel) return { error: 'Channel not found' }
+
+  const botToken = process.env.DISCORD_BOT_TOKEN
+  if (!botToken) return { error: 'The Discord bot is not configured on this deployment' }
+
+  const response = await fetch(`https://discord.com/api/v10/channels/${channel.channel_id}/messages`, {
+    method: 'POST',
+    headers: { Authorization: `Bot ${botToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      content: 'Test message from Edencom.link — alerts for this account will arrive here.',
+      allowed_mentions: { parse: [] },
+    }),
+  })
+
+  if (response.status === 403 || response.status === 404) {
+    // Permanent, same classification the sweep makes. Service role: the owner
+    // policy grants select/delete only, so the update needs to bypass RLS.
+    const { createServiceClient } = await import('@/utils/supabase/service')
+    await createServiceClient()
+      .from('discord_channel')
+      .update({ disabled_at: new Date().toISOString() })
+      .eq('id', channel.id)
+    revalidatePath('/account/settings')
+    return { error: "The bot can't post there — check it's still in the server and can see the channel" }
+  }
+  if (!response.ok) return { error: `Discord returned ${response.status}` }
+
+  return {}
+}
+
 // Remove a linked Discord channel. RLS's owner delete policy scopes the row to
 // the caller, so a foreign id matches nothing.
 export const removeDiscordChannel = async (id: string): Promise<{ error?: string }> => {

--- a/src/app/account/settings/discord.tsx
+++ b/src/app/account/settings/discord.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react'
 
-import { generateDiscordLinkCode, removeDiscordChannel } from './actions'
+import { generateDiscordLinkCode, removeDiscordChannel, sendDiscordTestMessage } from './actions'
 import Dot from './dot'
 
 export type DiscordChannel = {
@@ -59,6 +59,19 @@ const Discord = ({ appId, channels }: { appId: string | null; channels: DiscordC
     setResponse('Channel unlinked')
   }
 
+  const test = async (id: string) => {
+    setColor('#000000')
+    setResponse('Sending…')
+    const result = await sendDiscordTestMessage(id)
+    if (result.error) {
+      setColor('#FF0000')
+      setResponse(result.error)
+      return
+    }
+    setColor('#00AF00')
+    setResponse('Test message sent — check the channel')
+  }
+
   const installUrl = appId
     ? `https://discord.com/oauth2/authorize?client_id=${appId}&scope=bot+applications.commands&permissions=${BOT_PERMISSIONS}`
     : null
@@ -106,6 +119,7 @@ const Discord = ({ appId, channels }: { appId: string | null; channels: DiscordC
                 {channel.channel_name ? `#${channel.channel_name}` : `channel ${channel.channel_id}`} — linked{' '}
                 {channel.created_at.slice(0, 10)}
                 {channel.disabled_at && ' — bot lost access; remove and re-link'}{' '}
+                <button onClick={() => test(channel.id)}>Send test message</button>{' '}
                 <button onClick={() => remove(channel.id)}>Remove</button>
               </li>
             ))}

--- a/src/app/api/cron/discord-notification-send/route.ts
+++ b/src/app/api/cron/discord-notification-send/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { requireCronSecret } from '@/utils/cron'
+
+// Vercel Cron trigger for discord-notification-send (every 5 minutes): posts
+// pending notification outbox rows to their linked Discord channels. Like every
+// other scheduled job it just start()s the workflow
+// (src/workflows/discordNotificationSend.ts) — the workflow owns retries, its
+// run/step status shows under Observability → Workflows, and its step records
+// the heartbeat pair (source: 'vercel-workflow').
+export const runtime = 'nodejs'
+export const maxDuration = 60
+
+export async function GET(request: NextRequest) {
+  const denied = requireCronSecret(request)
+  if (denied) return denied
+
+  const { start } = await import('workflow/api')
+  const { discordNotificationSendWorkflow } = await import('@/workflows/discordNotificationSend')
+  const run = await start(discordNotificationSendWorkflow, [])
+  console.log(`[cron/discord-notification-send] started workflow run=${run.runId}`)
+
+  return NextResponse.json({ ok: true, runId: run.runId })
+}

--- a/src/app/jobs/registry.ts
+++ b/src/app/jobs/registry.ts
@@ -81,7 +81,8 @@ export const nextRunFor = (job: string, from: Date = new Date()): Date | null =>
 
 // A run can start a little late and takes time to record its heartbeat, so a
 // missed fire is only called out once it's this far past due. Well under the
-// tightest cadence (6h) and well over any job's runtime.
+// tightest cadence of any job listed here (1h, character-mercenary-dens) and
+// well over any job's runtime.
 const MISSED_GRACE_MINUTES = 30
 
 // Did the last scheduled fire not happen? True when the previous time this cron

--- a/src/jobs/discordDelivery.js
+++ b/src/jobs/discordDelivery.js
@@ -1,0 +1,51 @@
+// Pure delivery-outcome logic for the Discord notification sender
+// (docs/discord-bot/05-notification-sender.md). What a given Discord REST
+// status means for the outbox row and its channel is the part worth pinning in
+// tests — the HTTP call itself isn't. I/O lives in discordNotificationSend.js.
+
+// Give up on a row after this many failed attempts: abandoned but still
+// visible in the table (the ntfy plan's design), never retried forever.
+export const MAX_ATTEMPTS = 10
+
+// What the sweep should do with a row, given Discord's response status.
+//
+//   'sent'      — 2xx: stamp sent_at, done.
+//   'disabled'  — 403/404: the bot was kicked, lost permission, or the channel
+//                 is gone. Permanent, so stamp discord_channel.disabled_at
+//                 rather than burning MAX_ATTEMPTS; settings shows the state so
+//                 the user can re-link.
+//   'throttled' — 429: back off and let the next sweep retry.
+//   'retry'     — anything else (5xx, network): bump attempts and try again
+//                 next sweep until the cap.
+export const classifyDeliveryStatus = (status) => {
+  if (status >= 200 && status < 300) return 'sent'
+  if (status === 403 || status === 404) return 'disabled'
+  if (status === 429) return 'throttled'
+  return 'retry'
+}
+
+// A row is deliverable only while it's pending, due, aimed at a live channel,
+// and under the attempt cap. The SQL select already filters on all of these
+// except the channel join, which this re-checks so a row whose channel went
+// away mid-sweep can't slip through.
+export const isDeliverable = ({ row, channel, now = new Date() }) => {
+  if (row.sent_at != null) return false
+  if (row.attempts >= MAX_ATTEMPTS) return false
+  if (new Date(row.scheduled_at).getTime() > now.getTime()) return false
+  if (!channel || channel.disabled_at != null) return false
+  return true
+}
+
+// The message body Discord is asked to post. allowed_mentions parse: [] so
+// nothing is ever @-pinged — the <t:…:R> countdown carries the urgency until
+// per-channel role-mention config exists (a documented follow-up).
+export const deliveryPayload = (body) => ({ content: body, allowed_mentions: { parse: [] } })
+
+// Discord returns { retry_after: <seconds> } on a 429. Clamp to something sane
+// — the sweep runs every 5 minutes, so anything longer is better served by
+// simply waiting for the next run than by holding the invocation open.
+export const retryAfterMs = (payload, cap = 5000) => {
+  const seconds = Number(payload?.retry_after)
+  if (!Number.isFinite(seconds) || seconds <= 0) return 0
+  return Math.min(seconds * 1000, cap)
+}

--- a/src/jobs/discordNotificationSend.js
+++ b/src/jobs/discordNotificationSend.js
@@ -1,0 +1,125 @@
+// Sender sweep: pending notification rows → Discord channel messages
+// (docs/discord-bot/05-notification-sender.md). Closes the loop stage 04
+// opened — detection enqueues, this posts. Unlike the extract jobs it reads
+// only our own DB (plus Discord's REST API), but it follows the same
+// conventions: name = npm script = heartbeat label = workflow file.
+import { recordDiscordSend } from '../observability.js'
+import { sudoSupabase } from '../supabase.js'
+import {
+  classifyDeliveryStatus,
+  deliveryPayload,
+  isDeliverable,
+  MAX_ATTEMPTS,
+  retryAfterMs,
+} from './discordDelivery.js'
+import { cli, forEachSequential } from './lib.js'
+
+const TAG = 'discord-notification-send'
+
+// A single sweep's working set. Bounded so one run can't balloon; anything
+// left over goes out on the next sweep five minutes later.
+const BATCH = 100
+
+const DISCORD_API = 'https://discord.com/api/v10'
+
+const sleep = (ms) => (ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve())
+
+// Due rows, each joined to its target channel. The embedded select gives the
+// channel's snowflake and disabled_at in one round trip.
+const selectDueRows = async (now) => {
+  const { data, error } = await sudoSupabase
+    .from('notification')
+    .select('id, body, attempts, scheduled_at, sent_at, discord_channel_id, discord_channel:discord_channel(*)')
+    .eq('transport', 'discord')
+    .is('sent_at', null)
+    .lte('scheduled_at', now.toISOString())
+    .lt('attempts', MAX_ATTEMPTS)
+    .order('scheduled_at', { ascending: true })
+    .limit(BATCH)
+  if (error) throw error
+  return data ?? []
+}
+
+const bumpAttempts = (row) =>
+  sudoSupabase
+    .from('notification')
+    .update({ attempts: row.attempts + 1 })
+    .eq('id', row.id)
+
+// Post one row. Returns the classified outcome so the caller can tally it.
+const deliver = async (row, botToken) => {
+  const channel = row.discord_channel
+  const startedAt = Date.now()
+
+  const response = await fetch(`${DISCORD_API}/channels/${channel.channel_id}/messages`, {
+    method: 'POST',
+    headers: { Authorization: `Bot ${botToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(deliveryPayload(row.body)),
+  })
+  const outcome = classifyDeliveryStatus(response.status)
+  recordDiscordSend({ outcome, status: response.status, duration_ms: Date.now() - startedAt })
+
+  if (outcome === 'sent') {
+    const { error } = await sudoSupabase
+      .from('notification')
+      .update({ sent_at: new Date().toISOString() })
+      .eq('id', row.id)
+    if (error) throw error
+    return outcome
+  }
+
+  if (outcome === 'disabled') {
+    // Permanent: stop pointing at this channel rather than retrying ten times.
+    await sudoSupabase.from('discord_channel').update({ disabled_at: new Date().toISOString() }).eq('id', channel.id)
+    await bumpAttempts(row)
+    return outcome
+  }
+
+  if (outcome === 'throttled') {
+    const payload = await response.json().catch(() => null)
+    await sleep(retryAfterMs(payload))
+  }
+
+  await bumpAttempts(row)
+  return outcome
+}
+
+export const runDiscordNotificationSend = async () => {
+  const botToken = process.env.DISCORD_BOT_TOKEN
+  if (!botToken) {
+    console.log(`[${TAG}] DISCORD_BOT_TOKEN unset — nothing sent`)
+    return
+  }
+
+  const now = new Date()
+  const rows = await selectDueRows(now)
+  const tally = { sent: 0, disabled: 0, throttled: 0, retry: 0, skipped: 0 }
+
+  // Sequential: the volume is tiny and serial sends keep us far away from
+  // Discord's per-channel rate limits.
+  await forEachSequential(rows, async (row) => {
+    if (!isDeliverable({ row, channel: row.discord_channel, now })) {
+      // Channel deleted or disabled since enqueue — bump so the row eventually
+      // ages past the cap instead of being re-selected forever.
+      await bumpAttempts(row)
+      tally.skipped += 1
+      return
+    }
+    try {
+      const outcome = await deliver(row, botToken)
+      tally[outcome] += 1
+    } catch (e) {
+      // One bad row must not abort the sweep; the attempt counter is what
+      // eventually retires it.
+      console.error(`[${TAG}] row ${row.id} failed`, e)
+      await bumpAttempts(row)
+      tally.retry += 1
+    }
+  })
+
+  console.log(
+    `[${TAG}] ${rows.length} due: ${tally.sent} sent, ${tally.disabled} channel-disabled, ${tally.throttled} throttled, ${tally.retry} retry, ${tally.skipped} skipped`
+  )
+}
+
+cli(import.meta.url, TAG, runDiscordNotificationSend)

--- a/src/observability.js
+++ b/src/observability.js
@@ -67,3 +67,13 @@ export const recordPeakRss = ({ job, entry = null }) => {
 //   type: the Discord interaction type (1=PING, 2=APPLICATION_COMMAND, ...), or null
 //   outcome: 'pong' | 'unimplemented' | 'unhandled' | 'bad_signature'
 export const recordDiscordInteraction = ({ type, outcome }) => recordMetric('discord.interaction', { type, outcome })
+
+// One outbound Discord message attempt — see src/jobs/discordNotificationSend.js.
+// Group by outcome to watch delivery health without an OpenTelemetry exporter:
+// a rising 'disabled' count means bots are being kicked, 'throttled' means the
+// send rate is brushing Discord's limits.
+//   outcome: 'sent' | 'disabled' | 'throttled' | 'retry'
+//   status: the HTTP status Discord returned
+//   duration_ms: round-trip latency of the POST
+export const recordDiscordSend = ({ outcome, status, duration_ms }) =>
+  recordMetric('discord.send', { outcome, status, duration_ms })

--- a/src/workflows/discordNotificationSend.ts
+++ b/src/workflows/discordNotificationSend.ts
@@ -1,0 +1,28 @@
+// discord-notification-send as a Vercel Workflow — the sender sweep for the
+// notification outbox (docs/discord-bot/05-notification-sender.md). Single
+// step: runJobWithHeartbeat wraps runDiscordNotificationSend in the start/end
+// heartbeat pair (source: 'vercel-workflow'), same shape as the phase-1 direct
+// jobs. The stage doc predates the completed cron → Workflows migration and
+// suggested runDirectCronJob; that helper now survives only for the unscheduled
+// esf-data/sheet-csv bootstrap routes, so a scheduled job uses this shape
+// instead — one execution engine for everything on a cron.
+//
+// Safe to retry: the sweep is idempotent per row (a sent row is stamped
+// sent_at and never re-selected), so a step retry after a partial failure just
+// picks up whatever is still pending.
+
+// Both imports live inside the step body on purpose (workflow compiler bans
+// Node modules in workflow context — see src/workflows/lib.ts).
+async function runStep() {
+  'use step'
+  const { runJobWithHeartbeat } = await import('./lib')
+  await runJobWithHeartbeat(
+    'discord-notification-send',
+    async () => (await import('@/jobs/discordNotificationSend.js')).runDiscordNotificationSend
+  )
+}
+
+export async function discordNotificationSendWorkflow() {
+  'use workflow'
+  await runStep()
+}

--- a/test/discordDelivery.test.ts
+++ b/test/discordDelivery.test.ts
@@ -1,0 +1,67 @@
+// Unit coverage for the pure Discord delivery-outcome seam
+// (docs/discord-bot/05-notification-sender.md). The mapping from an HTTP
+// status to "stamp sent / disable the channel / back off / retry" is the part
+// that decides whether a kicked bot quietly burns ten retries or is retired
+// immediately, so it's pinned here rather than discovered in production.
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  classifyDeliveryStatus,
+  deliveryPayload,
+  isDeliverable,
+  MAX_ATTEMPTS,
+  retryAfterMs,
+} from '../src/jobs/discordDelivery.js'
+
+test('2xx is a send', () => {
+  assert.equal(classifyDeliveryStatus(200), 'sent')
+  assert.equal(classifyDeliveryStatus(204), 'sent')
+})
+
+test('403 and 404 permanently disable the channel', () => {
+  assert.equal(classifyDeliveryStatus(403), 'disabled')
+  assert.equal(classifyDeliveryStatus(404), 'disabled')
+})
+
+test('429 throttles, everything else retries', () => {
+  assert.equal(classifyDeliveryStatus(429), 'throttled')
+  assert.equal(classifyDeliveryStatus(500), 'retry')
+  assert.equal(classifyDeliveryStatus(502), 'retry')
+  assert.equal(classifyDeliveryStatus(401), 'retry')
+})
+
+const now = new Date('2026-08-06T12:00:00Z')
+const channel = { id: 'chan-a', channel_id: '123', disabled_at: null }
+const row = { sent_at: null, attempts: 0, scheduled_at: '2026-08-06T11:00:00Z' }
+
+test('a pending, due row aimed at a live channel is deliverable', () => {
+  assert.equal(isDeliverable({ row, channel, now }), true)
+})
+
+test('already-sent, over-cap, and not-yet-due rows are not deliverable', () => {
+  assert.equal(isDeliverable({ row: { ...row, sent_at: '2026-08-06T11:30:00Z' }, channel, now }), false)
+  assert.equal(isDeliverable({ row: { ...row, attempts: MAX_ATTEMPTS }, channel, now }), false)
+  assert.equal(isDeliverable({ row: { ...row, scheduled_at: '2026-08-06T13:00:00Z' }, channel, now }), false)
+})
+
+test('a missing or disabled channel makes a row undeliverable', () => {
+  assert.equal(isDeliverable({ row, channel: null, now }), false)
+  assert.equal(isDeliverable({ row, channel: { ...channel, disabled_at: '2026-08-05T00:00:00Z' }, now }), false)
+})
+
+test('the payload never pings anyone', () => {
+  assert.deepEqual(deliveryPayload('Friendly Den Reinforced - QQGH-G V'), {
+    content: 'Friendly Den Reinforced - QQGH-G V',
+    allowed_mentions: { parse: [] },
+  })
+})
+
+test('retry_after is seconds, clamped, and tolerant of junk', () => {
+  assert.equal(retryAfterMs({ retry_after: 1.5 }), 1500)
+  assert.equal(retryAfterMs({ retry_after: 30 }), 5000, 'clamped to the cap')
+  assert.equal(retryAfterMs({ retry_after: 0 }), 0)
+  assert.equal(retryAfterMs(null), 0)
+  assert.equal(retryAfterMs({}), 0)
+  assert.equal(retryAfterMs({ retry_after: 'soon' }), 0)
+})

--- a/test/schedule.test.ts
+++ b/test/schedule.test.ts
@@ -32,6 +32,11 @@ test('parses the field syntax vercel.json uses', () => {
     hourly?.hours,
     Array.from({ length: 24 }, (_, h) => h)
   )
+
+  // discord-notification-send sweeps every five minutes (stage 05).
+  const everyFiveMinutes = parseCron('*/5 * * * *')
+  assert.deepEqual(everyFiveMinutes?.minutes, [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55])
+  assert.equal(everyFiveMinutes?.hours.length, 24)
 })
 
 test('parses ranges, lists and stepped ranges', () => {

--- a/vercel.json
+++ b/vercel.json
@@ -18,6 +18,10 @@
       "schedule": "30 * * * *"
     },
     {
+      "path": "/api/cron/discord-notification-send",
+      "schedule": "*/5 * * * *"
+    },
+    {
       "path": "/api/cron/character-fittings",
       "schedule": "34 */6 * * *"
     },


### PR DESCRIPTION
Implements stage 05 (`docs/discord-bot/05-notification-sender.md`) and closes the MVP loop stage 04 opened: a den entering reinforcement now reaches the corp channel without anyone pasting anything.

## The job

`src/jobs/discordNotificationSend.js` (`runDiscordNotificationSend`, CLI-runnable as `pnpm run discord-notification-send`) sweeps pending `transport = 'discord'` rows joined to their channel and POSTs each to `channels/{id}/messages` with `allowed_mentions: { parse: [] }` — nothing is ever @-pinged; the `<t:…:R>` countdown carries the urgency until per-channel role config exists. Outcomes follow the spec:

| Status | Action |
|---|---|
| 2xx | stamp `sent_at` |
| 403 / 404 | stamp `discord_channel.disabled_at` and bump `attempts` — permanent, so it doesn't burn ten retries; settings shows the state |
| 429 | respect `retry_after` (clamped to 5s), bump `attempts` |
| other | bump `attempts`, cap 10 |

Sends are sequential and the batch is capped at 100 per sweep. A row that throws is logged, bumped, and skipped rather than aborting the run; a row whose channel vanished or was disabled since enqueue is bumped so it ages out instead of being re-selected forever.

The pure classification seam is `src/jobs/discordDelivery.js` (`classifyDeliveryStatus`, `isDeliverable`, `deliveryPayload`, `retryAfterMs`), unit-tested in `test/discordDelivery.test.ts`.

## Scheduling — one deviation from the stage doc

The doc suggested `requireCronSecret` + `runDirectCronJob`. That predates the completed cron → Workflows migration; `runDirectCronJob` now survives only for the unscheduled `esf-data`/`sheet-csv` bootstrap routes, so this runs as a **single-step Vercel Workflow** (`src/workflows/discordNotificationSend.ts`) like every other scheduled job — same `runJobWithHeartbeat` pair, retries and step status under Observability → Workflows. `vercel.json` gets `*/5 * * * *`; `test/schedule.test.ts` pins the new cron shape (it asserts every shape vercel.json uses).

Deliberately **not** added to `/jobs`'s registry or the `/character/refresh` matrix — it isn't per-character and isn't an ESI extract, per the stage doc. Its heartbeat row still proves liveness. (Drive-by: the `MISSED_GRACE_MINUTES` comment there still said "tightest cadence (6h)", stale since stage 04 made dens hourly — corrected.)

## Settings

Per-channel **Send test message** button (`sendDiscordTestMessage`) that posts directly rather than through the outbox, so users can verify the pipe before trusting it. A 403/404 marks the channel disabled with the same classification the sweep makes. The linked-channel list already surfaced `disabled_at`.

## Observability

`recordDiscordSend` emits `{ metric: 'discord.send', outcome, status, duration_ms }` to stdout, matching the `esi.conditional_request` precedent — delivery health is filterable in Vercel Observability without an OTel exporter.

## Verification

- `pnpm test` (158 pass, incl. 8 new delivery cases), `pnpm run lint`, `pnpm run build` all green; `/api/cron/discord-notification-send` appears in the route manifest.
- **Sending needs a real `DISCORD_BOT_TOKEN` in Vercel** — the current value is placeholder noise. Without it the sweep logs `DISCORD_BOT_TOKEN unset — nothing sent` and does nothing, so merging is safe ahead of setting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014saqfgmtTJk7SgtkLbi3F7

---
_Generated by [Claude Code](https://claude.ai/code/session_014saqfgmtTJk7SgtkLbi3F7)_