### PR TITLE
Accept and emit truncated lens ids

### DIFF
--- a/src/app/api/mcp/lensTools.ts
+++ b/src/app/api/mcp/lensTools.ts
@@ -30,6 +30,7 @@ import { lensRows } from '@/app/lens/flatten'
 import { lensEdits, resolveLensRef } from '@/app/lens/lensRef'
 import { runLens } from '@/app/lens/run'
 import { applyLensShare, fetchOwnAudiences } from '@/app/lens/share'
+import { shortLensId } from '@/app/lens/shortId'
 import { parseLensVariables, SESSION_ONLY_ARGUMENTS, SESSION_ONLY_FIELDS, validateLensQuery } from '@/app/lens/validate'
 import { LENS_FLAG, hasFlag } from '@/flags'
 import { signShare, tokenSalt } from '@/shareToken'
@@ -90,17 +91,19 @@ const EXAMPLES = [
 ]
 
 // The lens's own URLs. Absolute when the deployment knows its origin, paths
-// otherwise (see src/utils/siteUrl.ts).
-const lensLinks = (id: string, name: string) => ({
+// otherwise (see src/utils/siteUrl.ts). `pathId` is the shortest id that
+// resolves back to this lens (src/app/lens/shortId.ts) — the URLs carry it,
+// while `id` stays the full uuid for anything that needs the exact row.
+const lensLinks = (id: string, name: string, pathId: string) => ({
   id,
   name,
-  url: siteUrl(`/lens/${id}`),
-  csv_url: siteUrl(`/lens/${id}/csv`),
+  url: siteUrl(`/lens/${pathId}`),
+  csv_url: siteUrl(`/lens/${pathId}/csv`),
 })
 
 // Who a lens is shared with, in names rather than ids — the answer is read by
 // a human through a model, and "KarmaFleet" beats 98000001.
-const describeShare = (lensId: string, share: ShareState | null, own: OwnAudiences) => {
+const describeShare = (pathId: string, share: ShareState | null, own: OwnAudiences) => {
   if (!share) {
     return { shared_with_nobody: true, note: 'Saved, but not shared with anyone.' }
   }
@@ -113,8 +116,8 @@ const describeShare = (lensId: string, share: ShareState | null, own: OwnAudienc
     public: share.isPublic,
     // The signed link is the only URL that works without a session — it's also
     // the one a spreadsheet can pull the CSV from.
-    link_url: shareParam ? siteUrl(`/lens/${lensId}?share=${shareParam}`) : null,
-    link_csv_url: shareParam ? siteUrl(`/lens/${lensId}/csv?share=${shareParam}`) : null,
+    link_url: shareParam ? siteUrl(`/lens/${pathId}?share=${shareParam}`) : null,
+    link_csv_url: shareParam ? siteUrl(`/lens/${pathId}/csv?share=${shareParam}`) : null,
   }
 }
 
@@ -329,6 +332,7 @@ export const registerLensTools = (server: McpServer): void => {
         .maybeSingle<{ id: string }>()
       if (error || !inserted)
         return textResult(`Could not save the lens: ${error?.message ?? 'insert returned no row'}`)
+      const pathId = await shortLensId(inserted.id)
 
       const applied = await applyLensShare(caller.supabase, caller.userId, inserted.id, resolved.audience, {
         existingSecret: null,
@@ -337,7 +341,7 @@ export const registerLensTools = (server: McpServer): void => {
       // happened, or the model will try again and leave a duplicate behind.
       if (!applied.ok) {
         return textResult({
-          lens: lensLinks(inserted.id, name.trim()),
+          lens: lensLinks(inserted.id, name.trim(), pathId),
           shared: false,
           preview: preflight.report,
           warning: `The lens was saved but could not be shared: ${applied.message} Set the audience in the web editor at /lens.`,
@@ -345,8 +349,8 @@ export const registerLensTools = (server: McpServer): void => {
       }
 
       return textResult({
-        lens: lensLinks(inserted.id, name.trim()),
-        share: describeShare(inserted.id, applied.share, own),
+        lens: lensLinks(inserted.id, name.trim(), pathId),
+        share: describeShare(pathId, applied.share, own),
         preview: preflight.report,
       })
     }
@@ -375,12 +379,13 @@ export const registerLensTools = (server: McpServer): void => {
         fetchOwnLenses(caller.supabase, caller.userId),
         fetchOwnAudiences(caller.supabase),
       ])
+      const pathIds = await Promise.all(rows.map((row) => shortLensId(row.id)))
 
       return textResult({
-        lenses: rows.map((row) => ({
-          ...lensLinks(row.id, row.name),
+        lenses: rows.map((row, i) => ({
+          ...lensLinks(row.id, row.name, pathIds[i]),
           updated_at: row.updated_at,
-          share: describeShare(row.id, storedShare(row), own),
+          share: describeShare(pathIds[i], storedShare(row), own),
           ...(include_query === false
             ? {}
             : {
@@ -448,6 +453,7 @@ export const registerLensTools = (server: McpServer): void => {
       const picked = resolveLensRef(args.lens, rows)
       if (!picked.ok) return textResult(picked.message)
       const stored = rows.find((r) => r.id === picked.id) as LensRow
+      const pathId = await shortLensId(stored.id)
 
       // What the edit actually changes, and what the lens will run afterwards —
       // which is the stored query when only the audience is being touched.
@@ -495,7 +501,7 @@ export const registerLensTools = (server: McpServer): void => {
         return textResult({
           updated: false,
           error: 'Nothing was changed: running the query this lens would have returned no data at all.',
-          lens: lensLinks(stored.id, stored.name),
+          lens: lensLinks(stored.id, stored.name, pathId),
           preview: preflight.report,
         })
       }
@@ -517,7 +523,7 @@ export const registerLensTools = (server: McpServer): void => {
         : ({ ok: true, share: storedShare(stored) } as const)
       if (!applied.ok) {
         return textResult({
-          lens: lensLinks(stored.id, edits.changes.name ?? stored.name),
+          lens: lensLinks(stored.id, edits.changes.name ?? stored.name, pathId),
           changed: edits.changed,
           warning: `The lens was updated but its sharing could not be changed: ${applied.message}`,
           preview: preflight.report,
@@ -525,10 +531,10 @@ export const registerLensTools = (server: McpServer): void => {
       }
 
       return textResult({
-        lens: lensLinks(stored.id, edits.changes.name ?? stored.name),
+        lens: lensLinks(stored.id, edits.changes.name ?? stored.name, pathId),
         changed: [...edits.changed, ...(shareRequested ? ['share'] : [])],
         ...(edits.changed.length === 0 && !shareRequested && { note: 'Nothing to change — no fields were given.' }),
-        share: describeShare(stored.id, applied.share, own),
+        share: describeShare(pathId, applied.share, own),
         preview: preflight.report,
       })
     }

--- a/src/app/lens/access.ts
+++ b/src/app/lens/access.ts
@@ -14,13 +14,41 @@
 //
 // Either way the run is gated on the CREATOR still holding the lens flag —
 // un-flagging an account turns its shared lenses off, the dark-launch lever.
+//
+// The path id may be truncated (any canonical-format prefix of ≥8 hex digits,
+// e.g. /lens/da204490): it expands to the oldest-created matching lens before
+// either door is tried — see expandLensId.
 import { LENS_FLAG, hasFlag } from '@/flags'
 import { parseShareParam, tokenSalt, verifyShareToken } from '@/shareToken'
 import { createClient } from '@/utils/supabase/server'
 import { createServiceClient } from '@/utils/supabase/service'
 import type { LensRecord } from './run'
+import { uuidPrefixRange } from './uuidPrefix'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+// A truncated path id → the full lens id it canonically means, or null. The
+// service role on purpose: a short link must name the same lens for EVERY
+// viewer, and resolving through RLS would let each caller's visibility pick a
+// different prefix-match (a signed ?share= could then verify against the
+// wrong row). This resolves the name only — the caller still puts the full id
+// through the same RLS/signature doors as an untruncated URL, so it widens
+// access to nothing. Ties break to the oldest created_at, which is stable:
+// a lens created later can never capture an already-working short link.
+const expandLensId = async (prefix: string): Promise<string | null> => {
+  const range = uuidPrefixRange(prefix)
+  if (!range) return null
+  const service = createServiceClient()
+  const { data } = await service
+    .from('lens')
+    .select('id')
+    .gte('id', range.low)
+    .lte('id', range.high)
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .maybeSingle<{ id: string }>()
+  return data?.id ?? null
+}
 
 export type ResolvedLens = { lens: LensRecord; viewerIsOwner: boolean }
 
@@ -44,16 +72,17 @@ const resolveSignedLens = async (lensId: string, param: string): Promise<LensRec
 }
 
 export const resolveLens = async (lensId: string, shareParam?: string): Promise<ResolvedLens | null> => {
-  if (!UUID_RE.test(lensId)) return null
+  const id = UUID_RE.test(lensId) ? lensId.toLowerCase() : await expandLensId(lensId)
+  if (id === null) return null
 
   const supabase = await createClient()
   const { data: auth } = await supabase.auth.getUser()
   const viewerId = auth?.user?.id ?? null
 
   // RLS is the authority for the membership/public/owner doors.
-  const { data: rlsLens } = await supabase.from('lens').select('*').eq('id', lensId).maybeSingle<LensRecord>()
+  const { data: rlsLens } = await supabase.from('lens').select('*').eq('id', id).maybeSingle<LensRecord>()
 
-  const lens = rlsLens ?? (shareParam ? await resolveSignedLens(lensId, shareParam) : null)
+  const lens = rlsLens ?? (shareParam ? await resolveSignedLens(id, shareParam) : null)
   if (!lens) return null
   if (!(await hasFlag(lens.user_id, LENS_FLAG))) return null
 

--- a/src/app/lens/page.tsx
+++ b/src/app/lens/page.tsx
@@ -6,6 +6,7 @@ import { fetchShareAudiences, shareRowToState, type OwnRegistration } from '@/ap
 import { LENS_FLAG, hasFlag } from '@/flags'
 import { createClient } from '@/utils/supabase/server'
 import { revokeLensShare, saveLensShare } from './actions'
+import { shortLensId } from './shortId'
 import { LensEditor } from './lensEditor'
 import type { LensRecord } from './run'
 import styles from './lens.module.css'
@@ -35,6 +36,9 @@ const LensPage = async () => {
   ])
   const lenses = (lensRows ?? []) as LensRecord[]
   const audiences = await fetchShareAudiences(supabase, (regs ?? []) as OwnRegistration[])
+  // The dialog's copyable URL carries the shortest id that resolves back to
+  // each lens, so what people paste onward is the graceful form.
+  const shortIds = await Promise.all(lenses.map((lens) => shortLensId(lens.id)))
 
   return (
     <>
@@ -47,7 +51,7 @@ const LensPage = async () => {
 
       <LensEditor lens={null} />
 
-      {lenses.map((lens) => (
+      {lenses.map((lens, i) => (
         <section key={lens.id} className={styles.lens}>
           <div className={styles.lensHeading}>
             <h2>
@@ -55,7 +59,7 @@ const LensPage = async () => {
             </h2>
             <ShareDialog
               subjectLabel="lens"
-              urlPath={`/lens/${lens.id}`}
+              urlPath={`/lens/${shortIds[i]}`}
               hint="Whoever you share with can run this query and see its results — your data, live — until you stop sharing."
               data={{
                 share: lens.enabled ? shareRowToState(lens) : null,

--- a/src/app/lens/shortId.ts
+++ b/src/app/lens/shortId.ts
@@ -1,0 +1,32 @@
+// The emit side of truncated lens ids: the shortest path id that resolves
+// back to this lens, for the URLs the share dialog and the MCP tools hand
+// out. expandLensId (access.ts) takes the OLDEST-created match, so the prefix
+// only has to beat lenses created no later than this one — anything newer
+// loses the tie on its own, which is also why a short link emitted today can
+// never be captured by a lens created tomorrow.
+//
+// Service role on purpose: the contest spans every user's lenses, exactly
+// like resolution does. Only ids and created_at are read, and only to size
+// the prefix — nothing else leaves the function. Any doubt (query error, the
+// lens missing) falls back to the full id, which always works.
+import { createServiceClient } from '@/utils/supabase/service'
+import { shortestUuidPrefix, uuidPrefixRange } from './uuidPrefix'
+
+export const shortLensId = async (lensId: string): Promise<string> => {
+  const range = uuidPrefixRange(lensId.slice(0, 8))
+  if (!range) return lensId
+
+  const service = createServiceClient()
+  const { data, error } = await service.from('lens').select('id, created_at').gte('id', range.low).lte('id', range.high)
+  if (error || !data) return lensId
+
+  const rows = data as Array<{ id: string; created_at: string }>
+  const self = rows.find((r) => r.id === lensId)
+  if (!self) return lensId
+
+  // <= rather than <: a same-instant sibling would make resolution order
+  // undefined, so it must be beaten too, not tied with.
+  const cutoff = new Date(self.created_at).getTime()
+  const contested = rows.filter((r) => r.id !== lensId && new Date(r.created_at).getTime() <= cutoff).map((r) => r.id)
+  return shortestUuidPrefix(lensId, contested)
+}

--- a/src/app/lens/uuidPrefix.ts
+++ b/src/app/lens/uuidPrefix.ts
@@ -1,0 +1,33 @@
+// A truncated lens id in the /lens/[id] path: any prefix of the canonical
+// uuid formatting, at least 8 hex digits long (shorter invites typo-matches
+// and shrinks the scan space for probing which ids exist). Postgres compares
+// uuids bytewise — the same order as their hex strings — so a prefix becomes
+// a closed range: pad the missing digits with 0 for the low bound and f for
+// the high, and every uuid starting with the prefix falls between them. That
+// keeps the lookup an index range scan instead of a ::text LIKE.
+const UUID_TEMPLATE = '00000000-0000-0000-0000-000000000000'
+const MIN_HEX_DIGITS = 8
+
+export type UuidRange = { low: string; high: string }
+
+export const uuidPrefixRange = (param: string): UuidRange | null => {
+  const prefix = param.toLowerCase()
+  if (prefix.length > UUID_TEMPLATE.length) return null
+
+  // A valid prefix agrees with the canonical shape position by position:
+  // dashes exactly where the template has them, hex everywhere else.
+  let hexDigits = 0
+  for (let i = 0; i < prefix.length; i++) {
+    if (UUID_TEMPLATE[i] === '-') {
+      if (prefix[i] !== '-') return null
+    } else if (/[0-9a-f]/.test(prefix[i])) {
+      hexDigits += 1
+    } else {
+      return null
+    }
+  }
+  if (hexDigits < MIN_HEX_DIGITS) return null
+
+  const rest = UUID_TEMPLATE.slice(prefix.length)
+  return { low: prefix + rest, high: prefix + rest.replace(/0/g, 'f') }
+}

--- a/src/app/lens/uuidPrefix.ts
+++ b/src/app/lens/uuidPrefix.ts
@@ -1,12 +1,21 @@
-// A truncated lens id in the /lens/[id] path: any prefix of the canonical
-// uuid formatting, at least 8 hex digits long (shorter invites typo-matches
-// and shrinks the scan space for probing which ids exist). Postgres compares
-// uuids bytewise — the same order as their hex strings — so a prefix becomes
-// a closed range: pad the missing digits with 0 for the low bound and f for
-// the high, and every uuid starting with the prefix falls between them. That
-// keeps the lookup an index range scan instead of a ::text LIKE.
+// Truncated lens ids, both directions — pure string work only, so the node
+// test runner can cover it without a client.
+//
+// Accept side (uuidPrefixRange): a truncated id in the /lens/[id] path is any
+// prefix of the canonical uuid formatting, at least 8 hex digits long
+// (shorter invites typo-matches and shrinks the scan space for probing which
+// ids exist). Postgres compares uuids bytewise — the same order as their hex
+// strings — so a prefix becomes a closed range: pad the missing digits with 0
+// for the low bound and f for the high, and every uuid starting with the
+// prefix falls between them. That keeps the lookup an index range scan
+// instead of a ::text LIKE.
+//
+// Emit side (shortestUuidPrefix): the inverse — the shortest such prefix that
+// still resolves back to this id, git-style, given the ids it has to beat.
 const UUID_TEMPLATE = '00000000-0000-0000-0000-000000000000'
 const MIN_HEX_DIGITS = 8
+// The canonical 8-4-4-4-12 grouping, for re-inserting dashes into bare hex.
+const GROUP_SIZES = [8, 4, 4, 4, 12]
 
 export type UuidRange = { low: string; high: string }
 
@@ -16,18 +25,35 @@ export const uuidPrefixRange = (param: string): UuidRange | null => {
 
   // A valid prefix agrees with the canonical shape position by position:
   // dashes exactly where the template has them, hex everywhere else.
-  let hexDigits = 0
-  for (let i = 0; i < prefix.length; i++) {
-    if (UUID_TEMPLATE[i] === '-') {
-      if (prefix[i] !== '-') return null
-    } else if (/[0-9a-f]/.test(prefix[i])) {
-      hexDigits += 1
-    } else {
-      return null
-    }
-  }
-  if (hexDigits < MIN_HEX_DIGITS) return null
+  const chars = prefix.split('')
+  const shapeOk = chars.every((ch, i) => (UUID_TEMPLATE[i] === '-' ? ch === '-' : /[0-9a-f]/.test(ch)))
+  if (!shapeOk) return null
+  if (chars.filter((ch) => ch !== '-').length < MIN_HEX_DIGITS) return null
 
   const rest = UUID_TEMPLATE.slice(prefix.length)
   return { low: prefix + rest, high: prefix + rest.replace(/0/g, 'f') }
+}
+
+const stripDashes = (id: string): string => id.toLowerCase().replace(/-/g, '')
+
+// Bare hex digits → the canonical formatting truncated to them: dashes
+// re-inserted at the 8-4-4-4-12 boundaries, never trailing.
+const formatHexPrefix = (hex: string): string =>
+  GROUP_SIZES.reduce(
+    ({ groups, rest }, size) =>
+      rest === '' ? { groups, rest } : { groups: [...groups, rest.slice(0, size)], rest: rest.slice(size) },
+    { groups: [] as string[], rest: hex }
+  ).groups.join('-')
+
+// The shortest canonical-format prefix of `id` (≥ 8 hex digits) that no id in
+// `contested` shares, or the full id when nothing shorter disambiguates.
+// The caller decides which ids are contested — for lenses that's only ones
+// created no later than `id`, since resolution takes the oldest-created match
+// and anything newer loses the tie on its own.
+export const shortestUuidPrefix = (id: string, contested: string[]): string => {
+  const hex = stripDashes(id)
+  const others = contested.map(stripDashes)
+  const lengths = Array.from({ length: hex.length - MIN_HEX_DIGITS }, (_, i) => MIN_HEX_DIGITS + i)
+  const n = lengths.find((len) => !others.some((o) => o.startsWith(hex.slice(0, len))))
+  return n === undefined ? id.toLowerCase() : formatHexPrefix(hex.slice(0, n))
 }

--- a/test/uuidPrefix.test.ts
+++ b/test/uuidPrefix.test.ts
@@ -1,0 +1,54 @@
+// Unit coverage for the truncated-lens-id seam (src/app/lens/uuidPrefix.ts).
+// What's worth pinning: a prefix expands to the exact uuid range that a
+// bytewise (= hex-string-wise) comparison scans, only canonical-format
+// prefixes qualify, and the 8-hex-digit floor holds.
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { uuidPrefixRange } from '../src/app/lens/uuidPrefix.ts'
+
+test('a bare first group pads to the full range', () => {
+  assert.deepEqual(uuidPrefixRange('da204490'), {
+    low: 'da204490-0000-0000-0000-000000000000',
+    high: 'da204490-ffff-ffff-ffff-ffffffffffff',
+  })
+})
+
+test('a longer prefix keeps its dashes and pads the rest', () => {
+  assert.deepEqual(uuidPrefixRange('da204490-4d2'), {
+    low: 'da204490-4d20-0000-0000-000000000000',
+    high: 'da204490-4d2f-ffff-ffff-ffffffffffff',
+  })
+  // A trailing dash is a legitimate string prefix of the canonical form.
+  assert.deepEqual(uuidPrefixRange('da204490-'), {
+    low: 'da204490-0000-0000-0000-000000000000',
+    high: 'da204490-ffff-ffff-ffff-ffffffffffff',
+  })
+})
+
+test('uppercase input lowercases into the range', () => {
+  assert.deepEqual(uuidPrefixRange('DA204490'), {
+    low: 'da204490-0000-0000-0000-000000000000',
+    high: 'da204490-ffff-ffff-ffff-ffffffffffff',
+  })
+})
+
+test('a full uuid is its own single-point range', () => {
+  const full = 'da204490-4d28-41d8-a452-95aabcb65209'
+  assert.deepEqual(uuidPrefixRange(full), { low: full, high: full })
+})
+
+test('fewer than 8 hex digits is rejected', () => {
+  assert.equal(uuidPrefixRange('da20449'), null)
+  assert.equal(uuidPrefixRange(''), null)
+})
+
+test('non-canonical shapes are rejected', () => {
+  // Hex where the canonical form has a dash.
+  assert.equal(uuidPrefixRange('da2044904d28'), null)
+  // A dash where the canonical form has hex.
+  assert.equal(uuidPrefixRange('da2044-90'), null)
+  // Non-hex characters, and anything longer than a uuid.
+  assert.equal(uuidPrefixRange('da2044zz'), null)
+  assert.equal(uuidPrefixRange('da204490-4d28-41d8-a452-95aabcb652090'), null)
+})

--- a/test/uuidPrefix.test.ts
+++ b/test/uuidPrefix.test.ts
@@ -5,7 +5,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { uuidPrefixRange } from '../src/app/lens/uuidPrefix.ts'
+import { shortestUuidPrefix, uuidPrefixRange } from '../src/app/lens/uuidPrefix.ts'
 
 test('a bare first group pads to the full range', () => {
   assert.deepEqual(uuidPrefixRange('da204490'), {
@@ -51,4 +51,38 @@ test('non-canonical shapes are rejected', () => {
   // Non-hex characters, and anything longer than a uuid.
   assert.equal(uuidPrefixRange('da2044zz'), null)
   assert.equal(uuidPrefixRange('da204490-4d28-41d8-a452-95aabcb652090'), null)
+})
+
+// The emit side: the shortest prefix that still resolves back to the id,
+// given the ids it has to beat. Every emitted prefix must round-trip through
+// uuidPrefixRange — a short link the resolver rejects would be worse than a
+// long one.
+const ID = 'da204490-4d28-41d8-a452-95aabcb65209'
+
+test('an uncontested id shortens to its first group', () => {
+  const short = shortestUuidPrefix(ID, [])
+  assert.equal(short, 'da204490')
+  assert.notEqual(uuidPrefixRange(short), null)
+})
+
+test('a contested prefix extends only as far as the first differing digit', () => {
+  // Shares 8 digits with ID, differs at the 9th.
+  assert.equal(shortestUuidPrefix(ID, ['da204490-ffff-ffff-ffff-ffffffffffff']), 'da204490-4')
+  // Shares 12 digits, so the dash is crossed and the 13th digit decides.
+  const short = shortestUuidPrefix(ID, ['da204490-4d28-ffff-ffff-ffffffffffff'])
+  assert.equal(short, 'da204490-4d28-4')
+  assert.notEqual(uuidPrefixRange(short), null)
+})
+
+test('several contenders each push the prefix as far as the closest one', () => {
+  const contested = ['da204490-ffff-ffff-ffff-ffffffffffff', 'da204490-4d28-41d8-ffff-ffffffffffff']
+  assert.equal(shortestUuidPrefix(ID, contested), 'da204490-4d28-41d8-a')
+})
+
+test('only the full id disambiguates from an all-but-identical contender', () => {
+  assert.equal(shortestUuidPrefix(ID, ['da204490-4d28-41d8-a452-95aabcb65200']), ID)
+})
+
+test('a self-match in the contested set falls back to the full id', () => {
+  assert.equal(shortestUuidPrefix(ID, [ID]), ID)
 })


### PR DESCRIPTION
`/lens/da204490` now opens the same lens as `/lens/da204490-4d28-41d8-a452-95aabcb65209` — and the app now hands out that short form itself.

## Accept (commit 1)

Any canonical-format prefix of **≥8 hex digits** expands to the **oldest-created** matching lens before either access door is tried.

- **Oldest-created wins** makes short links stable: a lens created later can never capture a short link that already works, because it is by definition newer. Even in the astronomically-unlikely re-point case (prefix collision *plus* deletion of the older lens), a signed `?share=` link fails closed rather than opening the wrong lens, since the signature is an HMAC over the *full* id.
- **The 8-hex-digit floor** keeps typo-matches and existence-probing impractical (2³² prefix space), while matching the natural "first group of the UUID".
- **Expansion runs on the service role**, deliberately: a short id must name the same lens for every viewer — resolving through RLS would let each caller's visibility pick a different prefix-match, and a signed link could then verify against the wrong row. It resolves the *name* only; the full id still goes through the exact same RLS/signature doors, so access widens by nothing.

`uuidPrefixRange()` turns a prefix into a closed uuid range by padding with `0`s and `f`s — Postgres compares uuids bytewise, which is hex-string order, so the lookup is an index range scan, not a `::text LIKE`. Both the viewer page and the CSV route resolve through `resolveLens`, so both accept short ids.

## Emit (commit 2)

The `/lens` editor's ShareDialog URL and the MCP tools' `url` / `csv_url` / `link_url` / `link_csv_url` now carry the shortest id that resolves back to the lens, git-style: at least the first 8 hex digits, extended past any lens **created no later than this one** that shares the prefix. Because resolution takes the oldest-created match, emit-time uniqueness against older siblings is permanent — a lens created tomorrow can never capture a link emitted today.

- `shortestUuidPrefix()` (`src/app/lens/uuidPrefix.ts`) is the pure seam, unit-tested — including that every emitted prefix round-trips through `uuidPrefixRange()`.
- `shortLensId()` (`src/app/lens/shortId.ts`) sizes the prefix on the service role (the contest spans every user's lenses, exactly like resolution), reads only ids and `created_at`, and falls back to the full id on any doubt.
- In MCP output the `id` field stays the full uuid; only the URLs shorten.

## Base64 considered, rejected

Base64url of a full uuid would be 22 chars vs 36 — but the hex prefix is 8, stays a visible prefix of the real id, avoids a second spelling of every lens id, and avoids a real ambiguity: base64url's alphabet includes `-` and the hex letters, so a base64 id can be indistinguishable from a canonical hex prefix.

## Testing

`pnpm test` (199 pass), `pnpm run lint`, `pnpm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4CCFm6N7fe2GKUvNyCxPM