### PR TITLE
Page-load performance phase 2: stream the heavy pages, kill the waterfalls

### DIFF
--- a/src/app/asset/[locationId]/locationData.ts
+++ b/src/app/asset/[locationId]/locationData.ts
@@ -1,0 +1,86 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+// The shapes and the root-item query shared by the location page and the
+// sections it streams. It lives in its own module so those can't end up
+// importing each other.
+
+// invGroups.categoryID for the Ship category in CCP's SDE.
+export const SHIP_CATEGORY_ID = 6
+
+// Bigint ids arrive from PostgREST as strings; keep them as strings and only
+// convert at the API/system-lookup boundary (mirrors the assets index page).
+export type CharacterAsset = {
+  item_id: number | string
+  registration_id: string
+  type_id: number | string
+  location_id: number | string | null
+  location_flag: string | null
+  location_type: string | null
+  quantity: number | string | null
+  is_singleton: boolean | null
+  is_blueprint_copy: boolean | null
+  name: string | null
+}
+
+// Corp assets carry no player-assigned name column; owner is the corporation.
+export type CorpAsset = Omit<CharacterAsset, 'registration_id' | 'name'> & { corporation_id: number | string }
+
+// Either source's row, normalized to whoever owns it: a character
+// (registration uuid) or a corporation (EVE corporation id).
+export type Asset = Omit<CharacterAsset, 'registration_id'> & { owner_id: string }
+
+// Root-level assets at this location: ships, containers and loose stacks that
+// sit directly in the station/structure/system (not nested in another item),
+// from both the character and corp hangars. Only this level is fetched — the
+// whole asset table no longer pages into Node.
+export const fetchRootItems = async (
+  supabase: SupabaseClient,
+  locationId: string,
+  characterScope: string[] | null,
+  corpScope: number[] | null
+): Promise<{ rootItems: Asset[]; currentShipItemIds: Set<string> }> => {
+  let characterQuery = supabase
+    .from('character_asset')
+    .select(
+      'item_id, registration_id, type_id, location_id, location_flag, location_type, quantity, is_singleton, is_blueprint_copy, name'
+    )
+    .eq('location_id', locationId)
+  if (characterScope) characterQuery = characterQuery.in('registration_id', characterScope)
+  let corpQuery = supabase
+    .from('corp_asset')
+    .select(
+      'item_id, corporation_id, type_id, location_id, location_flag, location_type, quantity, is_singleton, is_blueprint_copy'
+    )
+    .eq('location_id', locationId)
+  if (corpScope) corpQuery = corpQuery.in('corporation_id', corpScope)
+  // A character's currently-piloted ship reports its location as wherever it's
+  // docked — physically indistinguishable from any other ship parked there —
+  // so it otherwise shows up as an ordinary item in that station's listing.
+  // Still shown (it belongs here from the DB's point of view), but flagged so
+  // the UI can tell it apart from a ship that's merely parked.
+  let currentShipQuery = supabase.from('character_ship').select('ship_item_id')
+  if (characterScope) currentShipQuery = currentShipQuery.in('registration_id', characterScope)
+
+  const [{ data: characterChildren }, { data: corpChildren }, { data: currentShips }] = await Promise.all([
+    characterQuery,
+    corpQuery,
+    currentShipQuery,
+  ])
+
+  return {
+    rootItems: [
+      ...((characterChildren ?? []) as CharacterAsset[]).map(({ registration_id, ...a }) => ({
+        ...a,
+        owner_id: registration_id,
+      })),
+      ...((corpChildren ?? []) as CorpAsset[]).map(({ corporation_id, ...a }) => ({
+        ...a,
+        owner_id: String(corporation_id),
+        name: null,
+      })),
+    ],
+    currentShipItemIds: new Set(
+      ((currentShips ?? []) as { ship_item_id: number | string }[]).map((s) => String(s.ship_item_id))
+    ),
+  }
+}

--- a/src/app/asset/[locationId]/locationItems.tsx
+++ b/src/app/asset/[locationId]/locationItems.tsx
@@ -1,0 +1,91 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import { getSdeTypes } from '@/sdeTypes'
+import { typeFacts } from '../../assetTypeFacts'
+import type { Owners } from '../../ownerFilter'
+import { fetchTypeNames } from '../../typeNames'
+import { SHIP_CATEGORY_ID, type Asset } from './locationData'
+import { LocationAssets, type ItemRow } from './locationAssets'
+
+// The item table, as its own async server component so the page can stream it.
+//
+// This is where the slow half of the page lives: counting what each container
+// holds means walking its whole subtree in Postgres, which is far and away the
+// most expensive query the route runs. The heading and breadcrumb above it need
+// none of that, so they flush first and this arrives when it's ready.
+export const LocationItems = async ({
+  supabase,
+  locationId,
+  rootItems,
+  currentShipItemIds,
+  owners,
+  // False on the anonymous share-token path. It turns off three things at once:
+  // the contents counts (those functions walk every asset unscoped when run as
+  // service_role), the drill-down links they feed (a nested level would need
+  // its own token), and the appraisal controls (no session to authorize with).
+  linkable,
+}: {
+  supabase: SupabaseClient
+  locationId: string
+  rootItems: Asset[]
+  currentShipItemIds: Set<string>
+  owners: Owners
+  linkable: boolean
+}) => {
+  // Total items held inside each ship/container at this location, counted across
+  // the whole subtree by the *_asset_location_contents() functions in Postgres.
+  // An item lives in exactly one of the two tables, so the maps can't collide.
+  const contentsByItem = new Map<string, number>()
+  if (linkable) {
+    const [{ data: characterContents }, { data: corpContents }] = await Promise.all([
+      supabase.rpc('character_asset_location_contents', { parent: locationId }),
+      supabase.rpc('corp_asset_location_contents', { parent: locationId }),
+    ])
+    for (const r of [...(characterContents ?? []), ...(corpContents ?? [])] as {
+      item_id: number | string
+      contents: number | string
+    }[]) {
+      contentsByItem.set(String(r.item_id), Number(r.contents))
+    }
+  }
+
+  // One bulk SDE lookup for every type in play. It feeds three things: the set
+  // of Ship-category type ids, so the per-row ship test stays a sync Set.has;
+  // each row's volume/group/category columns; and which image variation its
+  // icon has.
+  const itemTypes = await getSdeTypes(rootItems.map((a) => Number(a.type_id)))
+  const shipTypeIds = new Set(
+    Object.values(itemTypes)
+      .filter((t) => t.categoryID === SHIP_CATEGORY_ID)
+      .map((t) => t.typeID)
+  )
+  const isShip = (typeId: number | string) => shipTypeIds.has(Number(typeId))
+
+  // Resolve type names without blocking render: fire the lookup and let each
+  // TypeName stream in (Suspense), falling back to #id. A big hangar can hold
+  // hundreds of distinct types, and awaiting them all here times the page out.
+  const typeNamesPromise = fetchTypeNames(rootItems.map((a) => Number(a.type_id)))
+
+  // Containers/ships (those holding items) first, then a stable id order.
+  const rows: ItemRow[] = rootItems
+    .map((a) => {
+      const contents = contentsByItem.get(String(a.item_id)) ?? 0
+      const type = itemTypes[Number(a.type_id)]
+      return {
+        itemId: String(a.item_id),
+        ownerId: a.owner_id,
+        typeId: Number(a.type_id),
+        name: a.name,
+        quantity: a.quantity,
+        isSingleton: a.is_singleton,
+        flag: a.location_flag,
+        contents,
+        isCurrentShip: currentShipItemIds.has(String(a.item_id)),
+        href: !linkable ? null : isShip(a.type_id) ? `/ship/${a.item_id}` : contents > 0 ? `/asset/${a.item_id}` : null,
+        ...typeFacts(type, a.is_blueprint_copy),
+      }
+    })
+    .sort((a, b) => b.contents - a.contents || a.typeId - b.typeId)
+
+  return <LocationAssets rows={rows} owners={owners} typeNamesPromise={typeNamesPromise} canAppraise={linkable} />
+}

--- a/src/app/asset/[locationId]/page.tsx
+++ b/src/app/asset/[locationId]/page.tsx
@@ -1,66 +1,156 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
 import { notFound, redirect } from 'next/navigation'
+import { Suspense } from 'react'
 
 import { getSdeSystem } from '@/sdeSystems'
-import { getSdeTypes } from '@/sdeTypes'
+import { getSdeType } from '@/sdeTypes'
 import { createClient } from '@/utils/supabase/server'
 import { createServiceClient } from '@/utils/supabase/service'
 import { AssetPath, fetchAssetPath, regionSystemCrumbs, type Crumb } from '../../assetPath'
-import { typeFacts } from '../../assetTypeFacts'
 import { fetchOwners } from '../../owners'
-import { resolveLocations, type LocationRef } from '../../resolveLocations'
+import type { Owners } from '../../ownerFilter'
+import { SkeletonTable } from '../../skeleton'
+import { fetchStationNames, fetchStationSystems } from '../../stationNames'
+import { fetchSystemNames } from '../../systemNames'
+import { TypeIcon } from '../../typeIcon'
 import { resolveShareParams } from '../access'
 import { saveAssetShare, revokeAssetShare } from '../shareActions'
 import { fetchShareDialogData } from '../shareData'
 import { ShareDialog } from '../shareDialog'
-import { fetchStationNames, fetchStationSystems } from '../../stationNames'
-import { fetchSystemNames } from '../../systemNames'
-import { TypeIcon } from '../../typeIcon'
-import { fetchTypeNames } from '../../typeNames'
-import type { Owners } from '../../ownerFilter'
 import styles from '../assets.module.css'
-import { type Location } from '../assetsTable'
 import { AppraisalPanel } from './appraisalPanel'
-import { LocationAssets, type ItemRow } from './locationAssets'
-import { SystemLocations } from './systemLocations'
-
-// A row from the *_asset_location_summary() RPCs, normalized to whoever owns the
-// stacks (a character registration uuid or an EVE corporation id).
-type SummaryRow = {
-  location_id: number | string
-  location_type: string | null
-  owner_id: string
-  stacks: number | string
-}
-
-// invGroups.categoryID for the Ship category in CCP's SDE.
-const SHIP_CATEGORY_ID = 6
-
-// Bigint ids arrive from PostgREST as strings; keep them as strings and only
-// convert at the API/system-lookup boundary (mirrors the assets index page).
-type CharacterAsset = {
-  item_id: number | string
-  registration_id: string
-  type_id: number | string
-  location_id: number | string | null
-  location_flag: string | null
-  location_type: string | null
-  quantity: number | string | null
-  is_singleton: boolean | null
-  is_blueprint_copy: boolean | null
-  name: string | null
-}
-
-// Corp assets carry no player-assigned name column; owner is the corporation.
-type CorpAsset = Omit<CharacterAsset, 'registration_id' | 'name'> & { corporation_id: number | string }
-
-// Either source's row, normalized to whoever owns it: a character
-// (registration uuid) or a corporation (EVE corporation id).
-type Asset = Omit<CharacterAsset, 'registration_id'> & { owner_id: string }
+import { SHIP_CATEGORY_ID, fetchRootItems, type CharacterAsset, type CorpAsset } from './locationData'
+import { LocationItems } from './locationItems'
+import { SystemLocationsSection } from './systemLocationsSection'
 
 type Structure = {
   structure_id: number | string
   name: string | null
   system_id: number | string | null
+}
+
+// The location itself, when the id turns out to be one of our own items rather
+// than a place — a ship or container the user drilled into.
+type Self = Pick<CharacterAsset, 'item_id' | 'type_id' | 'location_id' | 'name'>
+
+// Whether this id is one of the caller's own items, and whose. Both tables are
+// probed at once and the character row wins: an item lives in exactly one of
+// them, so the extra lookup is a cheap indexed miss rather than a second
+// round trip waiting on the first to come back empty.
+const fetchSelf = async (
+  supabase: SupabaseClient,
+  locationId: string,
+  characterScope: string[] | null,
+  corpScope: number[] | null
+): Promise<{ self: Self | null; isOwnCharacterItem: boolean }> => {
+  let selfQuery = supabase
+    .from('character_asset')
+    .select('item_id, registration_id, type_id, location_id, name')
+    .eq('item_id', locationId)
+  if (characterScope) selfQuery = selfQuery.in('registration_id', characterScope)
+  let corpSelfQuery = supabase
+    .from('corp_asset')
+    .select('item_id, corporation_id, type_id, location_id')
+    .eq('item_id', locationId)
+  if (corpScope) corpSelfQuery = corpSelfQuery.in('corporation_id', corpScope)
+
+  const [{ data: characterSelf }, { data: corpSelf }] = await Promise.all([
+    selfQuery.maybeSingle<Pick<CharacterAsset, 'item_id' | 'registration_id' | 'type_id' | 'location_id' | 'name'>>(),
+    corpSelfQuery.maybeSingle<Pick<CorpAsset, 'item_id' | 'corporation_id' | 'type_id' | 'location_id'>>(),
+  ])
+
+  return {
+    self: characterSelf ?? (corpSelf ? { ...corpSelf, name: null } : null),
+    isOwnCharacterItem: characterSelf != null,
+  }
+}
+
+// Everything the heading needs when the id is a place rather than an item:
+// which structure/station/system it is, and the system it sits in. Resolved the
+// same way the index page does — own-corp + foreign player structures, NPC
+// stations, and systems all come from the universe_name DB cache.
+//
+// The four lookups are independent of each other, so they go out together; only
+// the system *name* has to wait, since which system to name depends on them.
+const fetchPlace = async (
+  supabase: SupabaseClient,
+  locationId: string,
+  corpScope: number[] | null,
+  // The location_type the root items report, when there are any. A location
+  // holding items already says what kind of place it is.
+  locationType: string | null
+) => {
+  const numericId = Number(locationId)
+
+  let corpStructureQuery = supabase
+    .from('corp_structure')
+    .select('structure_id, name, system_id')
+    .eq('structure_id', numericId)
+  if (corpScope) corpStructureQuery = corpStructureQuery.in('corporation_id', corpScope)
+
+  const [{ data: corpStructures }, { data: playerStructures }, stationNames, stationSystems, sdeSystemProbe] =
+    await Promise.all([
+      corpStructureQuery,
+      supabase.from('universe_structure').select('structure_id, name, system_id').eq('structure_id', numericId),
+      fetchStationNames([numericId]),
+      fetchStationSystems([numericId]),
+      // A system id resolves in the SDE; a station/structure id doesn't. Only
+      // needed when the type is unknown (no root items) — the case that needs
+      // disambiguating: a system opened directly with nothing floating in its
+      // space. Fired alongside the structure lookups rather than after them (it
+      // is a process-cached SDE read, so an unused probe costs nothing) and
+      // discarded below if this turns out to be a structure.
+      locationType == null && Number.isFinite(numericId) ? getSdeSystem(numericId) : null,
+    ])
+
+  const structure = (corpStructures?.[0] ?? playerStructures?.[0] ?? null) as Structure | null
+  const sdeSystem = structure ? null : sdeSystemProbe
+  const isSolarSystem = !structure && (locationType === 'solar_system' || sdeSystem != null)
+
+  const systemId = isSolarSystem
+    ? numericId
+    : structure?.system_id != null
+      ? Number(structure.system_id)
+      : stationSystems[numericId]
+  const systemNames = await fetchSystemNames(
+    [systemId, isSolarSystem ? numericId : undefined].filter((n): n is number => n != null)
+  )
+
+  const heading =
+    (structure
+      ? (structure.name ?? `Structure #${locationId}`)
+      : isSolarSystem
+        ? (systemNames[numericId] ?? sdeSystem?.name ?? `System #${locationId}`)
+        : stationNames[numericId]) ?? `Location #${locationId}`
+
+  return {
+    heading,
+    isSolarSystem,
+    systemId,
+    systemName: systemId != null ? (systemNames[systemId] ?? `#${systemId}`) : undefined,
+  }
+}
+
+// The share-token path has no session to read owner names with, so they come
+// from the resolved scope through the service client instead.
+const fetchScopeOwners = async (
+  supabase: SupabaseClient,
+  scope: NonNullable<Awaited<ReturnType<typeof resolveShareParams>>>
+): Promise<Owners> => {
+  const characters = [...scope.characterNames]
+    .map(([id, name]) => ({ id, name }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+  let corpNames: Record<number, string> = {}
+  if (scope.corporationIds.length > 0) {
+    const { data } = await supabase.from('universe_name').select('id, name').in('id', scope.corporationIds)
+    corpNames = Object.fromEntries(
+      ((data ?? []) as Array<{ id: number | string; name: string }>).map((r) => [Number(r.id), r.name])
+    )
+  }
+  const corporations = scope.corporationIds
+    .map((id) => ({ id: String(id), name: corpNames[id] ?? `Corporation #${id}` }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+  return { characters, corporations }
 }
 
 // Directory browsing for a location's contents. Ships are their own thing —
@@ -70,6 +160,13 @@ type Structure = {
 // client, so every query is explicitly filtered to the sharing user's
 // characters/corps — a shared station view must never reveal other users'
 // items parked in the same station.
+//
+// The page is deliberately split in two. What runs before the first byte is
+// only what the answer depends on: the share/auth check, the root items, who
+// this location is, and — because it decides whether this page is a redirect at
+// all — whether the id names a ship. Everything expensive (the per-container
+// subtree counts, and on a system page the whole-hangar location sweep) hangs
+// off a Suspense boundary below, so the heading and breadcrumb don't wait on it.
 const AssetLocationPage = async ({
   params,
   searchParams,
@@ -96,193 +193,68 @@ const AssetLocationPage = async ({
   const characterScope = scope?.registrationIds ?? null
   const corpScope = scope ? (scope.corporationIds.length > 0 ? scope.corporationIds : [-1]) : null
 
-  // Root-level assets at this location: ships, containers and loose stacks that
-  // sit directly in the station/structure/system (not nested in another item),
-  // from both the character and corp hangars. Only this level is fetched — the
-  // whole asset table no longer pages into Node.
-  let characterQuery = supabase
-    .from('character_asset')
-    .select(
-      'item_id, registration_id, type_id, location_id, location_flag, location_type, quantity, is_singleton, is_blueprint_copy, name'
-    )
-    .eq('location_id', locationId)
-  if (characterScope) characterQuery = characterQuery.in('registration_id', characterScope)
-  let corpQuery = supabase
-    .from('corp_asset')
-    .select(
-      'item_id, corporation_id, type_id, location_id, location_flag, location_type, quantity, is_singleton, is_blueprint_copy'
-    )
-    .eq('location_id', locationId)
-  if (corpScope) corpQuery = corpQuery.in('corporation_id', corpScope)
-  // A character's currently-piloted ship reports its location as wherever it's
-  // docked — physically indistinguishable from any other ship parked there —
-  // so it otherwise shows up as an ordinary item in that station's listing.
-  // Still shown (it belongs here from the DB's point of view), but flagged so
-  // the UI can tell it apart from a ship that's merely parked.
-  let currentShipQuery = supabase.from('character_ship').select('ship_item_id')
-  if (characterScope) currentShipQuery = currentShipQuery.in('registration_id', characterScope)
-  const [{ data: characterChildren }, { data: corpChildren }, { data: currentShips }] = await Promise.all([
-    characterQuery,
-    corpQuery,
-    currentShipQuery,
+  // Nothing here depends on anything else here, so it all goes out at once.
+  // These used to run one after another, each waiting on a round trip that had
+  // no reason to wait.
+  const [{ rootItems, currentShipItemIds }, { self, isOwnCharacterItem }, owners] = await Promise.all([
+    fetchRootItems(supabase, locationId, characterScope, corpScope),
+    fetchSelf(supabase, locationId, characterScope, corpScope),
+    // Owner names for the filter dropdown: the caller's own owners, or — in the
+    // token path — the sharer's characters/corps, resolved through the service
+    // client (the anonymous viewer has no session to read them with).
+    scope ? fetchScopeOwners(supabase, scope) : fetchOwners(),
   ])
-  const currentShipItemIds = new Set(
-    ((currentShips ?? []) as { ship_item_id: number | string }[]).map((s) => String(s.ship_item_id))
-  )
-  const rootItems: Asset[] = [
-    ...((characterChildren ?? []) as CharacterAsset[]).map(({ registration_id, ...a }) => ({
-      ...a,
-      owner_id: registration_id,
-    })),
-    ...((corpChildren ?? []) as CorpAsset[]).map(({ corporation_id, ...a }) => ({
-      ...a,
-      owner_id: String(corporation_id),
-      name: null,
-    })),
-  ]
 
-  // Total items held inside each ship/container at this location, counted across
-  // the whole subtree by the *_asset_location_contents() functions in Postgres.
-  // An item lives in exactly one of the two tables, so the maps can't collide.
-  // Skipped in the token path: those functions walk every asset unscoped when
-  // run as service_role, and a shared hangar doesn't offer drill-down anyway.
-  const contentsByItem = new Map<string, number>()
-  if (!scope) {
-    const [{ data: characterContents }, { data: corpContents }] = await Promise.all([
-      supabase.rpc('character_asset_location_contents', { parent: locationId }),
-      supabase.rpc('corp_asset_location_contents', { parent: locationId }),
-    ])
-    for (const r of [...(characterContents ?? []), ...(corpContents ?? [])] as {
-      item_id: number | string
-      contents: number | string
-    }[]) {
-      contentsByItem.set(String(r.item_id), Number(r.contents))
-    }
-  }
-
-  // The id is either a place (station / structure / solar system) or one of our
-  // own items — a ship or container the user drilled into, character- or
-  // corp-owned. Resolve the heading and the "back" target accordingly.
-  let selfQuery = supabase
-    .from('character_asset')
-    .select('item_id, registration_id, type_id, location_id, name')
-    .eq('item_id', locationId)
-  if (characterScope) selfQuery = selfQuery.in('registration_id', characterScope)
-  const { data: characterSelf } =
-    await selfQuery.maybeSingle<
-      Pick<CharacterAsset, 'item_id' | 'registration_id' | 'type_id' | 'location_id' | 'name'>
-    >()
-  let corpSelfQuery = supabase
-    .from('corp_asset')
-    .select('item_id, corporation_id, type_id, location_id')
-    .eq('item_id', locationId)
-  if (corpScope) corpSelfQuery = corpSelfQuery.in('corporation_id', corpScope)
-  const { data: corpSelf } = characterSelf
-    ? { data: null }
-    : await corpSelfQuery.maybeSingle<Pick<CorpAsset, 'item_id' | 'corporation_id' | 'type_id' | 'location_id'>>()
-  const self = characterSelf ?? (corpSelf ? { ...corpSelf, name: null } : null)
-
-  // Share dialog data for an owned character item; fetchShareDialogData
-  // returns null unless the caller actually owns it (visibility alone can now
-  // mean "shared with me").
-  const shareData = !scope && characterSelf ? await fetchShareDialogData(supabase, locationId) : null
-
-  // One bulk SDE lookup for every type in play (this location's root items plus
-  // the location itself, if it's an item). It feeds three things: the set of
-  // Ship-category type ids, so the per-row ship test stays a sync Set.has; each
-  // row's volume/group/category columns; and which image variation its icon has.
-  const itemTypes = await getSdeTypes([
-    ...rootItems.map((a) => Number(a.type_id)),
-    ...(self ? [Number(self.type_id)] : []),
-  ])
-  const shipTypeIds = new Set(
-    Object.values(itemTypes)
-      .filter((t) => t.categoryID === SHIP_CATEGORY_ID)
-      .map((t) => t.typeID)
-  )
-  const isShip = (typeId: number | string) => shipTypeIds.has(Number(typeId))
+  // The self type answers two questions at once — what to call this container,
+  // and whether it's a ship — off one process-cached SDE read.
+  const selfType = self ? await getSdeType(Number(self.type_id)) : null
 
   // A ship is its own page, not a directory level (a share link stays valid
   // through the redirect — a signed link covers the whole shared subtree, a
   // legacy token is bound to this same id).
-  if (self && isShip(self.type_id)) {
+  if (self && selfType?.categoryID === SHIP_CATEGORY_ID) {
     redirect(`/ship/${locationId}${share ? `?share=${share}` : token ? `?token=${token}` : ''}`)
   }
 
-  let heading: string
+  // Share dialog data for an owned character item; fetchShareDialogData returns
+  // null unless the caller actually owns it (visibility alone can now mean
+  // "shared with me"). Started rather than awaited: whether the item is ours was
+  // settled above, so this overlaps the heading work below instead of queueing
+  // behind it.
+  const shareDataPromise = !scope && isOwnCharacterItem ? fetchShareDialogData(supabase, locationId) : null
+
   // Where this location lives: the full container chain up to its root place,
   // rendered as the breadcrumb above the heading. A bare place (station /
   // structure / system) has no ancestry, so its path is just the Assets root.
-  // Skipped in the token path: the RPC would walk unscoped as service_role,
-  // and a shared hangar shouldn't reveal where it lives anyway.
+  // The ancestry RPC is skipped in the token path: it would walk unscoped as
+  // service_role, and a shared hangar shouldn't reveal where it lives anyway.
+  let heading: string
   let crumbs: Crumb[] = [{ href: '/asset', label: 'Assets' }]
   let systemName: string | undefined
   // True when the id is a solar system: its heading is the system name, and it
-  // lists the stations/structures in the system where we hold assets (see
-  // systemLocations below) rather than only the items floating in its space.
+  // lists the stations/structures in the system where we hold assets rather
+  // than only the items floating in its space.
   let isSolarSystem = false
-  let systemLocations: Location[] = []
+  let systemId: number | null = null
 
   if (self) {
-    // A container: title it by its custom name (if any) plus type.
-    const typeNames = await fetchTypeNames([Number(self.type_id)])
-    const typeName = typeNames[Number(self.type_id)] ?? `#${self.type_id}`
+    // A container: title it by its custom name (if any) plus type. The type
+    // name is already in hand from the redirect check above, so naming it costs
+    // no round trip of its own.
+    const typeName = selfType?.name ?? `#${self.type_id}`
     heading = self.name && self.name !== typeName ? `${self.name} (${typeName})` : typeName
-    if (!scope) {
-      crumbs = await fetchAssetPath(locationId, supabase)
-    }
+    if (!scope) crumbs = await fetchAssetPath(locationId, supabase)
   } else {
-    // Resolve the location's own name/system the same way the index page does:
-    // own-corp + foreign player structures, NPC stations, and systems all come
-    // from the universe_name DB cache.
-    const numericId = Number(locationId)
-    let corpStructureQuery = supabase
-      .from('corp_structure')
-      .select('structure_id, name, system_id')
-      .eq('structure_id', numericId)
-    if (corpScope) corpStructureQuery = corpStructureQuery.in('corporation_id', corpScope)
-    const { data: corpStructures } = await corpStructureQuery
-    const { data: playerStructures } = await supabase
-      .from('universe_structure')
-      .select('structure_id, name, system_id')
-      .eq('structure_id', numericId)
-    const structure = (corpStructures?.[0] ?? playerStructures?.[0] ?? null) as Structure | null
-
-    const locationType = rootItems[0]?.location_type ?? null
-    // A system id resolves in the SDE; a station/structure id doesn't. Only
-    // probed when the type is unknown (no root items) — the case that needs
-    // disambiguating: a system opened directly with nothing floating in its
-    // space. A location with items already reports its type.
-    const sdeSystem =
-      locationType == null && !structure && Number.isFinite(numericId) ? await getSdeSystem(numericId) : null
-    isSolarSystem = !structure && (locationType === 'solar_system' || sdeSystem != null)
-
-    const [stationNames, stationSystems] = await Promise.all([
-      fetchStationNames([numericId]),
-      fetchStationSystems([numericId]),
-    ])
-
-    const systemId = isSolarSystem
-      ? numericId
-      : structure?.system_id != null
-        ? Number(structure.system_id)
-        : stationSystems[numericId]
-    const systemNames = await fetchSystemNames(
-      [systemId, isSolarSystem ? numericId : undefined].filter((n): n is number => n != null)
-    )
-
-    heading =
-      (structure
-        ? (structure.name ?? `Structure #${locationId}`)
-        : isSolarSystem
-          ? (systemNames[numericId] ?? sdeSystem?.name ?? `System #${locationId}`)
-          : stationNames[numericId]) ?? `Location #${locationId}`
-    systemName = systemId != null ? (systemNames[systemId] ?? `#${systemId}`) : undefined
+    const place = await fetchPlace(supabase, locationId, corpScope, rootItems[0]?.location_type ?? null)
+    heading = place.heading
+    isSolarSystem = place.isSolarSystem
+    systemId = place.systemId ?? null
+    systemName = place.systemName
 
     // Breadcrumb: region › system for this place (the place itself is the
     // heading). For a bare solar system the system is the heading, so only the
     // region shows. Falls back to the Assets root when it can't be placed.
-    const prefix = await regionSystemCrumbs(systemId, systemName, isSolarSystem)
+    const prefix = await regionSystemCrumbs(place.systemId, place.systemName, place.isSolarSystem)
     if (prefix.length > 0) {
       crumbs = prefix
       // The system now lives in the breadcrumb (region › system), so drop the
@@ -290,103 +262,22 @@ const AssetLocationPage = async ({
       // fallback, where the breadcrumb can't show the system.
       systemName = undefined
     }
-
-    // For a solar system, the items parked in its stations/structures live under
-    // those locations (location_id = station/structure), not the system id, so
-    // the root-item query only surfaced things floating in space. List every
-    // station/structure in this system where we hold assets as a navigable
-    // directory, built from the same RLS-scoped location-summary RPCs the index
-    // page uses. Authenticated path only — those RPCs walk unscoped as
-    // service_role, and a share token is always bound to a single item.
-    if (isSolarSystem && !scope) {
-      const [{ data: characterSummary }, { data: corpSummary }] = await Promise.all([
-        supabase.rpc('character_asset_location_summary'),
-        supabase.rpc('corp_asset_location_summary'),
-      ])
-      const summary: SummaryRow[] = [
-        ...((characterSummary ?? []) as Array<Omit<SummaryRow, 'owner_id'> & { registration_id: string }>).map(
-          ({ registration_id, ...r }) => ({ ...r, owner_id: registration_id })
-        ),
-        ...((corpSummary ?? []) as Array<Omit<SummaryRow, 'owner_id'> & { corporation_id: number | string }>).map(
-          ({ corporation_id, ...r }) => ({ ...r, owner_id: String(corporation_id) })
-        ),
-      ]
-      // Tally stacks per location/owner, dropping the system's own space bucket
-      // (its items are already shown inline below, and it would self-link).
-      const byLocation = new Map<string, { root: LocationRef; counts: Map<string, number> }>()
-      for (const row of summary) {
-        const id = String(row.location_id)
-        if (id === locationId) continue
-        const entry = byLocation.get(id) ?? { root: { id, type: row.location_type }, counts: new Map() }
-        entry.counts.set(row.owner_id, (entry.counts.get(row.owner_id) ?? 0) + Number(row.stacks))
-        byLocation.set(id, entry)
-      }
-      const entries = [...byLocation.values()]
-      const { nameFor, systemIdFor } = await resolveLocations(
-        entries.map(({ root }) => root),
-        supabase
-      )
-      systemLocations = entries
-        .filter(({ root }) => systemIdFor(root) === numericId)
-        .map(({ root, counts }) => ({
-          id: root.id,
-          name: nameFor(root),
-          system: null,
-          counts: Object.fromEntries(counts),
-        }))
-    }
   }
 
-  // Owner names for the filter dropdown: the caller's own owners, or — in the
-  // token path — the sharer's characters/corps, resolved through the service
-  // client (the anonymous viewer has no session to read them with).
-  let owners: Owners
-  if (scope) {
-    const characters = [...scope.characterNames]
-      .map(([id, name]) => ({ id, name }))
-      .sort((a, b) => a.name.localeCompare(b.name))
-    let corpNames: Record<number, string> = {}
-    if (scope.corporationIds.length > 0) {
-      const { data } = await supabase.from('universe_name').select('id, name').in('id', scope.corporationIds)
-      corpNames = Object.fromEntries(
-        ((data ?? []) as Array<{ id: number | string; name: string }>).map((r) => [Number(r.id), r.name])
-      )
-    }
-    const corporations = scope.corporationIds
-      .map((id) => ({ id: String(id), name: corpNames[id] ?? `Corporation #${id}` }))
-      .sort((a, b) => a.name.localeCompare(b.name))
-    owners = { characters, corporations }
-  } else {
-    owners = await fetchOwners()
-  }
+  const shareData = shareDataPromise ? await shareDataPromise : null
 
-  // Resolve type names without blocking render: fire the lookup and let each
-  // TypeName stream in (Suspense), falling back to #id. A big hangar can hold
-  // hundreds of distinct types, and awaiting them all here times the page out.
-  const typeNamesPromise = fetchTypeNames(rootItems.map((a) => Number(a.type_id)))
-
-  // Containers/ships (those holding items) first, then a stable id order.
-  // Anonymous hangar viewers get no drill-down links: nested levels would
-  // need their own tokens.
-  const rows: ItemRow[] = rootItems
-    .map((a) => {
-      const contents = contentsByItem.get(String(a.item_id)) ?? 0
-      const type = itemTypes[Number(a.type_id)]
-      return {
-        itemId: String(a.item_id),
-        ownerId: a.owner_id,
-        typeId: Number(a.type_id),
-        name: a.name,
-        quantity: a.quantity,
-        isSingleton: a.is_singleton,
-        flag: a.location_flag,
-        contents,
-        isCurrentShip: currentShipItemIds.has(String(a.item_id)),
-        href: scope ? null : isShip(a.type_id) ? `/ship/${a.item_id}` : contents > 0 ? `/asset/${a.item_id}` : null,
-        ...typeFacts(type, a.is_blueprint_copy),
-      }
-    })
-    .sort((a, b) => b.contents - a.contents || a.typeId - b.typeId)
+  const items = (
+    <Suspense fallback={<ItemsFallback />}>
+      <LocationItems
+        supabase={supabase}
+        locationId={locationId}
+        rootItems={rootItems}
+        currentShipItemIds={currentShipItemIds}
+        owners={owners}
+        linkable={!scope}
+      />
+    </Suspense>
+  )
 
   return (
     <>
@@ -424,20 +315,36 @@ const AssetLocationPage = async ({
 
       {isSolarSystem ? (
         <>
-          <SystemLocations locations={systemLocations} owners={owners} />
+          {!scope && systemId != null ? (
+            <Suspense fallback={<SystemLocationsFallback />}>
+              <SystemLocationsSection supabase={supabase} locationId={locationId} systemId={systemId} owners={owners} />
+            </Suspense>
+          ) : null}
           {/* Items floating directly in the system's space (not docked in any of
               its stations) — usually none, so only shown when present. */}
           {rootItems.length > 0 ? (
             <>
               <h2 className="serif">In space</h2>
-              <LocationAssets rows={rows} owners={owners} typeNamesPromise={typeNamesPromise} canAppraise={!scope} />
+              {items}
             </>
           ) : null}
         </>
       ) : (
-        <LocationAssets rows={rows} owners={owners} typeNamesPromise={typeNamesPromise} canAppraise={!scope} />
+        items
       )}
     </>
   )
 }
 export default AssetLocationPage
+
+// Same shape the route's loading.tsx uses, so a streamed-in table and a
+// freshly-navigated one look like the same page at the same stage.
+const ItemsFallback = () => (
+  <SkeletonTable
+    columns={['Quantity', 'Item', 'Volume (m³)', 'Group', 'Category', 'Owner', 'Hangar', 'Contents']}
+    numeric={['Quantity', 'Volume (m³)', 'Contents']}
+    rows={8}
+  />
+)
+
+const SystemLocationsFallback = () => <SkeletonTable columns={['Location', 'Items']} numeric={['Items']} rows={5} />

--- a/src/app/asset/[locationId]/systemLocationsSection.tsx
+++ b/src/app/asset/[locationId]/systemLocationsSection.tsx
@@ -1,0 +1,81 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import type { Owners } from '../../ownerFilter'
+import { resolveLocations, type LocationRef } from '../../resolveLocations'
+import { type Location } from '../assetsTable'
+import { SystemLocations } from './systemLocations'
+
+// A row from the *_asset_location_summary() RPCs, normalized to whoever owns
+// the stacks (a character registration uuid or an EVE corporation id).
+type SummaryRow = {
+  location_id: number | string
+  location_type: string | null
+  owner_id: string
+  stacks: number | string
+}
+
+// For a solar system, the items parked in its stations/structures live under
+// those locations (location_id = station/structure), not the system id, so the
+// root-item query only surfaces things floating in space. This lists every
+// station/structure in the system where we hold assets as a navigable
+// directory, built from the same RLS-scoped location-summary RPCs the index
+// page uses.
+//
+// Its own async server component because those RPCs are the most expensive
+// thing on the page by a wide margin — unlike the contents counts, which walk
+// one location's subtree, these walk *every* asset the caller can see to bucket
+// it by location. Streaming it keeps a system page's heading and in-space items
+// from waiting on a whole-hangar sweep.
+//
+// Authenticated path only: those RPCs walk unscoped as service_role, and a
+// share token is always bound to a single item.
+export const SystemLocationsSection = async ({
+  supabase,
+  locationId,
+  systemId,
+  owners,
+}: {
+  supabase: SupabaseClient
+  locationId: string
+  systemId: number
+  owners: Owners
+}) => {
+  const [{ data: characterSummary }, { data: corpSummary }] = await Promise.all([
+    supabase.rpc('character_asset_location_summary'),
+    supabase.rpc('corp_asset_location_summary'),
+  ])
+  const summary: SummaryRow[] = [
+    ...((characterSummary ?? []) as Array<Omit<SummaryRow, 'owner_id'> & { registration_id: string }>).map(
+      ({ registration_id, ...r }) => ({ ...r, owner_id: registration_id })
+    ),
+    ...((corpSummary ?? []) as Array<Omit<SummaryRow, 'owner_id'> & { corporation_id: number | string }>).map(
+      ({ corporation_id, ...r }) => ({ ...r, owner_id: String(corporation_id) })
+    ),
+  ]
+
+  // Tally stacks per location/owner, dropping the system's own space bucket
+  // (its items are already shown inline below, and it would self-link).
+  const byLocation = new Map<string, { root: LocationRef; counts: Map<string, number> }>()
+  for (const row of summary) {
+    const id = String(row.location_id)
+    if (id === locationId) continue
+    const entry = byLocation.get(id) ?? { root: { id, type: row.location_type }, counts: new Map() }
+    entry.counts.set(row.owner_id, (entry.counts.get(row.owner_id) ?? 0) + Number(row.stacks))
+    byLocation.set(id, entry)
+  }
+  const entries = [...byLocation.values()]
+  const { nameFor, systemIdFor } = await resolveLocations(
+    entries.map(({ root }) => root),
+    supabase
+  )
+  const locations: Location[] = entries
+    .filter(({ root }) => systemIdFor(root) === systemId)
+    .map(({ root, counts }) => ({
+      id: root.id,
+      name: nameFor(root),
+      system: null,
+      counts: Object.fromEntries(counts),
+    }))
+
+  return <SystemLocations locations={locations} owners={owners} />
+}

--- a/src/app/fitting/page.tsx
+++ b/src/app/fitting/page.tsx
@@ -34,7 +34,17 @@ const FittingPage = async () => {
   // Every owner behind a visible fit, resolved to the EVE character id the
   // route addresses them by (see resolveCharacter.ts). Own registrations come
   // back too, so the filter can list a character that has saved no fits yet.
-  const owners = await fetchFittingOwners(supabase, [...new Set(rows.map((f) => f.registration_id))])
+  //
+  // The hull lookup that follows keys off the fits' own ship_type_id, not off
+  // anything the owner resolution produces, so the two run together rather than
+  // one after the other. It covers every entry the matrix can build, since an
+  // entry only ever comes from one of these rows.
+  const [owners, types] = await Promise.all([
+    fetchFittingOwners(supabase, [...new Set(rows.map((f) => f.registration_id))]),
+    // One bulk SDE lookup carries everything the matrix buckets by: hull name,
+    // group (→ class row), race and meta group (→ column).
+    getSdeTypes(rows.map((f) => Number(f.ship_type_id))),
+  ])
 
   const entries: FittingEntry[] = rows.flatMap((f) => {
     const owner = owners.get(f.registration_id)
@@ -66,10 +76,6 @@ const FittingPage = async () => {
     .filter((o) => !o.isOwn)
     .map(toFilterOwner)
     .sort(byName)
-
-  // One bulk SDE lookup carries everything the matrix buckets by: hull name,
-  // group (→ class row), race and meta group (→ column).
-  const types = await getSdeTypes(entries.map((e) => e.shipTypeId))
 
   return (
     <FittingMatrix entries={entries} types={types} ownCharacters={ownCharacters} sharedCharacters={sharedCharacters} />

--- a/src/app/ship/[itemId]/page.tsx
+++ b/src/app/ship/[itemId]/page.tsx
@@ -1,15 +1,15 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
 import { notFound, redirect } from 'next/navigation'
-import { ascend, sortWith } from 'ramda'
+import { Suspense } from 'react'
 
-import { getSdeType, getSdeTypes, type SdeType } from '@/sdeTypes'
+import { getSdeType, getSdeTypes } from '@/sdeTypes'
 import { createClient } from '@/utils/supabase/server'
 import { createServiceClient } from '@/utils/supabase/service'
 import { AssetPath, fetchAssetPath } from '../../assetPath'
 import { typeFacts } from '../../assetTypeFacts'
-import { fetchOwners } from '../../owners'
 import type { Owners } from '../../ownerFilter'
+import { SkeletonTable } from '../../skeleton'
 import { fetchTypeNames } from '../../typeNames'
-import { flagSortKey } from '../../fitting/fit'
 import { AppraisalPanel } from '../../asset/[locationId]/appraisalPanel'
 import { LocationAssets, type ItemRow } from '../../asset/[locationId]/locationAssets'
 import { resolveShareParams } from '../../asset/access'
@@ -17,83 +17,21 @@ import { saveAssetShare, revokeAssetShare } from '../../asset/shareActions'
 import { fetchShareDialogData } from '../../asset/shareData'
 import { ShareDialog } from '../../asset/shareDialog'
 import { toEsiFit } from './esfFit'
+import { FitPlaceholder } from './fitPlaceholder'
 import { characterPortrait, corporationLogo, ShipHeading, type ShipOwner } from './shipHeading'
+import { ShipContents } from './shipContents'
 import { ShipFitViewDynamic } from './shipFitViewDynamic'
-
-// invGroups.categoryID for the Ship category in CCP's SDE.
-const SHIP_CATEGORY_ID = 6
+import { SHIP_CATEGORY_ID, fittingOrder, hullRow, type ChildRow } from './shipRows'
 
 type ShipRow = {
   item_id: number | string
   type_id: number | string
-  location_id: number | string | null
-  location_type: string | null
+  location_id?: number | string | null
+  location_type?: string | null
   name: string | null
   registration_id?: string
   corporation_id?: number | string
 }
-
-type ChildRow = {
-  item_id: number | string
-  type_id: number | string
-  location_flag: string | null
-  quantity: number | string | null
-  is_singleton: boolean | null
-  is_blueprint_copy?: boolean | null
-  name?: string | null
-  registration_id?: string
-  corporation_id?: number | string
-}
-
-// Whether a single type is in the Ship category — one SDE lookup, for the
-// self-type gate that decides ship page vs asset browser.
-const isShipType = async (typeId: number | string): Promise<boolean> =>
-  (await getSdeType(Number(typeId)))?.categoryID === SHIP_CATEGORY_ID
-
-// Fitting-window order for the module table: slot family first (high → mid →
-// low → rigs → bays, via the same flagSortKey the fitting pages use), the flag
-// string within a family (HiSlot0 before HiSlot1), then type id. This is the
-// server order the unsorted table shows, so the listing reads top-to-bottom
-// the way the ship does.
-const fittingOrder = sortWith<ItemRow>([
-  ascend((r) => flagSortKey(r.flag ?? '')),
-  ascend((r) => r.flag ?? ''),
-  ascend((r) => r.typeId),
-])
-
-// The hull as a row of its own, heading the module table.
-//
-// It isn't one of the ship's children — it's their container — so nothing in
-// the child query produces it, and the table used to list a ship's contents
-// without listing the ship. That reads as an omission now that the table is
-// what gets selected and appraised: "everything shown in this list" has to
-// include the thing the page is about. Assembled, hence a singleton with no
-// stack size, and it links nowhere: this is already its page.
-const hullRow = (
-  self: Pick<ShipRow, 'item_id' | 'type_id' | 'name'>,
-  ownerId: string,
-  type: SdeType | undefined,
-  contents: number
-): ItemRow => ({
-  itemId: String(self.item_id),
-  ownerId,
-  typeId: Number(self.type_id),
-  name: self.name ?? null,
-  quantity: null,
-  isSingleton: true,
-  flag: null,
-  contents,
-  isCurrentShip: false,
-  href: null,
-  ...typeFacts(type),
-})
-
-// How many items the hull holds, all the way down: its own children plus
-// whatever each of them contains. The per-child counts come from the same
-// *_location_contents() walk the drill-in links use, so the hull's Contents
-// cell agrees with the rows under it.
-const nestedCount = (children: ChildRow[], contentsByItem: Map<string, number>): number =>
-  children.length + children.reduce((total, c) => total + (contentsByItem.get(String(c.item_id)) ?? 0), 0)
 
 // A ship's own page: the eveship.fit wheel + stats built from its fitted
 // modules, a full module/cargo table in fitting order (the same sortable
@@ -121,143 +59,46 @@ const ShipPage = async ({
     redirect('/')
   }
 
-  // The ship row, from whichever hangar owns it.
-  const { data: characterSelf } = await supabase
-    .from('character_asset')
-    .select('item_id, registration_id, type_id, location_id, location_type, name')
-    .eq('item_id', itemId)
-    .maybeSingle<ShipRow>()
-  const { data: corpSelf } = characterSelf
-    ? { data: null }
-    : await supabase
-        .from('corp_asset')
-        .select('item_id, corporation_id, type_id, location_id, location_type')
-        .eq('item_id', itemId)
-        .maybeSingle<ShipRow>()
-  const self = characterSelf ?? corpSelf
-  if (!self) notFound()
-  // Non-ships (containers, loose stacks) live on the asset browser instead.
-  if (!(await isShipType(self.type_id))) redirect(`/asset/${itemId}`)
-
-  const [{ data: characterChildren }, { data: corpChildren }] = await Promise.all([
+  // The ship row, from whichever hangar owns it. Both hangars are probed at
+  // once and the character row wins: an item lives in exactly one of them, so
+  // the corp lookup is a cheap indexed miss rather than a second round trip
+  // waiting on the first to come back empty.
+  const [{ data: characterSelf }, { data: corpSelf }] = await Promise.all([
     supabase
       .from('character_asset')
-      .select('item_id, registration_id, type_id, location_flag, quantity, is_singleton, is_blueprint_copy, name')
-      .eq('location_id', itemId),
+      .select('item_id, registration_id, type_id, location_id, location_type, name')
+      .eq('item_id', itemId)
+      .maybeSingle<ShipRow>(),
     supabase
       .from('corp_asset')
-      .select('item_id, corporation_id, type_id, location_flag, quantity, is_singleton, is_blueprint_copy')
-      .eq('location_id', itemId),
+      .select('item_id, corporation_id, type_id, location_id, location_type')
+      .eq('item_id', itemId)
+      .maybeSingle<ShipRow>(),
   ])
-  const children = [...((characterChildren ?? []) as ChildRow[]), ...((corpChildren ?? []) as ChildRow[])]
+  const self = characterSelf ?? corpSelf
+  if (!self) notFound()
 
-  // Nested-contents counts drive the drill-in links on container/ship rows.
-  const [{ data: characterContents }, { data: corpContents }] = await Promise.all([
-    supabase.rpc('character_asset_location_contents', { parent: itemId }),
-    supabase.rpc('corp_asset_location_contents', { parent: itemId }),
-  ])
-  const contentsByItem = new Map<string, number>(
-    (
-      [...(characterContents ?? []), ...(corpContents ?? [])] as {
-        item_id: number | string
-        contents: number | string
-      }[]
-    ).map((r) => [String(r.item_id), Number(r.contents)])
-  )
+  // One process-cached SDE read answers both questions this page opens with:
+  // whether the id is a ship at all, and what to call it.
+  const selfType = await getSdeType(Number(self.type_id))
+  // Non-ships (containers, loose stacks) live on the asset browser instead.
+  if (selfType?.categoryID !== SHIP_CATEGORY_ID) redirect(`/asset/${itemId}`)
 
-  // Owner: the holding character's name and portrait, or the corporation's
-  // cached name and logo. `character_id` here is the EVE numeric id (what the
-  // image server serves portraits for), not the registration uuid its
-  // sibling asset columns misname.
-  let owner: ShipOwner
-  if (characterSelf?.registration_id) {
-    const { data: registration } = await supabase
-      .from('registration')
-      .select('name, character_id')
-      .eq('id', characterSelf.registration_id)
-      .maybeSingle<{ name: string; character_id: number | string | null }>()
-    // A shared ship's owner is outside the caller's registration view (RLS);
-    // their public name resolves through the world-readable directory.
-    const { data: directory } = registration
-      ? { data: null }
-      : await supabase
-          .from('character_directory')
-          .select('name, character_id')
-          .eq('registration_id', characterSelf.registration_id)
-          .maybeSingle<{ name: string | null; character_id: number | string | null }>()
-    const eveCharacterId = registration?.character_id ?? directory?.character_id ?? null
-    owner = {
-      name: registration?.name ?? directory?.name ?? 'Unknown character',
-      portrait: eveCharacterId == null ? null : characterPortrait(eveCharacterId),
-    }
-  } else {
-    const corporationId = Number(corpSelf?.corporation_id)
-    const { data: corpName } = await supabase
-      .from('universe_name')
-      .select('name')
-      .eq('id', corporationId)
-      .maybeSingle<{ name: string }>()
-    owner = { name: corpName?.name ?? `Corporation #${corporationId}`, portrait: corporationLogo(corporationId) }
-  }
-
-  // Where the ship lives: the full container chain up to its station /
-  // structure / system, rendered as the breadcrumb above the heading.
-  const crumbs = await fetchAssetPath(itemId, supabase)
-
-  const typeNames = await fetchTypeNames([Number(self.type_id)])
-  const typeName = typeNames[Number(self.type_id)] ?? `#${self.type_id}`
+  const typeName = selfType?.name ?? `#${self.type_id}`
   const heading = self.name && self.name !== typeName ? `${self.name} (${typeName})` : typeName
 
-  // One bulk SDE lookup → set of Ship-category type ids among the cargo, so the
-  // per-row drill-in link test stays a sync Set.has. The hull's own type rides
-  // along for its row's volume/group/category columns.
-  const childTypes = await getSdeTypes([Number(self.type_id), ...children.map((c) => Number(c.type_id))])
-  const childShipTypeIds = new Set(
-    Object.values(childTypes)
-      .filter((t) => t.categoryID === SHIP_CATEGORY_ID)
-      .map((t) => t.typeID)
-  )
-
-  const typeNamesPromise = fetchTypeNames([Number(self.type_id), ...children.map((c) => Number(c.type_id))])
-  const rows: ItemRow[] = fittingOrder(
-    children.map((c) => {
-      const contents = contentsByItem.get(String(c.item_id)) ?? 0
-      return {
-        itemId: String(c.item_id),
-        ownerId: c.registration_id ?? String(c.corporation_id),
-        typeId: Number(c.type_id),
-        name: c.name ?? null,
-        quantity: c.quantity,
-        isSingleton: c.is_singleton,
-        flag: c.location_flag,
-        contents,
-        isCurrentShip: false,
-        href: childShipTypeIds.has(Number(c.type_id))
-          ? `/ship/${c.item_id}`
-          : contents > 0
-            ? `/asset/${c.item_id}`
-            : null,
-        ...typeFacts(childTypes[Number(c.type_id)], c.is_blueprint_copy),
-      }
-    })
-  )
-
-  // The hull heads the table; the fit viewer below is fed the children alone,
-  // since a ship isn't a module fitted to itself.
-  const tableRows: ItemRow[] = [
-    hullRow(
-      self,
-      characterSelf?.registration_id ?? String(corpSelf?.corporation_id),
-      childTypes[Number(self.type_id)],
-      nestedCount(children, contentsByItem)
-    ),
-    ...rows,
-  ]
-
-  // The share dialog appears only for a character item the caller actually
-  // owns — with phase 2's widening policy, RLS visibility alone can also mean
-  // "shared with me", which must not offer the dialog.
-  const [shareData, owners] = await Promise.all([fetchShareDialogData(supabase, itemId), fetchOwners()])
+  // Who this ship is and where it sits — all independent of each other, and of
+  // the contents below, so they go out together.
+  const [owner, crumbs, shareData] = await Promise.all([
+    fetchShipOwner(supabase, characterSelf, corpSelf),
+    // The full container chain up to its station / structure / system,
+    // rendered as the breadcrumb above the heading.
+    fetchAssetPath(itemId, supabase),
+    // The share dialog appears only for a character item the caller actually
+    // owns — with phase 2's widening policy, RLS visibility alone can also mean
+    // "shared with me", which must not offer the dialog.
+    fetchShareDialogData(supabase, itemId),
+  ])
 
   return (
     <>
@@ -283,10 +124,71 @@ const ShipPage = async ({
           </>
         }
       />
-      <ShipFitViewDynamic esiFit={toEsiFit(Number(self.type_id), self.name ?? null, rows)} />
-      <LocationAssets rows={tableRows} owners={owners} typeNamesPromise={typeNamesPromise} canAppraise />
+      <Suspense fallback={<ContentsFallback />}>
+        <ShipContents
+          supabase={supabase}
+          itemId={itemId}
+          self={self}
+          ownerId={characterSelf?.registration_id ?? String(corpSelf?.corporation_id)}
+        />
+      </Suspense>
     </>
   )
+}
+
+// While the child query and its subtree walk are in flight: the fit viewer's
+// own reserved footprint (it has a second, client-side wait after this) above a
+// stand-in for the module table.
+const ContentsFallback = () => (
+  <>
+    <FitPlaceholder />
+    <SkeletonTable
+      columns={['Quantity', 'Item', 'Volume (m³)', 'Group', 'Category', 'Owner', 'Hangar', 'Contents']}
+      numeric={['Quantity', 'Volume (m³)', 'Contents']}
+      rows={8}
+    />
+  </>
+)
+
+// Owner: the holding character's name and portrait, or the corporation's
+// cached name and logo. `character_id` here is the EVE numeric id (what the
+// image server serves portraits for), not the registration uuid its sibling
+// asset columns misname.
+const fetchShipOwner = async (
+  supabase: SupabaseClient,
+  characterSelf: ShipRow | null,
+  corpSelf: ShipRow | null
+): Promise<ShipOwner> => {
+  if (!characterSelf?.registration_id) {
+    const corporationId = Number(corpSelf?.corporation_id)
+    const { data: corpName } = await supabase
+      .from('universe_name')
+      .select('name')
+      .eq('id', corporationId)
+      .maybeSingle<{ name: string }>()
+    return { name: corpName?.name ?? `Corporation #${corporationId}`, portrait: corporationLogo(corporationId) }
+  }
+
+  // A shared ship's owner is outside the caller's registration view (RLS);
+  // their public name resolves through the world-readable directory. Both are
+  // probed together — only one of them can match.
+  const [{ data: registration }, { data: directory }] = await Promise.all([
+    supabase
+      .from('registration')
+      .select('name, character_id')
+      .eq('id', characterSelf.registration_id)
+      .maybeSingle<{ name: string; character_id: number | string | null }>(),
+    supabase
+      .from('character_directory')
+      .select('name, character_id')
+      .eq('registration_id', characterSelf.registration_id)
+      .maybeSingle<{ name: string | null; character_id: number | string | null }>(),
+  ])
+  const eveCharacterId = registration?.character_id ?? directory?.character_id ?? null
+  return {
+    name: registration?.name ?? directory?.name ?? 'Unknown character',
+    portrait: eveCharacterId == null ? null : characterPortrait(eveCharacterId),
+  }
 }
 
 // Anonymous share-link view: wheel + name + owner only. All queries run on
@@ -320,7 +222,7 @@ const SharedShipPage = async ({
         .maybeSingle<ShipRow>()
   const self = characterSelf ?? corpSelf
   // The share outlived the ship (sold, transferred, unlinked): dead link.
-  if (!self || !(await isShipType(self.type_id))) notFound()
+  if (!self || (await getSdeType(Number(self.type_id)))?.categoryID !== SHIP_CATEGORY_ID) notFound()
 
   const [{ data: characterChildren }, { data: corpChildren }] = await Promise.all([
     supabase

--- a/src/app/ship/[itemId]/shipContents.tsx
+++ b/src/app/ship/[itemId]/shipContents.tsx
@@ -1,0 +1,104 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { getSdeTypes } from '@/sdeTypes'
+import { typeFacts } from '../../assetTypeFacts'
+import { LocationAssets, type ItemRow } from '../../asset/[locationId]/locationAssets'
+import { fetchOwners } from '../../owners'
+import { fetchTypeNames } from '../../typeNames'
+import { toEsiFit } from './esfFit'
+import { ShipFitViewDynamic } from './shipFitViewDynamic'
+import { SHIP_CATEGORY_ID, fittingOrder, hullRow, nestedCount, type ChildRow, type Hull } from './shipRows'
+
+// The fit wheel and the module/cargo table, as their own async server component
+// so the page can stream them.
+//
+// What's above them — the ship's name, owner and breadcrumb — needs none of
+// this, and this is the part that costs: a subtree walk for the nested counts
+// on top of the child query. Splitting them lets the page identify the ship
+// immediately and fill in its contents when they arrive. (The wheel then has a
+// second, client-side wait of its own for the WASM chunk and protobufs, which
+// FitPlaceholder covers.)
+export const ShipContents = async ({
+  supabase,
+  itemId,
+  self,
+  ownerId,
+}: {
+  supabase: SupabaseClient
+  itemId: string
+  self: Hull
+  ownerId: string
+}) => {
+  const [{ data: characterChildren }, { data: corpChildren }, characterContents, corpContents, owners] =
+    await Promise.all([
+      supabase
+        .from('character_asset')
+        .select('item_id, registration_id, type_id, location_flag, quantity, is_singleton, is_blueprint_copy, name')
+        .eq('location_id', itemId),
+      supabase
+        .from('corp_asset')
+        .select('item_id, corporation_id, type_id, location_flag, quantity, is_singleton, is_blueprint_copy')
+        .eq('location_id', itemId),
+      // Nested-contents counts drive the drill-in links on container/ship rows.
+      supabase.rpc('character_asset_location_contents', { parent: itemId }),
+      supabase.rpc('corp_asset_location_contents', { parent: itemId }),
+      fetchOwners(),
+    ])
+
+  const children = [...((characterChildren ?? []) as ChildRow[]), ...((corpChildren ?? []) as ChildRow[])]
+  const contentsByItem = new Map<string, number>(
+    (
+      [...(characterContents.data ?? []), ...(corpContents.data ?? [])] as {
+        item_id: number | string
+        contents: number | string
+      }[]
+    ).map((r) => [String(r.item_id), Number(r.contents)])
+  )
+
+  // One bulk SDE lookup → set of Ship-category type ids among the cargo, so the
+  // per-row drill-in link test stays a sync Set.has. The hull's own type rides
+  // along for its row's volume/group/category columns.
+  const childTypes = await getSdeTypes([Number(self.type_id), ...children.map((c) => Number(c.type_id))])
+  const childShipTypeIds = new Set(
+    Object.values(childTypes)
+      .filter((t) => t.categoryID === SHIP_CATEGORY_ID)
+      .map((t) => t.typeID)
+  )
+
+  const typeNamesPromise = fetchTypeNames([Number(self.type_id), ...children.map((c) => Number(c.type_id))])
+  const rows: ItemRow[] = fittingOrder(
+    children.map((c) => {
+      const contents = contentsByItem.get(String(c.item_id)) ?? 0
+      return {
+        itemId: String(c.item_id),
+        ownerId: c.registration_id ?? String(c.corporation_id),
+        typeId: Number(c.type_id),
+        name: c.name ?? null,
+        quantity: c.quantity,
+        isSingleton: c.is_singleton,
+        flag: c.location_flag,
+        contents,
+        isCurrentShip: false,
+        href: childShipTypeIds.has(Number(c.type_id))
+          ? `/ship/${c.item_id}`
+          : contents > 0
+            ? `/asset/${c.item_id}`
+            : null,
+        ...typeFacts(childTypes[Number(c.type_id)], c.is_blueprint_copy),
+      }
+    })
+  )
+
+  // The hull heads the table; the fit viewer below is fed the children alone,
+  // since a ship isn't a module fitted to itself.
+  const tableRows: ItemRow[] = [
+    hullRow(self, ownerId, childTypes[Number(self.type_id)], nestedCount(children, contentsByItem)),
+    ...rows,
+  ]
+
+  return (
+    <>
+      <ShipFitViewDynamic esiFit={toEsiFit(Number(self.type_id), self.name ?? null, rows)} />
+      <LocationAssets rows={tableRows} owners={owners} typeNamesPromise={typeNamesPromise} canAppraise />
+    </>
+  )
+}

--- a/src/app/ship/[itemId]/shipRows.ts
+++ b/src/app/ship/[itemId]/shipRows.ts
@@ -1,0 +1,68 @@
+import { ascend, sortWith } from 'ramda'
+
+import { type SdeType } from '@/sdeTypes'
+import { typeFacts } from '../../assetTypeFacts'
+import { type ItemRow } from '../../asset/[locationId]/locationAssets'
+import { flagSortKey } from '../../fitting/fit'
+
+// The row-shaping the ship page shares with the contents section it streams,
+// and with the anonymous share-link view. In its own module so those can't end
+// up importing each other.
+
+// invGroups.categoryID for the Ship category in CCP's SDE.
+export const SHIP_CATEGORY_ID = 6
+
+export type ChildRow = {
+  item_id: number | string
+  type_id: number | string
+  location_flag: string | null
+  quantity: number | string | null
+  is_singleton: boolean | null
+  is_blueprint_copy?: boolean | null
+  name?: string | null
+  registration_id?: string
+  corporation_id?: number | string
+}
+
+// The hull itself, as far as the row-building needs to know it.
+export type Hull = { item_id: number | string; type_id: number | string; name?: string | null }
+
+// Fitting-window order for the module table: slot family first (high → mid →
+// low → rigs → bays, via the same flagSortKey the fitting pages use), the flag
+// string within a family (HiSlot0 before HiSlot1), then type id. This is the
+// server order the unsorted table shows, so the listing reads top-to-bottom
+// the way the ship does.
+export const fittingOrder = sortWith<ItemRow>([
+  ascend((r) => flagSortKey(r.flag ?? '')),
+  ascend((r) => r.flag ?? ''),
+  ascend((r) => r.typeId),
+])
+
+// The hull as a row of its own, heading the module table.
+//
+// It isn't one of the ship's children — it's their container — so nothing in
+// the child query produces it, and the table used to list a ship's contents
+// without listing the ship. That reads as an omission now that the table is
+// what gets selected and appraised: "everything shown in this list" has to
+// include the thing the page is about. Assembled, hence a singleton with no
+// stack size, and it links nowhere: this is already its page.
+export const hullRow = (self: Hull, ownerId: string, type: SdeType | undefined, contents: number): ItemRow => ({
+  itemId: String(self.item_id),
+  ownerId,
+  typeId: Number(self.type_id),
+  name: self.name ?? null,
+  quantity: null,
+  isSingleton: true,
+  flag: null,
+  contents,
+  isCurrentShip: false,
+  href: null,
+  ...typeFacts(type),
+})
+
+// How many items the hull holds, all the way down: its own children plus
+// whatever each of them contains. The per-child counts come from the same
+// *_location_contents() walk the drill-in links use, so the hull's Contents
+// cell agrees with the rows under it.
+export const nestedCount = (children: ChildRow[], contentsByItem: Map<string, number>): number =>
+  children.length + children.reduce((total, c) => total + (contentsByItem.get(String(c.item_id)) ?? 0), 0)


### PR DESCRIPTION
Phase 2 of [`docs/page-load-performance.md`](https://github.com/philihp/edencom-link/blob/main/docs/page-load-performance.md), on top of phase 1 (#822). Phase 1 made a slow page *feel* answered; this makes it actually faster. No behavior or data changes.

## The waterfall

`asset/[locationId]` ran about ten Supabase round trips strictly one after another, and most had no reason to wait on each other:

- the character and corp probes for the same item were serialized, the second only firing once the first came back empty — but an item lives in exactly one of those tables, so the second is a cheap indexed miss, not a dependency;
- `fetchOwners()` was awaited last despite depending on nothing at all;
- the structure/station/system lookups behind the heading each waited on the one before, though only the system *name* actually depends on the others;
- the container's type name was fetched separately from the bulk SDE lookup that already contained it.

`/ship/[itemId]` had the same shape. Both now fire the independent work together, which takes them from ~10 sequential round trips to 3–4. Two lookups also collapse into one where a single SDE read already answered both questions: what to call a container and whether it's a ship come off the same row, so the redirect check and the heading share it.

## The split

Each page is now cut at its real seam. What runs before the first byte is only what the response depends on: the auth and share checks, the root items, which location this is, and whether the id names a ship — that last one because it decides whether the page is a redirect at all, and a shell that flashed before redirecting would be worse than waiting.

Everything expensive hangs off a `Suspense` boundary below:

- **`LocationItems`** — the per-container subtree counts (`*_asset_location_contents`) plus the item table.
- **`SystemLocationsSection`** — on a system page, the whole-hangar sweep. Unlike the contents counts, which walk one location's subtree, `*_asset_location_summary()` walks *every* asset the caller can see; a system's heading and in-space items no longer wait on it.
- **`ShipContents`** — the module table and fit wheel, so the ship's name, owner and breadcrumb paint immediately. The wheel then has its own client-side wait for the WASM chunk, which `FitPlaceholder` already covered.

The streamed fallbacks reuse phase 1's skeleton primitives, so a table that streams in and one reached by a fresh navigation look like the same page at the same stage.

New modules (`locationData.ts`, `shipRows.ts`) hold the types and row-shaping the pages now share with their streamed sections, so those can't end up importing each other. `shipRows.ts` also de-duplicates helpers the anonymous share-link view shares with the owner's view.

Also overlaps `/fitting`'s owner resolution with its hull lookup — the latter keys off the fits' own `ship_type_id`, not off anything owner resolution produces.

## Verification

`pnpm run lint`, `pnpm run build`, and `pnpm test` (164 passing) clean, both before and after rebasing onto merged phase 1. As with phase 1, I could not exercise these visually — this sandbox has no Supabase credentials, so authenticated routes 500 on client construction.

Worth a careful eye on the share-token path in review, since it's the one I could least exercise: `linkable={!scope}` in `LocationItems` now gates the contents counts, the drill-down links and the appraisal controls together, where the old code gated them at three separate sites.

## What's not here

Phase 3 (folding the page's fetch prefix into one `asset_location_page()` RPC) is deliberately not attempted — the plan gates it on measurement, and the right time to judge it is after this lands and Speed Insights has p75 numbers for the new shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Nsrgp6wN8gVj6nmJhKFMr

---
_Generated by [Claude Code](https://claude.ai/code/session_014Nsrgp6wN8gVj6nmJhKFMr)_