### PR TITLE
feat(graphql): navigable entity edges on every row type

### DIFF
--- a/src/app/api/graphql/context.ts
+++ b/src/app/api/graphql/context.ts
@@ -17,6 +17,19 @@ import { createServiceClient } from '@/utils/supabase/service'
 // THE LEAK GUARD: every resolver must filter .in('registration_id', ...) from
 // ctx.registrationIds explicitly, in BOTH modes. In session mode that's
 // redundant with RLS (harmless); in token mode it is load-bearing.
+
+// The public identity behind an owner, for the Owner type's corp/alliance
+// fields. Everything here comes from world-readable directory tables, never
+// from `registration` (which RLS hides from non-owners), so a shared row's
+// foreign grantor resolves through exactly the same path as your own character.
+export type OwnerIdentity = {
+  characterId: string | null
+  corporationId: string | null
+  corporationName: string | null
+  allianceId: string | null
+  allianceName: string | null
+}
+
 export type GraphqlContext = {
   supabase: SupabaseClient
   mode: 'session' | 'token'
@@ -24,10 +37,89 @@ export type GraphqlContext = {
   registrationIds: string[]
   // registration uuid → character name, for owner filters and ownerName fields.
   ownerNameById: Map<string, string>
+  // registration uuid → EVE character id, for Owner.characterId on the caller's
+  // own characters (free — it rides along on the context's registration read).
+  ownerCharacterIdById: Map<string, string>
+  // Lazily load the identities for one result set's owners. The Owner type's
+  // corp/alliance fields are the only callers, so an unselected edge costs
+  // nothing; when they are selected, every row of a result set passes the SAME
+  // scope array (the root resolver hands each Owner the same reference), which
+  // this memoizes on — so the edge resolves in one pass, never per row.
+  ownerIdentities: (scope: readonly string[]) => Promise<Map<string, OwnerIdentity>>
 }
 
 const deny = (message: string, status: number): never => {
   throw new GraphQLError(message, { extensions: { http: { status } } })
+}
+
+const str = (v: number | string | null | undefined): string | null => (v == null ? null : String(v))
+
+type DirectoryRow = {
+  character_id: number | string | null
+  corporation_id: number | string | null
+  alliance_id: number | string | null
+  registration_id: string | null
+}
+
+// One pass over the world-readable directory tables for a whole result set's
+// owners: character_directory joins registration uuid → EVE identity, then the
+// corporation/alliance tables put names on those ids. Three small `in()` reads
+// at worst, and only when a query selects an Owner corp/alliance field.
+const loadOwnerIdentities = async (
+  supabase: SupabaseClient,
+  registrationIds: readonly string[]
+): Promise<Map<string, OwnerIdentity>> => {
+  const ids = [...new Set(registrationIds)]
+  if (ids.length === 0) return new Map()
+
+  const { data } = await supabase
+    .from('character_directory')
+    .select('character_id, corporation_id, alliance_id, registration_id')
+    .in('registration_id', ids)
+  const rows = ((data ?? []) as DirectoryRow[]).filter((r) => r.registration_id != null)
+
+  const idsOf = (pick: (row: DirectoryRow) => number | string | null): number[] =>
+    [...new Set(rows.map(pick).filter((v): v is number | string => v != null))].map(Number)
+  const corporationIds = idsOf((r) => r.corporation_id)
+  const allianceIds = idsOf((r) => r.alliance_id)
+
+  const [{ data: corporations }, { data: alliances }] = await Promise.all([
+    corporationIds.length
+      ? supabase.from('corporation').select('corporation_id, name').in('corporation_id', corporationIds)
+      : Promise.resolve({ data: [] }),
+    allianceIds.length
+      ? supabase.from('alliance').select('alliance_id, name').in('alliance_id', allianceIds)
+      : Promise.resolve({ data: [] }),
+  ])
+  const corporationNames = new Map(
+    ((corporations ?? []) as Array<{ corporation_id: number | string; name: string | null }>).map((c) => [
+      String(c.corporation_id),
+      c.name,
+    ])
+  )
+  const allianceNames = new Map(
+    ((alliances ?? []) as Array<{ alliance_id: number | string; name: string | null }>).map((a) => [
+      String(a.alliance_id),
+      a.name,
+    ])
+  )
+
+  return new Map(
+    rows.map((r): [string, OwnerIdentity] => {
+      const corporationId = str(r.corporation_id)
+      const allianceId = str(r.alliance_id)
+      return [
+        r.registration_id as string,
+        {
+          characterId: str(r.character_id),
+          corporationId,
+          corporationName: corporationId == null ? null : (corporationNames.get(corporationId) ?? null),
+          allianceId,
+          allianceName: allianceId == null ? null : (allianceNames.get(allianceId) ?? null),
+        },
+      ]
+    })
+  )
 }
 
 // The context for a given user on a given client — the tail every entry point
@@ -40,16 +132,35 @@ const contextFor = async (
   mode: GraphqlContext['mode'],
   userId: string
 ): Promise<GraphqlContext> => {
-  const { data: registrations, error } = await supabase.from('registration').select('id, name').eq('user_id', userId)
+  const { data: registrations, error } = await supabase
+    .from('registration')
+    .select('id, name, character_id')
+    .eq('user_id', userId)
   if (error) deny('Lookup failed', 500)
 
-  const rows = (registrations ?? []) as Array<{ id: string; name: string }>
+  const rows = (registrations ?? []) as Array<{ id: string; name: string; character_id: number | string | null }>
+
+  // Per-request memo keyed on the scope array's identity, not its contents: a
+  // root resolver hands every Owner in its result set the same array, so the
+  // first field resolver to look starts the load and the rest await it.
+  const identitiesByScope = new WeakMap<readonly string[], Promise<Map<string, OwnerIdentity>>>()
+
   return {
     supabase,
     mode,
     userId,
     registrationIds: rows.map((r) => r.id),
     ownerNameById: new Map(rows.map((r) => [r.id, r.name])),
+    ownerCharacterIdById: new Map(
+      rows.flatMap((r): Array<[string, string]> => (r.character_id == null ? [] : [[r.id, String(r.character_id)]]))
+    ),
+    ownerIdentities: (scope) => {
+      const inFlight = identitiesByScope.get(scope)
+      if (inFlight) return inFlight
+      const loading = loadOwnerIdentities(supabase, scope)
+      identitiesByScope.set(scope, loading)
+      return loading
+    },
   }
 }
 

--- a/src/app/api/graphql/resolvers.ts
+++ b/src/app/api/graphql/resolvers.ts
@@ -1,6 +1,13 @@
 // Root resolvers for /api/graphql. Flat by design: each Query field returns
 // fully-materialized rows with names resolved here, batched once per result
-// set — no nested resolvers, so no N+1 and no deep-query surface.
+// set.
+//
+// The `owner`/`type`/`location` entity edges (see the SDL header for why they
+// exist) are built RIGHT HERE, in the root resolver, out of data it already
+// had — the SDE type rows and resolved locations it used to mine for a single
+// name each. So the edges add no queries and cannot fan out per row. The one
+// type-level resolver is Owner's corp/alliance block at the bottom, which loads
+// lazily and once per result set.
 //
 // THE LEAK GUARD (see context.ts): every table read filters
 // .in('registration_id', …) from the context. In session mode that's
@@ -11,7 +18,7 @@ import { uniq } from 'ramda'
 
 import { guessLocationRef, resolveTypeFilter } from '@/app/api/mcp/lib'
 import { resolveLocations, type LocationRef, type ResolvedLocations } from '@/app/resolveLocations'
-import { getSdeTypeNames } from '@/sdeTypes'
+import { getSdeTypes, type SdeType } from '@/sdeTypes'
 import { ASSET_CAP, LIST_CAP, clampLimit, matchOwnerIds, parseIdArg, parseSince, parseTypeIdsArg } from './filters'
 import type { GraphqlContext } from './context'
 
@@ -64,8 +71,17 @@ const fetchCapped = async <T>(
   return acc.length >= cap || rows.length < to - from + 1 ? acc : fetchCapped(build, cap, from + PAGE_SIZE, acc)
 }
 
-const typeNamesFor = async (typeIds: Array<number | string | null | undefined>): Promise<Record<number, string>> =>
-  getSdeTypeNames(uniq(typeIds.filter((id): id is number | string => id != null).map(Number)))
+// Batch-resolve the SDE rows behind a result set's type ids. This used to ask
+// for names only; it now keeps the whole row, because getSdeTypes was fetching
+// (and per-process caching) group/category/volume all along — the ItemType edge
+// is those already-paid-for columns stopped being thrown away.
+type SdeTypes = Record<number, SdeType>
+
+const typesFor = async (typeIds: Array<number | string | null | undefined>): Promise<SdeTypes> =>
+  getSdeTypes(uniq(typeIds.filter((id): id is number | string => id != null).map(Number)))
+
+const typeNameOf = (types: SdeTypes, typeId: number | string | null | undefined): string | null =>
+  typeId == null ? null : (types[Number(typeId)]?.name ?? null)
 
 // Batch-resolve display names for a set of location refs (station, structure,
 // solar system, or a container/ship item id that falls back to a raw label).
@@ -75,6 +91,48 @@ const locationNamesFor = async (ctx: GraphqlContext, refs: Array<LocationRef | n
 }
 
 const str = (v: number | string | null | undefined): string | null => (v == null ? null : String(v))
+
+// --- The entity edges -------------------------------------------------------
+// Three pure reshapes of what the root resolver already holds. Each returns a
+// leaf-only object (the SDL invariant that keeps every row CSV-flattenable).
+
+const itemTypeOf = (types: SdeTypes, typeId: number | string | null | undefined) => {
+  if (typeId == null) return null
+  const t: SdeType | undefined = types[Number(typeId)]
+  return {
+    typeId: String(typeId),
+    name: t?.name ?? null,
+    groupId: str(t?.groupID),
+    groupName: t?.groupName ?? null,
+    categoryId: str(t?.categoryID),
+    categoryName: t?.categoryName ?? null,
+    metaGroupId: str(t?.metaGroupID),
+    volume: t?.volume ?? null,
+  }
+}
+
+const locationOf = (locations: ResolvedLocations, ref: LocationRef | null) => {
+  if (ref === null) return null
+  const systemId = locations.systemIdFor(ref)
+  return {
+    locationId: ref.id,
+    name: locations.nameFor(ref),
+    systemId: str(systemId),
+    systemName: locations.systemFor(ref) ?? null,
+  }
+}
+
+// The Owner edge. `scope` is the result set's full owner id list, carried on
+// every Owner of that set BY REFERENCE — it's what the context memoizes the
+// corp/alliance load on, so the whole set resolves in one pass. It isn't in the
+// SDL, so it's invisible to callers.
+type OwnerRef = { id: string; name: string; scope: readonly string[] }
+
+const ownerOf = (names: Map<string, string> | ReadonlyMap<string, string>, id: string, scope: readonly string[]) => ({
+  id,
+  name: names.get(id) ?? id,
+  scope,
+})
 
 // Session-only guard for the shared-data surfaces: the Bearer path runs on the
 // service client, where RLS can't arbitrate a widened filter — the designed
@@ -139,8 +197,12 @@ const assetLocationRef = (row: AssetRow): LocationRef | null =>
 
 export const resolvers = {
   Query: {
-    owners: (_parent: unknown, _args: unknown, ctx: GraphqlContext) =>
-      [...ctx.ownerNameById].map(([id, name]) => ({ id, name })).sort((a, b) => a.name.localeCompare(b.name)),
+    owners: (_parent: unknown, _args: unknown, ctx: GraphqlContext) => {
+      const scope = ctx.registrationIds
+      return [...ctx.ownerNameById]
+        .map(([id, name]) => ({ id, name, scope }))
+        .sort((a, b) => a.name.localeCompare(b.name))
+    },
 
     assets: async (
       _parent: unknown,
@@ -188,14 +250,15 @@ export const resolvers = {
         cap
       )
 
-      const [typeNames, locations, ownerNames] = await Promise.all([
-        typeNamesFor(rows.map((r) => r.type_id)),
+      const [types, locations, ownerNames] = await Promise.all([
+        typesFor(rows.map((r) => r.type_id)),
         locationNamesFor(ctx, rows.map(assetLocationRef)),
         ownerNamesFor(
           ctx,
           rows.map((r) => r.registration_id)
         ),
       ])
+      const ownerScope = uniq(rows.map((r) => r.registration_id))
 
       return {
         totalCount,
@@ -205,7 +268,7 @@ export const resolvers = {
           return {
             itemId: String(r.item_id),
             typeId: String(r.type_id),
-            typeName: typeNames[r.type_id] ?? null,
+            typeName: typeNameOf(types, r.type_id),
             quantity: String(r.quantity ?? 1),
             locationId: str(r.location_id),
             locationFlag: r.location_flag,
@@ -216,6 +279,9 @@ export const resolvers = {
             name: r.name,
             ownerId: r.registration_id,
             ownerName: ownerNames.get(r.registration_id) ?? r.registration_id,
+            owner: ownerOf(ownerNames, r.registration_id, ownerScope),
+            type: itemTypeOf(types, r.type_id),
+            location: locationOf(locations, ref),
           }
         }),
       }
@@ -252,23 +318,26 @@ export const resolvers = {
           Number(i.type_id),
         ])
       )
-      const [typeNames, ownerNames] = await Promise.all([
-        typeNamesFor([...typeByItem.values()]),
+      const [types, ownerNames] = await Promise.all([
+        typesFor([...typeByItem.values()]),
         ownerNamesFor(
           ctx,
           grants.map((g) => g.registration_id)
         ),
       ])
+      const ownerScope = uniq(grants.map((g) => g.registration_id))
 
       return grants.map((g) => {
         const typeId = typeByItem.get(String(g.item_id))
         return {
           shareId: g.id,
           itemId: String(g.item_id),
-          itemTypeName: typeId != null ? (typeNames[typeId] ?? null) : null,
+          itemTypeName: typeNameOf(types, typeId),
           ownerId: g.registration_id,
           ownerName: ownerNames.get(g.registration_id) ?? g.registration_id,
           sharedAt: g.created_at,
+          owner: ownerOf(ownerNames, g.registration_id, ownerScope),
+          itemType: itemTypeOf(types, typeId),
         }
       })
     },
@@ -315,8 +384,8 @@ export const resolvers = {
         cap
       )
 
-      const [typeNames, locations] = await Promise.all([
-        typeNamesFor(rows.map((r) => r.type_id)),
+      const [types, locations] = await Promise.all([
+        typesFor(rows.map((r) => r.type_id)),
         locationNamesFor(
           ctx,
           rows.map((r) => guessLocationRef(r.location_id))
@@ -331,7 +400,7 @@ export const resolvers = {
           return {
             itemId: String(r.item_id),
             typeId: String(r.type_id),
-            typeName: typeNames[r.type_id] ?? null,
+            typeName: typeNameOf(types, r.type_id),
             quantity: String(r.quantity ?? 1),
             locationId: str(r.location_id),
             locationFlag: r.location_flag,
@@ -341,6 +410,9 @@ export const resolvers = {
             runs: r.runs,
             ownerId: r.registration_id,
             ownerName: ctx.ownerNameById.get(r.registration_id) ?? r.registration_id,
+            owner: ownerOf(ctx.ownerNameById, r.registration_id, ownerIds),
+            type: itemTypeOf(types, r.type_id),
+            location: locationOf(locations, ref),
           }
         }),
       }
@@ -377,8 +449,8 @@ export const resolvers = {
         LIST_CAP
       )
 
-      const [typeNames, locations] = await Promise.all([
-        typeNamesFor(rows.map((r) => r.type_id)),
+      const [types, locations] = await Promise.all([
+        typesFor(rows.map((r) => r.type_id)),
         locationNamesFor(
           ctx,
           rows.map((r) => guessLocationRef(r.location_id))
@@ -390,10 +462,13 @@ export const resolvers = {
         return {
           orderId: String(r.order_id),
           typeId: String(r.type_id),
-          typeName: typeNames[r.type_id] ?? null,
+          typeName: typeNameOf(types, r.type_id),
           locationId: String(r.location_id),
           locationName: ref ? locations.nameFor(ref) : null,
           regionId: String(r.region_id),
+          owner: ownerOf(ctx.ownerNameById, r.registration_id, ownerIds),
+          type: itemTypeOf(types, r.type_id),
+          location: locationOf(locations, ref),
           isBuy: r.is_buy,
           price: Number(r.price),
           volumeTotal: String(r.volume_total),
@@ -448,8 +523,8 @@ export const resolvers = {
 
       const jobLocationRef = (r: JobRow): LocationRef | null => guessLocationRef(r.station_id ?? r.facility_id)
 
-      const [typeNames, locations] = await Promise.all([
-        typeNamesFor(rows.flatMap((r) => [r.blueprint_type_id, r.product_type_id])),
+      const [types, locations] = await Promise.all([
+        typesFor(rows.flatMap((r) => [r.blueprint_type_id, r.product_type_id])),
         locationNamesFor(ctx, rows.map(jobLocationRef)),
       ])
 
@@ -459,9 +534,13 @@ export const resolvers = {
           jobId: String(r.job_id),
           activityId: r.activity_id,
           blueprintTypeId: String(r.blueprint_type_id),
-          blueprintTypeName: typeNames[r.blueprint_type_id] ?? null,
+          blueprintTypeName: typeNameOf(types, r.blueprint_type_id),
           productTypeId: str(r.product_type_id),
-          productTypeName: r.product_type_id == null ? null : (typeNames[r.product_type_id] ?? null),
+          productTypeName: typeNameOf(types, r.product_type_id),
+          owner: ownerOf(ctx.ownerNameById, r.registration_id, ownerIds),
+          blueprintType: itemTypeOf(types, r.blueprint_type_id),
+          productType: itemTypeOf(types, r.product_type_id),
+          location: locationOf(locations, ref),
           runs: r.runs,
           licensedRuns: r.licensed_runs,
           probability: r.probability,
@@ -504,6 +583,7 @@ export const resolvers = {
           ownerName: ctx.ownerNameById.get(r.registration_id) ?? r.registration_id,
           balance: Number(r.balance),
           recordedAt: r.recorded_at,
+          owner: ownerOf(ctx.ownerNameById, r.registration_id, ctx.registrationIds),
         }))
         .sort((a, b) => a.ownerName.localeCompare(b.ownerName))
     },
@@ -548,8 +628,8 @@ export const resolvers = {
         return q
       }, cap)
 
-      const [typeNames, locations] = await Promise.all([
-        typeNamesFor(rows.map((r) => r.type_id)),
+      const [types, locations] = await Promise.all([
+        typesFor(rows.map((r) => r.type_id)),
         locationNamesFor(
           ctx,
           rows.map((r) => guessLocationRef(r.location_id))
@@ -562,7 +642,7 @@ export const resolvers = {
           transactionId: String(r.transaction_id),
           date: r.date,
           typeId: String(r.type_id),
-          typeName: typeNames[r.type_id] ?? null,
+          typeName: typeNameOf(types, r.type_id),
           quantity: String(r.quantity),
           unitPrice: Number(r.unit_price),
           isBuy: r.is_buy,
@@ -570,8 +650,29 @@ export const resolvers = {
           locationName: ref ? locations.nameFor(ref) : null,
           ownerId: r.registration_id,
           ownerName: ctx.ownerNameById.get(r.registration_id) ?? r.registration_id,
+          owner: ownerOf(ctx.ownerNameById, r.registration_id, ownerIds),
+          type: itemTypeOf(types, r.type_id),
+          location: locationOf(locations, ref),
         }
       })
     },
+  },
+
+  // The only type-level resolvers in the schema. id/name came with the parent;
+  // these four read, so they stay lazy — a query that doesn't ask for a corp or
+  // alliance issues no query at all, and one that does resolves the whole result
+  // set at once off the memoized scope (context.ts).
+  Owner: {
+    characterId: (parent: OwnerRef, _args: unknown, ctx: GraphqlContext) =>
+      ctx.ownerCharacterIdById.get(parent.id) ??
+      ctx.ownerIdentities(parent.scope).then((m) => m.get(parent.id)?.characterId ?? null),
+    corporationId: (parent: OwnerRef, _args: unknown, ctx: GraphqlContext) =>
+      ctx.ownerIdentities(parent.scope).then((m) => m.get(parent.id)?.corporationId ?? null),
+    corporationName: (parent: OwnerRef, _args: unknown, ctx: GraphqlContext) =>
+      ctx.ownerIdentities(parent.scope).then((m) => m.get(parent.id)?.corporationName ?? null),
+    allianceId: (parent: OwnerRef, _args: unknown, ctx: GraphqlContext) =>
+      ctx.ownerIdentities(parent.scope).then((m) => m.get(parent.id)?.allianceId ?? null),
+    allianceName: (parent: OwnerRef, _args: unknown, ctx: GraphqlContext) =>
+      ctx.ownerIdentities(parent.scope).then((m) => m.get(parent.id)?.allianceName ?? null),
   },
 }

--- a/src/app/api/graphql/schema.graphql.ts
+++ b/src/app/api/graphql/schema.graphql.ts
@@ -4,10 +4,30 @@
 //
 // Design stance: a flat schema — every list is a root Query field returning
 // fully-materialized rows, with names (typeName/locationName/ownerName)
-// resolved in the root resolver, batched once per result set. There are no
-// nested resolvers, so N+1 fan-out and deep-query abuse are impossible by
-// construction. Ids are String: EVE item ids exceed 2^53, and GraphQL Int is
-// 32-bit. Timestamps are ISO 8601 strings.
+// resolved in the root resolver, batched once per result set. Ids are String:
+// EVE item ids exceed 2^53, and GraphQL Int is 32-bit. Timestamps are ISO 8601
+// strings.
+//
+// Rows additionally carry ENTITY EDGES (`owner`, `type`, `location`) so the
+// GraphiQL docs explorer at GET /api/graphql is navigable — clicking through
+// Asset → ItemType is how you discover that group/category/volume exist at all.
+// Two invariants keep the edges from costing what nested resolvers usually
+// cost, both pinned by test/graphqlSchema.test.ts:
+//
+//  1. THE ENTITY TYPES ARE LEAF-ONLY. Owner, ItemType and Location contain
+//     scalars and nothing else, so a response is at most row → entity → scalar.
+//     Every row therefore flattens to exactly one CSV line (owner { name }
+//     becomes an owner_name column) — see src/app/graphql/flatten.ts, which the
+//     /graphql page's "Copy as CSV" uses. There is no deep-query surface.
+//  2. NO EDGE FANS OUT PER ROW. `type` and `location` are pure reshapes of data
+//     the root resolver already fetched (it was resolving names from the full
+//     SDE rows and throwing the rest away). Owner's corp/alliance fields are the
+//     one exception that reads: they load lazily and once per result set, memoed
+//     on the scope array in context.ts.
+//
+// Every entity field is ALSO reachable as a flat scalar on the row itself
+// (ownerName beside owner { name }, typeName beside type { name }). Pick the
+// scalars for a CSV-shaped query, the edges for exploring; both cost the same.
 export const typeDefs = /* GraphQL */ `
   type Query {
     "Your linked characters. ownerId on every row below is one of these ids."
@@ -54,10 +74,64 @@ export const typeDefs = /* GraphQL */ `
     ): [WalletTransaction!]!
   }
 
-  "A linked character (id is this site's registration id, not the EVE character id)."
+  """
+  The character a row belongs to. Reached as \`owner\` from every row type, and
+  listed on its own by the \`owners\` query. Leaf-only, so \`owner { … }\` still
+  flattens to one CSV line.
+
+  \`id\` is this site's registration id (the id \`ownerId\` carries and the
+  \`owner:\` filter matches on), NOT the EVE character id — that's
+  \`characterId\`. The corp/alliance fields load only when you select them.
+  """
   type Owner {
+    "This site's registration id — what ownerId carries and the owner: filter matches. NOT the EVE character id."
     id: String!
+    "The character's name, and what the owner: filter accepts."
     name: String!
+    "The EVE character id (what zKillboard, ESI and the image server use)."
+    characterId: String
+    corporationId: String
+    corporationName: String
+    allianceId: String
+    "Null for a character whose corporation is in no alliance."
+    allianceName: String
+  }
+
+  """
+  An EVE item type from the SDE mirror, reached as \`type\` (or
+  \`blueprintType\`/\`productType\`) from every row that names an item.
+  Leaf-only. Nothing here needs an extra query — the row's \`typeName\` was
+  already read from these same SDE rows.
+  """
+  type ItemType {
+    typeId: String!
+    name: String
+    groupId: String
+    "e.g. \\"Mineral\\", \\"Frigate\\" — the SDE group, one level under the category."
+    groupName: String
+    categoryId: String
+    "e.g. \\"Ship\\", \\"Blueprint\\", \\"Module\\" — the broadest SDE bucket."
+    categoryName: String
+    "Tech/faction tier (T2, faction, officer, …); null on plain T1 types, which the SDE doesn't stamp."
+    metaGroupId: String
+    "m³ per unit — the ASSEMBLED figure for ships and other singletons; the SDE carries no packaged volume."
+    volume: Float
+  }
+
+  """
+  Where a row sits, reached as \`location\`. Leaf-only. The name resolves the
+  same way the asset pages do: your own corp's structures beat the ESI-resolved
+  structure cache, NPC stations and systems come from the universe_name cache,
+  and anything unresolvable falls back to a \`#id\` label.
+
+  \`systemId\`/\`systemName\` are the solar system the location is in — null for a
+  container or ship whose own location we couldn't walk up to a system.
+  """
+  type Location {
+    locationId: String!
+    name: String
+    systemId: String
+    systemName: String
   }
 
   "An asset share another user has aimed at you; itemId is the shared root (a ship or container), covering everything inside it."
@@ -68,6 +142,10 @@ export const typeDefs = /* GraphQL */ `
     ownerId: String!
     ownerName: String!
     sharedAt: String!
+    "The sharing character."
+    owner: Owner!
+    "The shared root's item type."
+    itemType: ItemType
   }
 
   type Asset {
@@ -85,6 +163,10 @@ export const typeDefs = /* GraphQL */ `
     name: String
     ownerId: String!
     ownerName: String!
+    owner: Owner!
+    type: ItemType!
+    "Null only for a row ESI gave no location_id."
+    location: Location
   }
 
   type AssetPage {
@@ -108,6 +190,10 @@ export const typeDefs = /* GraphQL */ `
     runs: Int
     ownerId: String!
     ownerName: String!
+    owner: Owner!
+    "The blueprint's own item type — the product's type is not on this row."
+    type: ItemType!
+    location: Location
   }
 
   type BlueprintPage {
@@ -134,6 +220,9 @@ export const typeDefs = /* GraphQL */ `
     issued: String!
     ownerId: String!
     ownerName: String!
+    owner: Owner!
+    type: ItemType!
+    location: Location!
   }
 
   type IndustryJob {
@@ -157,6 +246,12 @@ export const typeDefs = /* GraphQL */ `
     locationName: String
     ownerId: String!
     ownerName: String!
+    owner: Owner!
+    blueprintType: ItemType!
+    "Null for research and copy jobs, which produce no new item type."
+    productType: ItemType
+    "The facility the job runs in — stationId when ESI gave one, else the structure."
+    location: Location
   }
 
   type WalletBalance {
@@ -164,6 +259,7 @@ export const typeDefs = /* GraphQL */ `
     ownerName: String!
     balance: Float!
     recordedAt: String!
+    owner: Owner!
   }
 
   type WalletTransaction {
@@ -178,5 +274,8 @@ export const typeDefs = /* GraphQL */ `
     locationName: String
     ownerId: String!
     ownerName: String!
+    owner: Owner!
+    type: ItemType!
+    location: Location!
   }
 `

--- a/src/app/graphql/queryEditor.tsx
+++ b/src/app/graphql/queryEditor.tsx
@@ -2,11 +2,18 @@
 
 import { useState } from 'react'
 
+import { csvRows } from '@/app/lens/flatten'
+import { toCsv } from '@/utils/csv'
 import styles from './graphql.module.css'
 
 // Deliberately simple in-browser editor (no GraphiQL dependency): a query
 // textarea, an optional variables JSON textarea, and the raw JSON response.
 // Posts same-origin, so the Supabase session cookie authenticates it.
+//
+// GET /api/graphql serves GraphiQL, which is where the schema-aware
+// autocomplete and the docs explorer live. This page keeps the examples, and
+// the CSV download GraphiQL can't offer — sharing the Lens flattening
+// (src/app/lens/flatten.ts), since a lens is a stored query of this same shape.
 
 const EXAMPLES: Array<{ label: string; query: string }> = [
   {
@@ -30,6 +37,35 @@ const EXAMPLES: Array<{ label: string; query: string }> = [
       quantity
       locationName
       ownerName
+    }
+  }
+}`,
+  },
+  {
+    // The edges in anger: group/category and the location's solar system are
+    // reachable only through `type`/`location`, and each nests exactly one
+    // level, so Download CSV still gives one line per row (type.groupName,
+    // location.systemName, …). Open the docs explorer at /api/graphql to see
+    // what else hangs off them.
+    label: 'Stockpile by group (nested)',
+    query: `{
+  assets(typeName: "Tritanium") {
+    rows {
+      quantity
+      type {
+        name
+        groupName
+        categoryName
+        volume
+      }
+      location {
+        name
+        systemName
+      }
+      owner {
+        name
+        corporationName
+      }
     }
   }
 }`,
@@ -72,6 +108,10 @@ export const QueryEditor = () => {
   const [query, setQuery] = useState(EXAMPLES[0].query)
   const [variables, setVariables] = useState('')
   const [result, setResult] = useState('')
+  // The last result as CSV, or '' when the response holds no single row list
+  // (several root fields at once) — which disables the download rather than
+  // handing over a misleading file.
+  const [csv, setCsv] = useState('')
   const [running, setRunning] = useState(false)
 
   const run = async () => {
@@ -94,11 +134,26 @@ export const QueryEditor = () => {
       })
       const json = await response.json()
       setResult(JSON.stringify(json, null, 2))
+      setCsv(toCsv(csvRows(json?.data)))
     } catch (e) {
       setResult(`Request failed: ${e instanceof Error ? e.message : String(e)}`)
+      setCsv('')
     } finally {
       setRunning(false)
     }
+  }
+
+  // Entity edges nest one level (`owner { name }`), which csvRows joins into
+  // `owner.name` columns — so a query written by clicking through the docs
+  // explorer downloads as a spreadsheet with no rewrite into flat scalars.
+  const downloadCsv = () => {
+    if (csv === '') return
+    const url = URL.createObjectURL(new Blob([csv], { type: 'text/csv;charset=utf-8' }))
+    const link = document.createElement('a')
+    link.href = url
+    link.download = 'edencom-link.csv'
+    link.click()
+    URL.revokeObjectURL(url)
   }
 
   const loadExample = (label: string) => {
@@ -141,6 +196,11 @@ export const QueryEditor = () => {
         <button type="button" onClick={run} disabled={running || query.trim() === ''}>
           {running ? 'Running…' : 'Run query'}
         </button>
+        {result !== '' && (
+          <button type="button" onClick={downloadCsv} disabled={csv === ''}>
+            Download CSV
+          </button>
+        )}
       </div>
       {result !== '' && <pre className={styles.result}>{result}</pre>}
     </div>

--- a/src/app/lens/[id]/csv/route.ts
+++ b/src/app/lens/[id]/csv/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { toCsv } from '@/utils/csv'
 import { resolveLens } from '../../access'
-import { lensRows } from '../../flatten'
+import { csvRows } from '../../flatten'
 import { runLens } from '../../run'
 
 // The Lens CSV rendering (docs/sharing-layer/07-lens.md): the lens's single
@@ -32,7 +32,10 @@ export const GET = async (
     return NextResponse.json({ error: result.errors.join(' — ') }, { status: 500 })
   }
 
-  return new NextResponse(toCsv(lensRows(result.data)), {
+  // csvRows, not lensRows: a lens selecting a nullable edge (location on an
+  // asset ESI gave no location_id for) returns ragged rows, and toCsv reads its
+  // header off the first one.
+  return new NextResponse(toCsv(csvRows(result.data)), {
     headers: { 'content-type': 'text/csv; charset=utf-8' },
   })
 }

--- a/src/app/lens/flatten.ts
+++ b/src/app/lens/flatten.ts
@@ -6,8 +6,13 @@
 // flattened to one level: scalars kept, nested objects dot-pathed, lists of
 // scalars joined — anything deeper is left for toCsv's JSON fallback.
 //
+// Shared with the /graphql editor's "Download CSV" — the same flattening, since
+// a lens IS a stored GraphQL query. The schema's entity edges (owner, type,
+// location) are leaf-only by construction, so one level is always enough; see
+// the SDL header in src/app/api/graphql/schema.graphql.ts.
+//
 // Pure module (ramda only) so `node --test` covers it: test/lensFlatten.test.ts.
-import { chain, toPairs } from 'ramda'
+import { chain, toPairs, uniq } from 'ramda'
 
 type Row = Record<string, unknown>
 
@@ -41,3 +46,31 @@ const flattenEntry = ([key, value]: [string, unknown]): Array<[string, unknown]>
 export const flattenRow = (row: Row): Row => Object.fromEntries(chain(flattenEntry, toPairs(row)))
 
 export const lensRows = (data: unknown): Row[] => primaryRows(data).map(flattenRow)
+
+// lensRows, then squared off so every row carries the SAME columns in the same
+// order — what toCsv needs, since it takes its header from the first row alone
+// and drops whatever isn't there. Two things make the rows ragged, both from
+// nullable entity edges:
+//
+//   - a null edge flattens to nothing, so `location { name }` yields
+//     `location.name` on the rows that have one and no such key on the rest;
+//   - the null rows keep a bare `location` key instead, which has to give way —
+//     a GraphQL field has one type, so a key that expands anywhere is an edge
+//     everywhere, and the bare key is always the null case.
+//
+// Missing cells become null, which toCsv writes as empty.
+export const csvRows = (data: unknown): Row[] => {
+  const rows = primaryRows(data)
+  const expanded = new Set(
+    chain(
+      (row: Row) =>
+        toPairs(row)
+          .filter(([, value]) => isPlainObject(value))
+          .map(([key]) => key),
+      rows
+    )
+  )
+  const flat = rows.map(flattenRow)
+  const columns = uniq(chain(Object.keys, flat)).filter((column) => !expanded.has(column))
+  return flat.map((row) => Object.fromEntries(columns.map((column) => [column, row[column] ?? null])))
+}

--- a/test/graphqlSchema.test.ts
+++ b/test/graphqlSchema.test.ts
@@ -6,9 +6,36 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { buildSchema, type GraphQLObjectType } from 'graphql'
+import {
+  buildSchema,
+  getNamedType,
+  isObjectType,
+  type GraphQLNamedType,
+  type GraphQLObjectType,
+  type GraphQLSchema,
+} from 'graphql'
 
 import { typeDefs } from '../src/app/api/graphql/schema.graphql.ts'
+
+// The three leaf-only entity types the row types point at.
+const ENTITY_TYPES = ['ItemType', 'Location', 'Owner']
+
+// Every type whose values are rows of a result set.
+const ROW_TYPES = [
+  'Asset',
+  'Blueprint',
+  'IndustryJob',
+  'MarketOrder',
+  'ShareGrant',
+  'WalletBalance',
+  'WalletTransaction',
+]
+
+const objectType = (schema: GraphQLSchema, name: string): GraphQLObjectType => {
+  const type: GraphQLNamedType | undefined = schema.getType(name) ?? undefined
+  assert.ok(type && isObjectType(type), `${name} is an object type`)
+  return type
+}
 
 test('the SDL parses and exposes the expected query fields', () => {
   const schema = buildSchema(typeDefs)
@@ -43,6 +70,65 @@ test('ids stay String — EVE item ids overflow GraphQL Int', () => {
   assert.equal(String(asset.getFields().quantity.type), 'String!')
   const order = schema.getType('MarketOrder') as GraphQLObjectType
   assert.equal(String(order.getFields().orderId.type), 'String!')
+})
+
+// The invariant the whole entity-edge design rests on: because the entity types
+// bottom out in scalars, a response is at most row → entity → scalar, so
+// src/app/graphql/flatten.ts can flatten any row to one CSV line by joining one
+// level of keys. Adding an object field to Owner/ItemType/Location silently
+// breaks CSV export (and opens the deep-query surface the flat design avoids) —
+// so it breaks here first.
+test('the entity types are leaf-only, which is what keeps rows CSV-flattenable', () => {
+  const schema = buildSchema(typeDefs)
+  for (const name of ENTITY_TYPES) {
+    for (const field of Object.values(objectType(schema, name).getFields())) {
+      const target = getNamedType(field.type)
+      assert.ok(
+        !isObjectType(target),
+        `${name}.${field.name} points at the object type ${target.name} — entity types must hold scalars only`
+      )
+    }
+  }
+})
+
+test('every row type carries an owner edge, and every object field on one is an entity type', () => {
+  const schema = buildSchema(typeDefs)
+  for (const name of ROW_TYPES) {
+    const fields = objectType(schema, name).getFields()
+    assert.equal(String(fields.owner?.type), 'Owner!', `${name}.owner`)
+    for (const field of Object.values(fields)) {
+      const target = getNamedType(field.type)
+      if (!isObjectType(target)) continue
+      assert.ok(
+        ENTITY_TYPES.includes(target.name),
+        `${name}.${field.name} points at the non-entity type ${target.name}`
+      )
+    }
+  }
+})
+
+// The edges are additive: a caller querying the flat scalars must keep working,
+// and a CSV-shaped query must stay writable without touching a nested selection.
+test('the flat scalar beside each edge survives', () => {
+  const schema = buildSchema(typeDefs)
+  const asset = objectType(schema, 'Asset').getFields()
+  assert.equal(String(asset.ownerName.type), 'String!')
+  assert.equal(String(asset.typeName.type), 'String')
+  assert.equal(String(asset.locationName.type), 'String')
+  const job = objectType(schema, 'IndustryJob').getFields()
+  assert.equal(String(job.blueprintTypeName.type), 'String')
+  assert.equal(String(job.productTypeName.type), 'String')
+})
+
+test('Owner exposes the EVE character id distinctly from the registration id', () => {
+  const schema = buildSchema(typeDefs)
+  const owner = objectType(schema, 'Owner').getFields()
+  // id is the registration uuid (what ownerId carries and `owner:` filters on);
+  // characterId is the EVE numeric id. Conflating them is the legacy wart
+  // docs/registration-id-rename.md exists to unwind — the schema states it.
+  assert.equal(String(owner.id.type), 'String!')
+  assert.equal(String(owner.characterId.type), 'String')
+  assert.ok(owner.id.description?.includes('registration id'))
 })
 
 test('the type-filtered fields all carry typeIds as a String list', () => {

--- a/test/graphqlSchema.test.ts
+++ b/test/graphqlSchema.test.ts
@@ -74,7 +74,7 @@ test('ids stay String — EVE item ids overflow GraphQL Int', () => {
 
 // The invariant the whole entity-edge design rests on: because the entity types
 // bottom out in scalars, a response is at most row → entity → scalar, so
-// src/app/graphql/flatten.ts can flatten any row to one CSV line by joining one
+// src/app/lens/flatten.ts can flatten any row to one CSV line by joining one
 // level of keys. Adding an object field to Owner/ItemType/Location silently
 // breaks CSV export (and opens the deep-query surface the flat design avoids) —
 // so it breaks here first.

--- a/test/lensFlatten.test.ts
+++ b/test/lensFlatten.test.ts
@@ -4,7 +4,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { flattenRow, lensRows, primaryRows } from '../src/app/lens/flatten.ts'
+import { csvRows, flattenRow, lensRows, primaryRows } from '../src/app/lens/flatten.ts'
 
 test('a root list field is the primary list', () => {
   const data = {
@@ -53,4 +53,41 @@ test('lensRows flattens the primary list end to end', () => {
     },
   }
   assert.deepEqual(lensRows(data), [{ typeName: 'Tritanium', quantity: '5', 'owner.name': 'A' }])
+})
+
+// csvRows is lensRows squared off for toCsv, which reads its header from the
+// first row alone. A nullable entity edge is what makes the rows ragged.
+test('csvRows gives every row the same columns when an edge is null on some', () => {
+  const data = {
+    assets: {
+      rows: [
+        { itemId: '1', location: null },
+        { itemId: '2', location: { name: 'Jita IV - Moon 4', systemName: 'Jita' } },
+      ],
+    },
+  }
+  const rows = csvRows(data)
+  // The bare `location` key the null row flattened to gives way to the columns
+  // the other row expanded into — otherwise toCsv's header would be
+  // `itemId,location` and row two's real values would never be written.
+  assert.deepEqual(Object.keys(rows[0]), ['itemId', 'location.name', 'location.systemName'])
+  assert.deepEqual(Object.keys(rows[1]), ['itemId', 'location.name', 'location.systemName'])
+  assert.equal(rows[0]['location.name'], null)
+  assert.equal(rows[1]['location.name'], 'Jita IV - Moon 4')
+})
+
+test('csvRows fills a column absent from an earlier row', () => {
+  const rows = csvRows({ marketOrders: [{ orderId: '1' }, { orderId: '2', escrow: 5 }] })
+  assert.deepEqual(rows, [
+    { orderId: '1', escrow: null },
+    { orderId: '2', escrow: 5 },
+  ])
+})
+
+test('csvRows keeps false rather than nulling it', () => {
+  assert.deepEqual(csvRows({ marketOrders: [{ isBuy: false }] }), [{ isBuy: false }])
+})
+
+test('csvRows yields nothing when there is no single row list', () => {
+  assert.deepEqual(csvRows({ a: [], b: [] }), [])
 })


### PR DESCRIPTION
## The problem

The autocomplete and docs explorer at `GET /api/graphql` (GraphiQL, served by yoga) render whatever introspection returns, and introspection returns the SDL in `src/app/api/graphql/schema.graphql.ts` — a hand-written string, nothing generated. That SDL was deliberately flat, so the explorer could only ever show a wall of scalars: `ownerId: String!` is a dead end even though `Owner` exists, and nothing in the autocomplete hinted that the SDE group, the location's solar system, or the owning corporation were reachable at all.

## The change

Row types now carry entity edges the explorer can click through:

| type | edges |
| --- | --- |
| `Asset`, `Blueprint`, `MarketOrder`, `WalletTransaction` | `owner`, `type`, `location` |
| `IndustryJob` | `owner`, `blueprintType`, `productType`, `location` |
| `ShareGrant` | `owner`, `itemType` |
| `WalletBalance` | `owner` |

They point at three new types. `ItemType` surfaces `groupId`/`groupName`/`categoryId`/`categoryName`/`metaGroupId`/`volume`; `Location` surfaces `systemId`/`systemName`; `Owner` surfaces `characterId` (the EVE id, distinct from the registration uuid `id` carries) plus `corporationId`/`corporationName`/`allianceId`/`allianceName`. None of that was reachable from this API before.

Two invariants keep the edges from costing what nested resolvers usually cost, both pinned by `test/graphqlSchema.test.ts` so a later change breaks the test before it breaks a caller:

1. **The entity types are leaf-only.** `Owner`, `ItemType` and `Location` hold scalars and nothing else, so a response is at most row → entity → scalar. There is still no deep-query surface, and every row flattens to exactly one CSV line.
2. **No edge fans out per row.** `type` and `location` are pure reshapes of data the root resolver already had — it was fetching full SDE type rows and resolved locations, mining one name out of each, and discarding the rest. `Owner`'s corp/alliance block is the one part that reads: it loads lazily (an unselected edge issues no query) and once per result set, memoized in `context.ts` on the scope array each root resolver hands its `Owner`s by reference. `characterId` comes free off the context's registration read for your own characters.

Every entity field is **also** still a flat scalar on the row — `ownerName` beside `owner { name }`, `typeName` beside `type { name }`. Existing queries are untouched, and a CSV-shaped query stays writable without a nested selection.

## Flat output for CSV

Nesting is capped at one level by invariant 1, so `owner { name }` joins to an `owner.name` column mechanically. Rather than a second copy of that logic, this reuses the Lens flattener (`src/app/lens/flatten.ts` — a lens is a stored query of this same shape) and adds the column alignment it was missing:

> `toCsv` takes its header from the first row's keys alone. A nullable edge that came back `null` on row one contributed no `location.*` keys, so those columns were dropped from every later row that did have them — and the bare `location` key the null row left behind took their place in the header.

`csvRows` squares the rows off first (union of columns, bare key gives way to the expanded ones, missing cells `null`). That fixes `/lens/[id]/csv` too, which had the bug latent. The `/graphql` editor gets a **Download CSV** button over the same path, plus a nested example query so the edges are discoverable from the page as well as the explorer.

## Testing

- `pnpm test` — 225 pass. New coverage: the leaf-only invariant, every row type's `owner` edge, object fields on row types pointing only at entity types, the flat scalars surviving, and four `csvRows` cases (ragged rows from a null edge, a column absent from an earlier row, `false` not being nulled, no-single-list).
- `pnpm run lint`, `pnpm run build` — clean.
- Not exercised against live data: the resolvers are I/O against Supabase, so `Owner`'s corp/alliance lookup and the `systemName` resolution are verified by build and by the shape of the helpers they reuse (`resolveLocations` already computed `systemFor`/`systemIdFor` for other callers), not by a test run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bc9JhHSDtPfgfJKbkgywwG)_