### PR TITLE
fix(db): close the Data API write surface opened by blanket default grants

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -169,8 +169,16 @@ end $$;
 
 -- ── Schema grants ──────────────────────────────────────────────────────────
 grant usage on schema public to anon, authenticated, service_role;
+-- Deliberately service_role only. Handing `all on tables` to anon/authenticated
+-- here silently overrode every careful per-table `grant select ... to
+-- authenticated` below it: each table ended up writable by the anon key, with
+-- RLS as the only gate, and every table showed up in the pg_graphql schema. One
+-- of those tables (registration) had a FOR ALL policy that made the write
+-- surface a real corp-data escalation. See
+-- supabase/migrations/20260809090000_data_api_grant_lockdown.sql. Each table
+-- now states its own grants.
 alter default privileges in schema public
-  grant all on tables to anon, authenticated, service_role;
+  grant all on tables to service_role;
 alter default privileges in schema public
   grant all on sequences to anon, authenticated, service_role;
 alter default privileges in schema public
@@ -205,8 +213,15 @@ create policy "Users manage own characters"
   using (user_id = (select auth.uid()))
   with check (user_id = (select auth.uid()));
 
-grant select, insert, update, delete on public.registration to authenticated;
-grant all                            on public.registration to service_role;
+-- Written only by the service role, in /character/callback, after the EVE SSO
+-- code exchange has proved the character. character_id is an authorization
+-- input — every corp_* policy and my_corporation_ids()/my_alliance_ids() trust
+-- it — and a user-session write is indistinguishable from a hand-crafted POST
+-- claiming someone else's character. is_main is the one field the browser
+-- legitimately edits, and it feeds no policy.
+grant select           on public.registration to authenticated;
+grant update (is_main) on public.registration to authenticated;
+grant all              on public.registration to service_role;
 
 -- ── token ─────────────────────────────────────────────────────────────────
 -- EVE SSO OAuth tokens, one row per character (refreshed before each fetch).
@@ -240,8 +255,11 @@ create policy "Users manage own tokens"
   using (user_id = (select auth.uid()))
   with check (user_id = (select auth.uid()));
 
-grant select, insert, update, delete on public.token to authenticated;
-grant all                            on public.token to service_role;
+-- Service role only. These are live EVE SSO refresh tokens: no user session
+-- needs them (the callback writes with the service role, and every reader is
+-- cron-side), and a browser that can read its own refresh_token is an
+-- XSS-to-EVE-account bridge for no benefit.
+grant all on public.token to service_role;
 
 -- ── character_asset_over_time ─────────────────────────────────────────────
 -- ESI /characters/{id}/assets/, written by the character-assets job. Assets as

--- a/src/app/character/callback/route.ts
+++ b/src/app/character/callback/route.ts
@@ -5,6 +5,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { character } from '@/esi'
 import { createClient } from '@/utils/supabase/server'
+import { createServiceClient } from '@/utils/supabase/service'
 
 import { dispatchRefresh } from '../dispatchRefresh'
 import { sso } from '../sso'
@@ -40,7 +41,11 @@ const ensureMainCharacter = (supabase: SupabaseClient) => async (user_id: string
   if (oldestError) throw new Error(`oldest registration lookup failed: ${JSON.stringify(oldestError)}`)
   if (!oldest?.id) return
 
-  const { error: updateError } = await supabase.from('registration').update({ is_main: true }).eq('id', oldest.id)
+  const { error: updateError } = await supabase
+    .from('registration')
+    .update({ is_main: true })
+    .eq('id', oldest.id)
+    .eq('user_id', user_id)
   if (updateError) throw new Error(`mark main character failed: ${JSON.stringify(updateError)}`)
 }
 
@@ -55,10 +60,10 @@ const upsertToken =
     expires_at: string
     scope: string[]
   }) => {
-    const response = await supabase.from('token').upsert(columns, { onConflict: 'registration_id' }).select()
+    // No .select(): the caller never used the id, and not reading the row back
+    // keeps the refresh_token out of this process's memory a moment longer.
+    const response = await supabase.from('token').upsert(columns, { onConflict: 'registration_id' })
     if (response.error) throw new Error(`upsert token failed: ${JSON.stringify(response.error)}`)
-    if (!response.data?.[0]?.id) throw new Error(`upsert token returned no row: ${JSON.stringify(response)}`)
-    return response.data[0].id
   }
 
 export const GET = async (request: NextRequest) => {
@@ -68,6 +73,23 @@ export const GET = async (request: NextRequest) => {
   } = await supabase.auth.getUser()
   if (!user?.id) throw new Error('no authenticated supabase user on /character/callback')
   const user_id = user.id
+
+  // registration and token are service-role-only at the grant layer, and this
+  // route is their sole writer. The reason is that registration.character_id is
+  // an authorization input — every corp_* policy and
+  // my_corporation_ids()/my_alliance_ids() trust it — but a user-session write
+  // is indistinguishable from a hand-crafted POST claiming someone else's
+  // character. What separates them is the EVE SSO code exchange below, whose
+  // RS256 signature @philihp/eve-sso verifies against CCP's JWKS. That check
+  // can only happen here: no Postgres extension on this project can verify
+  // RS256 (pgjwt is HMAC-only, pgcrypto and pgsodium have no RSA verify), so
+  // the database cannot be handed the proof and left to police itself.
+  //
+  // Service-role clients bypass RLS, so treat this as a deliberate exception,
+  // not a pattern to copy: every write below is scoped to user_id by hand, and
+  // nothing here reads on the caller's behalf. Prefer the session client
+  // (`supabase`) anywhere the caller's own RLS scope is sufficient.
+  const service = createServiceClient()
 
   const { searchParams } = new URL(request.url)
   const code = searchParams.get('code')
@@ -96,15 +118,15 @@ export const GET = async (request: NextRequest) => {
   // upsertCharacter returns registration.id — a uuid — not an EVE id. The
   // `character_id` column it writes is registration's own, which really is the
   // EVE numeric id.
-  const registration_id = await upsertCharacter(supabase)({
+  const registration_id = await upsertCharacter(service)({
     user_id,
     owner,
     name,
     character_id: eve_character_id,
     ...(corporation_id != null ? { corporation_id } : {}),
   })
-  await ensureMainCharacter(supabase)(user_id)
-  await upsertToken(supabase)({
+  await ensureMainCharacter(service)(user_id)
+  await upsertToken(service)({
     user_id,
     registration_id,
     access_token,

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -109,18 +109,19 @@ export const authenticate = async () => {
   return error ?? data
 }
 
+// registration and token are service-role-only at the grant layer (see the
+// data_api_grant_lockdown migration), so these three use sudoSupabase like the
+// rest of this module's cron helpers. Their only caller is the src/refresh.js
+// CLI utility, which already runs with the service key in the environment —
+// this is the cron/CLI side, not an app-side service query.
 export const upsertCharacter = async (columns) => {
-  const response = await supabase.from('registration').upsert(columns, { onConflict: 'user_id, owner' }).select()
+  const response = await sudoSupabase.from('registration').upsert(columns, { onConflict: 'user_id, owner' }).select()
   return response.data?.[0]?.id
 }
 
 export const upsertToken = async (columns) => {
-  const response = await supabase
-    .from('token')
-    .upsert(columns, { onConflict: ['registration_id'] })
-    .select()
+  const response = await sudoSupabase.from('token').upsert(columns, { onConflict: ['registration_id'] })
   if (response.error) console.error(response.error)
-  return response.data?.[0]?.id
 }
 
 export const upsertAssets = async (assets) => {
@@ -189,7 +190,7 @@ export const groupRegistrationIdsByCorporation = async (scopes) => {
 }
 
 export const selectToken = async (registration_id, scope = []) => {
-  const response = await supabase
+  const response = await sudoSupabase
     .from('token')
     .select('refresh_token, scope')
     .eq('registration_id', registration_id)

--- a/supabase/migrations/20260809090000_data_api_grant_lockdown.sql
+++ b/supabase/migrations/20260809090000_data_api_grant_lockdown.sql
@@ -1,0 +1,125 @@
+-- Close the Data API / GraphQL write surface that the schema's blanket default
+-- privileges opened.
+--
+-- schema.sql sets `alter default privileges in schema public grant all on
+-- tables to anon, authenticated, service_role` before creating anything, so
+-- every table minted since has carried INSERT/UPDATE/DELETE (and SELECT) for
+-- `anon` and `authenticated` regardless of the careful per-table `grant select
+-- ... to authenticated` lines below it. That is why every table shows up in the
+-- pg_graphql schema and in the Supabase advisor's
+-- pg_graphql_{anon,authenticated}_table_exposed lints. RLS still gated the
+-- data, so most of that exposure was cosmetic — with one exception that was
+-- not.
+--
+-- ── The escalation: public.registration ───────────────────────────────────
+-- Its policy is FOR ALL keyed only on user_id, and nothing constrains
+-- character_id or corporation_id. Any account holding the `authenticated` role
+-- — which includes anonymous sign-ins, since Supabase gives those the same
+-- role — could POST /rest/v1/registration claiming another corporation and
+-- satisfy every corp-scoped policy (corp_asset_over_time,
+-- corp_blueprint_over_time, corp_industry_job_over_time, corp_contract,
+-- corp_contract_item, corp_structure, corp_structure_rig,
+-- corp_structure_status, corp_wallet_journal) plus
+-- my_corporation_ids()/my_alliance_ids(), which widen the asset, fitting, den
+-- and lens share audiences. Confirmed against production in a rolled-back
+-- transaction: one forged row exposed 7,571 corp_wallet_journal rows for a corp
+-- the account had no character in.
+--
+-- Locking corporation_id alone would not have fixed it: character-directory
+-- resolves affiliations from registration.character_id with no ownership check,
+-- so a forged character_id gets the victim's corp written back on the next cron
+-- run. character_id is the authorization input, and the only thing that proves
+-- it is the EVE SSO code exchange — an RS256 JWT that @philihp/eve-sso verifies
+-- against CCP's JWKS. No extension on this project can verify RS256 in-database
+-- (pgjwt is HMAC-only; pgcrypto and pgsodium have no RSA verify), so the check
+-- has to happen in /character/callback, which now writes both tables with the
+-- service role.
+--
+-- is_main stays user-writable as a column-level grant — it is the one field the
+-- browser legitimately edits ("Set as Main" on /account/settings) and it feeds
+-- no policy.
+revoke insert, update, delete on public.registration from anon, authenticated;
+grant update (is_main) on public.registration to authenticated;
+
+-- token holds live EVE SSO refresh tokens. With the callback on the service
+-- role, no user session needs this table at all: a browser that can read its
+-- own refresh_token is an XSS-to-EVE-account bridge, and everything that reads
+-- them is cron-side. The RLS policy stays as a second line of defence.
+revoke all on public.token from anon, authenticated;
+
+-- Orphaned pre-migration backup tables: referenced nowhere in the codebase,
+-- exposed over the Data API, and their FOR ALL policies are granted to PUBLIC
+-- (so `anon` as well, not just `authenticated`). token_backup is the reason
+-- these are dropped rather than just revoked — it holds 22 rows of live EVE
+-- refresh tokens, and stale credentials at rest are a liability whether or not
+-- anything can currently reach them. asset_backup is empty; character_backup
+-- holds 15 rows duplicated from registration.
+drop table if exists public.token_backup;
+drop table if exists public.character_backup;
+drop table if exists public.asset_backup;
+
+-- get_user_id_by_email is SECURITY DEFINER over auth.users, has no pinned
+-- search_path, is referenced nowhere in the codebase, and is callable without
+-- signing in via /rest/v1/rpc/get_user_id_by_email — an email-to-user_id
+-- enumeration oracle. Dropped outright; nothing calls it.
+drop function if exists public.get_user_id_by_email(text);
+
+-- These four are service-role-only by design: RLS is on and they carry no
+-- policy at all, so every anon/authenticated read already returned zero rows.
+-- Revoking SELECT takes them out of the pg_graphql schema and the PostgREST
+-- schema cache entirely, so they stop being discoverable rather than merely
+-- unreadable. schema.sql already grants them only to service_role — it was the
+-- blanket default privileges that put them on the API in the first place.
+revoke select on public.esi_etag             from anon, authenticated;
+revoke select on public.impersonation_log    from anon, authenticated;
+revoke select on public.innominate_appraisal from anon, authenticated;
+revoke select on public.innominate_throttle  from anon, authenticated;
+
+-- ── The cosmetic-but-untidy rest ─────────────────────────────────────────
+-- Every remaining public table that has no INSERT/UPDATE/DELETE policy still
+-- carries the default write grants. RLS denies those writes today, so this
+-- changes no behaviour; it removes the standing dependency on RLS being the
+-- only thing between the anon key and a write, and shrinks what the advisor
+-- and the GraphQL schema report. A DO block rather than a list because the
+-- sde_* mirror tables are minted at runtime by ensure_sde_mirror_table()
+-- (which already claws its own grants back the same way).
+--
+-- Read grants are deliberately left alone: `anon` SELECT is load-bearing for
+-- the sde_* mirror, the world-readable directory tables (alliance, corporation,
+-- character_directory, esf_data, industry_system_index) and the anonymous
+-- share-link audiences.
+do $$
+declare r record;
+begin
+  for r in
+    select c.oid, c.relname
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'public'
+      and c.relkind in ('r', 'p')
+      and not exists (
+        select 1 from pg_policy p
+        where p.polrelid = c.oid and p.polcmd in ('a', 'w', 'd', '*')
+      )
+      and (
+        has_table_privilege('anon', c.oid, 'INSERT')
+        or has_table_privilege('anon', c.oid, 'UPDATE')
+        or has_table_privilege('anon', c.oid, 'DELETE')
+        or has_table_privilege('authenticated', c.oid, 'INSERT')
+        or has_table_privilege('authenticated', c.oid, 'UPDATE')
+        or has_table_privilege('authenticated', c.oid, 'DELETE')
+      )
+  loop
+    execute format('revoke insert, update, delete on public.%I from anon, authenticated', r.relname);
+  end loop;
+end $$;
+
+-- Stop new tables inheriting the blanket grant, so each table's explicit
+-- `grant select ... to authenticated` is the whole story from here on. Mirrors
+-- the schema.sql change. This only affects tables created after it, which is
+-- what the statements above are for. Sequence and function defaults are left
+-- as they are: sequence USAGE is what lets an authenticated INSERT call
+-- nextval() on a future serial column, and Postgres grants function EXECUTE to
+-- PUBLIC by its own default anyway, so revoking here would buy nothing.
+alter default privileges in schema public
+  revoke all on tables from anon, authenticated;


### PR DESCRIPTION
Audit of what is exposed to the Data API / pg_graphql, and fixes for everything it turned up.

## Why every table looks public

`schema.sql` ran this before creating anything:

```sql
alter default privileges in schema public
  grant all on tables to anon, authenticated, service_role;
```

So every table minted since has carried `SELECT/INSERT/UPDATE/DELETE` for `anon` and `authenticated`, regardless of the careful per-table `grant select ... to authenticated` lines further down. That is why all 159 relations show up in the GraphQL schema and in the advisor's `pg_graphql_anon_table_exposed` / `pg_graphql_authenticated_table_exposed` lints.

RLS was still gating the data, so most of that exposure was cosmetic. One case was not.

## The escalation: `registration`

`public.registration` has a `FOR ALL` policy keyed only on `user_id`, and nothing constrains `character_id` or `corporation_id`. Any account holding the `authenticated` role — **which includes anonymous sign-ins, since Supabase gives those the same role** — could `POST /rest/v1/registration` claiming another corporation and instantly satisfy every corp-scoped policy (`corp_asset_over_time`, `corp_blueprint_over_time`, `corp_industry_job_over_time`, `corp_contract`, `corp_contract_item`, `corp_structure`, `corp_structure_rig`, `corp_structure_status`, `corp_wallet_journal`) plus `my_corporation_ids()` / `my_alliance_ids()`, which widen the asset, fitting, den and lens share audiences.

Confirmed against production inside a transaction that was rolled back (verified 0 rows left behind): one forged row exposed **7,571 `corp_wallet_journal` rows** for a corp the account had no character in. No sign it was ever exploited — zero registrations and zero `user_settings` rows are owned by an anonymous user.

**Why the fix is where it is.** Locking `corporation_id` alone would not have worked: `character-directory` resolves affiliations from `registration.character_id` with no ownership check, so a forged `character_id` gets the victim's corp written back on the next cron run. `character_id` is the authorization input, and the only thing that proves it is the EVE SSO code exchange — an RS256 JWT that `@philihp/eve-sso` verifies against CCP's JWKS. That check cannot be pushed into the database: no extension on this project can verify RS256 (`pgjwt` is HMAC-only; `pgcrypto` and `pgsodium` have no RSA verify), so storing the JWT as a checksum column would be inert.

So `registration` and `token` are now **service-role-only**, written solely by `/character/callback` after the SSO exchange has proved the character. `registration.is_main` stays user-writable as a column-level grant — the one field the browser legitimately edits, and it feeds no policy. The service client is confined to that one route, scoped to `user_id` by hand on every write, with a comment saying why it is an exception rather than a pattern.

## Everything else

- **`token`** — service-role only. A browser that can read its own EVE `refresh_token` is an XSS-to-EVE-account bridge; every reader is cron-side.
- **`asset_backup` / `character_backup` / `token_backup`** — **dropped**. Referenced nowhere, exposed over the API, `FOR ALL` policies granted to `PUBLIC`, and `token_backup` held 22 rows of live refresh tokens.
- **`get_user_id_by_email(text)`** — **dropped**. `SECURITY DEFINER` over `auth.users`, no pinned `search_path`, unused, and callable without signing in via `/rest/v1/rpc/`.
- **`esi_etag`, `impersonation_log`, `innominate_appraisal`, `innominate_throttle`** — `SELECT` revoked. RLS-on-no-policy already returned zero rows; this takes them out of the pg_graphql schema and PostgREST cache so they stop being discoverable at all.
- **43 tables with no write policy** — unused write grants revoked (a `DO` block, since `sde_*` tables are minted at runtime by `ensure_sde_mirror_table()`, which already claws its own grants back the same way).
- **`schema.sql`** — default privileges narrowed to `service_role`, so each table's explicit grant is the whole story from here on.

Read grants are otherwise untouched: `anon` SELECT is load-bearing for the `sde_*` mirror, the world-readable directory tables (`alliance`, `corporation`, `character_directory`, `esf_data`, `industry_system_index`) and the anonymous share-link audiences.

## Deliberately not changed

- `universe_structure`, `universe_name`, `character_affiliation` and `heartbeat` are readable by any signed-in account (`using (true)`). Reviewed and accepted.
- 29 functions carry a mutable `search_path` (advisor `function_search_path_mutable`). All five RLS helper predicates already fully schema-qualify their bodies, so they are not exposed to search_path shadowing — and adding `SET search_path` would make them non-inlinable inside policies evaluated per row over 100k+ row tables. Left alone on purpose.
- Leaked-password protection and MFA options are dashboard settings, not schema.

## Testing

`pnpm test` (217 pass), `pnpm run lint`, `pnpm run build`, and the migration ordering check all clean. The migration applies on merge via the `Migrate` workflow — it has not been applied to production from this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWoYhYsz742LurWjdNrm72