### PR TITLE
feat(graphql): filter by a list of characters, by name or id

### DIFF
--- a/src/app/api/graphql/filters.ts
+++ b/src/app/api/graphql/filters.ts
@@ -20,7 +20,7 @@ export const clampLimit = (limit: number | null | undefined, cap: number): numbe
 // listing what's available — same semantics as the MCP resolveOwnerFilter.
 export type OwnerMatch = { ok: true; ids: string[] | null } | { ok: false; message: string }
 
-export const matchOwnerIds = (owner: string | null | undefined, nameById: Map<string, string>): OwnerMatch => {
+export const matchOwnerIds = (owner: string | null | undefined, nameById: ReadonlyMap<string, string>): OwnerMatch => {
   const trimmed = (owner ?? '').trim().toLowerCase()
   if (trimmed === '') return { ok: true, ids: null }
   const ids = [...nameById].filter(([, name]) => name.toLowerCase().includes(trimmed)).map(([id]) => id)
@@ -29,6 +29,82 @@ export const matchOwnerIds = (owner: string | null | undefined, nameById: Map<st
     return { ok: false, message: `No character matched "${owner}". Available: ${available.join(', ')}.` }
   }
   return { ok: true, ids }
+}
+
+// The exact counterpart of the fuzzy `owner` filter: a LIST of characters,
+// each named by whichever id the caller has to hand. An entry is
+//
+//   - all digits          → an EVE character id (Owner.characterId),
+//   - a uuid              → this site's registration id (Owner.id / ownerId),
+//   - anything else       → a character name, matched case-insensitively but
+//                           WHOLE — a list is the exact question, `owner` is
+//                           the fuzzy one, exactly as typeIds is to typeName.
+//
+// Every entry must match, and an unmatched one errors listing what exists,
+// rather than quietly narrowing a lens nobody re-reads for a year. The result
+// is the union, deduped, in the caller's order.
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export type OwnerDirectory = {
+  // registration uuid → character name
+  nameById: ReadonlyMap<string, string>
+  // registration uuid → EVE character id
+  characterIdById: ReadonlyMap<string, string>
+}
+
+const idsForEntry = (entry: string, { nameById, characterIdById }: OwnerDirectory): string[] => {
+  if (/^\d+$/.test(entry)) {
+    return [...characterIdById].filter(([, characterId]) => characterId === entry).map(([id]) => id)
+  }
+  if (UUID.test(entry)) {
+    return nameById.has(entry) ? [entry] : []
+  }
+  const wanted = entry.toLowerCase()
+  return [...nameById].filter(([, name]) => name.toLowerCase() === wanted).map(([id]) => id)
+}
+
+const availableOwners = ({ nameById, characterIdById }: OwnerDirectory): string =>
+  [...nameById]
+    .map(([id, name]) => {
+      const characterId = characterIdById.get(id)
+      return characterId === undefined ? name : `${name} (${characterId})`
+    })
+    .sort((a, b) => a.localeCompare(b))
+    .join(', ')
+
+export const matchOwnerRefs = (owners: readonly string[] | null | undefined, directory: OwnerDirectory): OwnerMatch => {
+  const entries = (owners ?? []).map((o) => (o ?? '').trim()).filter((o) => o !== '')
+  if (entries.length === 0) return { ok: true, ids: null }
+
+  const matched = entries.map((entry) => ({ entry, ids: idsForEntry(entry, directory) }))
+  const unmatched = matched.filter((m) => m.ids.length === 0).map((m) => m.entry)
+  if (unmatched.length > 0) {
+    return {
+      ok: false,
+      message: `No character matched ${unmatched.map((u) => `"${u}"`).join(', ')}. Available: ${availableOwners(directory)}.`,
+    }
+  }
+  return { ok: true, ids: [...new Set(matched.flatMap((m) => m.ids))] }
+}
+
+// The two ways to name characters, resolved to one filter — mutually exclusive
+// for the same reason typeIds and typeName are: `owner` substring-matches and
+// `owners` matches whole names/ids, and a stored lens that blended both would
+// be unpredictable a year later.
+export const matchOwnerFilter = (
+  owner: string | null | undefined,
+  owners: readonly string[] | null | undefined,
+  directory: OwnerDirectory
+): OwnerMatch => {
+  const listed = (owners ?? []).some((o) => (o ?? '').trim() !== '')
+  if (!listed) return matchOwnerIds(owner, directory.nameById)
+  if ((owner ?? '').trim() !== '') {
+    return {
+      ok: false,
+      message: 'Pass owner or owners, not both — one is a name search, the other an exact list.',
+    }
+  }
+  return matchOwnerRefs(owners, directory)
 }
 
 // Parse the `since` argument (full ISO timestamp or a date prefix) into an

--- a/src/app/api/graphql/resolvers.ts
+++ b/src/app/api/graphql/resolvers.ts
@@ -19,7 +19,7 @@ import { uniq } from 'ramda'
 import { guessLocationRef, resolveTypeFilter } from '@/app/api/mcp/lib'
 import { resolveLocations, type LocationRef, type ResolvedLocations } from '@/app/resolveLocations'
 import { getSdeTypes, type SdeType } from '@/sdeTypes'
-import { ASSET_CAP, LIST_CAP, clampLimit, matchOwnerIds, parseIdArg, parseSince, parseTypeIdsArg } from './filters'
+import { ASSET_CAP, LIST_CAP, clampLimit, matchOwnerFilter, parseIdArg, parseSince, parseTypeIdsArg } from './filters'
 import type { GraphqlContext } from './context'
 
 const badRequest = (message: string): never => {
@@ -30,10 +30,17 @@ const queryFailed = (): never => {
   throw new GraphQLError('Query failed', { extensions: { http: { status: 500 } } })
 }
 
-// The registration ids a field should read for, after the optional owner-name
-// filter — always a subset of the caller's own registrations.
-const scopeIds = (ctx: GraphqlContext, owner: string | null | undefined): string[] => {
-  const match = matchOwnerIds(owner, ctx.ownerNameById)
+// The registration ids a field should read for, after the optional owner
+// filter (`owner` fuzzy by name, `owners` an exact list of names/character
+// ids/registration ids) — always a subset of the caller's own registrations.
+const scopeIds = (
+  ctx: GraphqlContext,
+  args: { owner?: string | null; owners?: readonly string[] | null }
+): string[] => {
+  const match = matchOwnerFilter(args.owner, args.owners, {
+    nameById: ctx.ownerNameById,
+    characterIdById: ctx.ownerCharacterIdById,
+  })
   if (!match.ok) return badRequest(match.message)
   return match.ids ?? ctx.registrationIds
 }
@@ -211,6 +218,7 @@ export const resolvers = {
         typeName?: string | null
         locationId?: string | null
         owner?: string | null
+        owners?: readonly string[] | null
         limit?: number | null
         includeShared?: boolean | null
       },
@@ -222,7 +230,7 @@ export const resolvers = {
       // The owner-name filter still narrows only the caller's own characters;
       // shared rows ride along unfiltered.
       if (args.includeShared) requireSession(ctx)
-      const ownerIds = scopeIds(ctx, args.owner)
+      const ownerIds = scopeIds(ctx, args)
       const sharedIds = args.includeShared ? await grantorRegistrationIds(ctx) : []
       const scopedIds = [...ownerIds, ...sharedIds]
       const typeIds = await typeIdsFor(args)
@@ -348,11 +356,12 @@ export const resolvers = {
         typeIds?: readonly string[] | null
         typeName?: string | null
         owner?: string | null
+        owners?: readonly string[] | null
         limit?: number | null
       },
       ctx: GraphqlContext
     ) => {
-      const ownerIds = scopeIds(ctx, args.owner)
+      const ownerIds = scopeIds(ctx, args)
       const typeIds = await typeIdsFor(args)
       const cap = clampLimit(args.limit, LIST_CAP)
 
@@ -418,8 +427,12 @@ export const resolvers = {
       }
     },
 
-    marketOrders: async (_parent: unknown, args: { owner?: string | null }, ctx: GraphqlContext) => {
-      const ownerIds = scopeIds(ctx, args.owner)
+    marketOrders: async (
+      _parent: unknown,
+      args: { owner?: string | null; owners?: readonly string[] | null },
+      ctx: GraphqlContext
+    ) => {
+      const ownerIds = scopeIds(ctx, args)
 
       type OrderRow = {
         order_id: number
@@ -486,10 +499,10 @@ export const resolvers = {
 
     industryJobs: async (
       _parent: unknown,
-      args: { owner?: string | null; includeDelivered?: boolean | null },
+      args: { owner?: string | null; owners?: readonly string[] | null; includeDelivered?: boolean | null },
       ctx: GraphqlContext
     ) => {
-      const ownerIds = scopeIds(ctx, args.owner)
+      const ownerIds = scopeIds(ctx, args)
 
       type JobRow = {
         job_id: number
@@ -594,12 +607,13 @@ export const resolvers = {
         typeIds?: readonly string[] | null
         typeName?: string | null
         owner?: string | null
+        owners?: readonly string[] | null
         since?: string | null
         limit?: number | null
       },
       ctx: GraphqlContext
     ) => {
-      const ownerIds = scopeIds(ctx, args.owner)
+      const ownerIds = scopeIds(ctx, args)
       const typeIds = await typeIdsFor(args)
       const since = parseSince(args.since)
       if (!since.ok) return badRequest(since.message)

--- a/src/app/api/graphql/schema.graphql.ts
+++ b/src/app/api/graphql/schema.graphql.ts
@@ -36,15 +36,18 @@ export const typeDefs = /* GraphQL */ `
     """
     Current asset rows (live inventory) across your characters. typeIds filters
     on exact SDE type ids; typeName is a fuzzy name search — pass one or the
-    other, never both. includeShared additionally returns rows other users have
-    shared with you (session auth only — the api_token path is own-data only; a
-    Lens is the way to hand shared data to external tools).
+    other, never both. Likewise owners is an exact list of characters and owner
+    a name search — pass one or the other. locationId pins one station,
+    structure or system id. includeShared additionally returns rows other users
+    have shared with you (session auth only — the api_token path is own-data
+    only; a Lens is the way to hand shared data to external tools).
     """
     assets(
       typeIds: [String!]
       typeName: String
       locationId: String
       owner: String
+      owners: [String!]
       limit: Int
       includeShared: Boolean = false
     ): AssetPage!
@@ -52,23 +55,24 @@ export const typeDefs = /* GraphQL */ `
     "Asset shares other users have aimed at you (corporation/alliance/public). Session auth only."
     sharedWithMe: [ShareGrant!]!
 
-    "Current blueprint rows (BPOs and BPCs) across your characters. typeIds and typeName are mutually exclusive."
-    blueprints(typeIds: [String!], typeName: String, owner: String, limit: Int): BlueprintPage!
+    "Current blueprint rows (BPOs and BPCs) across your characters. typeIds and typeName are mutually exclusive, as are owners and owner."
+    blueprints(typeIds: [String!], typeName: String, owner: String, owners: [String!], limit: Int): BlueprintPage!
 
     "Open market orders across your characters."
-    marketOrders(owner: String): [MarketOrder!]!
+    marketOrders(owner: String, owners: [String!]): [MarketOrder!]!
 
     "Industry jobs across your characters. Delivered jobs are excluded unless includeDelivered."
-    industryJobs(owner: String, includeDelivered: Boolean = false): [IndustryJob!]!
+    industryJobs(owner: String, owners: [String!], includeDelivered: Boolean = false): [IndustryJob!]!
 
     "Latest known wallet balance per character."
     walletBalances: [WalletBalance!]!
 
-    "Market transaction history across your characters, newest first. typeIds and typeName are mutually exclusive."
+    "Market transaction history across your characters, newest first. typeIds and typeName are mutually exclusive, as are owners and owner."
     walletTransactions(
       typeIds: [String!]
       typeName: String
       owner: String
+      owners: [String!]
       since: String
       limit: Int
     ): [WalletTransaction!]!
@@ -79,16 +83,22 @@ export const typeDefs = /* GraphQL */ `
   listed on its own by the \`owners\` query. Leaf-only, so \`owner { … }\` still
   flattens to one CSV line.
 
-  \`id\` is this site's registration id (the id \`ownerId\` carries and the
-  \`owner:\` filter matches on), NOT the EVE character id — that's
-  \`characterId\`. The corp/alliance fields load only when you select them.
+  \`id\` is this site's registration id (the id \`ownerId\` carries), NOT the EVE
+  character id — that's \`characterId\`. The corp/alliance fields load only when
+  you select them.
+
+  The two owner filters name characters differently. \`owner:\` is a
+  case-insensitive substring of \`name\`. \`owners:\` is an exact list, and each
+  entry may be any of the three ids on this type: a whole \`name\`, an EVE
+  \`characterId\`, or a registration \`id\` — mix them freely. An entry that
+  matches nothing is an error, never a silently narrower result.
   """
   type Owner {
-    "This site's registration id — what ownerId carries and the owner: filter matches. NOT the EVE character id."
+    "This site's registration id — what ownerId carries, and one of the forms the owners: filter accepts. NOT the EVE character id."
     id: String!
-    "The character's name, and what the owner: filter accepts."
+    "The character's name. The owner: filter substring-matches it; the owners: filter matches it whole."
     name: String!
-    "The EVE character id (what zKillboard, ESI and the image server use)."
+    "The EVE character id (what zKillboard, ESI and the image server use), and one of the forms the owners: filter accepts."
     characterId: String
     corporationId: String
     corporationName: String

--- a/test/graphqlFilters.test.ts
+++ b/test/graphqlFilters.test.ts
@@ -10,7 +10,9 @@ import {
   ASSET_CAP,
   LIST_CAP,
   clampLimit,
+  matchOwnerFilter,
   matchOwnerIds,
+  matchOwnerRefs,
   parseIdArg,
   parseSince,
   parseTypeIdsArg,
@@ -53,6 +55,71 @@ test('matchOwnerIds rejects an unknown owner, listing what exists', () => {
   const match = matchOwnerIds('nobody', OWNERS)
   assert.equal(match.ok, false)
   assert.match(!match.ok ? match.message : '', /Philihp Alt, Philihp Busby, Someone Else/)
+})
+
+// The list filter resolves against both maps the context carries: registration
+// uuid → name, and registration uuid → EVE character id.
+const REG_A = '11111111-1111-4111-8111-111111111111'
+const REG_B = '22222222-2222-4222-8222-222222222222'
+const REG_C = '33333333-3333-4333-8333-333333333333'
+
+const DIRECTORY = {
+  nameById: new Map([
+    [REG_A, 'Philihp Busby'],
+    [REG_B, 'Philihp Alt'],
+    [REG_C, 'Someone Else'],
+  ]),
+  characterIdById: new Map([
+    [REG_A, '95465499'],
+    [REG_B, '90000001'],
+    [REG_C, '90000002'],
+  ]),
+}
+
+test('matchOwnerRefs passes an absent or empty list through as no filter', () => {
+  assert.deepEqual(matchOwnerRefs(undefined, DIRECTORY), { ok: true, ids: null })
+  assert.deepEqual(matchOwnerRefs([], DIRECTORY), { ok: true, ids: null })
+  assert.deepEqual(matchOwnerRefs(['  '], DIRECTORY), { ok: true, ids: null })
+})
+
+test('matchOwnerRefs takes whole names, EVE character ids and registration ids, mixed', () => {
+  const byName = matchOwnerRefs(['philihp busby', 'Someone Else'], DIRECTORY)
+  assert.deepEqual(byName.ok && byName.ids, [REG_A, REG_C])
+  const byCharacterId = matchOwnerRefs(['95465499'], DIRECTORY)
+  assert.deepEqual(byCharacterId.ok && byCharacterId.ids, [REG_A])
+  const mixed = matchOwnerRefs([REG_B, '95465499', 'Someone Else'], DIRECTORY)
+  assert.deepEqual(mixed.ok && mixed.ids, [REG_B, REG_A, REG_C])
+})
+
+test('matchOwnerRefs dedupes a character named twice', () => {
+  const match = matchOwnerRefs(['Philihp Busby', '95465499', REG_A], DIRECTORY)
+  assert.deepEqual(match.ok && match.ids, [REG_A])
+})
+
+test('matchOwnerRefs matches names whole, not by substring — that is what owner: is for', () => {
+  const partial = matchOwnerRefs(['philihp'], DIRECTORY)
+  assert.equal(partial.ok, false)
+  assert.match(!partial.ok ? partial.message : '', /"philihp"/)
+})
+
+test('matchOwnerRefs rejects unknown entries, listing names with their character ids', () => {
+  const match = matchOwnerRefs(['Someone Else', 'Nobody', '12345'], DIRECTORY)
+  assert.equal(match.ok, false)
+  const message = !match.ok ? match.message : ''
+  assert.match(message, /"Nobody", "12345"/)
+  assert.match(message, /Philihp Busby \(95465499\)/)
+})
+
+test('matchOwnerFilter routes to the fuzzy or the exact matcher, never both', () => {
+  const none = matchOwnerFilter(null, null, DIRECTORY)
+  assert.deepEqual(none, { ok: true, ids: null })
+  const fuzzy = matchOwnerFilter('philihp', null, DIRECTORY)
+  assert.deepEqual(fuzzy.ok && fuzzy.ids, [REG_A, REG_B])
+  const exact = matchOwnerFilter(null, ['Philihp Alt'], DIRECTORY)
+  assert.deepEqual(exact.ok && exact.ids, [REG_B])
+  const both = matchOwnerFilter('philihp', ['Philihp Alt'], DIRECTORY)
+  assert.equal(both.ok, false)
+  assert.match(!both.ok ? both.message : '', /not both/)
 })
 
 test('parseSince accepts ISO timestamps and date prefixes, rejects junk', () => {

--- a/test/graphqlSchema.test.ts
+++ b/test/graphqlSchema.test.ts
@@ -131,6 +131,18 @@ test('Owner exposes the EVE character id distinctly from the registration id', (
   assert.ok(owner.id.description?.includes('registration id'))
 })
 
+test('every owner-filtered field carries both the fuzzy owner and the exact owners list', () => {
+  const schema = buildSchema(typeDefs)
+  const fields = (schema.getQueryType() as GraphQLObjectType).getFields()
+  for (const name of ['assets', 'blueprints', 'industryJobs', 'marketOrders', 'walletTransactions']) {
+    const args = new Map(fields[name].args.map((a) => [a.name, String(a.type)]))
+    assert.equal(args.get('owner'), 'String', `${name}.owner`)
+    // A list of characters — names, EVE character ids or registration ids —
+    // and String for the same reason typeIds is: EVE ids overflow Int.
+    assert.equal(args.get('owners'), '[String!]', `${name}.owners`)
+  }
+})
+
 test('the type-filtered fields all carry typeIds as a String list', () => {
   const schema = buildSchema(typeDefs)
   const fields = (schema.getQueryType() as GraphQLObjectType).getFields()


### PR DESCRIPTION
A lens narrows its stored query with whatever arguments the GraphQL schema offers — `typeIds:`/`typeName:` for items, `locationId:` for a place. Characters were the weak one: `owner:` took a single case-insensitive **substring** of a character name, so "just these three alts" wasn't expressible, and an EVE character id wasn't accepted at all.

## What changed

`owners: [String!]` beside `owner:` on every owner-filtered field — `assets`, `blueprints`, `industryJobs`, `marketOrders`, `walletTransactions`. Each entry is matched **whole** against whichever id the caller has to hand, and the forms may be mixed in one list:

| entry | matched against |
| --- | --- |
| all digits | the EVE character id (`Owner.characterId`) |
| a uuid | this site's registration id (`Owner.id`, what `ownerId` carries) |
| anything else | the character name, case-insensitively, whole |

The result is the deduped union, so a lens reads:

```graphql
{
  assets(typeIds: ["4051", "4246"], locationId: "60003760", owners: ["Philihp Busby", "95465499"]) {
    rows { typeName quantity locationName ownerName }
  }
}
```

`owner` and `owners` are **mutually exclusive**, for the same reason `typeIds` and `typeName` are: one asks a fuzzy question and the other an exact one, and a stored lens that blended both is one nobody can predict a year later. An entry matching nothing is an error listing the caller's characters with their character ids, rather than a silently narrower result.

Nothing about scoping changes: `owners` can only ever narrow within the caller's own registrations, and the resolvers' leak-guard `.in('registration_id', …)` is unchanged.

## Files

- `src/app/api/graphql/filters.ts` — `matchOwnerRefs` (the exact list) and `matchOwnerFilter` (routes to it or to the existing fuzzy `matchOwnerIds`, rejecting both)
- `src/app/api/graphql/schema.graphql.ts` — the new argument plus doc strings on `Owner` spelling out which of its three ids each filter accepts
- `src/app/api/graphql/resolvers.ts` — `scopeIds` now takes the args object and reads both filters off it

## Testing

- `pnpm test` — 232 pass, including new coverage for mixed-form lists, dedupe, whole-name-not-substring matching, the unmatched-entry error, and a schema drift guard asserting every owner-filtered field carries both arguments
- `pnpm run build` (typecheck), `pnpm run lint`, prettier clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4zEGSjPDXFbeLinb36Mmj)_