### PR TITLE
fix(db): drop the backup tables in FK dependency order

### DIFF
--- a/supabase/migrations/20260809090000_data_api_grant_lockdown.sql
+++ b/supabase/migrations/20260809090000_data_api_grant_lockdown.sql
@@ -54,9 +54,15 @@ revoke all on public.token from anon, authenticated;
 -- refresh tokens, and stale credentials at rest are a liability whether or not
 -- anything can currently reach them. asset_backup is empty; character_backup
 -- holds 15 rows duplicated from registration.
+--
+-- Order matters: token_backup.token_character_id_fkey and
+-- asset_backup.asset_character_id_fkey both reference character_backup, so the
+-- parent drops last. Deliberately not `cascade` — if some other object ever
+-- grows a dependency on these, this should fail loudly rather than quietly
+-- drop it.
 drop table if exists public.token_backup;
-drop table if exists public.character_backup;
 drop table if exists public.asset_backup;
+drop table if exists public.character_backup;
 
 -- get_user_id_by_email is SECURITY DEFINER over auth.users, has no pinned
 -- search_path, is referenced nowhere in the codebase, and is callable without


### PR DESCRIPTION
Follow-up to #854. **That migration failed on merge and rolled back, so none of it is in production yet.** This unblocks it.

## What happened

The `Migrate` workflow on the merge commit ([run 31363309360](https://github.com/philihp/edencom-link/actions/runs/31363309360)) failed:

```
ERROR: cannot drop table character_backup because other objects depend on it (SQLSTATE 2BP01)
constraint asset_character_id_fkey on table asset_backup depends on table character_backup
At statement: 4
```

Both `token_backup.token_character_id_fkey` and `asset_backup.asset_character_id_fkey` reference `character_backup`, so the parent has to drop last. I had it dropping second. My mistake — I checked the row counts on those tables but not their constraints.

The migration is atomic, so it rolled back cleanly: I verified against production that all three backup tables are still present and `registration` still grants `INSERT` to `authenticated`. **The escalation described in #854 is therefore still open until this lands.**

## The fix

Reorder the drops so the two dependents go first:

```sql
drop table if exists public.token_backup;
drop table if exists public.asset_backup;
drop table if exists public.character_backup;
```

Deliberately not `cascade` — if some other object ever grows a dependency on these, that should fail loudly rather than quietly take it along.

## Why this edits the migration instead of adding a new one

The repo convention is to add a new migration rather than change an existing one, and I'd normally follow it. It doesn't apply here: `20260809090000` never reached `schema_migrations`, so `supabase db push --include-all` retries it on every future run and would keep failing — blocking every subsequent migration behind it. A new migration cannot fix that; the failing file itself has to work.

The **filename is unchanged**, so no environment's migration history is disturbed — that's the part of the rule that protects against the #614/#615/#616 breakage.

## Verification

Ran the migration's full statement list against production inside a transaction forced to roll back, then confirmed production was untouched afterward. All statements succeed:

- `registration` loses `INSERT` (`reg_insert=f`)
- `is_main` keeps its column-level `UPDATE` (`is_main_update=t`)
- all three backup tables drop (`backup_tables_left=0`)

Migration ordering check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWoYhYsz742LurWjdNrm72

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWoYhYsz742LurWjdNrm72)_