### PR TITLE
Page-load performance phase 1: instant navigation feedback

### DIFF
--- a/src/app/asset/[locationId]/loading.tsx
+++ b/src/app/asset/[locationId]/loading.tsx
@@ -1,0 +1,15 @@
+import { LoadingShell, SkeletonTable } from '../../skeleton'
+
+// The heading is the location's own name, which is one of the things being
+// fetched — so it's a bar rather than text, and the breadcrumb line above it is
+// reserved so the heading doesn't jump when the real crumbs arrive.
+const AssetLocationLoading = () => (
+  <LoadingShell crumbs>
+    <SkeletonTable
+      columns={['Quantity', 'Item', 'Volume (m³)', 'Group', 'Category', 'Owner', 'Hangar', 'Contents']}
+      numeric={['Quantity', 'Volume (m³)', 'Contents']}
+      rows={12}
+    />
+  </LoadingShell>
+)
+export default AssetLocationLoading

--- a/src/app/asset/[locationId]/locationAssets.tsx
+++ b/src/app/asset/[locationId]/locationAssets.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ascend, descend, difference, sortWith, union } from 'ramda'
 
+import { LinkSpinner } from '../../linkSpinner'
 import { ALL_OWNERS, OwnerSelect, ownerNames, useOwnerFilter, type Owners } from '../../ownerFilter'
 import retro from '../../retro.module.css'
 import { TypeIcon, type IconVariation } from '../../typeIcon'
@@ -347,6 +348,7 @@ export const LocationAssets = ({ rows, owners, typeNamesPromise, canAppraise }: 
                         // Ships open their own /ship page; containers drill into /asset.
                         <Link href={row.href}>
                           <TypeName id={row.typeId} name={row.name} promise={typeNamesPromise} />
+                          <LinkSpinner />
                         </Link>
                       ) : (
                         <TypeName id={row.typeId} name={row.name} promise={typeNamesPromise} />

--- a/src/app/asset/[locationId]/systemLocations.tsx
+++ b/src/app/asset/[locationId]/systemLocations.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 
+import { LinkSpinner } from '../../linkSpinner'
 import { ALL_OWNERS, OwnerSelect, useOwnerFilter, type Owners } from '../../ownerFilter'
 import retro from '../../retro.module.css'
 import styles from '../assets.module.css'
@@ -46,6 +47,7 @@ export const SystemLocations = ({ locations, owners }: { locations: Location[]; 
               <td>
                 <Link href={`/asset/${loc.id}`} className="serif">
                   {loc.name}
+                  <LinkSpinner />
                 </Link>
               </td>
               <td className={retro.num}>{count}</td>

--- a/src/app/asset/assetsTable.tsx
+++ b/src/app/asset/assetsTable.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { reduce } from 'ramda'
 
+import { LinkSpinner } from '../linkSpinner'
 import { ALL_OWNERS, OwnerSelect, useOwnerFilter, type Owners } from '../ownerFilter'
 import retro from '../retro.module.css'
 import styles from './assets.module.css'
@@ -113,8 +114,12 @@ export const AssetsTable = ({ locations, owners }: AssetsTableProps) => {
                   <tr key={`location-${loc.id}`}>
                     <td aria-hidden="true" />
                     <td>
+                      {/* Opening a busy hangar takes a moment; the spinner says
+                          which row is being opened, which the whole-page
+                          loading fallback can't. */}
                       <Link href={`/asset/${loc.id}`} className="serif">
                         {loc.name}
+                        <LinkSpinner />
                       </Link>
                     </td>
                     <td className={retro.num}>{count}</td>

--- a/src/app/asset/loading.tsx
+++ b/src/app/asset/loading.tsx
@@ -1,0 +1,10 @@
+import { LoadingShell, SkeletonTable } from '../skeleton'
+
+// Building the location buckets means two location-summary RPCs plus a name
+// resolution pass, so this stands in from the moment the link is clicked.
+const AssetsLoading = () => (
+  <LoadingShell title="Assets">
+    <SkeletonTable columns={['System', 'Location', 'Items']} numeric={['Items']} rows={10} />
+  </LoadingShell>
+)
+export default AssetsLoading

--- a/src/app/asset/page.tsx
+++ b/src/app/asset/page.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
-import { Suspense } from 'react'
 import { map, reduce } from 'ramda'
 
 import { createClient } from '@/utils/supabase/server'
@@ -44,25 +43,13 @@ const AssetsPage = async () => {
     redirect('/')
   }
 
-  // The location buckets are expensive to build (every asset is paged in and walked
-  // up its location chain, then station/structure/system names are resolved), so the
-  // page shell streams immediately and the table streams in once Locations() resolves.
-  return (
-    <Suspense fallback={<AssetsLoading />}>
-      <Locations />
-    </Suspense>
-  )
+  // The location buckets are expensive to build (two location-summary RPCs plus
+  // a name-resolution pass), so the wait is covered by ./loading.tsx — which
+  // paints the instant the link is clicked, rather than only once the server
+  // has started responding, as an in-page Suspense fallback did.
+  return <Locations />
 }
 export default AssetsPage
-
-const AssetsLoading = () => (
-  <section>
-    <div className={styles.header}>
-      <h1>Assets</h1>
-    </div>
-    <p>Loading locations…</p>
-  </section>
-)
 
 const Locations = async () => {
   const supabase = await createClient()

--- a/src/app/asset/search/loading.tsx
+++ b/src/app/asset/search/loading.tsx
@@ -1,0 +1,12 @@
+import { LoadingShell, SkeletonTable } from '../../skeleton'
+
+const AssetSearchLoading = () => (
+  <LoadingShell title="Search Assets">
+    <SkeletonTable
+      columns={['Owner', 'System', 'Station', 'Item', 'Quantity', 'Hangar', 'Contents']}
+      numeric={['Quantity', 'Contents']}
+      rows={10}
+    />
+  </LoadingShell>
+)
+export default AssetSearchLoading

--- a/src/app/asset/search/page.tsx
+++ b/src/app/asset/search/page.tsx
@@ -7,6 +7,7 @@ import { getSdeTypes, searchSdeTypesAll } from '@/sdeTypes'
 import { BLUEPRINT_CATEGORY_ID } from '@/utils/sdeCategories'
 import { createClient } from '@/utils/supabase/server'
 
+import { LinkSpinner } from '../../linkSpinner'
 import { fetchOwners } from '../../owners'
 import { resolveLocations, type LocationRef } from '../../resolveLocations'
 import retro from '../../retro.module.css'
@@ -263,19 +264,30 @@ const AssetSearchPage = async ({ searchParams }: { searchParams: Promise<{ q?: s
                 <td>{ownerMap.get(row.ownerId) ?? row.ownerId}</td>
                 <td className="serif">
                   {row.root && floating ? (
-                    <Link href={`/asset/${row.root.id}`}>{systemName}</Link>
+                    <Link href={`/asset/${row.root.id}`}>
+                      {systemName}
+                      <LinkSpinner />
+                    </Link>
                   ) : (
                     (systemName ?? '—')
                   )}
                 </td>
                 <td className="serif">
-                  {row.root && !floating ? <Link href={`/asset/${row.root.id}`}>{stationName}</Link> : '—'}
+                  {row.root && !floating ? (
+                    <Link href={`/asset/${row.root.id}`}>
+                      {stationName}
+                      <LinkSpinner />
+                    </Link>
+                  ) : (
+                    '—'
+                  )}
                 </td>
                 <td>
                   <TypeIcon id={row.typeId} variation={iconFor(row.typeId)} />
                   {row.contents > 0 ? (
                     <Link href={`/asset/${row.itemId}`}>
                       <TypeName id={row.typeId} name={row.name} promise={typeNamesPromise} />
+                      <LinkSpinner />
                     </Link>
                   ) : (
                     <TypeName id={row.typeId} name={row.name} promise={typeNamesPromise} />
@@ -293,6 +305,7 @@ const AssetSearchPage = async ({ searchParams }: { searchParams: Promise<{ q?: s
                           {row.parentTypeId != null && <TypeIcon id={row.parentTypeId} />}
                           <Link className="serif" href={`/ship/${row.parentId}`}>
                             {shipLabel}
+                            <LinkSpinner />
                           </Link>
                           {row.flag ? <span className={retro.muted}> · {row.flag}</span> : null}
                         </>

--- a/src/app/blueprint/[typeID]/loading.tsx
+++ b/src/app/blueprint/[typeID]/loading.tsx
@@ -1,0 +1,9 @@
+import { LoadingShell, SkeletonLines } from '../../skeleton'
+
+// The heading is the blueprint's product name, resolved from the SDE mirror.
+const BlueprintLoading = () => (
+  <LoadingShell>
+    <SkeletonLines count={6} />
+  </LoadingShell>
+)
+export default BlueprintLoading

--- a/src/app/character/refresh/loading.tsx
+++ b/src/app/character/refresh/loading.tsx
@@ -1,0 +1,10 @@
+import { LoadingShell, SkeletonLines } from '../../skeleton'
+
+// The freshness matrix is one column per job, so its width depends on data;
+// bars rather than a table with invented columns.
+const RefreshLoading = () => (
+  <LoadingShell title="Refresh ESI">
+    <SkeletonLines count={8} />
+  </LoadingShell>
+)
+export default RefreshLoading

--- a/src/app/fitting/[characterId]/[fittingId]/loading.tsx
+++ b/src/app/fitting/[characterId]/[fittingId]/loading.tsx
@@ -1,0 +1,9 @@
+import { LoadingShell, SkeletonLines } from '../../../skeleton'
+
+// One fit in the eveship.fit wheel; the heading is the fit's own name.
+const FittingDetailLoading = () => (
+  <LoadingShell>
+    <SkeletonLines count={6} />
+  </LoadingShell>
+)
+export default FittingDetailLoading

--- a/src/app/fitting/fittingMatrix.tsx
+++ b/src/app/fitting/fittingMatrix.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 
 import type { SdeType } from '@/sdeTypes'
+import { LinkSpinner } from '../linkSpinner'
 import { ALL_OWNERS, useOwnerFilter, type Owner } from '../ownerFilter'
 import { OWNER_STORAGE_KEY } from './filterKey'
 import { buildMatrix, RACE_COLUMNS, type MatrixEntry } from './shipMatrix'
@@ -113,6 +114,7 @@ export const FittingMatrix = ({ entries, types, ownCharacters, sharedCharacters 
                             <li key={f.href}>
                               <Link href={f.href} className={styles.fitLink}>
                                 {f.name}
+                                <LinkSpinner />
                               </Link>
                               <span className={styles.fitHull}>{f.hull}</span>
                               {f.owner ? <span className={styles.fitOwner}>shared by {f.owner}</span> : null}

--- a/src/app/fitting/loading.tsx
+++ b/src/app/fitting/loading.tsx
@@ -1,0 +1,11 @@
+import { LoadingShell, SkeletonTable } from '../skeleton'
+import { RACE_COLUMNS } from './shipMatrix'
+
+// The library is a hull-class × race chart, and both axes are static — so the
+// fallback can lay out the real grid and only the cells are placeholders.
+const FittingLoading = () => (
+  <LoadingShell title="Fittings">
+    <SkeletonTable columns={['Class', ...RACE_COLUMNS]} rows={6} />
+  </LoadingShell>
+)
+export default FittingLoading

--- a/src/app/industry/loading.tsx
+++ b/src/app/industry/loading.tsx
@@ -1,0 +1,12 @@
+import { LoadingShell, SkeletonTable } from '../skeleton'
+
+const IndustryLoading = () => (
+  <LoadingShell title="Industry">
+    <SkeletonTable
+      columns={['Owner', 'Activity', 'Product', 'Runs', 'Station', 'Start', 'End', 'Remaining']}
+      numeric={['Runs']}
+      rows={10}
+    />
+  </LoadingShell>
+)
+export default IndustryLoading

--- a/src/app/linkSpinner.module.css
+++ b/src/app/linkSpinner.module.css
@@ -1,0 +1,44 @@
+/*
+ * The pending indicator shown inside a <Link> while its navigation is in
+ * flight (see linkSpinner.tsx). Deliberately small and inline: it marks *which*
+ * link was clicked, which is the thing a whole-page fallback can't say.
+ */
+
+.spinner {
+  display: inline-block;
+  width: 0.7em;
+  height: 0.7em;
+  margin-left: 0.45em;
+  vertical-align: baseline;
+  border: 1.5px solid var(--line);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/*
+ * With motion suppressed the spin is out, but the indicator still has to say
+ * "working" — so it pulses between the line and accent colors instead.
+ */
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation: fade 1.4s ease-in-out infinite;
+    border-top-color: var(--accent);
+  }
+
+  @keyframes fade {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.35;
+    }
+  }
+}

--- a/src/app/linkSpinner.tsx
+++ b/src/app/linkSpinner.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { useLinkStatus } from 'next/link'
+
+import styles from './linkSpinner.module.css'
+
+// A spinner that appears inside the link the user just clicked, for as long as
+// that navigation is pending.
+//
+// It complements the route-level `loading.tsx` fallbacks rather than repeating
+// them: the fallback answers "the app heard you" only once the new segment
+// starts rendering and it replaces the whole page, so it can't say *which* of
+// twenty rows is being opened. This can, and it shows up immediately at the
+// click site.
+//
+// `useLinkStatus` reports the pending state of the nearest enclosing <Link>, so
+// this must be rendered as a descendant of one — outside a link it simply never
+// turns on. Server components can render it; it's a client component of its
+// own, so a server-rendered table doesn't have to become one.
+export const LinkSpinner = () => {
+  const { pending } = useLinkStatus()
+  // Nothing at all when idle: an always-present element would reserve width
+  // next to every link in a table of hundreds.
+  if (!pending) return null
+  return <span className={styles.spinner} role="status" aria-label="Loading" />
+}

--- a/src/app/market/loading.tsx
+++ b/src/app/market/loading.tsx
@@ -1,0 +1,12 @@
+import { LoadingShell, SkeletonTable } from '../skeleton'
+
+const MarketLoading = () => (
+  <LoadingShell title="Market">
+    <SkeletonTable
+      columns={['Seller', 'Type', 'Qty', 'Unit (kISK)', 'Total (kISK)', 'Sold', 'Seen']}
+      numeric={['Qty', 'Unit (kISK)', 'Total (kISK)']}
+      rows={12}
+    />
+  </LoadingShell>
+)
+export default MarketLoading

--- a/src/app/mercenary-dens/loading.tsx
+++ b/src/app/mercenary-dens/loading.tsx
@@ -1,0 +1,24 @@
+import { LoadingShell, SkeletonLines, SkeletonTable } from '../skeleton'
+
+// The page is a server-rendered SVG topology above the den table; the lines
+// stand in for the map, which is drawn from the same query as the rows.
+const MercenaryDensLoading = () => (
+  <LoadingShell title="Mercenary Dens">
+    <SkeletonLines count={4} />
+    <SkeletonTable
+      columns={[
+        'System',
+        'Planet',
+        'Owner',
+        'State',
+        'Development',
+        'Anarchy',
+        'Infomorphs',
+        'Reinforced',
+        'Observed At',
+      ]}
+      rows={10}
+    />
+  </LoadingShell>
+)
+export default MercenaryDensLoading

--- a/src/app/ship/[itemId]/loading.tsx
+++ b/src/app/ship/[itemId]/loading.tsx
@@ -1,0 +1,17 @@
+import { LoadingShell, SkeletonLines, SkeletonTable } from '../../skeleton'
+
+// A ship page is the fit wheel plus the module/cargo listing. The wheel already
+// reserves its own space once the page renders (fitPlaceholder.tsx), so what
+// this stands in for is everything before that: the ship's own row, its owner,
+// and the contents query.
+const ShipLoading = () => (
+  <LoadingShell crumbs>
+    <SkeletonLines count={3} />
+    <SkeletonTable
+      columns={['Quantity', 'Item', 'Volume (m³)', 'Group', 'Category', 'Owner', 'Hangar', 'Contents']}
+      numeric={['Quantity', 'Volume (m³)', 'Contents']}
+      rows={10}
+    />
+  </LoadingShell>
+)
+export default ShipLoading

--- a/src/app/skeleton.module.css
+++ b/src/app/skeleton.module.css
@@ -1,0 +1,106 @@
+/*
+ * Loading placeholders for the route-level `loading.tsx` fallbacks.
+ *
+ * These paint the moment a navigation starts, so their whole job is to occupy
+ * roughly the shape the real page will take — a heading, a table of the right
+ * width — rather than to be decorative. Colors come from the same palette as
+ * everything else, so the fallback reads as the page mid-load and not as a
+ * different screen.
+ */
+
+.block {
+  display: inline-block;
+  height: 1em;
+  min-width: 2ch;
+  vertical-align: middle;
+  border-radius: var(--radius-sm);
+  background: var(--line-soft);
+  animation: pulse 1.4s ease-in-out infinite;
+}
+
+/* A heading's bar is taller than a cell's, and sits on the h1's own baseline. */
+.heading {
+  height: 0.7em;
+  border-radius: var(--radius);
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}
+
+/*
+ * A pulsing rectangle is exactly the kind of motion that triggers vestibular
+ * discomfort, and it conveys nothing the layout doesn't already: hold it still.
+ */
+@media (prefers-reduced-motion: reduce) {
+  .block {
+    animation: none;
+  }
+}
+
+/* A stack of bars, for the pages whose content isn't a table. */
+.lines {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 16px 0;
+}
+
+/* The card grid the structures page lays its tiles out in. */
+.tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+  margin: 16px 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tile {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius);
+  background: var(--paper-raised);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12pt;
+}
+
+.header h1 {
+  margin: 0;
+}
+
+/* The breadcrumb line some pages carry above their heading. */
+.crumbs {
+  margin: 12px 0;
+  font-size: 12px;
+}
+
+/*
+ * Announced to screen readers, invisible to everyone else — the shimmer itself
+ * is aria-hidden, so this carries the "we're loading" message.
+ */
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/app/skeleton.tsx
+++ b/src/app/skeleton.tsx
@@ -1,0 +1,133 @@
+import { map, times } from 'ramda'
+
+import retro from './retro.module.css'
+import styles from './skeleton.module.css'
+
+// The building blocks each route's `loading.tsx` composes into a fallback.
+//
+// A `loading.tsx` renders the instant a navigation into its segment starts,
+// before the server has done any work, so nothing here can know a single real
+// value — the point is only to hold the page's shape (heading, table, the
+// right number of columns) so the click feels answered and the layout doesn't
+// jump when the real content lands.
+
+// Cell widths cycle through a fixed list rather than being random: the
+// fallback renders on the server too, and a random width would differ between
+// that render and hydration.
+const WIDTHS = ['72%', '48%', '86%', '55%', '64%', '40%', '78%', '58%']
+
+// One shimmering bar. Decorative by definition — the surrounding <Loading…>
+// wrapper is what announces the state — so it's hidden from assistive tech.
+export const Skeleton = ({ width, heading }: { width?: string; heading?: boolean }) => (
+  <span
+    className={heading ? `${styles.block} ${styles.heading}` : styles.block}
+    style={width ? { width } : undefined}
+    aria-hidden="true"
+  />
+)
+
+// A table with the real column headers (they're static, so showing them costs
+// nothing and makes the fallback recognizably *this* page) over placeholder
+// rows. `numeric` names the columns that render right-aligned in the real
+// table, so the shimmer sits where the digits will.
+export const SkeletonTable = ({
+  columns,
+  rows = 8,
+  numeric = [],
+}: {
+  columns: string[]
+  rows?: number
+  numeric?: string[]
+}) => (
+  <table className={retro.retro}>
+    <thead>
+      <tr>
+        {map(
+          (column) => (
+            <th key={column} className={numeric.includes(column) ? retro.num : undefined}>
+              {column}
+            </th>
+          ),
+          columns
+        )}
+      </tr>
+    </thead>
+    <tbody>
+      {times(
+        (row) => (
+          <tr key={`row-${row}`}>
+            {map(
+              (column) => (
+                <td key={column} className={numeric.includes(column) ? retro.num : undefined}>
+                  <Skeleton width={WIDTHS[(row * columns.length + columns.indexOf(column)) % WIDTHS.length]} />
+                </td>
+              ),
+              columns
+            )}
+          </tr>
+        ),
+        rows
+      )}
+    </tbody>
+  </table>
+)
+
+// For the pages whose body isn't a table (a fit viewer, a chart, prose): a
+// stack of bars of varying width, roughly where the text will be.
+export const SkeletonLines = ({ count = 4 }: { count?: number }) => (
+  <div className={styles.lines}>
+    {times(
+      (line) => (
+        <Skeleton key={`line-${line}`} width={WIDTHS[line % WIDTHS.length]} />
+      ),
+      count
+    )}
+  </div>
+)
+
+// The structures page lays its content out as a card grid rather than a table,
+// so its fallback does too.
+export const SkeletonTiles = ({ count = 6 }: { count?: number }) => (
+  <ul className={styles.tiles}>
+    {times(
+      (tile) => (
+        <li key={`tile-${tile}`} className={styles.tile}>
+          <Skeleton width="60%" heading />
+          <Skeleton width={WIDTHS[tile % WIDTHS.length]} />
+          <Skeleton width={WIDTHS[(tile + 3) % WIDTHS.length]} />
+        </li>
+      ),
+      count
+    )}
+  </ul>
+)
+
+// The whole-page wrapper: a heading (its text when the route knows it
+// statically, a bar when the heading is the very thing being fetched) and
+// whatever the caller puts below it.
+export const LoadingShell = ({
+  title,
+  crumbs = false,
+  children,
+}: {
+  title?: string
+  // Reserve the breadcrumb line for routes that render one, so the heading
+  // doesn't jump up the page when the real crumbs arrive.
+  crumbs?: boolean
+  children?: React.ReactNode
+}) => (
+  <section aria-busy="true">
+    <span className={styles.srOnly} role="status">
+      Loading…
+    </span>
+    {crumbs ? (
+      <p className={styles.crumbs}>
+        <Skeleton width="24ch" />
+      </p>
+    ) : null}
+    <div className={styles.header}>
+      <h1>{title ?? <Skeleton width="18ch" heading />}</h1>
+    </div>
+    {children}
+  </section>
+)

--- a/src/app/structure/[structureId]/loading.tsx
+++ b/src/app/structure/[structureId]/loading.tsx
@@ -1,0 +1,9 @@
+import { LoadingShell, SkeletonLines } from '../../skeleton'
+
+// The heading is the structure's own name, so it's a bar until it resolves.
+const StructureDetailLoading = () => (
+  <LoadingShell>
+    <SkeletonLines count={8} />
+  </LoadingShell>
+)
+export default StructureDetailLoading

--- a/src/app/structure/loading.tsx
+++ b/src/app/structure/loading.tsx
@@ -1,0 +1,10 @@
+import { LoadingShell, SkeletonTiles } from '../skeleton'
+
+// Structures render as a card grid, not a table — each tile carrying a
+// silhouette, fuel and service state, and industry-index sparklines.
+const StructuresLoading = () => (
+  <LoadingShell title="Structures">
+    <SkeletonTiles count={6} />
+  </LoadingShell>
+)
+export default StructuresLoading

--- a/src/app/structure/revenue/loading.tsx
+++ b/src/app/structure/revenue/loading.tsx
@@ -1,0 +1,12 @@
+import { LoadingShell, SkeletonTable } from '../../skeleton'
+
+const RevenueLoading = () => (
+  <LoadingShell title="Tax Revenue">
+    <SkeletonTable
+      columns={['Timestamp', 'Payer', 'Amount (ISK)', 'Structure', 'Output']}
+      numeric={['Amount (ISK)']}
+      rows={12}
+    />
+  </LoadingShell>
+)
+export default RevenueLoading


### PR DESCRIPTION
Phase 1 of [`docs/page-load-performance.md`](https://github.com/philihp/edencom-link/blob/main/docs/page-load-performance.md). No data-layer changes — this fixes the "the click did nothing" half of the problem, not the server latency half (that's phase 2).

## The problem

In the App Router a `<Link>` to a dynamically-rendered route renders **nothing** until the target page's server component tree resolves — unless the segment has a `loading.tsx`. The repo had zero of them, so every heavy navigation (opening a busy asset location, a ship, the fitting matrix) left the old page sitting there looking dead. It also meant `<Link>` prefetching had nothing to prefetch: for dynamic routes, prefetch only reaches as far as the nearest loading boundary.

## What's here

**Shared skeleton primitives** (`src/app/skeleton.tsx` + module CSS) — `LoadingShell`, `SkeletonTable`, `SkeletonLines`, `SkeletonTiles`. Each fallback holds the real page's shape rather than showing a generic spinner: the heading text where the route knows it statically (a shimmer bar where the heading is itself being fetched, like a location or fit name), the table's actual column headers, and the breadcrumb line reserved on routes that render one so the heading doesn't jump. Placeholder widths cycle through a fixed list rather than being random, since these render on the server too and a random width would differ at hydration. The pulse is dropped under `prefers-reduced-motion`, and the shimmer is `aria-hidden` behind a `role="status"` "Loading…" so it announces once rather than as a wall of blank elements.

**`loading.tsx` for fourteen segments**, worst first: `asset/[locationId]`, `ship/[itemId]`, `asset/search`, `asset`, `fitting`, `fitting/[characterId]/[fittingId]`, `industry`, `market`, `structure`, `structure/[structureId]`, `structure/revenue`, `blueprint/[typeID]`, `character/refresh`, `mercenary-dens`.

**`LinkSpinner`** (`useLinkStatus`) — a small client component rendered inside a `<Link>`, showing a spinner at the click site while that specific navigation is pending. This covers what a whole-page fallback structurally can't: *which* of twenty rows is being opened. Added to the assets index table, the in-system location list, the location item table, the asset search results, and the fitting matrix.

**`/asset` converted** — it had hand-rolled this idea with a page-level `<Suspense>`. That's now its `loading.tsx`, so the two fallbacks can't flash in sequence. Its shell was empty anyway, so nothing was actually streaming.

## Verification

`pnpm run lint`, `pnpm run build`, and `pnpm test` (164 passing) all clean. Confirmed the loading modules compile into their route boundaries in the build output. I could not exercise the fallbacks visually — this sandbox has no Supabase credentials, so every authenticated route 500s on client construction before rendering.

## One thing I noticed but left alone

The structures page links its tiles with `<a href>` rather than `<Link>`, so those are full document loads — no client navigation, no prefetch, and no benefit from any of this. Converting them is a small change but it's a behavior change rather than a fallback, so it's not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Nsrgp6wN8gVj6nmJhKFMr

---
_Generated by [Claude Code](https://claude.ai/code/session_014Nsrgp6wN8gVj6nmJhKFMr)_