### PR TITLE
Rank a structure's tax payers as portrait cards

### DIFF
--- a/src/app/structure/[structureId]/page.tsx
+++ b/src/app/structure/[structureId]/page.tsx
@@ -197,6 +197,20 @@ const StructurePage = async ({ params, searchParams }: StructureParams) => {
   const taxTotalIsk = taxRows.reduce((sum, r) => sum + Number(r.isk ?? 0), 0)
   const taxTotalJobs = taxRows.reduce((sum, r) => sum + Number(r.jobs ?? 0), 0)
 
+  // The payer leaderboard above the table: the same rows folded from
+  // (payer, day) down to (payer), ranked by ISK. No extra query — the window's
+  // rows are already in hand, and re-aggregating here keeps the two views
+  // guaranteed consistent with each other.
+  const byPayer = new Map<string, { payerId: string; isk: number; jobs: number }>()
+  for (const r of taxRows) {
+    const payerId = r.payer_id != null ? String(r.payer_id) : 'unknown'
+    const entry = byPayer.get(payerId) ?? { payerId, isk: 0, jobs: 0 }
+    entry.isk += Number(r.isk ?? 0)
+    entry.jobs += Number(r.jobs ?? 0)
+    byPayer.set(payerId, entry)
+  }
+  const leaderboard = [...byPayer.values()].sort((a, b) => b.isk - a.isk)
+
   const typeNames = await fetchTypeNames([
     Number(s.type_id),
     ...rigs.map((r) => Number(r.type_id)),
@@ -326,6 +340,37 @@ const StructurePage = async ({ params, searchParams }: StructureParams) => {
           <WindowSelect days={windowDays} path={`/structure/${s.structure_id}`} />
         </span>
       </div>
+      {leaderboard.length > 0 && (
+        <ol className={structureStyles.payerGrid}>
+          {leaderboard.map((p, i) => {
+            const known = p.payerId !== 'unknown'
+            return (
+              <li key={`payer-${p.payerId}`} className={structureStyles.payerCard}>
+                <span className={structureStyles.payerRank}>#{i + 1}</span>
+                {/* Plain <img>, like the app's other CCP image-server uses, which
+                    keeps images.evetech.net out of next.config.mjs's remote patterns. */}
+                {known ? (
+                  <img
+                    className={structureStyles.payerAvatar}
+                    src={`https://images.evetech.net/characters/${p.payerId}/portrait?size=64`}
+                    alt=""
+                    width={48}
+                    height={48}
+                    loading="lazy"
+                  />
+                ) : (
+                  <span className={structureStyles.payerAvatar} />
+                )}
+                <span className={structureStyles.payerCardName}>
+                  <Name name={known ? payerNames.get(p.payerId) : undefined} id={known ? p.payerId : undefined} />
+                </span>
+                <span className={`${structureStyles.payerTotal} ${retro.num}`}>{formatIskValue(p.isk)}</span>
+              </li>
+            )
+          })}
+        </ol>
+      )}
+
       {taxRows.length > 0 ? (
         <table className={retro.retro}>
           <thead>

--- a/src/app/structure/structures.module.css
+++ b/src/app/structure/structures.module.css
@@ -358,3 +358,57 @@
   color: var(--ink-faint);
   font-size: 11px;
 }
+
+/* Payer leaderboard on the structure detail page: the same raised-tile idea as
+   the Structures grid above, shrunk to portrait size and stacked centre-aligned
+   so a row of them reads as a ranking rather than a table. An <ol>, so the
+   ranking survives with styles off and for screen readers; the #n badge is
+   drawn rather than relying on the list marker, which auto-hides with the
+   list-style reset. */
+.payerGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  gap: 10px;
+  list-style: none;
+  padding: 0;
+  margin: 12px 0 16px;
+}
+
+.payerCard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  padding: 10px 8px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper-raised);
+  text-align: center;
+  min-width: 0;
+}
+
+.payerRank {
+  font-size: 11px;
+  color: var(--ink-faint);
+}
+
+.payerAvatar {
+  width: 48px;
+  height: 48px;
+  flex: none;
+  /* Round, matching the pilot portrait on the ship page. */
+  border-radius: 50%;
+  background: var(--line-soft);
+}
+
+.payerCardName {
+  font-size: 13px;
+  min-width: 0;
+  /* Pilot names are one long token often enough to overflow a 130px card. */
+  overflow-wrap: anywhere;
+}
+
+.payerTotal {
+  font-size: 13px;
+  color: var(--ink-soft);
+}


### PR DESCRIPTION
Follow-on to #850. That PR added the per-payer-per-day table; this puts a ranked summary above it, so the answer to "who are my best tenants" is the first thing you see.

## What it adds

On `/structure/[structureId]`, above the Tax Revenue table: one small card per payer — rank badge, character portrait, name, and their ISK total for the selected window — ordered highest-paying first.

```
   #1            #2            #3
 (portrait)   (portrait)    (portrait)
 Bricktop72    SomeGuy      ThirdPilot
   19.7m         4.2m          0.9m
```

Same raised-tile treatment as the Structures grid, shrunk to portrait size and centre-stacked so a row reads as a ranking rather than a table. It shares the existing `?days` window control with the table below it.

## Notes

**No extra query.** `structure_tax_revenue()` already returns the window's `(payer, day)` rows, so the cards are those rows folded down to `(payer)` in the page. Beyond saving a round trip, this means the cards and the table can't disagree with each other — they're the same numbers summed twice, not two separate fetches.

**Markup.** Rendered as an `<ol>`, so the ranking survives with styles off and for screen readers. The `#n` badge is drawn rather than left to the list marker, which auto-hides with the `list-style` reset. Portraits are plain `<img>` tags, matching the app's other CCP image-server uses (`typeIcon.tsx`, the corpses page) and keeping `images.evetech.net` out of `next.config.mjs`'s remote patterns; `alt=""` because the name is right underneath. A payer whose id didn't resolve gets an empty avatar slot rather than a broken image.

**Card width** is 130px minimum with `overflow-wrap: anywhere` on the name — EVE pilot names are frequently one long unbroken token and would otherwise overflow.

## Testing

`pnpm run lint` and `pnpm run build` are clean. No new SQL, so the existing `test/sql/structure_tax_revenue.sql` still covers the data path unchanged; the aggregation added here is a pure fold over rows that function already returns.

Worth an eyeball on the preview deploy for the visual side — card proportions and how a long pilot name wraps are the two things a build can't confirm.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPDySCH4Yen4CFSWaHqUeY)_