### PR TITLE
Navigate to structure pages client-side

### DIFF
--- a/src/app/industry/activeJobs.tsx
+++ b/src/app/industry/activeJobs.tsx
@@ -1,8 +1,10 @@
 'use client'
 
+import Link from 'next/link'
 import { useEffect, useState } from 'react'
 
 import { DateTime } from '../DateTime'
+import { LinkSpinner } from '../linkSpinner'
 import { Name } from '../names'
 import { ALL_OWNERS, OwnerSelect, ownerNames, useExcludedCorps, useOwnerFilter, type Owners } from '../ownerFilter'
 import retro from '../retro.module.css'
@@ -125,7 +127,14 @@ export const ActiveJobs = ({ jobs, owners, initialNow, typeNamesPromise, station
                     const stationId = j.station_id ?? j.facility_id
                     if (stationId == null) return '—'
                     const name = stationNames[String(stationId)]
-                    return name ? <a href={`/structure/${stationId}`}>{name}</a> : String(stationId)
+                    return name ? (
+                      <Link href={`/structure/${stationId}`}>
+                        {name}
+                        <LinkSpinner />
+                      </Link>
+                    ) : (
+                      String(stationId)
+                    )
                   })()}
                 </td>
                 <td>

--- a/src/app/mercenary-dens/page.tsx
+++ b/src/app/mercenary-dens/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
 import { getSdePlanets } from '@/sdePlanets'
@@ -242,9 +243,9 @@ const MercenaryDensPage = async () => {
     <>
       <div className={styles.pageHeader}>
         {/* The header nav no longer carries this page — it's reached from /structure. */}
-        <a href="/structure" className={styles.backLink}>
+        <Link href="/structure" className={styles.backLink}>
           &laquo; Structures
-        </a>
+        </Link>
         <h1>Mercenary Dens</h1>
         <ShareAlliance alliances={alliances} sharedAllianceIds={sharedAllianceIds} />
       </div>

--- a/src/app/structure/[structureId]/page.tsx
+++ b/src/app/structure/[structureId]/page.tsx
@@ -90,7 +90,7 @@ const StructurePage = async ({ params }: StructureParams) => {
         <h1>Structure not found</h1>
         <p>
           No structure {structureId} is visible. It may not exist, or you may need to re-link a director character on
-          the <a href="/character">Characters</a> page. Back to <Link href="/structure">Structures</Link>.
+          the <Link href="/character">Characters</Link> page. Back to <Link href="/structure">Structures</Link>.
         </p>
       </>
     )

--- a/src/app/structure/page.tsx
+++ b/src/app/structure/page.tsx
@@ -1,9 +1,11 @@
+import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { concat } from 'ramda'
 
 import { createClient } from '@/utils/supabase/server'
 import { DateTime } from '../DateTime'
 import { formatIsk, formatKisk } from '../isk'
+import { LinkSpinner } from '../linkSpinner'
 import { Name, SystemName } from '../names'
 import { fetchSystemNames } from '../systemNames'
 import { fetchTypeNames } from '../typeNames'
@@ -288,8 +290,8 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
         </span>
       </div>
       <p className={styles.pageLinks}>
-        <a href="/structure/revenue">Tax revenue events &raquo;</a>
-        <a href="/mercenary-dens">Mercenary dens &raquo;</a>
+        <Link href="/structure/revenue">Tax revenue events &raquo;</Link>
+        <Link href="/mercenary-dens">Mercenary dens &raquo;</Link>
       </p>
       {list.length > 0 ? (
         <>
@@ -305,9 +307,10 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
                   <StructureSilhouette typeId={s.type_id} className={styles.silhouette} />
                   <div className={styles.head}>
                     <div>
-                      <a href={`/structure/${s.structure_id}`} className={styles.name}>
+                      <Link href={`/structure/${s.structure_id}`} className={styles.name}>
                         {s.name ?? `Structure #${s.structure_id}`}
-                      </a>
+                        <LinkSpinner />
+                      </Link>
                       {/* Upwell structures share their structure_id with the station/facility id industry jobs run at. */}
                       <span className={styles.subId}>#{s.structure_id}</span>
                     </div>
@@ -438,8 +441,8 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
         </>
       ) : (
         <p>
-          No structures visible. Re-link a director character on the <a href="/character">Characters</a> page so the
-          hourly job can fetch them.
+          No structures visible. Re-link a director character on the <Link href="/character">Characters</Link> page so
+          the hourly job can fetch them.
         </p>
       )}
       <p className={styles.lastRun}>


### PR DESCRIPTION
Follow-up to the page-load performance work (#822, #823) — the loose end noted in #822.

The structures page linked its tiles with a plain `<a href>`, so opening a structure was a full document reload: no client navigation, no prefetch, and none of the loading fallbacks added in #822. Same for its revenue, mercenary-dens and Characters links.

This wasn't a deliberate choice to force a fresh load — the page simply never imported `Link`, and its own sibling detail page (`structure/[structureId]`) already uses `<Link>` for the same destination in the same sentence as one of the anchors being fixed here.

## Changes

- `structure/page.tsx` — the tile name link (plus a `LinkSpinner`, since the grid is the page's primary navigation and a structure page isn't instant), the two page links, and the empty-state Characters link.
- `structure/[structureId]/page.tsx` — the Characters link in the not-found state, which sat next to an existing `<Link>`.
- `mercenary-dens/page.tsx` — the "« Structures" back link.
- `industry/activeJobs.tsx` — the job table's station link, which points at `/structure/[id]`.

The last two are on other pages but are the same defect pointed at structure pages, so navigating *into* a structure is now client-side from every direction.

The one anchor deliberately left alone is `lastRun.run_url` on the structures page — that's an external GitHub Actions URL, not an app route.

## Verification

`pnpm run lint`, `pnpm run build`, and `pnpm test` (186 passing) clean. Grepped the three touched directories afterwards to confirm no internal `<a href>` remain. As with the earlier phases I couldn't click through it — this sandbox has no Supabase credentials, so authenticated routes 500 before rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Nsrgp6wN8gVj6nmJhKFMr

---
_Generated by [Claude Code](https://claude.ai/code/session_014Nsrgp6wN8gVj6nmJhKFMr)_