### PR TITLE
Re-enable pg_graphql, and stop ensure_sde_mirror_table re-applying its shape

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1,6 +1,16 @@
 -- Canonical schema for edencom-link, in the default `public` schema (PostgREST
 -- exposes it out of the box, so there is no "Exposed schemas" dashboard step).
 --
+-- Nothing here adds a schema to that list, but the list still needs to stay in
+-- sync when one is *dropped*: PostgREST reads it only when building a cold
+-- schema cache, so a stale entry sits harmless for weeks and then takes the
+-- whole Data API down at the next restart. On 2026-08-09 a Postgres upgrade
+-- restarted it, the rebuild hit the long-dropped `evesde` schema, and every
+-- REST request returned PGRST002 for 26 minutes while auth kept working (GoTrue
+-- does not use the schema cache) — so the site looked slow and logged-in users
+-- appeared to have no characters. If you drop a schema, clear it from
+-- Settings -> Data API -> Exposed schemas in the same change.
+--
 -- This file is the single source of truth and a full reset: it DROPs the app's
 -- objects and recreates them from scratch. Re-running it WIPES existing data in
 -- these tables. Apply with `psql ... -f schema.sql` or paste into the Supabase
@@ -4065,10 +4075,29 @@ grant all    on public.gice_account to service_role;
 
 create extension if not exists pg_trgm with schema extensions;
 
+-- Supabase enables pg_graphql by default and `graphql_public` is an exposed
+-- schema, so /graphql/v1 needs it present; without it the endpoint answers
+-- every query with "pg_graphql extension is not enabled." Declared here so a
+-- rebuilt database matches the exposed-schema list (see the header note).
+create extension if not exists pg_graphql;
+
 -- Create (or align) one SDE mirror table. SECURITY DEFINER so the ingest can
 -- call it over PostgREST RPC; execute is service-role only, the stem is
 -- regex-validated, and all DDL goes through format('%I'), so the service role
 -- can only ever mint read-only sde_* mirror tables of this exact shape.
+--
+-- Every step is guarded by a catalog lookup so a table that is already correct
+-- costs zero DDL. sde-mirror calls this once per JSONL file, so an unguarded
+-- body re-applies the whole shape ~560 times a night across 80 tables — and
+-- ALTER TABLE ... ENABLE ROW LEVEL SECURITY and CREATE POLICY each take an
+-- ACCESS EXCLUSIVE lock on a table the app reads on every page hit. It also
+-- bumps pg_graphql's schema version (its ddl_command_end trigger increments
+-- unconditionally, without checking whether anything reflected changed),
+-- invalidating the cached GraphQL schema each time.
+--
+-- The policy check compares the full shape rather than just the name, so a
+-- policy that has drifted by hand is still dropped and recreated — preserving
+-- the self-healing the old unconditional drop-and-recreate gave for free.
 create or replace function public.ensure_sde_mirror_table(p_stem text, p_key_type text default 'bigint')
 returns void
 language plpgsql
@@ -4077,6 +4106,7 @@ set search_path = ''
 as $$
 declare
   v_table text;
+  v_oid oid;
 begin
   if p_stem !~ '^[a-z][a-z0-9_]{0,58}$' then
     raise exception 'invalid SDE mirror table stem: %', p_stem;
@@ -4085,20 +4115,64 @@ begin
     raise exception 'invalid SDE mirror key type: %', p_key_type;
   end if;
   v_table := 'sde_' || p_stem;
-  execute format(
-    'create table if not exists public.%I (_key %s primary key, data jsonb not null, sde_build bigint not null)',
-    v_table,
-    p_key_type
-  );
-  execute format('alter table public.%I enable row level security', v_table);
-  execute format('drop policy if exists "Anyone reads SDE data" on public.%I', v_table);
-  execute format('create policy "Anyone reads SDE data" on public.%I for select using (true)', v_table);
-  execute format('grant select on public.%I to anon, authenticated', v_table);
+  v_oid := to_regclass('public.' || quote_ident(v_table));
+
+  if v_oid is null then
+    execute format(
+      'create table public.%I (_key %s primary key, data jsonb not null, sde_build bigint not null)',
+      v_table,
+      p_key_type
+    );
+    v_oid := to_regclass('public.' || quote_ident(v_table));
+  end if;
+
+  if not exists (
+    select 1 from pg_catalog.pg_class c where c.oid = v_oid and c.relrowsecurity
+  ) then
+    execute format('alter table public.%I enable row level security', v_table);
+  end if;
+
+  if not exists (
+    select 1
+    from pg_catalog.pg_policy p
+    where p.polrelid = v_oid
+      and p.polname = 'Anyone reads SDE data'
+      and p.polcmd = 'r'
+      and p.polpermissive
+      and p.polroles = '{0}'::oid[]
+      and pg_catalog.pg_get_expr(p.polqual, p.polrelid) = 'true'
+  ) then
+    execute format('drop policy if exists "Anyone reads SDE data" on public.%I', v_table);
+    execute format('create policy "Anyone reads SDE data" on public.%I for select using (true)', v_table);
+  end if;
+
+  if not (
+    pg_catalog.has_table_privilege('anon', v_oid, 'select')
+    and pg_catalog.has_table_privilege('authenticated', v_oid, 'select')
+  ) then
+    execute format('grant select on public.%I to anon, authenticated', v_table);
+  end if;
+
   -- The schema's default privileges hand new tables ALL to anon/authenticated;
   -- claw the write privileges back so the mirror is read-only at the grant
   -- layer too, not just via the missing write policies.
-  execute format('revoke insert, update, delete on public.%I from anon, authenticated', v_table);
-  execute format('grant select, insert, update, delete on public.%I to service_role', v_table);
+  if pg_catalog.has_table_privilege('anon', v_oid, 'insert')
+     or pg_catalog.has_table_privilege('anon', v_oid, 'update')
+     or pg_catalog.has_table_privilege('anon', v_oid, 'delete')
+     or pg_catalog.has_table_privilege('authenticated', v_oid, 'insert')
+     or pg_catalog.has_table_privilege('authenticated', v_oid, 'update')
+     or pg_catalog.has_table_privilege('authenticated', v_oid, 'delete') then
+    execute format('revoke insert, update, delete on public.%I from anon, authenticated', v_table);
+  end if;
+
+  if not (
+    pg_catalog.has_table_privilege('service_role', v_oid, 'select')
+    and pg_catalog.has_table_privilege('service_role', v_oid, 'insert')
+    and pg_catalog.has_table_privilege('service_role', v_oid, 'update')
+    and pg_catalog.has_table_privilege('service_role', v_oid, 'delete')
+  ) then
+    execute format('grant select, insert, update, delete on public.%I to service_role', v_table);
+  end if;
 end
 $$;
 

--- a/supabase/migrations/20260809062205_pg_graphql.sql
+++ b/supabase/migrations/20260809062205_pg_graphql.sql
@@ -1,0 +1,21 @@
+-- Re-enable pg_graphql.
+--
+-- Supabase enables this by default, but it had been dropped from this project.
+-- The giveaway was that the `graphql` and `graphql_public` schemas and the
+-- graphql_public.graphql() wrapper all survived — the fingerprint of a dropped
+-- extension rather than one that was never installed. With it gone, every
+-- request to /graphql/v1 answered:
+--
+--   {"errors": [{"message": "pg_graphql extension is not enabled."}]}
+--
+-- while `graphql_public` stayed listed in the Data API's exposed schemas. That
+-- is the same class of latent config/schema mismatch that took the Data API
+-- down on 2026-08-09: PostgREST held a stale reference to the dropped `evesde`
+-- schema, which only surfaced when a Postgres upgrade restarted it and forced a
+-- cold schema-cache build (PGRST002, 26 minutes of 503s). Rather than leave a
+-- second dangling reference to trip over on the next cold start, the extension
+-- is restored so the exposed schema matches reality.
+--
+-- Applied directly to production ahead of this migration; `if not exists` makes
+-- re-application a no-op.
+create extension if not exists pg_graphql;

--- a/supabase/migrations/20260809070000_sde_mirror_table_idempotent.sql
+++ b/supabase/migrations/20260809070000_sde_mirror_table_idempotent.sql
@@ -1,0 +1,126 @@
+-- Make ensure_sde_mirror_table() a genuine no-op when the table is already
+-- correct, instead of re-applying its whole shape on every call.
+--
+-- The previous body guarded only the CREATE TABLE; the six statements after it
+-- ran unconditionally:
+--
+--   create table if not exists ...            -- no-op once it exists
+--   alter table ... enable row level security -- ran every call
+--   drop policy if exists ...                 -- ran every call
+--   create policy ...                         -- ran every call
+--   grant select ...                          -- ran every call
+--   revoke insert, update, delete ...         -- ran every call
+--   grant select, insert, update, delete ...  -- ran every call
+--
+-- sde-mirror calls this once per JSONL file, so at 80 mirror tables that is
+-- ~560 DDL statements per nightly run to arrive at a state the database was
+-- already in. Two costs follow from that:
+--
+--   * ALTER TABLE ... ENABLE ROW LEVEL SECURITY and CREATE POLICY each take an
+--     ACCESS EXCLUSIVE lock on the table. Every run therefore briefly
+--     exclusive-locks all 80 sde_* tables — the tables every page hit reads to
+--     resolve type, system, station and planet names.
+--   * pg_graphql's graphql_watch_ddl event trigger calls
+--     graphql.increment_schema_version() on ddl_command_end without inspecting
+--     whether the DDL changed anything reflected, so each of those statements
+--     invalidates the cached GraphQL schema and forces a re-reflection on the
+--     next GraphQL request.
+--
+-- The fix is at the source rather than in the event trigger. pg_graphql's
+-- triggers are extension-owned, so disabling or replacing them means a
+-- platform-side extension upgrade can silently restore them, and the failure
+-- mode there is a *stale* GraphQL schema (new tables invisible, queries 404) —
+-- worse and far less visible than a slow one. Removing the spurious DDL fixes
+-- both costs and leaves the extension untouched.
+--
+-- Each step is now guarded by a catalog lookup, which is free next to the DDL
+-- it replaces. Real migrations still bump the GraphQL schema version, because
+-- they are real changes.
+--
+-- Drift repair is preserved. The old unconditional drop-and-recreate doubled as
+-- self-healing if a policy or grant were ever changed by hand, so the policy
+-- check compares the full shape (SELECT, permissive, applies to PUBLIC, a bare
+-- `true` qualifier) rather than merely testing that the name exists — a policy
+-- that has drifted in definition is still dropped and recreated.
+create or replace function public.ensure_sde_mirror_table(p_stem text, p_key_type text default 'bigint')
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_table text;
+  v_oid oid;
+begin
+  if p_stem !~ '^[a-z][a-z0-9_]{0,58}$' then
+    raise exception 'invalid SDE mirror table stem: %', p_stem;
+  end if;
+  if p_key_type not in ('bigint', 'text') then
+    raise exception 'invalid SDE mirror key type: %', p_key_type;
+  end if;
+  v_table := 'sde_' || p_stem;
+  v_oid := to_regclass('public.' || quote_ident(v_table));
+
+  if v_oid is null then
+    execute format(
+      'create table public.%I (_key %s primary key, data jsonb not null, sde_build bigint not null)',
+      v_table,
+      p_key_type
+    );
+    v_oid := to_regclass('public.' || quote_ident(v_table));
+  end if;
+
+  if not exists (
+    select 1 from pg_catalog.pg_class c where c.oid = v_oid and c.relrowsecurity
+  ) then
+    execute format('alter table public.%I enable row level security', v_table);
+  end if;
+
+  -- Full-shape comparison, not just the name: a hand-altered policy still gets
+  -- dropped and recreated, matching the old unconditional behaviour.
+  if not exists (
+    select 1
+    from pg_catalog.pg_policy p
+    where p.polrelid = v_oid
+      and p.polname = 'Anyone reads SDE data'
+      and p.polcmd = 'r'
+      and p.polpermissive
+      and p.polroles = '{0}'::oid[]
+      and pg_catalog.pg_get_expr(p.polqual, p.polrelid) = 'true'
+  ) then
+    execute format('drop policy if exists "Anyone reads SDE data" on public.%I', v_table);
+    execute format('create policy "Anyone reads SDE data" on public.%I for select using (true)', v_table);
+  end if;
+
+  if not (
+    pg_catalog.has_table_privilege('anon', v_oid, 'select')
+    and pg_catalog.has_table_privilege('authenticated', v_oid, 'select')
+  ) then
+    execute format('grant select on public.%I to anon, authenticated', v_table);
+  end if;
+
+  -- The schema's default privileges hand new tables ALL to anon/authenticated;
+  -- claw the write privileges back so the mirror is read-only at the grant
+  -- layer too, not just via the missing write policies.
+  if pg_catalog.has_table_privilege('anon', v_oid, 'insert')
+     or pg_catalog.has_table_privilege('anon', v_oid, 'update')
+     or pg_catalog.has_table_privilege('anon', v_oid, 'delete')
+     or pg_catalog.has_table_privilege('authenticated', v_oid, 'insert')
+     or pg_catalog.has_table_privilege('authenticated', v_oid, 'update')
+     or pg_catalog.has_table_privilege('authenticated', v_oid, 'delete') then
+    execute format('revoke insert, update, delete on public.%I from anon, authenticated', v_table);
+  end if;
+
+  if not (
+    pg_catalog.has_table_privilege('service_role', v_oid, 'select')
+    and pg_catalog.has_table_privilege('service_role', v_oid, 'insert')
+    and pg_catalog.has_table_privilege('service_role', v_oid, 'update')
+    and pg_catalog.has_table_privilege('service_role', v_oid, 'delete')
+  ) then
+    execute format('grant select, insert, update, delete on public.%I to service_role', v_table);
+  end if;
+end
+$$;
+
+revoke execute on function public.ensure_sde_mirror_table(text, text) from public, anon, authenticated;
+grant execute on function public.ensure_sde_mirror_table(text, text) to service_role;


### PR DESCRIPTION
## Background: today's Data API outage

PostgREST's exposed-schema list still named `evesde`, dropped long ago. PostgREST reads that list only when building a **cold** schema cache, so it sat harmless on a warm cache for weeks. This morning's Postgres upgrade restarted it, the rebuild hit `ERROR: schema "evesde" does not exist`, and it retried on a 32-second loop without ever serving a request:

```
PGRST002: Could not query the database for the schema cache
```

Every REST call returned 503 after burning 1.5–2.5s first — the site read as "slow" — while GoTrue stayed up, because auth doesn't use the schema cache. So login worked and logged-in users appeared to have no characters. `pg_stat_statements` recorded **zero** application queries for the whole 26 minutes. No data was ever lost; RLS returned the right rows the moment a valid JWT was supplied by hand.

That was fixed in the dashboard (removing `evesde` from Exposed schemas) and needs no code. This PR addresses the **second instance of the same latent mismatch**, found while looking for others.

## 1. `pg_graphql` was dropped; `graphql_public` is still exposed

`/graphql/v1` answered every query with:

```json
{"errors": [{"message": "pg_graphql extension is not enabled."}]}
```

The `graphql` and `graphql_public` schemas and the `graphql_public.graphql()` wrapper all survived — the fingerprint of a *dropped* extension rather than one never installed, since Supabase enables it by default. Meanwhile `graphql_public` remained in the exposed-schema list: another dangling reference waiting for the next cold start.

The extension has been restored (applied to production ahead of this PR; `create extension if not exists` makes re-application a no-op). GraphQL now serves the SDE tables:

```
{"data": {"sde_typesCollection": {"edges": [
  {"node": {"_key": "0", "sde_build": "3458726"}}, ...]}}}
```

The `schema.sql` header now states the rule directly: dropping a schema means clearing it from **Settings → Data API → Exposed schemas** in the same change.

For the record, the `sde_*` tables were *already* reachable over PostgREST throughout — they live in `public` with `anon`/`authenticated` SELECT, which is what `src/utils/supabase/sde.ts` depends on. Only GraphQL was broken.

## 2. `ensure_sde_mirror_table()` re-applied its whole shape on every call

Enabling pg_graphql installs a `ddl_command_end` event trigger that bumps the cached GraphQL schema version — and it increments **unconditionally**, never checking whether the DDL touched anything reflected. That made this worth fixing first.

The function guarded only its `CREATE TABLE`; the six statements after it ran on every call:

```sql
create table if not exists ...            -- no-op once it exists
alter table ... enable row level security -- ran every call
drop policy if exists ...                 -- ran every call
create policy ...                         -- ran every call
grant select ...                          -- ran every call
revoke insert, update, delete ...         -- ran every call
grant select, insert, update, delete ...  -- ran every call
```

`sde-mirror` calls it once per JSONL file, so at 80 mirror tables that's **~560 DDL statements per nightly run** to reach a state the database was already in.

**The GraphQL invalidation is the cheaper half.** `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` and `CREATE POLICY` each take an `ACCESS EXCLUSIVE` lock, so every run has been briefly exclusive-locking all 80 `sde_*` tables — the tables every page hit reads to resolve type, system, station and planet names. That was happening before pg_graphql existed.

Each step is now guarded by a catalog lookup, free next to the DDL it replaces.

### Why fix the source rather than the event trigger

The tempting move is a schema-filtered replacement for `graphql_watch_ddl`. Declined: pg_graphql's triggers are extension-owned, so a platform-side extension upgrade can silently re-enable or recreate them, and that failure mode is a **stale** GraphQL schema — new tables invisible, queries 404 — which is worse and far less visible than a slow one. Removing the spurious DDL fixes both costs and leaves the extension untouched. Real migrations still bump the version, because they're real changes.

### Drift repair is preserved

The old unconditional drop-and-recreate doubled as self-healing if a policy or grant were ever changed by hand. The policy check therefore compares the **full shape** — SELECT, permissive, applies to PUBLIC, bare `true` qualifier — rather than merely testing that the name exists, so a drifted policy is still dropped and recreated.

## Verification

Run against production inside a rolled-back transaction, with a temporary event trigger counting real `ddl_command_end` firings:

| case | DDL events |
|---|---|
| create brand-new table | 5 |
| re-apply to that table | **0** |
| existing real `sde_types` | **0** (was 7) |
| policy broken by hand | 2, qualifier repaired to `true` |

A newly created table ends up with RLS on, one policy, `anon` SELECT, no `anon` INSERT, and `service_role` writes — identical to the old function's output. Separately, a read-only sweep confirmed all 80 existing `sde_*` tables already satisfy every guard, so the steady-state cost is provably zero.

`pnpm test` 217/217 pass; `.github/scripts/check-migrations.mjs` clean.

## Note on timing

`sde-mirror` runs at 12:21 UTC. The migration applies via the `Migrate` workflow on merge to `main`, so merging before then lands the fix for tonight's run. Nothing breaks if it misses — that run just behaves as it does today.

## Not included

`anon` and `authenticated` also hold `TRUNCATE` on the 87 `sde_*` tables, inherited from the schema's default privileges — the existing `revoke` claws back only INSERT/UPDATE/DELETE. TRUNCATE isn't subject to RLS, though PostgREST never exposes it, so it isn't reachable through the Data API. Left out to keep this PR scoped; it needs its own migration to sweep the existing tables as well as change the function.

---
_Generated by [Claude Code](https://claude.ai/code/session_01STcBU2FosWw3tXquTSDq6J)_