### PR TITLE
Drop the share id from share-link tokens

### DIFF
--- a/docs/sharing-layer/01-asset-share-table.md
+++ b/docs/sharing-layer/01-asset-share-table.md
@@ -126,6 +126,19 @@ recomputes and compares with `timingSafeEqual`. Revoking a link = nulling
 `secret` (or rotating it, which invalidates old URLs); deleting the row
 revokes everything.
 
+**Superseded — the token is now just `?share=<signature>`.** Carrying the id
+was redundant: the URL's own path already identifies the share row (a lens
+share IS the lens, so `/lens/<id>?share=<id>.<sig>` said it twice; a fitting
+share is the path's `(registration, fitting)` pair; an asset share is one of
+the ≤16 shares covering the requested item's ancestry, and the signature says
+which). Resolvers look the row up from the path and verify the signature
+against it. `parseShareParam()` (`src/shareToken.ts`) still splits the old
+form so issued links keep working — the id half only ever _narrows_ the
+lookup, never selects a row the path doesn't already identify — and the pages
+rewrite such a URL to the short form in the address bar via
+`ShareUrlCleanup` (`src/app/shareUrlCleanup.tsx`, a `history.replaceState`
+with no navigation). Nothing mints the long form any more.
+
 `signShare`/`verifyShareToken` are pure given their inputs — unit-test them in
 `test/shareToken.test.ts` with a fixed salt injected as a parameter (read
 `process.env.TOKEN_SALT` only at the callers, so the node test runner needs

--- a/docs/sharing-layer/README.md
+++ b/docs/sharing-layer/README.md
@@ -90,6 +90,10 @@ The ordering runs safest-first:
 | [06-supersede-mercenary-dens.md](06-supersede-mercenary-dens.md) | Fold `character_mercenary_den_share` into the unified model                                                                                       | ✅ **Done** — migration `20260806000000`, `test/sql/den_share.sql`                        |
 | [07-lens.md](07-lens.md)                                         | Lenses: shared GraphQL queries under the creator's context, CSV rendering to supersede the Sheets endpoints; `/lens` editor behind a feature flag | ✅ **Done** — migration `20260806130000`, `test/sql/lens.sql`                            |
 
+Since then the URL token dropped its `<shareId>.` prefix — see the superseded
+note in [01-asset-share-table.md](01-asset-share-table.md#token-signing--srcsharetokents--token_salt).
+Old links still resolve and rewrite themselves to the short form.
+
 ## What already exists (build on this, don't reinvent it)
 
 - `my_corporation_ids()` / `my_alliance_ids()` — invoker-rights membership

--- a/src/app/api/mcp/lensTools.ts
+++ b/src/app/api/mcp/lensTools.ts
@@ -182,7 +182,7 @@ const storedShare = (row: LensRow): ShareState | null => {
     corporationIds: row.corporation_ids ?? [],
     allianceIds: row.alliance_ids ?? [],
     hasLink: row.secret != null,
-    shareParam: row.secret && salt ? `${row.id}.${signShare(row.id, row.secret, salt)}` : null,
+    shareParam: row.secret && salt ? signShare(row.id, row.secret, salt) : null,
     isPublic: row.secret == null && (row.corporation_ids ?? []).length === 0 && (row.alliance_ids ?? []).length === 0,
   }
 }

--- a/src/app/asset/[locationId]/page.tsx
+++ b/src/app/asset/[locationId]/page.tsx
@@ -6,7 +6,9 @@ import { getSdeSystem } from '@/sdeSystems'
 import { getSdeType } from '@/sdeTypes'
 import { createClient } from '@/utils/supabase/server'
 import { createServiceClient } from '@/utils/supabase/service'
+import { parseShareParam } from '@/shareToken'
 import { AssetPath, fetchAssetPath, regionSystemCrumbs, type Crumb } from '../../assetPath'
+import { ShareUrlCleanup } from '../../shareUrlCleanup'
 import { fetchOwners } from '../../owners'
 import type { Owners } from '../../ownerFilter'
 import { SkeletonTable } from '../../skeleton'
@@ -211,9 +213,11 @@ const AssetLocationPage = async ({
 
   // A ship is its own page, not a directory level (a share link stays valid
   // through the redirect — a signed link covers the whole shared subtree, a
-  // legacy token is bound to this same id).
+  // legacy token is bound to this same id). The redirect is also where a
+  // legacy `<shareId>.<signature>` param sheds its id half.
   if (self && selfType?.categoryID === SHIP_CATEGORY_ID) {
-    redirect(`/ship/${locationId}${share ? `?share=${share}` : token ? `?token=${token}` : ''}`)
+    const shipShare = share ? parseShareParam(share).signature : undefined
+    redirect(`/ship/${locationId}${shipShare ? `?share=${shipShare}` : token ? `?token=${token}` : ''}`)
   }
 
   // Share dialog data for an owned character item; fetchShareDialogData returns
@@ -281,6 +285,7 @@ const AssetLocationPage = async ({
 
   return (
     <>
+      {share && <ShareUrlCleanup />}
       {!scope ? <AssetPath crumbs={crumbs} current={heading} /> : null}
       <div className={styles.header}>
         <h1 className="serif">

--- a/src/app/asset/access.ts
+++ b/src/app/asset/access.ts
@@ -4,17 +4,19 @@
 // registration/corporation ids.
 //
 // Two link generations live here:
-//  - resolveSignedShare: the sharing layer's ?share=<shareId>.<signature>
+//  - resolveSignedShare: the sharing layer's ?share=<signature>
 //    (docs/sharing-layer/03-share-dialog.md). The signature is an HMAC over
 //    the share id keyed by the row's secret + TOKEN_SALT (src/shareToken.ts),
 //    and the link is RECURSIVE: it opens the share's subject item and
-//    anything nested inside it — the requested id must be the subject or
-//    have it among its ancestors.
+//    anything nested inside it — so the candidate rows are the shares whose
+//    subject is the requested item or one of its ancestors, and the signature
+//    picks which of those (if any) the link was issued for. Legacy
+//    `<shareId>.<signature>` links narrow that candidate set to the named row.
 //  - resolveShareToken: the legacy shared_asset_token ?token=… link, kept
 //    resolving through a deprecation window (no UI mints these any more;
 //    saving a share from the dialog retires the item's legacy row). Exact-id
 //    only, as it always was.
-import { tokenSalt, verifyShareToken } from '@/shareToken'
+import { parseShareParam, tokenSalt, verifyShareToken } from '@/shareToken'
 import { createServiceClient } from '@/utils/supabase/service'
 
 export type ShareScope = {
@@ -27,18 +29,18 @@ export type ShareScope = {
   corporationIds: number[]
 }
 
-// Whether `subject` is `from` itself or among its enclosing containers —
-// climbing best-known parents one indexed probe at a time, depth-capped to
-// match asset_ancestors()/asset_share_covers(). Service client: the anonymous
+// `from` itself followed by its enclosing containers — climbing best-known
+// parents one indexed probe at a time, depth-capped to match
+// asset_ancestors()/asset_share_covers(). Every id a recursive share could
+// have been issued for and still cover `from`. Service client: the anonymous
 // caller has no RLS visibility yet, that's the point of the walk.
-const subjectInAncestry = async (
+const ancestryChain = async (
   supabase: ReturnType<typeof createServiceClient>,
   from: string,
-  subject: string,
-  depth = 0
-): Promise<boolean> => {
-  if (from === subject) return true
-  if (depth >= 16) return false
+  acc: string[] = []
+): Promise<string[]> => {
+  const chain = [...acc, from]
+  if (chain.length > 16) return chain
   const { data } = await supabase
     .from('character_asset_over_time')
     .select('location_id')
@@ -48,17 +50,15 @@ const subjectInAncestry = async (
     .limit(1)
     .maybeSingle<{ location_id: number | string | null }>()
   const parent = data?.location_id
-  return parent == null ? false : subjectInAncestry(supabase, String(parent), subject, depth + 1)
+  return parent == null ? chain : ancestryChain(supabase, String(parent), chain)
 }
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 export const resolveSignedShare = async (param: string, itemId: string): Promise<ShareScope | null> => {
-  const dot = param.indexOf('.')
-  if (dot <= 0) return null
-  const shareId = param.slice(0, dot)
-  const signature = param.slice(dot + 1)
-  if (!UUID_RE.test(shareId) || signature === '') return null
+  const { shareId, signature } = parseShareParam(param)
+  if (signature === '') return null
+  if (shareId !== null && !UUID_RE.test(shareId)) return null
 
   // A deployment without its salt can't verify anything — treat as no share
   // rather than throwing into the page.
@@ -69,15 +69,16 @@ export const resolveSignedShare = async (param: string, itemId: string): Promise
     return null
   }
 
+  // Every share that covers the requested item, then the signature says which
+  // one (if any) minted this link. A legacy link's id narrows it to one row.
   const supabase = createServiceClient()
-  const { data: share } = await supabase
-    .from('character_asset_share')
-    .select('id, registration_id, item_id, secret')
-    .eq('id', shareId)
-    .maybeSingle<{ id: string; registration_id: string; item_id: number | string; secret: string | null }>()
-  if (!share?.secret) return null
-  if (!verifyShareToken(share.id, share.secret, salt, signature)) return null
-  if (!(await subjectInAncestry(supabase, itemId, String(share.item_id)))) return null
+  const chain = await ancestryChain(supabase, itemId)
+  const query = supabase.from('character_asset_share').select('id, registration_id, secret').in('item_id', chain)
+  const { data: covering } = await (shareId === null ? query : query.eq('id', shareId))
+  const share = ((covering ?? []) as Array<{ id: string; registration_id: string; secret: string | null }>).find(
+    (row) => row.secret != null && verifyShareToken(row.id, row.secret, salt, signature)
+  )
+  if (!share) return null
 
   const { data: registration } = await supabase
     .from('registration')

--- a/src/app/asset/shareActions.ts
+++ b/src/app/asset/shareActions.ts
@@ -125,7 +125,7 @@ export const saveAssetShare = async (itemId: string, input: SaveShareInput): Pro
       corporationIds,
       allianceIds,
       hasLink: secret != null,
-      shareParam: secret != null && salt != null ? `${saved.id}.${signShare(saved.id, secret, salt)}` : null,
+      shareParam: secret != null && salt != null ? signShare(saved.id, secret, salt) : null,
       isPublic: secret == null && corporationIds.length === 0 && allianceIds.length === 0,
     },
   }

--- a/src/app/asset/shareData.ts
+++ b/src/app/asset/shareData.ts
@@ -13,7 +13,10 @@ export type ShareState = {
   corporationIds: number[]
   allianceIds: number[]
   hasLink: boolean
-  // `<shareId>.<signature>` for the ?share= param, when a link is enabled.
+  // The signature for the ?share= param, when a link is enabled. Bare — the
+  // row it verifies against is the one the URL's own path identifies, so the
+  // token doesn't repeat any id (links issued before this carried
+  // `<shareId>.<signature>` and still resolve; src/shareToken.ts).
   shareParam: string | null
   isPublic: boolean
 }
@@ -95,7 +98,7 @@ export const shareRowToState = (row: ShareRowLike | null): ShareState | null => 
   let shareParam: string | null = null
   if (row.secret) {
     try {
-      shareParam = `${row.id}.${signShare(row.id, row.secret, tokenSalt())}`
+      shareParam = signShare(row.id, row.secret, tokenSalt())
     } catch {
       shareParam = null
     }

--- a/src/app/fitting/[characterId]/[fittingId]/page.tsx
+++ b/src/app/fitting/[characterId]/[fittingId]/page.tsx
@@ -7,6 +7,7 @@ import { ShipFitViewDynamic } from '../../../ship/[itemId]/shipFitViewDynamic'
 import { Name } from '../../../names'
 import { fetchTypeNames } from '../../../typeNames'
 import { ShareDialog } from '../../../asset/shareDialog'
+import { ShareUrlCleanup } from '../../../shareUrlCleanup'
 import { verifySignedFittingShare } from '../../access'
 import { saveFittingShare, revokeFittingShare } from '../../actions'
 import { toEsiFit, type FittingItem, type FittingRow } from '../../fit'
@@ -86,6 +87,7 @@ const FittingDetailPage = async ({
 
   return (
     <div className={isOwner ? undefined : styles.sharedPage}>
+      {share && <ShareUrlCleanup />}
       {isOwner ? null : (
         <div className={styles.sharedFrom}>
           <img

--- a/src/app/fitting/access.ts
+++ b/src/app/fitting/access.ts
@@ -5,7 +5,7 @@
 // and the URL's fit IS the share's subject. Service role, because the
 // anonymous caller has no RLS visibility; the page then reads the fit
 // explicitly scoped to that pair.
-import { tokenSalt, verifyShareToken } from '@/shareToken'
+import { parseShareParam, tokenSalt, verifyShareToken } from '@/shareToken'
 import { createServiceClient } from '@/utils/supabase/service'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -15,11 +15,11 @@ export const verifySignedFittingShare = async (
   registrationId: string,
   fittingId: string
 ): Promise<boolean> => {
-  const dot = param.indexOf('.')
-  if (dot <= 0) return false
-  const shareId = param.slice(0, dot)
-  const signature = param.slice(dot + 1)
-  if (!UUID_RE.test(shareId) || signature === '') return false
+  const { shareId, signature } = parseShareParam(param)
+  if (signature === '') return false
+  // Legacy `<shareId>.<signature>` links name the row; it still has to be the
+  // one covering this fit, so the id only narrows the lookup below.
+  if (shareId !== null && !UUID_RE.test(shareId)) return false
 
   let salt: string
   try {
@@ -28,13 +28,18 @@ export const verifySignedFittingShare = async (
     return false
   }
 
+  // (registration_id, fitting_id) is unique, so the URL's own path identifies
+  // the share row without the token having to carry its id.
   const supabase = createServiceClient()
-  const { data: share } = await supabase
+  const query = supabase
     .from('character_fitting_share')
-    .select('id, registration_id, fitting_id, secret')
-    .eq('id', shareId)
-    .maybeSingle<{ id: string; registration_id: string; fitting_id: number | string; secret: string | null }>()
+    .select('id, secret')
+    .eq('registration_id', registrationId)
+    .eq('fitting_id', fittingId)
+  const { data: share } = await (shareId === null ? query : query.eq('id', shareId)).maybeSingle<{
+    id: string
+    secret: string | null
+  }>()
   if (!share?.secret) return false
-  if (share.registration_id !== registrationId || String(share.fitting_id) !== fittingId) return false
   return verifyShareToken(share.id, share.secret, salt, signature)
 }

--- a/src/app/fitting/actions.ts
+++ b/src/app/fitting/actions.ts
@@ -117,7 +117,7 @@ export const saveFittingShare = async (
       corporationIds,
       allianceIds,
       hasLink: secret != null,
-      shareParam: secret != null && salt != null ? `${saved.id}.${signShare(saved.id, secret, salt)}` : null,
+      shareParam: secret != null && salt != null ? signShare(saved.id, secret, salt) : null,
       isPublic: secret == null && corporationIds.length === 0 && allianceIds.length === 0,
     },
   }

--- a/src/app/lens/[id]/page.tsx
+++ b/src/app/lens/[id]/page.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 
+import { parseShareParam } from '@/shareToken'
+import { ShareUrlCleanup } from '../../shareUrlCleanup'
 import { resolveLens } from '../access'
 import { lensRows } from '../flatten'
 import { runLens } from '../run'
@@ -31,10 +33,13 @@ const LensViewerPage = async ({
   const result = await runLens(lens)
   const rows = lensRows(result.data)
   const headers = rows.length > 0 ? Object.keys(rows[0]) : []
-  const csvHref = `/lens/${lens.id}/csv${share ? `?share=${encodeURIComponent(share)}` : ''}`
+  // Hand the CSV link the short token, whichever generation arrived here.
+  const cleanShare = share ? parseShareParam(share).signature : undefined
+  const csvHref = `/lens/${lens.id}/csv${cleanShare ? `?share=${encodeURIComponent(cleanShare)}` : ''}`
 
   return (
     <>
+      {share && <ShareUrlCleanup />}
       <div className={styles.lensHeading}>
         <h1>{lens.name}</h1>
         <div className={styles.buttons}>

--- a/src/app/lens/access.ts
+++ b/src/app/lens/access.ts
@@ -5,14 +5,17 @@
 //   policy or the audience policy (corporation/alliance membership, or a
 //   fully-public shared lens) decides. Works signed-out too: the anon role
 //   reaches only shared-and-public rows.
-// - Signed link: ?share=<lensId>.<signature> verified against the row's
-//   secret + TOKEN_SALT via the service client (an anonymous HTTP request is
-//   invisible to RLS — link-only lenses match no one there by design).
+// - Signed link: ?share=<signature> verified against the row's secret +
+//   TOKEN_SALT via the service client (an anonymous HTTP request is invisible
+//   to RLS — link-only lenses match no one there by design). The lens the
+//   signature must verify against is the one in the path, so the token needn't
+//   name it; legacy `<lensId>.<signature>` links still resolve, and the viewer
+//   rewrites them to the short form in the address bar.
 //
 // Either way the run is gated on the CREATOR still holding the lens flag —
 // un-flagging an account turns its shared lenses off, the dark-launch lever.
 import { LENS_FLAG, hasFlag } from '@/flags'
-import { tokenSalt, verifyShareToken } from '@/shareToken'
+import { parseShareParam, tokenSalt, verifyShareToken } from '@/shareToken'
 import { createClient } from '@/utils/supabase/server'
 import { createServiceClient } from '@/utils/supabase/service'
 import type { LensRecord } from './run'
@@ -22,11 +25,10 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 export type ResolvedLens = { lens: LensRecord; viewerIsOwner: boolean }
 
 const resolveSignedLens = async (lensId: string, param: string): Promise<LensRecord | null> => {
-  const dot = param.indexOf('.')
-  if (dot <= 0) return null
-  const shareId = param.slice(0, dot)
-  const signature = param.slice(dot + 1)
-  if (shareId !== lensId || signature === '') return null
+  const { shareId, signature } = parseShareParam(param)
+  if (signature === '') return null
+  // A legacy link names the lens it was issued for; it has to be this one.
+  if (shareId !== null && shareId !== lensId) return null
 
   let salt: string
   try {

--- a/src/app/lens/share.ts
+++ b/src/app/lens/share.ts
@@ -119,7 +119,7 @@ export const applyLensShare = async (
       corporationIds: audience.corporationIds,
       allianceIds: audience.allianceIds,
       hasLink: secret != null,
-      shareParam: secret != null && salt != null ? `${lensId}.${signShare(lensId, secret, salt)}` : null,
+      shareParam: secret != null && salt != null ? signShare(lensId, secret, salt) : null,
       isPublic: secret == null && audience.corporationIds.length === 0 && audience.allianceIds.length === 0,
     },
   }

--- a/src/app/shareUrlCleanup.tsx
+++ b/src/app/shareUrlCleanup.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useEffect } from 'react'
+
+// Graceful migration off the old `?share=<shareId>.<signature>` links, which
+// repeated an id the path already carries (a lens's worst case:
+// /lens/<id>?share=<id>.<sig>). Rendered only by a page that has ALREADY
+// resolved the share server-side, it rewrites the address bar to the short
+// `?share=<signature>` form the resolvers now also accept — so the URL a
+// visitor copies onward, or bookmarks, is the clean one.
+//
+// history.replaceState rather than a redirect: no round trip, no re-render, no
+// entry added to the back stack, and a share that resolved stays resolved.
+export const ShareUrlCleanup = () => {
+  useEffect(() => {
+    const url = new URL(window.location.href)
+    const share = url.searchParams.get('share')
+    if (share === null) return
+    const dot = share.indexOf('.')
+    if (dot < 0) return
+    url.searchParams.set('share', share.slice(dot + 1))
+    window.history.replaceState(window.history.state, '', url)
+  }, [])
+  return null
+}

--- a/src/app/ship/[itemId]/page.tsx
+++ b/src/app/ship/[itemId]/page.tsx
@@ -6,6 +6,7 @@ import { getSdeType, getSdeTypes } from '@/sdeTypes'
 import { createClient } from '@/utils/supabase/server'
 import { createServiceClient } from '@/utils/supabase/service'
 import { AssetPath, fetchAssetPath } from '../../assetPath'
+import { ShareUrlCleanup } from '../../shareUrlCleanup'
 import { typeFacts } from '../../assetTypeFacts'
 import type { Owners } from '../../ownerFilter'
 import { SkeletonTable } from '../../skeleton'
@@ -300,6 +301,7 @@ const SharedShipPage = async ({
 
   return (
     <>
+      {shareParams.share && <ShareUrlCleanup />}
       <ShipHeading typeId={Number(self.type_id)} heading={heading} owner={owner} />
       <ShipFitViewDynamic esiFit={toEsiFit(Number(self.type_id), self.name ?? null, rows)} />
       {/* Hull first here too, so a shared ship lists the same things the

--- a/src/shareToken.ts
+++ b/src/shareToken.ts
@@ -2,12 +2,12 @@ import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
 
 // Signed share links (sharing layer Revision 3, phase 1 — see
 // docs/sharing-layer/01-asset-share-table.md). A link share stores a random
-// `secret` on its share row; the URL carries `?share=<shareId>.<signature>`
-// where the signature is HMAC-SHA256 over the share id, keyed by the secret
-// concatenated with the TOKEN_SALT environment variable. Neither half alone
-// mints a valid link: a database dump lacks the salt, the environment lacks
-// the secret. Rotating the secret (or nulling it) invalidates every URL ever
-// issued for the share; deleting the row revokes everything.
+// `secret` on its share row; the URL carries `?share=<signature>` where the
+// signature is HMAC-SHA256 over the share id, keyed by the secret concatenated
+// with the TOKEN_SALT environment variable. Neither half alone mints a valid
+// link: a database dump lacks the salt, the environment lacks the secret.
+// Rotating the secret (or nulling it) invalidates every URL ever issued for
+// the share; deleting the row revokes everything.
 //
 // The salt is a parameter rather than read here, so the node test runner can
 // exercise signing without env plumbing — callers pass tokenSalt().
@@ -19,6 +19,27 @@ export const verifyShareToken = (shareId: string, secret: string, salt: string, 
   const expected = Buffer.from(signShare(shareId, secret, salt))
   const presented = Buffer.from(token)
   return expected.length === presented.length && timingSafeEqual(expected, presented)
+}
+
+// Links minted before the URL cleanup carried the share id ahead of the
+// signature — `?share=<shareId>.<signature>` — which for a lens repeated the
+// id already sitting in the path. Both forms parse; the id half, when present,
+// only ever NARROWS the row lookup (a caller rejects a mismatch), it never
+// selects a row the URL's own path doesn't already identify. New links carry
+// the bare signature, so this exists purely to keep issued URLs working.
+export type ParsedShareParam = {
+  // The legacy `<shareId>` half, or null for a bare-signature link. An empty
+  // string when the param started with the separator — never a valid id, and
+  // callers reject it the same way they reject any other mismatch.
+  shareId: string | null
+  signature: string
+}
+
+export const parseShareParam = (param: string): ParsedShareParam => {
+  const dot = param.indexOf('.')
+  return dot < 0
+    ? { shareId: null, signature: param }
+    : { shareId: param.slice(0, dot), signature: param.slice(dot + 1) }
 }
 
 // The stored private key for a new link share: 32 random bytes, hex.

--- a/test/shareToken.test.ts
+++ b/test/shareToken.test.ts
@@ -6,7 +6,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { mintShareSecret, signShare, verifyShareToken } from '../src/shareToken.ts'
+import { mintShareSecret, parseShareParam, signShare, verifyShareToken } from '../src/shareToken.ts'
 
 const SECRET = 'a'.repeat(64)
 const SALT = 'test-salt'
@@ -29,6 +29,23 @@ test('malformed presented tokens fail without throwing', () => {
   assert.equal(verifyShareToken('share-1', SECRET, SALT, ''), false)
   assert.equal(verifyShareToken('share-1', SECRET, SALT, 'short'), false)
   assert.equal(verifyShareToken('share-1', SECRET, SALT, 'x'.repeat(300)), false)
+})
+
+// The two link generations. A current link is the bare signature; one issued
+// before the URL cleanup prefixes the share id and a dot. A signature is
+// base64url, which can't contain a dot, so the split is unambiguous.
+test('a bare param is all signature, with no id claimed', () => {
+  const token = signShare('share-1', SECRET, SALT)
+  assert.deepEqual(parseShareParam(token), { shareId: null, signature: token })
+})
+
+test('a legacy param splits into its id and signature halves', () => {
+  const token = signShare('share-1', SECRET, SALT)
+  assert.deepEqual(parseShareParam(`share-1.${token}`), { shareId: 'share-1', signature: token })
+  // Either half missing yields an empty half, never a mis-attributed one —
+  // callers reject on the empty signature or the unmatched id.
+  assert.deepEqual(parseShareParam('.sig'), { shareId: '', signature: 'sig' })
+  assert.deepEqual(parseShareParam('share-1.'), { shareId: 'share-1', signature: '' })
 })
 
 test('minted secrets are 32 random bytes, hex, and unique', () => {


### PR DESCRIPTION
A share URL carried `?share=<shareId>.<signature>`, which for a lens meant the id appeared twice:

```
/lens/6115f2e8-…/csv?share=6115f2e8-….3SV7llFd1I2iTTJdYRONDwHD0Kaz8JkGHoJ6zIcAJAA
/lens/6115f2e8-…/csv?share=3SV7llFd1I2iTTJdYRONDwHD0Kaz8JkGHoJ6zIcAJAA
```

The id was never load-bearing — the URL's own path already identifies the share row — so tokens are now the bare signature.

## How each resolver finds its row without the token naming it

- **Lens** (`src/app/lens/access.ts`) — the share *is* the lens, so it's the id in the path.
- **Fitting** (`src/app/fitting/access.ts`) — `character_fitting_share` is unique on `(registration_id, fitting_id)`, both in the path.
- **Asset** (`src/app/asset/access.ts`) — a signed asset link is recursive, so the candidates are the shares whose subject is the requested item or one of its ≤16 ancestors, and the signature says which one minted the link. This inverts the old walk: collect the ancestry chain, ask for the shares over it, verify against each.

Signing itself is unchanged — still HMAC over the share id, keyed by the row's `secret` + `TOKEN_SALT`.

## Graceful migration

Links already in the wild keep working. `parseShareParam()` (`src/shareToken.ts`) splits the legacy form, and its id half only ever *narrows* the row lookup — it can never select a row the path doesn't already identify, so an old link authorizes exactly what it did before.

A page that resolved a legacy link renders `ShareUrlCleanup` (`src/app/shareUrlCleanup.tsx`), which rewrites the address bar to the short form with `history.replaceState` — no redirect, no refetch, no back-stack entry, and the resolved share stays resolved. Wired into the lens viewer, `/ship/[itemId]`, `/asset/[locationId]` and the fitting detail page; the lens page also hands its CSV link the short token, and the asset→ship redirect sheds the id half on the way through.

Nothing mints the long form any more: the shared `shareRowToState()` and the three save actions (asset / fitting / lens) all emit the bare signature.

## Testing

`pnpm test` (166 pass, including new `parseShareParam` coverage of both link generations), `pnpm run lint`, `pnpm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4CCFm6N7fe2GKUvNyCxPM

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4CCFm6N7fe2GKUvNyCxPM)_