### PR TITLE
Break down a structure's tax revenue by payer and day

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -3678,6 +3678,63 @@ $$;
 revoke execute on function public.industry_job_tax_facility(bigint[]) from public, anon;
 grant  execute on function public.industry_job_tax_facility(bigint[]) to authenticated, service_role;
 
+-- ── structure_tax_revenue ─────────────────────────────────────────────────
+-- Per-structure industry tax revenue, broken down by payer and UTC day, for the
+-- Tax Revenue table on /structure/[structureId].
+--
+-- This can't be a plain PostgREST query: corp_wallet_journal knows only the job
+-- (context_id), never the structure, so "tax earned by THIS structure" needs the
+-- job -> facility hop before it can filter. Doing that in the page would mean
+-- pulling every tax entry in the window past PostgREST's 1000-row cap and
+-- discarding most of them client-side; here the join, the filter and the
+-- aggregation all happen in one round trip.
+--
+-- security INVOKER, deliberately: corp_wallet_journal's own policy scopes the
+-- caller to their corps' entries, which is exactly the right scope. The one step
+-- that needs to see past RLS — resolving another player's job to its structure —
+-- is delegated to industry_job_tax_facility(), which is security definer and
+-- carries the whole disclosure rule (the structure owner who was paid tax for a
+-- job learns which of their structures it ran in). auth.uid() survives the call,
+-- so that function scopes to the same caller. Keeping the rule in one place
+-- means this function cannot widen it.
+--
+-- Payer identity crosses no new boundary: first_party_id is already on the
+-- journal row the caller can read, and /structure/revenue already displays it.
+create or replace function public.structure_tax_revenue(structure_id bigint, since timestamptz)
+returns table (payer_id bigint, day date, jobs bigint, isk numeric)
+language sql
+stable
+as $$
+  with tax as (
+    select w.first_party_id, w.date, w.amount, w.context_id
+    from public.corp_wallet_journal w
+    where w.ref_type = 'industry_job_tax'
+      and w.context_id is not null
+      and w.date >= since
+  ),
+  -- One call for the whole window rather than per row; the function dedupes to
+  -- at most one location per job.
+  located as (
+    select f.job_id, f.station_id, f.facility_id
+    from public.industry_job_tax_facility(array(select distinct t.context_id from tax t)) f
+  )
+  select
+    t.first_party_id                  as payer_id,
+    (t.date at time zone 'UTC')::date as day,
+    count(*)                          as jobs,
+    sum(coalesce(t.amount, 0))        as isk
+  from tax t
+  join located l on l.job_id = t.context_id
+  -- Upwell structures share the id between station_id and facility_id; jobs in
+  -- NPC stations carry only station_id. Same coalesce the revenue page uses.
+  where coalesce(l.station_id, l.facility_id) = structure_tax_revenue.structure_id
+  -- Positional, so the output column names can't shadow anything in `tax`.
+  group by 1, 2
+  order by 2 desc, 4 desc;
+$$;
+
+grant execute on function public.structure_tax_revenue(bigint, timestamptz) to authenticated, service_role;
+
 -- ── universe_name ─────────────────────────────────────────────────────────
 -- ESI /universe/names/, written by the universe-names job: cache of resolved
 -- EVE id -> name/category lookups.

--- a/src/app/structure/[structureId]/page.tsx
+++ b/src/app/structure/[structureId]/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from 'next/navigation'
 import { createClient } from '@/utils/supabase/server'
 import { DateTime } from '../../DateTime'
 import { ACTIVITY_NAMES } from '../../industry/jobFields'
+import { formatIskValue } from '../../isk'
 import { CharacterName, Name, SystemName } from '../../names'
 import { fetchSystemNames } from '../../systemNames'
 import { fetchTypeNames } from '../../typeNames'
@@ -13,7 +14,10 @@ import {
   INDEX_ACTIVITY_LABELS,
   structureIndexActivities,
 } from '../industryIndex'
+import { WindowSelect } from '../windowSelect'
+import { structureWindowDays } from '../windows'
 import retro from '../../retro.module.css'
+import structureStyles from '../structures.module.css'
 
 type Structure = {
   structure_id: number
@@ -54,16 +58,27 @@ type Rig = {
   type_id: number | string
 }
 
+// One row per (payer, UTC day) from structure_tax_revenue().
+type TaxRow = {
+  payer_id: number | string | null
+  day: string
+  jobs: number | string
+  isk: number | string | null
+}
+
 type StructureParams = {
   params: Promise<{
     structureId: string
   }>
+  searchParams: Promise<{ days?: string }>
 }
 
 const show = (value: string | number | null | undefined) => (value === null || value === undefined ? '—' : value)
 
-const StructurePage = async ({ params }: StructureParams) => {
+const StructurePage = async ({ params, searchParams }: StructureParams) => {
   const { structureId } = await params
+  const { days: daysParam } = await searchParams
+  const windowDays = structureWindowDays(daysParam)
   const supabase = await createClient()
 
   const { data: auth, error: authError } = await supabase.auth.getUser()
@@ -131,6 +146,56 @@ const StructurePage = async ({ params }: StructureParams) => {
     .order('location_flag', { ascending: true })
 
   const rigs = (rigData ?? []) as Rig[]
+
+  // Tax this structure earned over the selected window, grouped by payer and
+  // UTC day. The join to each job's structure happens inside the function —
+  // including, via industry_job_tax_facility(), for jobs installed by players
+  // whose own rows this caller can't read (see the migration comment).
+  const since = new Date(Date.now() - windowDays * 86_400_000).toISOString()
+  const { data: taxData } = await supabase.rpc('structure_tax_revenue', {
+    structure_id: structureId,
+    since,
+  })
+  const taxRows = (taxData ?? []) as TaxRow[]
+
+  // Payer names and the corp they fly for, same sources as /structure/revenue:
+  // universe_name (the universe-names job) and character_affiliation (the
+  // character-directory job).
+  const payerIds = [...new Set(taxRows.map((r) => r.payer_id).filter((p) => p != null))].map(Number)
+  const payerNames = new Map<string, string>()
+  const payerCorps = new Map<string, string>()
+  if (payerIds.length > 0) {
+    const [{ data: charNames }, { data: affiliations }] = await Promise.all([
+      supabase.from('universe_name').select('id, name').in('id', payerIds),
+      supabase.from('character_affiliation').select('character_id, corporation_id').in('character_id', payerIds),
+    ])
+    for (const r of (charNames ?? []) as Array<{ id: number | string; name: string }>) {
+      payerNames.set(String(r.id), r.name)
+    }
+    const corpByPayer = new Map<string, string>()
+    const corpIds = new Set<number>()
+    for (const a of (affiliations ?? []) as Array<{ character_id: number | string; corporation_id: number | string }>) {
+      corpByPayer.set(String(a.character_id), String(a.corporation_id))
+      corpIds.add(Number(a.corporation_id))
+    }
+    if (corpIds.size > 0) {
+      const { data: corpNames } = await supabase
+        .from('universe_name')
+        .select('id, name')
+        .in('id', [...corpIds])
+      const corpNameById = new Map<string, string>()
+      for (const r of (corpNames ?? []) as Array<{ id: number | string; name: string }>) {
+        corpNameById.set(String(r.id), r.name)
+      }
+      for (const [payer, corpId] of corpByPayer) {
+        const name = corpNameById.get(corpId)
+        if (name) payerCorps.set(payer, name)
+      }
+    }
+  }
+
+  const taxTotalIsk = taxRows.reduce((sum, r) => sum + Number(r.isk ?? 0), 0)
+  const taxTotalJobs = taxRows.reduce((sum, r) => sum + Number(r.jobs ?? 0), 0)
 
   const typeNames = await fetchTypeNames([
     Number(s.type_id),
@@ -253,6 +318,56 @@ const StructurePage = async ({ params }: StructureParams) => {
           </tr>
         </tbody>
       </table>
+
+      <div className={structureStyles.header}>
+        <h2>Tax Revenue</h2>
+        <span className={structureStyles.headerControl}>
+          <span className={structureStyles.headerControlLabel}>Window</span>
+          <WindowSelect days={windowDays} path={`/structure/${s.structure_id}`} />
+        </span>
+      </div>
+      {taxRows.length > 0 ? (
+        <table className={retro.retro}>
+          <thead>
+            <tr>
+              <th>Payer</th>
+              <th>Day</th>
+              <th className={retro.num}>Jobs</th>
+              <th className={retro.num}>ISK</th>
+            </tr>
+          </thead>
+          <tbody>
+            {taxRows.map((r) => {
+              const payer = r.payer_id != null ? String(r.payer_id) : undefined
+              return (
+                <tr key={`tax-${payer ?? 'unknown'}-${r.day}`}>
+                  <td>
+                    <span className={structureStyles.payer}>
+                      <Name name={payer ? payerNames.get(payer) : undefined} id={r.payer_id} />
+                      {payer && payerCorps.get(payer) && (
+                        <span className={structureStyles.payerCorp}>{payerCorps.get(payer)}</span>
+                      )}
+                    </span>
+                  </td>
+                  <td className="serif">{r.day}</td>
+                  <td className={retro.num}>{Number(r.jobs)}</td>
+                  <td className={retro.num}>{formatIskValue(r.isk)}</td>
+                </tr>
+              )
+            })}
+          </tbody>
+          <tfoot>
+            <tr>
+              <th>Total</th>
+              <th />
+              <th className={retro.num}>{taxTotalJobs}</th>
+              <th className={retro.num}>{formatIskValue(taxTotalIsk)}</th>
+            </tr>
+          </tfoot>
+        </table>
+      ) : (
+        <p>No industry tax from this structure in the last {windowDays} days.</p>
+      )}
 
       <h2>Industry Jobs</h2>
       {jobs.length > 0 ? (

--- a/src/app/structure/windowSelect.tsx
+++ b/src/app/structure/windowSelect.tsx
@@ -11,7 +11,10 @@ import styles from './structures.module.css'
 // (per-structure Revenue, unaccounted tax, clone revenue) and the industry-index
 // sparklines. The window lives in the URL (?days=N) so the server component
 // refetches exactly the span it needs.
-export const WindowSelect = ({ days }: { days: number }) => {
+//
+// `path` lets the structure detail page reuse the control for its own Tax
+// Revenue table; it defaults to the Structures page it was written for.
+export const WindowSelect = ({ days, path = '/structure' }: { days: number; path?: string }) => {
   const router = useRouter()
   const [pending, startTransition] = useTransition()
 
@@ -22,7 +25,7 @@ export const WindowSelect = ({ days }: { days: number }) => {
         value={days}
         onChange={(e) => {
           const next = Number(e.target.value)
-          startTransition(() => router.replace(`/structure?days=${next}`, { scroll: false }))
+          startTransition(() => router.replace(`${path}?days=${next}`, { scroll: false }))
         }}
       >
         {STRUCTURE_WINDOW_OPTIONS.map((o) => (

--- a/supabase/migrations/20260809080000_structure_tax_revenue.sql
+++ b/supabase/migrations/20260809080000_structure_tax_revenue.sql
@@ -1,0 +1,55 @@
+-- Per-structure industry tax revenue, broken down by payer and UTC day, for the
+-- Tax Revenue table on /structure/[structureId].
+--
+-- This can't be a plain PostgREST query: corp_wallet_journal knows only the job
+-- (context_id), never the structure, so "tax earned by THIS structure" needs the
+-- job -> facility hop before it can filter. Doing that in the page would mean
+-- pulling every tax entry in the window past PostgREST's 1000-row cap and
+-- discarding most of them client-side; here the join, the filter and the
+-- aggregation all happen in one round trip.
+--
+-- security INVOKER, deliberately: corp_wallet_journal's own policy scopes the
+-- caller to their corps' entries, which is exactly the right scope. The one step
+-- that needs to see past RLS — resolving another player's job to its structure —
+-- is delegated to industry_job_tax_facility(), which is security definer and
+-- carries the whole disclosure rule (the structure owner who was paid tax for a
+-- job learns which of their structures it ran in). auth.uid() survives the call,
+-- so that function scopes to the same caller. Keeping the rule in one place
+-- means this function cannot widen it.
+--
+-- Payer identity crosses no new boundary: first_party_id is already on the
+-- journal row the caller can read, and /structure/revenue already displays it.
+create or replace function public.structure_tax_revenue(structure_id bigint, since timestamptz)
+returns table (payer_id bigint, day date, jobs bigint, isk numeric)
+language sql
+stable
+as $$
+  with tax as (
+    select w.first_party_id, w.date, w.amount, w.context_id
+    from public.corp_wallet_journal w
+    where w.ref_type = 'industry_job_tax'
+      and w.context_id is not null
+      and w.date >= since
+  ),
+  -- One call for the whole window rather than per row; the function dedupes to
+  -- at most one location per job.
+  located as (
+    select f.job_id, f.station_id, f.facility_id
+    from public.industry_job_tax_facility(array(select distinct t.context_id from tax t)) f
+  )
+  select
+    t.first_party_id                  as payer_id,
+    (t.date at time zone 'UTC')::date as day,
+    count(*)                          as jobs,
+    sum(coalesce(t.amount, 0))        as isk
+  from tax t
+  join located l on l.job_id = t.context_id
+  -- Upwell structures share the id between station_id and facility_id; jobs in
+  -- NPC stations carry only station_id. Same coalesce the revenue page uses.
+  where coalesce(l.station_id, l.facility_id) = structure_tax_revenue.structure_id
+  -- Positional, so the output column names can't shadow anything in `tax`.
+  group by 1, 2
+  order by 2 desc, 4 desc;
+$$;
+
+grant execute on function public.structure_tax_revenue(bigint, timestamptz) to authenticated, service_role;

--- a/test/sql/structure_tax_revenue.sql
+++ b/test/sql/structure_tax_revenue.sql
@@ -1,0 +1,144 @@
+-- SQL-level coverage for structure_tax_revenue() — the per-structure tax
+-- breakdown behind the Tax Revenue table on /structure/[structureId].
+--
+-- The disclosure rule itself is pinned by industry_job_tax_facility.sql; this
+-- file covers what the aggregation layered on top can get wrong: attributing a
+-- job to the wrong structure, grouping days in local time instead of UTC,
+-- dropping the station_id/facility_id fallback, or letting the window leak
+-- older entries in.
+--
+-- Run against a THROWAWAY database from the repo root (same harness as
+-- asset_share.sql): DATABASE_URL='postgresql://…/throwaway' pnpm run test:sql
+begin;
+
+do $$ begin create role anon nologin; exception when duplicate_object then null; end $$;
+do $$ begin create role authenticated nologin; exception when duplicate_object then null; end $$;
+do $$ begin create role service_role nologin; exception when duplicate_object then null; end $$;
+
+create schema if not exists auth;
+create or replace function auth.uid() returns uuid
+language sql stable
+as $$ select nullif(current_setting('test.uid', true), '')::uuid $$;
+
+create table public.registration (
+  id uuid primary key,
+  user_id uuid,
+  corporation_id bigint
+);
+create table public.character_industry_job_over_time (
+  job_id bigint, registration_id uuid, station_id bigint, facility_id bigint, is_current boolean
+);
+create table public.corp_industry_job_over_time (
+  job_id bigint, corporation_id bigint, station_id bigint, facility_id bigint, is_current boolean
+);
+create table public.corp_wallet_journal (
+  corporation_id bigint, division smallint, entry_id bigint,
+  date timestamptz, ref_type text, context_id bigint, amount numeric(20, 2), first_party_id bigint
+);
+
+insert into public.registration (id, user_id, corporation_id) values
+  ('11111111-1111-1111-1111-111111111111', '99999999-0000-0000-0000-000000000001', 1000);
+
+-- Jobs 1-3 in structure 60000001 (the one under test), job 4 in 60000002, and
+-- job 6 carrying only station_id to exercise the coalesce fallback.
+insert into public.character_industry_job_over_time values
+  (1, '11111111-1111-1111-1111-111111111111', 60000001, 60000001, true),
+  (2, '11111111-1111-1111-1111-111111111111', 60000001, 60000001, true),
+  (3, '11111111-1111-1111-1111-111111111111', 60000001, 60000001, true),
+  (4, '11111111-1111-1111-1111-111111111111', 60000002, 60000002, true),
+  (6, '11111111-1111-1111-1111-111111111111', 60000001, null,     true);
+insert into public.corp_industry_job_over_time values
+  (5, 3000, null, 60000001, true);
+
+-- Payer 7001 pays twice on 2026-08-08 and once on 2026-08-07; payer 7002 pays
+-- once on 2026-08-07. Job 4's tax belongs to a different structure, and the
+-- 2026-06-01 entry is outside every window used below.
+insert into public.corp_wallet_journal values
+  (1000, 1, 1, '2026-08-08T01:00:00Z', 'industry_job_tax', 1, 1000.00, 7001),
+  (1000, 1, 2, '2026-08-08T23:30:00Z', 'industry_job_tax', 2,  500.00, 7001),
+  (1000, 1, 3, '2026-08-07T12:00:00Z', 'industry_job_tax', 3,  250.00, 7001),
+  (1000, 1, 4, '2026-08-07T12:00:00Z', 'industry_job_tax', 5,  700.00, 7002),
+  (1000, 1, 5, '2026-08-08T12:00:00Z', 'industry_job_tax', 4, 9999.00, 7001),
+  (1000, 1, 6, '2026-08-08T06:00:00Z', 'industry_job_tax', 6,  125.00, 7002),
+  (1000, 1, 7, '2026-06-01T12:00:00Z', 'industry_job_tax', 1, 4242.00, 7001);
+
+\i supabase/migrations/20260809000000_industry_job_tax_facility.sql
+\i supabase/migrations/20260809080000_structure_tax_revenue.sql
+
+set local test.uid = '99999999-0000-0000-0000-000000000001';
+
+-- Payer 7001 on 2026-08-08: two entries, 1500 ISK. Both fall on the same UTC
+-- day despite one landing at 23:30, which local-time grouping would split.
+do $$
+declare got record;
+begin
+  select * into got
+  from public.structure_tax_revenue(60000001, '2026-08-01T00:00:00Z')
+  where payer_id = 7001 and day = date '2026-08-08';
+  assert got.jobs = 2, 'expected 2 jobs for 7001 on 08-08, got ' || coalesce(got.jobs::text, 'null');
+  assert got.isk = 1500.00, 'expected 1500 ISK, got ' || coalesce(got.isk::text, 'null');
+end $$;
+
+-- The structure filter holds: job 4's 9999 ISK belongs to 60000002 and must
+-- never appear in 60000001's total.
+do $$
+declare total numeric;
+begin
+  select coalesce(sum(isk), 0) into total
+  from public.structure_tax_revenue(60000001, '2026-08-01T00:00:00Z');
+  -- 1000 + 500 + 250 (char jobs) + 700 (corp job) + 125 (station_id-only job)
+  assert total = 2575.00, 'expected 2575 ISK for this structure, got ' || total;
+
+  select coalesce(sum(isk), 0) into total
+  from public.structure_tax_revenue(60000002, '2026-08-01T00:00:00Z');
+  assert total = 9999.00, 'the other structure should carry its own tax, got ' || total;
+end $$;
+
+-- A corp-installed job (5, facility_id only) and a station_id-only job (6) both
+-- resolve through the coalesce.
+do $$
+declare n int;
+begin
+  select count(*) into n
+  from public.structure_tax_revenue(60000001, '2026-08-01T00:00:00Z')
+  where payer_id = 7002;
+  assert n = 2, 'payer 7002 should have a row on each of two days, got ' || n;
+end $$;
+
+-- Grouping is one row per (payer, day), not one per entry.
+do $$
+declare n int;
+begin
+  select count(*) into n from public.structure_tax_revenue(60000001, '2026-08-01T00:00:00Z');
+  -- 7001 on 08-08 and 08-07; 7002 on 08-08 and 08-07.
+  assert n = 4, 'expected 4 (payer, day) rows, got ' || n;
+end $$;
+
+-- The window excludes the June entry, which would otherwise inflate 08-08.
+do $$
+declare total numeric;
+begin
+  select coalesce(sum(isk), 0) into total
+  from public.structure_tax_revenue(60000001, '2026-05-01T00:00:00Z');
+  assert total = 6817.00, 'a wider window should pull the June entry in, got ' || total;
+end $$;
+
+-- Ordering is newest day first, so the page can render rows as returned.
+do $$
+declare days date[];
+begin
+  select array_agg(day) into days from public.structure_tax_revenue(60000001, '2026-08-01T00:00:00Z');
+  assert days[1] >= days[array_length(days, 1)], 'rows should come back newest day first';
+end $$;
+
+-- A caller with no journal entries of their own gets nothing, since the
+-- delegated disclosure rule scopes to their corps.
+set local test.uid = '99999999-0000-0000-0000-000000000002';
+do $$
+declare n int;
+begin
+  select count(*) into n from public.structure_tax_revenue(60000001, '2026-08-01T00:00:00Z');
+  assert n = 0, 'an unentitled caller must get nothing, got ' || n;
+end $$;
+
+rollback;


### PR DESCRIPTION
Follow-on to #846. That PR made tax attributable to a structure at all; this one surfaces it where you'd actually look for it.

## What it adds

`/structure/[structureId]` showed what a structure is *building* but never what it *earned*. New **Tax Revenue** table, one row per (payer, UTC day) with job count and ISK total, plus a grand total:

```
Payer            Day         Jobs   ISK
Bricktop72       2026-08-08     7   12.4m
Bricktop72       2026-08-07     3    5.1m
SomeGuy          2026-08-07     1    0.9m
─────────────────────────────────────────
Total                          11   18.4m
```

It reuses the Structures page's trailing-window control (`?days=N`, default 30) — `WindowSelect` now takes an optional `path` so the detail page can point it at itself.

## Why a Postgres function

This can't be a plain PostgREST query. `corp_wallet_journal` knows only the job (`context_id`), never the structure, so "tax earned by *this* structure" needs the job → facility hop *before* it can filter. Doing that in the page would mean pulling every tax entry in the window past PostgREST's 1000-row cap and discarding most of them client-side. `structure_tax_revenue()` does the join, the filter and the aggregation in one round trip.

## On the security boundary

`structure_tax_revenue()` is **security invoker** on purpose. `corp_wallet_journal`'s own policy scopes the caller to their corps' entries, which is already the right scope. The one step that needs to see past RLS — resolving another player's job to its structure — is delegated to `industry_job_tax_facility()` from #846, which is `security definer` and carries the entire disclosure rule. `auth.uid()` survives the call, so the inner function scopes to the same caller.

That composition is the point: the rule lives in exactly one function, and this one **cannot widen it** — there's no second copy to drift.

Payer identity crosses no new boundary either: `first_party_id` is already on the journal row the caller can read, and `/structure/revenue` has always displayed it. What's disclosed here is the same set of facts, pivoted.

## Testing

`test/sql/structure_tax_revenue.sql` (new) covers what the aggregation layered on top can get wrong, rather than re-testing the boundary #846 already pins:

- tax for a job in a *different* structure never appears in this one's total
- UTC day grouping — an entry at 23:30 must not split into its own local-time day
- the `station_id`/`facility_id` coalesce, exercised by both a corp-installed job (facility only) and an NPC-station-shaped job (station only)
- one row per (payer, day), not one per journal entry
- window bounds exclude older entries, and widening the window pulls them back in
- newest-day-first ordering, so the page renders rows as returned
- an unentitled caller gets nothing

Verified against a throwaway Postgres 16. `pnpm run lint`, `pnpm run build`, `pnpm test` (217 pass) and the migration-ordering guard are all clean.

## Note on the branch

#846 merged, so per repo convention this branch was restarted from the latest `main` rather than stacked on the merged history; the migration is renumbered to `20260809080000` to sort above everything now on main.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPDySCH4Yen4CFSWaHqUeY)_