### PR TITLE
Let Renovate PRs land as soon as their checks pass

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "description": [
+    "Automerge relies on GitHub's native auto-merge (Settings -> General -> Pull Requests -> Allow auto-merge). Without it Renovate can only merge during its own hourly run, and the PR has to be green at that exact moment.",
+    "rebaseWhen=conflicted keeps that window open: main moves several times a day, and rebasing an open PR every time restarts its Vercel deploy, so the branch is rarely green when Renovate looks. Nothing here requires a PR to be up to date with main, so merging slightly behind is fine."
+  ],
   "schedule": ["every weekend"],
   "semanticCommits": "enabled",
   "dependencyDashboard": true,
@@ -8,6 +12,9 @@
   "transitiveRemediation": true,
   "labels": ["dependencies"],
   "prConcurrentLimit": 10,
+  "platformAutomerge": true,
+  "automergeStrategy": "squash",
+  "rebaseWhen": "conflicted",
   "lockFileMaintenance": {
     "enabled": true
   },


### PR DESCRIPTION
Renovate PRs do automerge today — #847 went from open to merged in 90 minutes, merged by `renovate[bot]` itself — but most take a day or more, and #844 / #845 have been sitting green-ish since Aug 8. Two things are in the way.

**GitHub's native auto-merge is off for this repository.** Confirmed by trying to enable it on #844:

> Auto-merge is not enabled for this repository. Enable it in repository Settings → General → Pull Requests → Allow auto-merge.

Renovate prefers that path (`platformAutomerge`, on by default). With it unavailable, Renovate falls back to merging from its own run — roughly hourly — and only if the branch is green at that exact moment. That fallback is why things merge at all, and why they merge late. **This half needs a repository setting flipped, which the config can't do:** Settings → General → Pull Requests → check *Allow auto-merge*.

**Rebase churn keeps closing the green window.** `rebaseWhen` defaulted to rebasing an open PR whenever it fell behind base. `main` moves several times a day, every rebase restarts the Vercel preview deploy, and Renovate's next look lands mid-build. The two PRs still open are the ones that have been rebased the most.

## Changes

`.github/renovate.json`:

- `rebaseWhen: "conflicted"` — rebase only when a PR actually conflicts, so the branch stays green between Renovate runs. Nothing in this repo requires a PR to be up to date with `main` (no branch protection, no required checks), so merging slightly behind is safe.
- `platformAutomerge: true` — already the default; stated explicitly so intent is on the page once the repository setting is on.
- `automergeStrategy: "squash"` — matches how everything else lands on `main`.
- A top-level `description` recording why, since the reasoning isn't visible from the keys alone.

Which updates automerge is unchanged: minor/patch/pin/digest, all devDependencies, and grouped GitHub Actions bumps. Majors on production dependencies still wait for you.

## Verification

`.github/renovate.json` parses as JSON; keys check out against the Renovate schema. The real test is the next Renovate run after the repository setting is enabled.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3Az9QH6CbCc3m9ENALNRL)_