### PR TITLE
Record run success/failure on the heartbeat (ok + error columns)

### DIFF
--- a/docs/jobs-page.md
+++ b/docs/jobs-page.md
@@ -212,31 +212,23 @@ The open-heartbeat clause is what makes **scheduled** runs visible as
 no new RPC: a direct `heartbeat` select is already RLS-scoped correctly (own
 characters, own corps, and the `user_id IS NULL` shared rows).
 
-### Known gap: a failed _scheduled_ run looks identical to a successful one
+### Closed gap: failed runs are now recorded on the heartbeat ✅
 
 `withHeartbeat` (`src/jobs/lib.js`) and `runJobWithHeartbeat`
-(`src/workflows/lib.ts`) both close the heartbeat pair from a `finally`, so a
-run that threw still writes `ended_at` and the table cannot tell the two
-apart. Only `refresh_task` records failure, and only for on-demand runs. So
-`✗ failed` in the table above is reachable from section 4's data but not from
-a cron run — a nightly job that has failed every night for a week shows a
-red-ish freshness dot and nothing more.
+(`src/workflows/lib.ts`) used to close the heartbeat pair from a `finally`, so
+a run that threw wrote the same end row as one that succeeded and only
+`refresh_task` recorded failure — and only for on-demand runs. Both wrappers
+now stamp the end row with **`heartbeat.ok`** (true/false) and **`error`**
+(the message, truncated) — see the `20260807020000_heartbeat_ok_error`
+migration. Null means "outcome unknown": still-open rows, rows predating the
+column, and CLI runs through code paths that don't pass it.
 
-Two ways out, both deliberately **out of scope for the page PR** so it stays a
-UI change:
-
-1. **`heartbeat.ok boolean` / `heartbeat.error text`** — set from the same
-   `finally` that already writes `ended_at`. A normal dual write (`schema.sql`
-   - an incremental migration) and a two-line change in the two heartbeat
-     wrappers. Makes "last run failed" a first-class cell on this page and would
-     also improve the header indicator.
-2. **Leave it to Vercel Observability → Workflows**, and have the page link
-   there per job.
-
-Recommend (1) as a small follow-up PR once the page exists and the gap is
-visible. Note that a fan-out workflow's `AggregateError` (one bad character in
-a lane) already fails the _run_ while every other character's heartbeat closes
-normally — so per-entity `ok` is the meaningful granularity, not per-job.
+So the page can render `✗ failed` for scheduled runs too: a cell whose newest
+end row has `ok = false` shows the failure (and its message on hover) instead
+of an undifferentiated stale dot. Per-entity granularity comes free — the
+per-character/per-corp rows are written by `withHeartbeat` per entity, so one
+character with a dead token shows failed while its neighbors show fresh,
+which is exactly the "1 lagging" diagnosis made explicit.
 
 ### Known gap: fan-out jobs have no whole-job heartbeat
 

--- a/schema.sql
+++ b/schema.sql
@@ -706,6 +706,15 @@ create table public.heartbeat (
   -- 'github' (Actions). Null for local CLI runs and the per-character/per-corp
   -- loop rows, which don't know how they were invoked.
   source text,
+  -- Whether the run succeeded: true/false once the end heartbeat lands (the
+  -- wrappers in src/jobs/lib.js and src/workflows/lib.ts write it from their
+  -- catch), null for still-open rows and for rows written before this column
+  -- existed. Without it a failed scheduled run is indistinguishable from a
+  -- successful one — both close their pair from a finally — which is the gap
+  -- docs/jobs-page.md documents.
+  ok boolean,
+  -- The failure's message (truncated), null when ok.
+  error text,
   started_at timestamptz,
   ended_at timestamptz,
   -- How long the run took for that job/entity; null until ended_at lands.

--- a/src/jobs/lib.js
+++ b/src/jobs/lib.js
@@ -18,9 +18,14 @@ const withHeartbeat = async (tag, owner, fn) => {
   const runId = randomInt(1, 2 ** 48)
   await recordHeartbeat(tag, 'start', { runId, ...owner })
   try {
-    return await fn()
-  } finally {
-    await recordHeartbeat(tag, 'end', { runId, ...owner })
+    const result = await fn()
+    await recordHeartbeat(tag, 'end', { runId, ...owner, ok: true })
+    return result
+  } catch (e) {
+    // Stamp the failure on the end row (heartbeat.ok/error) and rethrow — the
+    // caller's catch still logs and skips to the next character/corp as before.
+    await recordHeartbeat(tag, 'end', { runId, ...owner, ok: false, error: e?.message ?? e })
+    throw e
   }
 }
 

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -81,6 +81,12 @@ export const recordHeartbeat = async (job, phase = 'end', opts = {}) => {
     // is known (local CLI runs, the per-character/per-corp loop rows).
     source: opts.source ?? gh.source,
     ...(phase === 'start' ? { started_at: now } : { ended_at: now }),
+    // Outcome, end phase only: the wrappers pass ok (and error's message on a
+    // failure) so a run that threw is distinguishable from one that succeeded.
+    // Callers that don't pass ok leave it null — same as every pre-column row.
+    ...(phase === 'end' && opts.ok != null
+      ? { ok: opts.ok, error: opts.error != null ? String(opts.error).slice(0, 500) : null }
+      : {}),
   }
   const table = sudoSupabase.from('heartbeat')
   const { error } =

--- a/src/workflows/lib.ts
+++ b/src/workflows/lib.ts
@@ -81,9 +81,19 @@ export async function runJobWithHeartbeat(job: string, load: () => Promise<() =>
   await recordHeartbeat(job, 'start', { runId, source: 'vercel-workflow' })
   try {
     await run()
-  } finally {
     recordPeakRss({ job })
-    await recordHeartbeat(job, 'end', { runId, source: 'vercel-workflow' })
+    await recordHeartbeat(job, 'end', { runId, source: 'vercel-workflow', ok: true })
+  } catch (e) {
+    // Stamp the failure on the end row (heartbeat.ok/error) and rethrow so the
+    // step still fails visibly in Observability and gets its bounded retries.
+    recordPeakRss({ job })
+    await recordHeartbeat(job, 'end', {
+      runId,
+      source: 'vercel-workflow',
+      ok: false,
+      error: e instanceof Error ? e.message : String(e),
+    })
+    throw e
   }
 }
 

--- a/supabase/migrations/20260807020000_heartbeat_ok_error.sql
+++ b/supabase/migrations/20260807020000_heartbeat_ok_error.sql
@@ -1,0 +1,20 @@
+-- Record whether a heartbeat's run succeeded. Both heartbeat wrappers
+-- (withHeartbeat in src/jobs/lib.js, runJobWithHeartbeat in
+-- src/workflows/lib.ts) close their start/end pair from a finally, so until
+-- now a run that threw wrote the same end row as one that succeeded — a
+-- nightly job could fail every night and the table couldn't say so (the gap
+-- documented in docs/jobs-page.md's "Status semantics"). The wrappers now
+-- stamp the end row with ok=true, or ok=false plus the error's message.
+--
+-- Both columns are nullable on purpose: a still-open row has no outcome yet,
+-- and every row written before this migration has an unknown one — backfilling
+-- either would be a lie. Failure visibility starts at deploy time.
+
+alter table public.heartbeat
+  add column ok boolean,
+  add column error text;
+
+comment on column public.heartbeat.ok is
+  'Whether the run succeeded; written with the end heartbeat, null for open rows and rows predating the column.';
+comment on column public.heartbeat.error is
+  'The failure''s message (truncated), null when ok.';


### PR DESCRIPTION
Standalone follow-up to phase 5 (#798), closing the failure-visibility gap `docs/jobs-page.md`'s "Status semantics" documents.

## The gap

Both heartbeat wrappers — `withHeartbeat` (`src/jobs/lib.js`) and `runJobWithHeartbeat` (`src/workflows/lib.ts`) — closed their start/end pair from a `finally`, so a run that threw wrote the same end row as one that succeeded. Only `refresh_task` recorded failure, and only for on-demand runs: a nightly job could fail every night and the `heartbeat` table couldn't say so.

## The change

- **Schema (dual write per CLAUDE.md):** `heartbeat` gains nullable `ok boolean` and `error text` — in `schema.sql` and `supabase/migrations/20260807020000_heartbeat_ok_error.sql`. Nullable on purpose: open rows have no outcome yet, and rows predating the column have an unknown one — backfilling either would be a lie. No index; nothing queries by outcome alone yet.
- **Writers:** both wrappers replace the `finally` with success/catch paths — `ok: true` on success, `ok: false` plus the error's truncated message on a throw that **rethrows**, so failure still propagates exactly as before (`forEachCharacter`'s skip-and-log, the workflow step's bounded retries). `recordHeartbeat` passes the fields through on the end phase only; callers that don't pass `ok` write null, same as every pre-column row.

Per-entity granularity comes free: the per-character/per-corp rows are written by `withHeartbeat` per entity, so one character with a dead token reads `ok = false` while its neighbors read fresh — the future `/jobs` page's "1 lagging" diagnosis made explicit. The jobs-page plan's known-gap section is updated to closed.

**History note:** the branch was rebased onto current `main` and the migration renumbered `20260807000000` → `20260807020000` after `20260807000000_asset_location_perf.sql` (#826) and `20260807010000_asset_location_summary_scope.sql` landed with the earlier timestamps — the migration-order check caught the collision, which is exactly the two-open-PRs case it exists for. The two companion PRs this description previously referenced (#828, #829) were closed as superseded: #798 landed the same phase-5 work from a parallel session.

Verified with `pnpm run lint`, `node .github/scripts/check-migrations.mjs origin/main` (clean after the renumber), and `node --test` (the two failing suites, `graphqlSchema`/`lensValidate`, fail identically on `origin/main` in this sandbox — a missing local `graphql` install, not this change). The husky pre-commit hook can't run here (its `pnpm install` trips the `minimumReleaseAge` policy), so prettier `--check` and eslint were run manually.