### PR TITLE
Fix the asset browser's two slow location queries

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -260,6 +260,11 @@ create index character_asset_over_time_registration_id_idx on public.character_a
 create unique index character_asset_over_time_current_item_idx on public.character_asset_over_time (item_id) where is_current;
 -- Time-travel lookups walking an item's version history.
 create index character_asset_over_time_item_id_idx on public.character_asset_over_time (item_id, valid_until desc);
+-- "What is at this location": the root-item query behind /asset/[locationId]
+-- and the recursive descend in character_asset_location_contents(). Partial to
+-- match the character_asset view those go through — history rows are never
+-- location-filtered, so indexing them would only slow the extract's writes.
+create index character_asset_over_time_current_location_idx on public.character_asset_over_time (location_id) where is_current;
 
 alter table public.character_asset_over_time enable row level security;
 create policy "Users read own assets"
@@ -2567,6 +2572,8 @@ create index corp_asset_over_time_corporation_id_idx on public.corp_asset_over_t
 create unique index corp_asset_over_time_current_item_idx on public.corp_asset_over_time (item_id) where is_current;
 -- Time-travel lookups walking an item's version history.
 create index corp_asset_over_time_item_id_idx on public.corp_asset_over_time (item_id, valid_until desc);
+-- Location lookups, as for character_asset_over_time above.
+create index corp_asset_over_time_current_location_idx on public.corp_asset_over_time (location_id) where is_current;
 
 alter table public.corp_asset_over_time enable row level security;
 create policy "Users read assets for own corps"
@@ -2827,7 +2834,11 @@ returns table (item_id bigint, type_id bigint, name text, location_id bigint, lo
 language sql
 stable
 as $$
-  with recursive parent_of as (
+  -- `not materialized` matters: parent_of is referenced twice (base term and
+  -- recursive term), so by default Postgres materializes all ~117k current
+  -- character+corp asset rows and then filters down to one, leaving the
+  -- item_id index unused. Inlined, the base term is an index seek.
+  with recursive parent_of as not materialized (
     select item_id, type_id, name, location_id, location_type
     from public.character_asset
     union all
@@ -2844,9 +2855,20 @@ as $$
     join parent_of p on p.item_id = w.location_id
     where w.depth < 16
   )
-  select w.item_id, w.type_id, w.name, w.location_id, w.location_type, w.depth, t.name as type_name
+  -- The type name is a scalar subquery, not a join: a recursive CTE's row
+  -- estimate is wild (41,202 against an actual 1 on a real container), and
+  -- against `left join sde_published_type` that made the planner hash the whole
+  -- view — a seq scan parsing 52,848 jsonb documents, ~3s, to label one row.
+  -- Keyed on _key, so at most one row matches and this is equivalent.
+  select
+    w.item_id,
+    w.type_id,
+    w.name,
+    w.location_id,
+    w.location_type,
+    w.depth,
+    (select t.name from public.sde_published_type t where t.type_id = w.type_id) as type_name
   from walk w
-  left join public.sde_published_type t on t.type_id = w.type_id
   order by w.depth;
 $$;
 

--- a/supabase/migrations/20260807000000_asset_location_perf.sql
+++ b/supabase/migrations/20260807000000_asset_location_perf.sql
@@ -1,0 +1,107 @@
+-- Two fixes for the asset browser's page load, both measured against production
+-- on /asset/1049965150127 (a Station Warehouse Container holding 934 items).
+--
+-- 1. asset_ancestors() took 3,199 ms — and it is awaited before the page's
+--    first byte, so it was essentially the whole of that page's TTFB.
+-- 2. Nothing indexes location_id, so every "what is at this location" query
+--    scanned the entire current asset snapshot.
+
+-- ---------------------------------------------------------------------------
+-- 1. The location_id indexes.
+--
+-- character_asset_over_time holds 281k rows (91,770 of them current) and
+-- corp_asset_over_time 57k (25,199 current), and every location-scoped query
+-- read all of them:
+--
+--   * the root-item query behind /asset/[locationId] read 91,770 rows to
+--     return 934 — 34 ms, now 1.1 ms;
+--   * character_asset_location_contents() took 128 ms, 94 ms of which was an
+--     external merge sort spilling 2.3 MB to disk in order to compute a
+--     recursive join that returned *zero* rows — nothing in that container is
+--     nested inside anything else, but without an index Postgres had to sort
+--     the whole table to find that out. Now 65-75 ms: the disk sort is gone
+--     (the index supplies location_id order, so the merge join needs no sort)
+--     and the base case drops 31 ms -> 1.6 ms. The rest is the recursive step
+--     still reading the whole index to feed that merge join, because the
+--     planner estimates the descend CTE at 1.2M rows against an actual 934.
+--     Worth another look, but it is no longer the page's problem.
+--   * corp_asset_location_contents(): 13.7 ms -> 0.06 ms.
+--
+-- Partial, matching the `where is_current` predicate of the character_asset /
+-- corp_asset views every one of those queries actually goes through: the
+-- history rows are never location-filtered, so indexing them would only make
+-- the index bigger and the extract's writes slower.
+--
+-- Plain CREATE INDEX rather than CONCURRENTLY: the Supabase CLI runs a
+-- migration inside a transaction, which CONCURRENTLY cannot join. These tables
+-- are 82 MB and 16 MB, so the build takes about a second, and the extract jobs
+-- that write them are the only thing the lock can block.
+create index if not exists character_asset_over_time_current_location_idx
+  on public.character_asset_over_time (location_id) where is_current;
+create index if not exists corp_asset_over_time_current_location_idx
+  on public.corp_asset_over_time (location_id) where is_current;
+
+-- ---------------------------------------------------------------------------
+-- 2. asset_ancestors(): 3,199 ms -> 73 ms.
+--
+-- The breadcrumb walk for /asset/[locationId] and /ship/[itemId]. Same
+-- signature, same rows (verified equal over 26 sampled ids); only the plan
+-- changes. Two independent problems compounded:
+--
+-- (a) `parent_of` is referenced twice — once by the base term, once by the
+--     recursive one — so Postgres materialized it instead of inlining it:
+--     all 116,969 current character+corp asset rows were built into a temp
+--     result and then filtered down to one (`Rows Removed by Filter: 116,968`),
+--     with the item_id index that would have answered it instantly unused.
+--     `not materialized` restores the index seek (0.07 ms for the base term).
+--
+-- (b) The type name came from `left join public.sde_published_type`. The
+--     recursive CTE's row estimate is 41,202 against an actual of 1, so the
+--     planner chose a hash join and built the hash from the whole view — a
+--     sequential scan of sde_types decompressing and parsing 52,848 jsonb
+--     documents, 2,955 ms cold and ~600 ms warm, to label a single row. As a
+--     scalar subquery it is one index probe per output row (0.15 ms), and a
+--     row estimate this wrong can no longer choose a catastrophic plan.
+--     sde_published_type is keyed on _key, so at most one row matches and the
+--     subquery is exactly equivalent to the left join it replaces.
+--
+-- Both plans were measured on production inside a transaction that was rolled
+-- back. The 72 ms that remains is the recursive step scanning the full
+-- character+corp append rather than probing the item_id index — the same bad
+-- recursive-CTE row estimate as in (b), just no longer expensive enough to
+-- matter next to a 3.2 s page.
+create or replace function public.asset_ancestors(start_id bigint)
+returns table (item_id bigint, type_id bigint, name text, location_id bigint, location_type text, depth int, type_name text)
+language sql
+stable
+as $$
+  with recursive parent_of as not materialized (
+    select item_id, type_id, name, location_id, location_type
+    from public.character_asset
+    union all
+    select item_id, type_id, null::text as name, location_id, location_type
+    from public.corp_asset
+  ),
+  walk as (
+    select p.item_id, p.type_id, p.name, p.location_id, p.location_type, 1 as depth
+    from parent_of p
+    where p.item_id = start_id
+    union all
+    select p.item_id, p.type_id, p.name, p.location_id, p.location_type, w.depth + 1
+    from walk w
+    join parent_of p on p.item_id = w.location_id
+    where w.depth < 16
+  )
+  select
+    w.item_id,
+    w.type_id,
+    w.name,
+    w.location_id,
+    w.location_type,
+    w.depth,
+    (select t.name from public.sde_published_type t where t.type_id = w.type_id) as type_name
+  from walk w
+  order by w.depth;
+$$;
+
+grant execute on function public.asset_ancestors(bigint) to authenticated;


### PR DESCRIPTION
Follow-up to the page-load work (#822, #823). Those made a slow page *feel* answered and cut the app's round trips; this fixes the queries themselves.

Diagnosed against `/asset/1049965150127` — **"Modules", a Station Warehouse Container holding 934 items across 895 distinct types.** A container, not a station, which matters: container and ship pages resolve a breadcrumb through `asset_ancestors()`; station pages don't.

## Measured, before and after

Both measured on production. Blocking = runs before the first byte.

| query | before | after | |
|---|---|---|---|
| `asset_ancestors()` | **3,199 ms** | **72 ms** | blocking |
| root items | 34 ms | 1.1 ms | blocking |
| `character_asset_location_contents()` | 128 ms | 65–75 ms | streamed |
| `corp_asset_location_contents()` | 13.7 ms | 0.06 ms | streamed |

Blocking prefix: **~3,233 ms → ~73 ms.**

## 1. `asset_ancestors()` — 3.2 seconds for a one-row breadcrumb

Two independent problems compounded:

**The `parent_of` CTE was materialized.** It's referenced twice — base term and recursive term — so Postgres materialized it rather than inlining: all 116,969 current character+corp asset rows built into a temp result, then filtered to one (`Rows Removed by Filter: 116,968`), with the `item_id` index that would have answered it instantly unused. `not materialized` restores the seek — the base term is now 0.07 ms.

**The type-name join hashed the entire SDE.** `left join public.sde_published_type` for the breadcrumb labels. The recursive CTE's row estimate is 41,202 against an actual of **1**, so the planner built a hash from the whole view — a sequential scan of `sde_types` decompressing and parsing **52,848 jsonb documents**, 2,955 ms cold and ~600 ms warm, to label one row. As a scalar subquery it's one index probe (0.15 ms), and an estimate that wrong can no longer select a catastrophic plan. `sde_published_type` is keyed on `_key`, so at most one row matches — exactly equivalent to the left join.

Same signature, same rows: I diffed old against new over 26 sampled ids (50 rows), zero differing in either direction.

This also fixes `/ship/[itemId]`, which calls the same RPC.

## 2. No index on `location_id` — anywhere

Confirmed absent from `schema.sql`, from every migration, and from production. So every location-scoped query scanned the full current snapshot. The ugliest case: `character_asset_location_contents()` spent 94 of its 128 ms on an **external merge sort spilling 2.3 MB to disk**, to compute a recursive join that returned **zero rows** — nothing in this container is nested, but without an index Postgres had to sort the whole table to find that out.

Partial indexes matching the `where is_current` predicate the `character_asset` / `corp_asset` views go through — history rows are never location-filtered, so indexing them would only enlarge the index and slow the extract's writes.

Plain `CREATE INDEX`, not `CONCURRENTLY`: the Supabase CLI runs migrations in a transaction, which `CONCURRENTLY` can't join. The tables are 82 MB and 16 MB, so the build is about a second, and the 6-hourly extract jobs are the only writers the lock can block.

## How this was verified

`EXPLAIN ANALYZE` and catalog reads against production, plus the full migration applied inside a transaction that was **rolled back** — I re-checked afterwards that neither index exists and the function is unchanged. Nothing has been applied; `db push` on merge will be the first real application.

`schema.sql` carries the same changes so a fresh reset matches, per the house rule. `check-migrations.mjs` passes; lint, build and 188 tests are clean.

## Known residual, deliberately not chased here

Both remaining costs are the same root cause — recursive-CTE row estimates that are wildly wrong — and neither is load-bearing now:

- `asset_ancestors()`'s 72 ms is its recursive step scanning the character+corp append instead of probing the `item_id` index.
- `character_asset_location_contents()`'s 65 ms is the recursive step reading the whole index to feed a merge join (estimate: 1.2M rows; actual: 934).

Separately, and worth knowing rather than acting on blind: the second RLS policy on assets calls `asset_share_covers()` — a `SECURITY DEFINER` function with its own 16-level recursive walk — **per row**. It costs nothing here because the owner check short-circuits first, but on a page where the viewer owns few of the scanned rows it would be expensive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Nsrgp6wN8gVj6nmJhKFMr

---
_Generated by [Claude Code](https://claude.ai/code/session_014Nsrgp6wN8gVj6nmJhKFMr)_