### PR TITLE
Cache navigations client-side, narrow the asset location rollups

### DIFF
--- a/docs/page-load-performance.md
+++ b/docs/page-load-performance.md
@@ -121,11 +121,20 @@ lookups) is already process-cached for 6h in `src/sdeCache.ts`. Revisit
 only if profiling shows SDE round trips dominating a hot page on cold
 lambdas.
 
-### 6. Router cache tuning (`staleTimes`), prefetch hints — no
+### 6. Router cache tuning (`staleTimes`) — **yes, reversed**
 
-Marginal next to 1–4, and `staleTimes` trades staleness of player data
-(freshness is a product feature here — see `freshness.ts`) for
-back-navigation speed the browser bfcache mostly covers anyway.
+> **This was originally a "no" and the reasoning was wrong.** It said
+> `staleTimes` trades staleness of player data (freshness being a product
+> feature — see `freshness.ts`) for back-navigation speed the bfcache mostly
+> covers anyway. Two errors: the bfcache does not cover in-app client
+> navigation, and there is no freshness to trade — the extract jobs run every
+> six hours, so a segment reused within a minute cannot differ from a fresh
+> render. In practice `staleTimes.dynamic` defaults to **0**, and every page
+> here is dynamic (cookie session), so the router cache was holding nothing at
+> all: each back/forward re-ran the entire server render. Set to 60s in
+> `next.config.mjs`. Kept to 60 rather than the 300s ceiling because the
+> header's freshness indicator rides on these same renders and should not sit
+> visibly behind an on-demand refresh.
 
 ## The plan
 
@@ -194,10 +203,58 @@ shape, for the contents counts.
 lands, note the current p75 for the worst routes; after each phase,
 compare. No new tooling needed.
 
+## What measurement actually found
+
+Phase 4 said to measure before doing more. It was worth it — the biggest wins
+were not where this plan predicted, and phase 3's premise turned out to be
+wrong.
+
+| | |
+| --- | --- |
+| `asset_ancestors()` (breadcrumb, blocking) | **3,199 ms → 59 ms** |
+| `character_asset_location_summary()` (index + system pages, blocking) | 970 ms → 588 ms |
+| `corp_asset_location_summary()` | 257 ms → 126 ms |
+| `character_asset_location_contents()` | 128 ms → 63 ms |
+| root items | 34 ms → 0.8 ms |
+
+None of it was round-trip count, which is what phases 2 and 3 were aimed at.
+It was three query-level faults:
+
+1. **A materialized CTE.** `asset_ancestors`' `parent_of` is referenced twice,
+   so Postgres built all ~117k current asset rows and filtered to one, with the
+   `item_id` index unused. `not materialized` fixed it.
+2. **A hash join against jsonb.** The same function joined `sde_published_type`
+   for one row; with a recursive-CTE row estimate of 41,202 against an actual 1,
+   the planner hashed the whole view — a seq scan parsing 52,848 jsonb
+   documents. A scalar subquery made it one index probe.
+3. **A missing index.** Nothing indexed `location_id`, anywhere, so every
+   location query scanned the full current snapshot.
+
+(1) and (2) shipped in `20260807000000`, along with the indexes; the summary
+narrowing in `20260807010000`.
+
+**Phase 3 as written is dead.** It proposed folding the location page's fetch
+prefix into one `asset_location_page()` RPC, gated on measurement. Measurement
+says the prefix was never the problem — it was ~35 ms of round trips behind a
+3.2 s query. Collapsing them would have saved tens of milliseconds while the
+real fault sat untouched. Do not build it.
+
+What replaces it, if the index page still feels slow: the summary functions
+still walk every current asset up its container chain on every request, to
+produce ~1.5k rows from data that changes every six hours. The fix is to stop
+recomputing per request — a rollup table maintained by the `character-assets`
+extract, turning the page read into an indexed select. Considered and rejected
+for the same job: wrapping the RPCs in Next's data cache, since the key would
+have to carry the user id and a wrong key serves one player another player's
+hangar.
+
+Reach for `EXPLAIN ANALYZE` before reasoning about waterfall depth next time.
+
 ## Non-goals
 
-- No caching of player data across users or requests (RLS + freshness are
-  product features).
+- No caching of player data **on the server**, shared across users or
+  requests (RLS makes a mis-keyed cache a data leak). The per-client router
+  cache is a different thing and is now on — see option 6.
 - No PPR / `use cache` adoption.
 - No client-side data fetching rewrite (SWR/React Query) — server
   components + streaming stay the architecture.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,6 +11,27 @@ const nextConfig = {
   // pre-existing incompatibility between that route and the webpack build
   // path, so Turbopack is the only viable option here regardless.)
   turbopack: {},
+  experimental: {
+    staleTimes: {
+      // How long the client-side router cache may reuse an already-rendered
+      // dynamic segment — every page here is dynamic, since they all read a
+      // cookie session. The default is 0, meaning a back/forward or a repeat
+      // visit re-runs the whole server render, which is why navigating around
+      // the asset browser never felt cached.
+      //
+      // 60s is chosen against what the data can actually do: the extract jobs
+      // run every 6 hours, so a page reused within a minute cannot be showing
+      // anything a fresh render would have changed. It is deliberately not
+      // longer — the header's "Refreshed N minutes ago" freshness indicator
+      // rides on these same renders, and a multi-minute cache would let it sit
+      // visibly behind an on-demand refresh the user just triggered.
+      //
+      // (docs/page-load-performance.md originally listed this as a non-goal,
+      // on the reasoning that it trades data freshness for navigation speed.
+      // That was wrong: at a 6-hourly cadence there is no freshness to trade.)
+      dynamic: 60,
+    },
+  },
   env: {
     // Captured at build time (i.e. when the deployment is built).
     BUILD_TIME: new Date().toISOString(),

--- a/schema.sql
+++ b/schema.sql
@@ -315,8 +315,16 @@ as $$
     -- enclosing structure instead of stranding them on the bare item id. RLS
     -- keeps character_asset_over_time scoped to the caller's own characters, so
     -- a container owned by someone else (a corpmate's) still can't be bridged.
+    --
+    -- Narrowed to ids that appear as some row's location: those are exactly
+    -- the ids the walk and the root test below can probe, and there are ~28x
+    -- fewer of them than there are distinct item ids. Equivalence-preserving
+    -- — any id either side probes is by construction a location_id.
     select distinct on (item_id) item_id, location_id, location_type
     from public.character_asset_over_time
+    where item_id in (
+      select location_id from public.character_asset_over_time where location_id is not null
+    )
     order by item_id, is_current desc, valid_until desc
   ),
   walk as (
@@ -2614,8 +2622,12 @@ as $$
     -- One best-known parent per item the caller can see: the live row if there
     -- is one, otherwise the most recent historical sighting, so the walk can
     -- bridge a container that momentarily dropped out of the current snapshot.
+    -- Narrowed as in character_asset_location_summary() above.
     select distinct on (item_id) item_id, location_id, location_type
     from public.corp_asset_over_time
+    where item_id in (
+      select location_id from public.corp_asset_over_time where location_id is not null
+    )
     order by item_id, is_current desc, valid_until desc
   ),
   walk as (

--- a/supabase/migrations/20260807010000_asset_location_summary_scope.sql
+++ b/supabase/migrations/20260807010000_asset_location_summary_scope.sql
@@ -1,0 +1,134 @@
+-- The asset index and solar-system pages call character_asset_location_summary()
+-- and corp_asset_location_summary() to bucket the caller's hangar by location.
+-- They cost 970 ms and 257 ms on production, in parallel and blocking, which is
+-- what was left of the "1-2 second" asset navigation after 20260807000000.
+--
+-- Both build a `parent_of` CTE of one best-known parent per item across the
+-- whole SCD history — 102,880 distinct item ids for the character table. But
+-- only ids that appear as *somebody's location* can ever be looked up: the walk
+-- probes `parent_of` by `w.location_id`, and the root test asks whether a
+-- `w.location_id` is itself one of our items. There are 3,617 such ids, a
+-- factor of 28 fewer.
+--
+-- Restricting the CTE to them is equivalence-preserving rather than an
+-- approximation. Every id either side probes is by construction a location_id,
+-- so an item that is a real parent necessarily appears as some row's
+-- location_id and survives the filter; an item that never appears as anyone's
+-- location could never have been probed. Verified on production: identical row
+-- counts (1,482 character / 84 corp) with zero rows differing in either
+-- direction.
+--
+--   character_asset_location_summary(): 970 ms -> 588 ms
+--   corp_asset_location_summary():      257 ms -> 126 ms
+--
+-- This does not make the pages fast, and is not meant to — the functions still
+-- walk every current asset up its container chain on every request, to produce
+-- ~1.5k rows from data that only changes when the 6-hourly extract runs. The
+-- fix for that is to stop recomputing it per request (a rollup table maintained
+-- by the extract job); this is the cheap, verified half taken meanwhile.
+
+create or replace function public.character_asset_location_summary()
+returns table (location_id bigint, location_type text, registration_id uuid, stacks bigint, station_name text, system_id bigint)
+language sql
+stable
+as $$
+  with recursive parent_of as (
+    -- One best-known parent per item the caller can see: the live row if there is
+    -- one, otherwise the most recent historical sighting. The walk climbs through
+    -- this rather than the live-only character_asset view so it can bridge a
+    -- container or ship that has momentarily dropped out of the current snapshot
+    -- — e.g. one handed between the player's own characters, whose per-character
+    -- extracts run at different times — and still roll its contents up to the
+    -- enclosing structure instead of stranding them on the bare item id. RLS
+    -- keeps character_asset_over_time scoped to the caller's own characters, so
+    -- a container owned by someone else (a corpmate's) still can't be bridged.
+    --
+    -- Narrowed to ids that appear as some row's location: those are exactly the
+    -- ids the walk and the root test below can probe, and there are ~28x fewer
+    -- of them than there are distinct item ids.
+    select distinct on (item_id) item_id, location_id, location_type
+    from public.character_asset_over_time
+    where item_id in (
+      select location_id from public.character_asset_over_time where location_id is not null
+    )
+    order by item_id, is_current desc, valid_until desc
+  ),
+  walk as (
+    select
+      a.item_id       as start_item,
+      a.registration_id  as registration_id,
+      a.location_id   as location_id,
+      a.location_type as location_type,
+      1               as depth
+    from public.character_asset a
+    union all
+    select
+      w.start_item,
+      w.registration_id,
+      p.location_id,
+      p.location_type,
+      w.depth + 1
+    from walk w
+    join parent_of p on p.item_id = w.location_id
+    where w.depth < 64
+  )
+  select
+    w.location_id,
+    w.location_type,
+    w.registration_id,
+    count(*) as stacks,
+    st.name as station_name,
+    st.system_id
+  from walk w
+  left join public.sde_station st on st.station_id = w.location_id
+  where w.location_id is not null
+    and not exists (select 1 from parent_of o where o.item_id = w.location_id)
+  group by w.location_id, w.location_type, w.registration_id, st.name, st.system_id;
+$$;
+
+create or replace function public.corp_asset_location_summary()
+returns table (location_id bigint, location_type text, corporation_id bigint, stacks bigint, station_name text, system_id bigint)
+language sql
+stable
+as $$
+  with recursive parent_of as (
+    -- Same narrowing as the character version above.
+    select distinct on (item_id) item_id, location_id, location_type
+    from public.corp_asset_over_time
+    where item_id in (
+      select location_id from public.corp_asset_over_time where location_id is not null
+    )
+    order by item_id, is_current desc, valid_until desc
+  ),
+  walk as (
+    select
+      a.item_id        as start_item,
+      a.corporation_id as corporation_id,
+      a.location_id    as location_id,
+      a.location_type  as location_type,
+      1                as depth
+    from public.corp_asset a
+    union all
+    select
+      w.start_item,
+      w.corporation_id,
+      p.location_id,
+      p.location_type,
+      w.depth + 1
+    from walk w
+    join parent_of p on p.item_id = w.location_id
+    where w.depth < 64
+  )
+  select
+    w.location_id,
+    w.location_type,
+    w.corporation_id,
+    count(*) as stacks,
+    st.name as station_name,
+    st.system_id
+  from walk w
+  left join public.sde_station st on st.station_id = w.location_id
+  where w.location_id is not null
+    and not exists (select 1 from parent_of o where o.item_id = w.location_id)
+  group by w.location_id, w.location_type, w.corporation_id, st.name, st.system_id;
+$$;


### PR DESCRIPTION
The two things still making asset navigation slow after #825 took container pages from 3.2 s to 60 ms: nothing was cached, and the index/system pages were still ~1 s.

## Nothing was cached

`experimental.staleTimes.dynamic` defaults to **0**, and every page here is dynamic (cookie session) — so the client router cache held nothing at all, and a back/forward re-ran the entire server render. Set to **60 s**.

The value is chosen against what the data can actually do: the extract jobs run every 6 hours, so a segment reused within a minute cannot show anything a fresh render would have changed. Deliberately not longer — the header's "Refreshed N minutes ago" indicator rides on these same renders, and a multi-minute cache would let it sit visibly behind an on-demand refresh the user just triggered.

I'd listed this as a **non-goal** in the plan doc, reasoning that it trades data freshness for navigation speed and that the bfcache covers back-navigation anyway. Both halves were wrong: the bfcache doesn't cover in-app client navigation, and at a 6-hourly cadence there's no freshness to trade. The doc is corrected in this PR rather than left to mislead.

## The remaining ~1 second

`/asset` and solar-system pages call both location-summary RPCs in parallel, blocking:

| | before | after |
|---|---|---|
| `character_asset_location_summary()` | 970 ms | **588 ms** |
| `corp_asset_location_summary()` | 257 ms | **126 ms** |

Both build `parent_of` — one best-known parent per item across the whole SCD history — for **102,880** distinct item ids. But only ids that appear as *somebody's location* can ever be probed: the walk looks up `w.location_id`, and the root test asks whether a `w.location_id` is itself one of our items. There are **3,617** such ids, 28× fewer.

Narrowing to them is **equivalence-preserving, not an approximation** — every id either side probes is by construction a `location_id`, so a real parent necessarily appears as some row's `location_id` and survives the filter, and an item that's never anyone's location could never have been probed.

Verified on production by snapshotting each function's output into a temp table, replacing the function, and diffing: **1,482 / 84 rows before and after, zero rows differing in either direction.**

## What this does *not* do

It does not make those pages fast, and isn't meant to. The functions still walk every current asset up its container chain on every request, to produce ~1.5k rows from data that changes every six hours. That's the rollup-table change we discussed, and it's deliberately its own PR.

## Verification

`EXPLAIN ANALYZE` and the equivalence check ran on production inside a transaction that was **rolled back**; I re-confirmed afterwards that neither function is modified. `db push` on merge will be the first real application. `schema.sql` carries the same narrowing (only the two summary functions — `character_asset_search` / `corp_asset_search` share the CTE shape and are deliberately untouched, since they're already seeded from a filter). Migration guard, lint, build and 188 tests pass.

## Doc changes

`docs/page-load-performance.md` gets the `staleTimes` reversal, plus a "what measurement actually found" section recording that the wins were query-level faults (a materialized CTE, a hash join against jsonb, a missing index) rather than round-trip count — and that **phase 3's proposed `asset_location_page()` RPC is dead**: it would have saved tens of milliseconds of round trips sitting behind a 3.2 s query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Nsrgp6wN8gVj6nmJhKFMr

---
_Generated by [Claude Code](https://claude.ai/code/session_014Nsrgp6wN8gVj6nmJhKFMr)_