### PR TITLE
Attribute industry tax revenue to the structure that earned it

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -3397,6 +3397,72 @@ $$;
 
 grant execute on function public.corp_industry_jobs(uuid[], boolean, timestamptz) to service_role;
 
+-- ── industry_job_tax_facility ─────────────────────────────────────────────
+-- Attribute industry tax revenue to the structure that earned it.
+--
+-- /structure/revenue lists corp_wallet_journal entries with ref_type
+-- 'industry_job_tax' and resolves each one's structure by looking the job up in
+-- character_industry_job / corp_industry_job. Both are RLS-scoped to the
+-- caller, so a job installed by another player who uses this site — their rows
+-- live under their own registration — resolves to nothing and the entry lands
+-- in the "unknown structure" bucket, even though the tax landed in the
+-- caller's wallet.
+--
+-- This function discloses exactly one fact about such a job, and nothing else:
+-- the structure owner who was paid tax for a job learns which of their
+-- structures it ran in. No installer, product, runs, cost, blueprint, or
+-- status crosses the boundary — only job_id -> station_id/facility_id, and
+-- only for a job the caller can already prove they were taxed for.
+--
+-- security definer bypasses RLS on every table read here, so the caller's
+-- scope is restated explicitly in the exists() clause below rather than
+-- inherited from corp_wallet_journal's policy. That clause is the whole
+-- disclosure rule; there is no other path to a row.
+--
+-- Matching is on context_id only (context_id_type = 'industry_job_id'). The
+-- page also scrapes numeric tokens out of older entries' description text as a
+-- fallback, but those tokens must not reach this function: a token that
+-- happened to collide with a real job id would turn it into an oracle for
+-- jobs the caller was never taxed for.
+create or replace function public.industry_job_tax_facility(job_ids bigint[])
+returns table (job_id bigint, station_id bigint, facility_id bigint)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  -- distinct on keeps one row per job; the two sources are disjoint in
+  -- practice (personal vs corp-installed jobs), but the page keys by job_id
+  -- and a duplicate would be silently ambiguous.
+  select distinct on (j.job_id) j.job_id, j.station_id, j.facility_id
+  from (
+    select job_id, station_id, facility_id
+      from public.character_industry_job_over_time
+      where is_current
+    union all
+    select job_id, station_id, facility_id
+      from public.corp_industry_job_over_time
+      where is_current
+  ) j
+  where j.job_id = any(job_ids)
+    and exists (
+      select 1
+      from public.corp_wallet_journal w
+      where w.context_id = j.job_id
+        and w.ref_type = 'industry_job_tax'
+        and w.corporation_id in (
+          select corporation_id from public.registration
+          where user_id = (select auth.uid()) and corporation_id is not null
+        )
+    )
+  order by j.job_id;
+$$;
+
+-- anon would get nothing anyway (auth.uid() is null collapses the corp
+-- subselect to empty), but the grant says so rather than relying on it.
+revoke execute on function public.industry_job_tax_facility(bigint[]) from public, anon;
+grant  execute on function public.industry_job_tax_facility(bigint[]) to authenticated, service_role;
+
 -- ── universe_name ─────────────────────────────────────────────────────────
 -- ESI /universe/names/, written by the universe-names job: cache of resolved
 -- EVE id -> name/category lookups.

--- a/src/app/structure/revenue/page.tsx
+++ b/src/app/structure/revenue/page.tsx
@@ -38,11 +38,13 @@ type JournalRow = {
   first_party_id: number | string | null
 }
 
+// runs/product_type_id are null for jobs resolved through
+// industry_job_tax_facility, which discloses only the location (see below).
 type JobRow = {
   job_id: number | string
   station_id: number | string | null
   facility_id: number | string | null
-  runs: number
+  runs: number | null
   product_type_id: number | string | null
 }
 
@@ -108,8 +110,16 @@ const RevenuePage = async ({ searchParams }: RevenueParams) => {
   // corp can run a job here, so corp_industry_job (pulled by a director,
   // covering every corp member) is checked too.
   const jobIds = new Set<string>()
+  // context_ids alone, kept apart from the description tokens below: these are
+  // the only ids the tax-attribution lookup may be asked about (see the
+  // industry_job_tax_facility comment in schema.sql — a loose token colliding
+  // with a real job id would make it an oracle).
+  const contextJobIds = new Set<string>()
   for (const entry of entries) {
-    if (entry.context_id != null) jobIds.add(String(entry.context_id))
+    if (entry.context_id != null) {
+      jobIds.add(String(entry.context_id))
+      contextJobIds.add(String(entry.context_id))
+    }
     for (const token of entry.description?.match(/\d+/g) ?? []) jobIds.add(token)
   }
   const [{ data: characterJobRows }, { data: corpJobRows }] = jobIds.size
@@ -128,6 +138,21 @@ const RevenuePage = async ({ searchParams }: RevenueParams) => {
   const jobById = new Map<string, JobRow>()
   for (const j of [...((characterJobRows ?? []) as JobRow[]), ...((corpJobRows ?? []) as JobRow[])]) {
     jobById.set(String(j.job_id), j)
+  }
+
+  // Anything still unresolved was installed by someone whose jobs this caller
+  // can't read — typically another player using this site, running jobs in the
+  // caller's structure. industry_job_tax_facility returns just the location for
+  // those, and only because the tax for that job was paid into a wallet the
+  // caller can see. The Output column stays empty for them by design.
+  const unresolved = [...contextJobIds].filter((id) => !jobById.has(id))
+  if (unresolved.length > 0) {
+    const { data: taxedJobRows } = await supabase.rpc('industry_job_tax_facility', {
+      job_ids: unresolved,
+    })
+    for (const j of (taxedJobRows ?? []) as Array<Pick<JobRow, 'job_id' | 'station_id' | 'facility_id'>>) {
+      jobById.set(String(j.job_id), { ...j, runs: null, product_type_id: null })
+    }
   }
 
   const jobForEntry = (entry: JournalRow): JobRow | undefined => {
@@ -199,7 +224,10 @@ const RevenuePage = async ({ searchParams }: RevenueParams) => {
   }
 
   const typeNames = await fetchTypeNames(
-    [...jobById.values()].map((j) => Number(j.product_type_id)).filter((id) => Number.isFinite(id))
+    [...jobById.values()]
+      .filter((j) => j.product_type_id != null)
+      .map((j) => Number(j.product_type_id))
+      .filter((id) => Number.isFinite(id))
   )
 
   const dayTotal = entries.reduce((sum, e) => sum + Number(e.amount ?? 0), 0)

--- a/supabase/migrations/20260809000000_industry_job_tax_facility.sql
+++ b/supabase/migrations/20260809000000_industry_job_tax_facility.sql
@@ -1,0 +1,64 @@
+-- Attribute industry tax revenue to the structure that earned it.
+--
+-- /structure/revenue lists corp_wallet_journal entries with ref_type
+-- 'industry_job_tax' and resolves each one's structure by looking the job up in
+-- character_industry_job / corp_industry_job. Both are RLS-scoped to the
+-- caller, so a job installed by another player who uses this site — their rows
+-- live under their own registration — resolves to nothing and the entry lands
+-- in the "unknown structure" bucket, even though the tax landed in the
+-- caller's wallet.
+--
+-- This function discloses exactly one fact about such a job, and nothing else:
+-- the structure owner who was paid tax for a job learns which of their
+-- structures it ran in. No installer, product, runs, cost, blueprint, or
+-- status crosses the boundary — only job_id -> station_id/facility_id, and
+-- only for a job the caller can already prove they were taxed for.
+--
+-- security definer bypasses RLS on every table read here, so the caller's
+-- scope is restated explicitly in the exists() clause below rather than
+-- inherited from corp_wallet_journal's policy. That clause is the whole
+-- disclosure rule; there is no other path to a row.
+--
+-- Matching is on context_id only (context_id_type = 'industry_job_id'). The
+-- page also scrapes numeric tokens out of older entries' description text as a
+-- fallback, but those tokens must not reach this function: a token that
+-- happened to collide with a real job id would turn it into an oracle for
+-- jobs the caller was never taxed for.
+create or replace function public.industry_job_tax_facility(job_ids bigint[])
+returns table (job_id bigint, station_id bigint, facility_id bigint)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  -- distinct on keeps one row per job; the two sources are disjoint in
+  -- practice (personal vs corp-installed jobs), but the page keys by job_id
+  -- and a duplicate would be silently ambiguous.
+  select distinct on (j.job_id) j.job_id, j.station_id, j.facility_id
+  from (
+    select job_id, station_id, facility_id
+      from public.character_industry_job_over_time
+      where is_current
+    union all
+    select job_id, station_id, facility_id
+      from public.corp_industry_job_over_time
+      where is_current
+  ) j
+  where j.job_id = any(job_ids)
+    and exists (
+      select 1
+      from public.corp_wallet_journal w
+      where w.context_id = j.job_id
+        and w.ref_type = 'industry_job_tax'
+        and w.corporation_id in (
+          select corporation_id from public.registration
+          where user_id = (select auth.uid()) and corporation_id is not null
+        )
+    )
+  order by j.job_id;
+$$;
+
+-- anon would get nothing anyway (auth.uid() is null collapses the corp
+-- subselect to empty), but the grant says so rather than relying on it.
+revoke execute on function public.industry_job_tax_facility(bigint[]) from public, anon;
+grant  execute on function public.industry_job_tax_facility(bigint[]) to authenticated, service_role;

--- a/test/sql/industry_job_tax_facility.sql
+++ b/test/sql/industry_job_tax_facility.sql
@@ -1,0 +1,187 @@
+-- SQL-level coverage for industry_job_tax_facility() — the disclosure rule that
+-- lets /structure/revenue attribute another player's industry job to the
+-- structure it ran in.
+--
+-- The rule the function exists to enforce, in one sentence: the structure owner
+-- who was paid tax for a job learns which of their structures it ran in — and
+-- nothing else about that job. It is security definer, so it reads every table
+-- with RLS bypassed and the caller's scope lives entirely in its own exists()
+-- clause. That makes it exactly the kind of boundary worth pinning down here:
+-- a wrong predicate leaks strangers' industry activity and no RLS policy is
+-- standing behind it to catch the mistake.
+--
+-- Run against a THROWAWAY database from the repo root (same harness as
+-- asset_share.sql): DATABASE_URL='postgresql://…/throwaway' pnpm run test:sql
+begin;
+
+do $$ begin create role anon nologin; exception when duplicate_object then null; end $$;
+do $$ begin create role authenticated nologin; exception when duplicate_object then null; end $$;
+do $$ begin create role service_role nologin; exception when duplicate_object then null; end $$;
+
+create schema if not exists auth;
+create or replace function auth.uid() returns uuid
+language sql stable
+as $$ select nullif(current_setting('test.uid', true), '')::uuid $$;
+
+-- Stand-ins for the three tables the function reads. RLS is enabled on all of
+-- them with no policy at all: under a security definer function that is a
+-- no-op (the owner bypasses it), which is precisely the condition the real
+-- deployment runs under and the reason the scoping has to be explicit. If the
+-- function ever loses its exists() clause, these tables will not save it — and
+-- the assertions below will fail, which is the point.
+create table public.registration (
+  id uuid primary key,
+  user_id uuid,
+  corporation_id bigint
+);
+create table public.character_industry_job_over_time (
+  job_id bigint, registration_id uuid, station_id bigint, facility_id bigint,
+  product_type_id bigint, runs int, is_current boolean
+);
+create table public.corp_industry_job_over_time (
+  job_id bigint, corporation_id bigint, station_id bigint, facility_id bigint,
+  product_type_id bigint, runs int, is_current boolean
+);
+create table public.corp_wallet_journal (
+  corporation_id bigint, division smallint, entry_id bigint,
+  ref_type text, context_id bigint, context_id_type text, amount numeric(20, 2)
+);
+alter table public.registration                     enable row level security;
+alter table public.character_industry_job_over_time enable row level security;
+alter table public.corp_industry_job_over_time      enable row level security;
+alter table public.corp_wallet_journal              enable row level security;
+
+-- Two accounts. `owner` runs corp 1000 and owns the structures; `stranger` is
+-- another player using the site, whose jobs live under their own registration
+-- and are invisible to `owner` through every ordinary path.
+insert into public.registration (id, user_id, corporation_id) values
+  ('11111111-1111-1111-1111-111111111111', '99999999-0000-0000-0000-000000000001', 1000),
+  ('22222222-2222-2222-2222-222222222222', '99999999-0000-0000-0000-000000000002', 2000);
+
+-- Jobs 1-3 belong to the stranger and ran in the owner's structure 60000001.
+-- Job 4 ran in a structure that is nobody's business here.
+insert into public.character_industry_job_over_time values
+  (1, '22222222-2222-2222-2222-222222222222', 60000001, 60000001, 34, 10, true),
+  (2, '22222222-2222-2222-2222-222222222222', null,     60000001, 35, 20, true),
+  (3, '22222222-2222-2222-2222-222222222222', 60000001, 60000001, 36, 30, true),
+  (4, '22222222-2222-2222-2222-222222222222', 60000009, 60000009, 37, 40, true),
+  -- A superseded version of job 1, pointing somewhere else: the function reads
+  -- the live snapshot only, so this must never be what comes back.
+  (1, '22222222-2222-2222-2222-222222222222', 60000099, 60000099, 34, 10, false);
+
+-- A corp-installed job, taxed the same way.
+insert into public.corp_industry_job_over_time values
+  (5, 3000, 60000001, 60000001, 38, 50, true);
+
+-- The owner's wallet: taxed for jobs 1 and 5. Job 2's tax went to corp 4000 —
+-- neither account here belongs to it, so that entry entitles nobody in this
+-- test. Job 3 produced a non-tax entry, and job 4 produced nothing at all.
+insert into public.corp_wallet_journal values
+  (1000, 1, 500001, 'industry_job_tax',  1, 'industry_job_id', 1000.00),
+  (1000, 1, 500005, 'industry_job_tax',  5, 'industry_job_id', 5000.00),
+  (4000, 1, 500002, 'industry_job_tax',  2, 'industry_job_id', 2000.00),
+  (1000, 1, 500003, 'player_donation',   3, 'industry_job_id', 3000.00);
+
+\i supabase/migrations/20260809000000_industry_job_tax_facility.sql
+
+-- ── the owner ─────────────────────────────────────────────────────────────
+set local test.uid = '99999999-0000-0000-0000-000000000001';
+
+-- Taxed for job 1 → learns where it ran, even though the job is a stranger's
+-- and no ordinary query would return it. This is the whole feature.
+do $$
+declare got record;
+begin
+  select * into got from public.industry_job_tax_facility(array[1]::bigint[]);
+  assert got.job_id = 1, 'owner should resolve a job they were taxed for';
+  assert got.station_id = 60000001, 'station_id should be the live row, got ' || coalesce(got.station_id::text, 'null');
+  assert got.facility_id = 60000001, 'facility_id should be the live row';
+end $$;
+
+-- The superseded row for job 1 must not surface: exactly one row, and it is the
+-- current one (60000001, not 60000099).
+do $$
+declare n int;
+begin
+  select count(*) into n from public.industry_job_tax_facility(array[1]::bigint[]);
+  assert n = 1, 'expected one row per job, got ' || n;
+  select count(*) into n from public.industry_job_tax_facility(array[1]::bigint[]) where station_id = 60000099;
+  assert n = 0, 'superseded job versions must not be disclosed';
+end $$;
+
+-- Corp-installed jobs resolve through the same rule.
+do $$
+declare n int;
+begin
+  select count(*) into n from public.industry_job_tax_facility(array[5]::bigint[]) where facility_id = 60000001;
+  assert n = 1, 'corp-installed taxed job should resolve';
+end $$;
+
+-- Everything the owner was NOT taxed for stays dark, including jobs that ran in
+-- their own structure (2 and 3). Being the landlord is not the credential —
+-- the tax payment is.
+do $$
+declare n int;
+begin
+  select count(*) into n from public.industry_job_tax_facility(array[2]::bigint[]);
+  assert n = 0, 'a job whose tax went to another corp must not resolve';
+
+  select count(*) into n from public.industry_job_tax_facility(array[3]::bigint[]);
+  assert n = 0, 'a non-industry_job_tax journal entry must not resolve a job';
+
+  select count(*) into n from public.industry_job_tax_facility(array[4]::bigint[]);
+  assert n = 0, 'a job with no journal entry at all must not resolve';
+end $$;
+
+-- Asking for everything at once returns only the entitled subset, rather than
+-- letting a wide array smuggle the rest through.
+do $$
+declare ids bigint[];
+begin
+  select array_agg(job_id order by job_id) into ids
+    from public.industry_job_tax_facility(array[1, 2, 3, 4, 5]::bigint[]);
+  assert ids = array[1, 5]::bigint[], 'bulk lookup should return only taxed jobs, got ' || coalesce(ids::text, 'null');
+end $$;
+
+-- ── the stranger ──────────────────────────────────────────────────────────
+-- The job's own installer gets nothing from this function; it is not a general
+-- lookup, and they were never taxed. Their own jobs reach them through RLS on
+-- character_industry_job instead.
+set local test.uid = '99999999-0000-0000-0000-000000000002';
+do $$
+declare n int;
+begin
+  select count(*) into n from public.industry_job_tax_facility(array[1, 2, 3, 4, 5]::bigint[]);
+  assert n = 0, 'a caller with no matching tax entries must get nothing';
+end $$;
+
+-- ── anonymous ─────────────────────────────────────────────────────────────
+-- auth.uid() null collapses the corp subselect to empty. The grant already
+-- keeps anon out; this pins the belt-and-braces claim the migration comment
+-- makes about the body being safe on its own.
+set local test.uid = '';
+do $$
+declare n int;
+begin
+  select count(*) into n from public.industry_job_tax_facility(array[1, 2, 3, 4, 5]::bigint[]);
+  assert n = 0, 'an unauthenticated caller must get nothing';
+end $$;
+
+-- ── the shape of what is disclosed ────────────────────────────────────────
+-- Location only. If someone widens the return type to carry product_type_id,
+-- runs, installer or cost, this fails and they have to come argue with the
+-- sentence at the top of this file.
+do $$
+declare cols text;
+begin
+  select string_agg(p.name, ',' order by p.ord) into cols
+  from unnest(
+    (select proargnames from pg_proc where proname = 'industry_job_tax_facility'),
+    (select proargmodes from pg_proc where proname = 'industry_job_tax_facility')
+  ) with ordinality as p(name, mode, ord)
+  where p.mode = 't';
+  assert cols = 'job_id,station_id,facility_id',
+    'industry_job_tax_facility must disclose location only, got ' || coalesce(cols, 'null');
+end $$;
+
+rollback;


### PR DESCRIPTION
## The problem

`/structure/revenue` resolves each `industry_job_tax` journal entry to a structure by looking the job up in `character_industry_job` / `corp_industry_job`. Both are RLS-scoped to the caller, so a job installed by another player who uses this site — their rows live under their own `registration` — resolves to nothing, and the entry renders `—` for Structure even though the tax landed in the caller's own wallet.

Concretely: Bricktop72 is paying real industry tax into the corp wallet and none of it was being attributed to the structure it came from.

## The rule

`industry_job_tax_facility(job_ids)` discloses exactly one fact, and nothing else:

> The structure owner who was paid tax for a job learns which of their structures it ran in.

No installer, product, runs, cost, blueprint, or status crosses the boundary — only `job_id → station_id/facility_id`, and only for a job the caller can already prove they were taxed for. The tax payment is the credential; nothing is made public, and the job's installer never has to opt in.

## Notes on the implementation

- **`security definer` bypasses RLS on every table it reads**, so the caller's scope is restated explicitly in the function's own `exists()` clause rather than inherited from `corp_wallet_journal`'s policy. That clause is the entire disclosure rule and there is no other path to a row — which is also why it gets its own SQL test.
- **Matching is on `context_id` only.** The page also scrapes numeric tokens out of older entries' `description` text as a fallback; those deliberately do not reach the function. A token that happened to collide with a real job id would turn it into an oracle for jobs the caller was never taxed for.
- The Output column stays empty for jobs resolved this way, by design — "Bricktop built *something* in your structure" is a different disclosure from "here is what he built."
- Reads the live SCD-2 snapshot (`is_current`), with `distinct on (job_id)` so a job can never come back twice.
- `revoke ... from public, anon` is belt-and-braces; an anonymous caller's null `auth.uid()` already collapses the corp subselect to empty, and the test pins that too.

## Not included

An OR'd "any job that ran in a structure you can see" predicate was considered and dropped. `/structure/revenue` is driven *by* journal entries, so a job with no tax entry has no row to attribute — it would have added zero rows here while widening the audience considerably, since `corp_structure` has a second permissive policy opening it to alliance-mates. The active-job views on `/structure` and `/structure/[structureId]` still show only jobs the caller owns; that's the feature such a predicate would serve, and it can make its own case later.

## Testing

- `test/sql/industry_job_tax_facility.sql` (new) — the landlord does **not** resolve untaxed jobs in their own structure, a job taxed to another corp stays dark, a non-`industry_job_tax` entry doesn't unlock anything, the installer themselves gets nothing back, superseded SCD-2 versions stay hidden, a wide `job_ids` array returns only the entitled subset, and the return type is asserted to carry location only.
- Verified against a throwaway Postgres 16, including a mutation check: removing the corporation scoping from the `exists()` clause makes the suite fail, so the test isn't vacuous.
- `pnpm run lint`, `pnpm run build`, `pnpm test` (210 pass), and the migration-ordering guard all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPDySCH4Yen4CFSWaHqUeY)_