### PR TITLE
refactor(graphql)!: one singular/plural filter pair per entity type

### DIFF
--- a/docs/sharing-layer/07-lens.md
+++ b/docs/sharing-layer/07-lens.md
@@ -61,7 +61,7 @@ members can _discover_ lenses aimed at them. Public = empty lists + null
 secret, same as everywhere.
 
 `variables` are **fixed by the creator** at save time. Viewers cannot supply
-variables in v1 — a variable substituted into `assets(typeName: $x)` doesn't
+variables in v1 — a variable substituted into `assets(type: $x)` doesn't
 widen access (still the creator's rows), but fixed variables keep the output
 exactly what the creator reviewed. Loosen later if wanted, deliberately.
 

--- a/src/app/api/graphql/filters.ts
+++ b/src/app/api/graphql/filters.ts
@@ -130,15 +130,17 @@ export const parseSince = (since: string | null | undefined): SinceParse => {
   return { ok: true, iso: parsed.toISOString() }
 }
 
-// A numeric id argument (GraphQL String, since EVE ids overflow Int). Rejects
-// anything that isn't a plain positive integer literal.
-export type IdParse = { ok: true; id: string | null } | { ok: false; message: string }
+// A list of numeric id arguments (GraphQL String, since EVE ids overflow Int),
+// deduped, or `null` for no filter. Rejects anything that isn't a plain
+// positive integer literal rather than widening the filter to everything.
+export type IdsParse = { ok: true; ids: string[] | null } | { ok: false; message: string }
 
-export const parseIdArg = (raw: string | null | undefined, label: string): IdParse => {
-  const trimmed = (raw ?? '').trim()
-  if (trimmed === '') return { ok: true, id: null }
-  if (!/^\d+$/.test(trimmed)) return { ok: false, message: `${label} must be a numeric id, got "${raw}".` }
-  return { ok: true, id: trimmed }
+export const parseIdsArg = (raw: readonly string[] | null | undefined, label: string): IdsParse => {
+  const ids = (raw ?? []).map((id) => (id ?? '').trim()).filter((id) => id !== '')
+  if (ids.length === 0) return { ok: true, ids: null }
+  const bad = ids.find((id) => !/^\d+$/.test(id))
+  if (bad !== undefined) return { ok: false, message: `${label} must be numeric ids, got "${bad}".` }
+  return { ok: true, ids: [...new Set(ids)] }
 }
 
 // The two ways to name item types, resolved to one filter. They are mutually

--- a/src/app/api/graphql/filters.ts
+++ b/src/app/api/graphql/filters.ts
@@ -15,6 +15,77 @@ export const clampLimit = (limit: number | null | undefined, cap: number): numbe
   return Math.min(Math.max(1, Math.floor(limit)), cap)
 }
 
+// EVERY FILTER DIMENSION IS NAMED THE SAME TWO WAYS — character, location and
+// item type all take a singular and a plural argument:
+//
+//   - the SINGULAR (`character:`, `location:`, `type:`) is a case-insensitive
+//     substring SEARCH over names. It may match several things; that's the
+//     point — it's how you ask a fuzzy question.
+//   - the PLURAL (`characters:`, `locations:`, `types:`) is an EXACT list whose
+//     entries are ids or whole names, freely mixed. Every entry must match
+//     something, and one that doesn't is an error rather than a silently
+//     narrower result.
+//
+// The two are mutually exclusive: one asks a fuzzy question and the other an
+// exact one, and a stored lens that blended them is one nobody can predict a
+// year later. Resolving the names is per-dimension (the caller's characters,
+// the SDE, the structure caches) and lives with the resolvers; the shaping and
+// the refusals are here, where they stay pure and testable.
+export type RefQuery = { kind: 'none' } | { kind: 'search'; term: string } | { kind: 'exact'; entries: string[] }
+
+export type RefParse = { ok: true; query: RefQuery } | { ok: false; message: string }
+
+export const parseRefFilter = (
+  single: string | null | undefined,
+  list: readonly string[] | null | undefined,
+  label: string
+): RefParse => {
+  const term = (single ?? '').trim()
+  const entries = (list ?? []).map((e) => (e ?? '').trim()).filter((e) => e !== '')
+  if (entries.length === 0) {
+    return { ok: true, query: term === '' ? { kind: 'none' } : { kind: 'search', term } }
+  }
+  if (term !== '') {
+    return {
+      ok: false,
+      message: `Pass ${label} or ${label}s, not both — one is a name search, the other an exact list.`,
+    }
+  }
+  return { ok: true, query: { kind: 'exact', entries: [...new Set(entries)] } }
+}
+
+// An exact-list entry is an id when it's a bare positive integer, and a name
+// otherwise. (A character may also be named by its registration uuid — see
+// matchCharacterRefs, the one dimension with three id forms.)
+export const splitRefEntries = (entries: readonly string[]): { ids: string[]; names: string[] } => ({
+  ids: entries.filter((e) => /^\d+$/.test(e)),
+  names: entries.filter((e) => !/^\d+$/.test(e)),
+})
+
+// Whole-name (case-insensitive) matching of exact-list entries against
+// whatever the dimension's resolver turned up, keeping every candidate that
+// matches — two things really can share a name.
+export type NamedRef = { id: string; name: string }
+
+export const matchExactNames = (
+  names: readonly string[],
+  candidatesFor: (name: string) => readonly NamedRef[]
+): { ids: string[]; unmatched: string[] } => {
+  const matched = names.map((name) => {
+    const wanted = name.toLowerCase()
+    return {
+      name,
+      ids: candidatesFor(name)
+        .filter((c) => c.name.toLowerCase() === wanted)
+        .map((c) => c.id),
+    }
+  })
+  return {
+    ids: [...new Set(matched.flatMap((m) => m.ids))],
+    unmatched: matched.filter((m) => m.ids.length === 0).map((m) => m.name),
+  }
+}
+
 // Case-insensitive substring match of the `character:` filter against the
 // caller's characters. Returns the matching registration ids, or an error
 // listing what's available — same semantics as the MCP resolveOwnerFilter.
@@ -93,24 +164,19 @@ export const matchCharacterRefs = (
   return { ok: true, ids: [...new Set(matched.flatMap((m) => m.ids))] }
 }
 
-// The two ways to name characters, resolved to one filter — mutually exclusive
-// for the same reason typeIds and typeName are: `character` substring-matches
-// and `characters` matches whole names/ids, and a stored lens that blended both
-// would be unpredictable a year later.
+// The character dimension of the two-argument shape above: the singular
+// substring-searches the caller's character names, the plural matches whole
+// names / EVE character ids / registration ids.
 export const matchCharacterFilter = (
   character: string | null | undefined,
   characters: readonly string[] | null | undefined,
   directory: CharacterDirectory
 ): CharacterMatch => {
-  const listed = (characters ?? []).some((c) => (c ?? '').trim() !== '')
-  if (!listed) return matchCharacterName(character, directory.nameById)
-  if ((character ?? '').trim() !== '') {
-    return {
-      ok: false,
-      message: 'Pass character or characters, not both — one is a name search, the other an exact list.',
-    }
-  }
-  return matchCharacterRefs(characters, directory)
+  const parsed = parseRefFilter(character, characters, 'character')
+  if (!parsed.ok) return { ok: false, message: parsed.message }
+  if (parsed.query.kind === 'none') return { ok: true, ids: null }
+  if (parsed.query.kind === 'search') return matchCharacterName(parsed.query.term, directory.nameById)
+  return matchCharacterRefs(parsed.query.entries, directory)
 }
 
 // Parse the `since` argument (full ISO timestamp or a date prefix) into an
@@ -128,40 +194,4 @@ export const parseSince = (since: string | null | undefined): SinceParse => {
     }
   }
   return { ok: true, iso: parsed.toISOString() }
-}
-
-// A list of numeric id arguments (GraphQL String, since EVE ids overflow Int),
-// deduped, or `null` for no filter. Rejects anything that isn't a plain
-// positive integer literal rather than widening the filter to everything.
-export type IdsParse = { ok: true; ids: string[] | null } | { ok: false; message: string }
-
-export const parseIdsArg = (raw: readonly string[] | null | undefined, label: string): IdsParse => {
-  const ids = (raw ?? []).map((id) => (id ?? '').trim()).filter((id) => id !== '')
-  if (ids.length === 0) return { ok: true, ids: null }
-  const bad = ids.find((id) => !/^\d+$/.test(id))
-  if (bad !== undefined) return { ok: false, message: `${label} must be numeric ids, got "${bad}".` }
-  return { ok: true, ids: [...new Set(ids)] }
-}
-
-// The two ways to name item types, resolved to one filter. They are mutually
-// EXCLUSIVE rather than unioned: typeIds asks an exact question and typeName a
-// fuzzy one (it substring-matches the SDE, so "Fuel Block" also catches the
-// blueprints), and a lens whose stored query silently blends both is a lens
-// nobody can predict a year later. Returns the exact ids when given, `null`
-// for "no id filter" (the caller then applies its fuzzy typeName path), and an
-// error when both or a malformed id arrive.
-export type TypeIdsParse = { ok: true; ids: number[] | null } | { ok: false; message: string }
-
-export const parseTypeIdsArg = (
-  typeIds: readonly string[] | null | undefined,
-  typeName: string | null | undefined
-): TypeIdsParse => {
-  const ids = (typeIds ?? []).map((id) => (id ?? '').trim()).filter((id) => id !== '')
-  if (ids.length === 0) return { ok: true, ids: null }
-  if ((typeName ?? '').trim() !== '') {
-    return { ok: false, message: 'Pass typeIds or typeName, not both — one is exact, the other is a name search.' }
-  }
-  const bad = ids.find((id) => !/^\d+$/.test(id))
-  if (bad !== undefined) return { ok: false, message: `typeIds must be numeric ids, got "${bad}".` }
-  return { ok: true, ids: [...new Set(ids.map(Number))] }
 }

--- a/src/app/api/graphql/filters.ts
+++ b/src/app/api/graphql/filters.ts
@@ -15,44 +15,47 @@ export const clampLimit = (limit: number | null | undefined, cap: number): numbe
   return Math.min(Math.max(1, Math.floor(limit)), cap)
 }
 
-// Case-insensitive substring match of an owner-name filter against the
+// Case-insensitive substring match of the `character:` filter against the
 // caller's characters. Returns the matching registration ids, or an error
 // listing what's available — same semantics as the MCP resolveOwnerFilter.
-export type OwnerMatch = { ok: true; ids: string[] | null } | { ok: false; message: string }
+export type CharacterMatch = { ok: true; ids: string[] | null } | { ok: false; message: string }
 
-export const matchOwnerIds = (owner: string | null | undefined, nameById: ReadonlyMap<string, string>): OwnerMatch => {
-  const trimmed = (owner ?? '').trim().toLowerCase()
+export const matchCharacterName = (
+  character: string | null | undefined,
+  nameById: ReadonlyMap<string, string>
+): CharacterMatch => {
+  const trimmed = (character ?? '').trim().toLowerCase()
   if (trimmed === '') return { ok: true, ids: null }
   const ids = [...nameById].filter(([, name]) => name.toLowerCase().includes(trimmed)).map(([id]) => id)
   if (ids.length === 0) {
     const available = [...nameById.values()].sort((a, b) => a.localeCompare(b))
-    return { ok: false, message: `No character matched "${owner}". Available: ${available.join(', ')}.` }
+    return { ok: false, message: `No character matched "${character}". Available: ${available.join(', ')}.` }
   }
   return { ok: true, ids }
 }
 
-// The exact counterpart of the fuzzy `owner` filter: a LIST of characters,
-// each named by whichever id the caller has to hand. An entry is
+// The exact counterpart of the fuzzy `character:` filter: a LIST of
+// characters, each named by whichever id the caller has to hand. An entry is
 //
 //   - all digits          → an EVE character id (Owner.characterId),
 //   - a uuid              → this site's registration id (Owner.id / ownerId),
 //   - anything else       → a character name, matched case-insensitively but
-//                           WHOLE — a list is the exact question, `owner` is
-//                           the fuzzy one, exactly as typeIds is to typeName.
+//                           WHOLE — a list is the exact question, `character`
+//                           is the fuzzy one, as typeIds is to typeName.
 //
 // Every entry must match, and an unmatched one errors listing what exists,
 // rather than quietly narrowing a lens nobody re-reads for a year. The result
 // is the union, deduped, in the caller's order.
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
-export type OwnerDirectory = {
+export type CharacterDirectory = {
   // registration uuid → character name
   nameById: ReadonlyMap<string, string>
   // registration uuid → EVE character id
   characterIdById: ReadonlyMap<string, string>
 }
 
-const idsForEntry = (entry: string, { nameById, characterIdById }: OwnerDirectory): string[] => {
+const idsForEntry = (entry: string, { nameById, characterIdById }: CharacterDirectory): string[] => {
   if (/^\d+$/.test(entry)) {
     return [...characterIdById].filter(([, characterId]) => characterId === entry).map(([id]) => id)
   }
@@ -63,7 +66,7 @@ const idsForEntry = (entry: string, { nameById, characterIdById }: OwnerDirector
   return [...nameById].filter(([, name]) => name.toLowerCase() === wanted).map(([id]) => id)
 }
 
-const availableOwners = ({ nameById, characterIdById }: OwnerDirectory): string =>
+const availableCharacters = ({ nameById, characterIdById }: CharacterDirectory): string =>
   [...nameById]
     .map(([id, name]) => {
       const characterId = characterIdById.get(id)
@@ -72,8 +75,11 @@ const availableOwners = ({ nameById, characterIdById }: OwnerDirectory): string 
     .sort((a, b) => a.localeCompare(b))
     .join(', ')
 
-export const matchOwnerRefs = (owners: readonly string[] | null | undefined, directory: OwnerDirectory): OwnerMatch => {
-  const entries = (owners ?? []).map((o) => (o ?? '').trim()).filter((o) => o !== '')
+export const matchCharacterRefs = (
+  characters: readonly string[] | null | undefined,
+  directory: CharacterDirectory
+): CharacterMatch => {
+  const entries = (characters ?? []).map((c) => (c ?? '').trim()).filter((c) => c !== '')
   if (entries.length === 0) return { ok: true, ids: null }
 
   const matched = entries.map((entry) => ({ entry, ids: idsForEntry(entry, directory) }))
@@ -81,30 +87,30 @@ export const matchOwnerRefs = (owners: readonly string[] | null | undefined, dir
   if (unmatched.length > 0) {
     return {
       ok: false,
-      message: `No character matched ${unmatched.map((u) => `"${u}"`).join(', ')}. Available: ${availableOwners(directory)}.`,
+      message: `No character matched ${unmatched.map((u) => `"${u}"`).join(', ')}. Available: ${availableCharacters(directory)}.`,
     }
   }
   return { ok: true, ids: [...new Set(matched.flatMap((m) => m.ids))] }
 }
 
 // The two ways to name characters, resolved to one filter — mutually exclusive
-// for the same reason typeIds and typeName are: `owner` substring-matches and
-// `owners` matches whole names/ids, and a stored lens that blended both would
-// be unpredictable a year later.
-export const matchOwnerFilter = (
-  owner: string | null | undefined,
-  owners: readonly string[] | null | undefined,
-  directory: OwnerDirectory
-): OwnerMatch => {
-  const listed = (owners ?? []).some((o) => (o ?? '').trim() !== '')
-  if (!listed) return matchOwnerIds(owner, directory.nameById)
-  if ((owner ?? '').trim() !== '') {
+// for the same reason typeIds and typeName are: `character` substring-matches
+// and `characters` matches whole names/ids, and a stored lens that blended both
+// would be unpredictable a year later.
+export const matchCharacterFilter = (
+  character: string | null | undefined,
+  characters: readonly string[] | null | undefined,
+  directory: CharacterDirectory
+): CharacterMatch => {
+  const listed = (characters ?? []).some((c) => (c ?? '').trim() !== '')
+  if (!listed) return matchCharacterName(character, directory.nameById)
+  if ((character ?? '').trim() !== '') {
     return {
       ok: false,
-      message: 'Pass owner or owners, not both — one is a name search, the other an exact list.',
+      message: 'Pass character or characters, not both — one is a name search, the other an exact list.',
     }
   }
-  return matchOwnerRefs(owners, directory)
+  return matchCharacterRefs(characters, directory)
 }
 
 // Parse the `since` argument (full ISO timestamp or a date prefix) into an

--- a/src/app/api/graphql/locationSearch.ts
+++ b/src/app/api/graphql/locationSearch.ts
@@ -1,0 +1,57 @@
+// Name → location id for the `location:`/`locations:` filters. The rest of the
+// schema only ever walks the other way (an id off an asset row, resolved to a
+// display name by resolveLocations), so this is the one place that searches.
+//
+// It searches the same three places a location name can come from, in the same
+// precedence resolveLocations reads them: our own corp's structures, the
+// ESI-resolved structure cache, NPC stations from the SDE mirror, and solar
+// systems from the SDE mirror.
+//
+// SEARCHING IS NOT READING. The structure caches aren't scoped to the caller
+// here (in token mode the client is service-role, where RLS can't scope them),
+// and that's deliberate: this resolves a name to an ID, which the caller then
+// filters their OWN rows by — the resolvers' .in('registration_id', …) leak
+// guard is untouched, and a foreign structure's id simply matches nothing.
+// Candidate names are never echoed back; an error repeats only what was typed.
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import { searchSdeSystems } from '@/sdeSystems'
+import { escapeLike } from '@/utils/escapeLike'
+import { sdeSupabase } from '@/utils/supabase/sde'
+import type { NamedRef } from './filters'
+
+// Per source. A term matching more than this many places is a term worth
+// narrowing, and the cap keeps one filter from becoming an unbounded `in`.
+const PER_SOURCE = 200
+
+type StructureRow = { structure_id: number | string; name: string | null }
+type StationRow = { station_id: number | string; name: string | null }
+
+const named = (rows: Array<{ id: number | string; name: string | null }>): NamedRef[] =>
+  rows.filter((r) => r.name != null).map((r) => ({ id: String(r.id), name: r.name as string }))
+
+export const searchLocationCandidates = async (term: string, supabase: SupabaseClient): Promise<NamedRef[]> => {
+  const trimmed = term.trim()
+  if (trimmed === '') return []
+  const pattern = `%${escapeLike(trimmed)}%`
+
+  const [corpStructures, cachedStructures, stations, systems] = await Promise.all([
+    supabase.from('corp_structure').select('structure_id, name').ilike('name', pattern).limit(PER_SOURCE),
+    supabase.from('universe_structure').select('structure_id, name').ilike('name', pattern).limit(PER_SOURCE),
+    sdeSupabase().from('sde_station').select('station_id, name').ilike('name', pattern).limit(PER_SOURCE),
+    searchSdeSystems(trimmed, PER_SOURCE),
+  ])
+
+  const candidates = [
+    ...named(((corpStructures.data ?? []) as StructureRow[]).map((r) => ({ id: r.structure_id, name: r.name }))),
+    ...named(((cachedStructures.data ?? []) as StructureRow[]).map((r) => ({ id: r.structure_id, name: r.name }))),
+    ...named(((stations.data ?? []) as StationRow[]).map((r) => ({ id: r.station_id, name: r.name }))),
+    ...systems.map((s): NamedRef => ({ id: String(s.systemID), name: s.name })),
+  ]
+
+  // One id can turn up twice (a structure in both caches). Map keeps the LAST
+  // entry for a key, so reversing first lets corp_structure's name win — the
+  // precedence resolveLocations applies when it renders the same location.
+  const byId = new Map(candidates.map((c): [string, NamedRef] => [c.id, c]).reverse())
+  return [...byId.values()]
+}

--- a/src/app/api/graphql/resolvers.ts
+++ b/src/app/api/graphql/resolvers.ts
@@ -19,7 +19,15 @@ import { uniq } from 'ramda'
 import { guessLocationRef, resolveTypeFilter } from '@/app/api/mcp/lib'
 import { resolveLocations, type LocationRef, type ResolvedLocations } from '@/app/resolveLocations'
 import { getSdeTypes, type SdeType } from '@/sdeTypes'
-import { ASSET_CAP, LIST_CAP, clampLimit, matchOwnerFilter, parseIdArg, parseSince, parseTypeIdsArg } from './filters'
+import {
+  ASSET_CAP,
+  LIST_CAP,
+  clampLimit,
+  matchCharacterFilter,
+  parseIdArg,
+  parseSince,
+  parseTypeIdsArg,
+} from './filters'
 import type { GraphqlContext } from './context'
 
 const badRequest = (message: string): never => {
@@ -30,14 +38,15 @@ const queryFailed = (): never => {
   throw new GraphQLError('Query failed', { extensions: { http: { status: 500 } } })
 }
 
-// The registration ids a field should read for, after the optional owner
-// filter (`owner` fuzzy by name, `owners` an exact list of names/character
-// ids/registration ids) — always a subset of the caller's own registrations.
+// The registration ids a field should read for, after the optional character
+// filter (`character` fuzzy by name, `characters` an exact list of
+// names/character ids/registration ids) — always a subset of the caller's own
+// registrations.
 const scopeIds = (
   ctx: GraphqlContext,
-  args: { owner?: string | null; owners?: readonly string[] | null }
+  args: { character?: string | null; characters?: readonly string[] | null }
 ): string[] => {
-  const match = matchOwnerFilter(args.owner, args.owners, {
+  const match = matchCharacterFilter(args.character, args.characters, {
     nameById: ctx.ownerNameById,
     characterIdById: ctx.ownerCharacterIdById,
   })
@@ -217,8 +226,8 @@ export const resolvers = {
         typeIds?: readonly string[] | null
         typeName?: string | null
         locationId?: string | null
-        owner?: string | null
-        owners?: readonly string[] | null
+        character?: string | null
+        characters?: readonly string[] | null
         limit?: number | null
         includeShared?: boolean | null
       },
@@ -227,7 +236,7 @@ export const resolvers = {
       // includeShared widens the leak-guard filter to own ∪ grantor
       // registrations and lets RLS decide which grantor rows come back — the
       // DB is the authority; the widened .in() is just no longer the barrier.
-      // The owner-name filter still narrows only the caller's own characters;
+      // The character filter still narrows only the caller's own characters;
       // shared rows ride along unfiltered.
       if (args.includeShared) requireSession(ctx)
       const ownerIds = scopeIds(ctx, args)
@@ -355,8 +364,8 @@ export const resolvers = {
       args: {
         typeIds?: readonly string[] | null
         typeName?: string | null
-        owner?: string | null
-        owners?: readonly string[] | null
+        character?: string | null
+        characters?: readonly string[] | null
         limit?: number | null
       },
       ctx: GraphqlContext
@@ -429,7 +438,7 @@ export const resolvers = {
 
     marketOrders: async (
       _parent: unknown,
-      args: { owner?: string | null; owners?: readonly string[] | null },
+      args: { character?: string | null; characters?: readonly string[] | null },
       ctx: GraphqlContext
     ) => {
       const ownerIds = scopeIds(ctx, args)
@@ -499,7 +508,7 @@ export const resolvers = {
 
     industryJobs: async (
       _parent: unknown,
-      args: { owner?: string | null; owners?: readonly string[] | null; includeDelivered?: boolean | null },
+      args: { character?: string | null; characters?: readonly string[] | null; includeDelivered?: boolean | null },
       ctx: GraphqlContext
     ) => {
       const ownerIds = scopeIds(ctx, args)
@@ -606,8 +615,8 @@ export const resolvers = {
       args: {
         typeIds?: readonly string[] | null
         typeName?: string | null
-        owner?: string | null
-        owners?: readonly string[] | null
+        character?: string | null
+        characters?: readonly string[] | null
         since?: string | null
         limit?: number | null
       },

--- a/src/app/api/graphql/resolvers.ts
+++ b/src/app/api/graphql/resolvers.ts
@@ -24,7 +24,7 @@ import {
   LIST_CAP,
   clampLimit,
   matchCharacterFilter,
-  parseIdArg,
+  parseIdsArg,
   parseSince,
   parseTypeIdsArg,
 } from './filters'
@@ -225,7 +225,7 @@ export const resolvers = {
       args: {
         typeIds?: readonly string[] | null
         typeName?: string | null
-        locationId?: string | null
+        locationIds?: readonly string[] | null
         character?: string | null
         characters?: readonly string[] | null
         limit?: number | null
@@ -243,8 +243,8 @@ export const resolvers = {
       const sharedIds = args.includeShared ? await grantorRegistrationIds(ctx) : []
       const scopedIds = [...ownerIds, ...sharedIds]
       const typeIds = await typeIdsFor(args)
-      const location = parseIdArg(args.locationId, 'locationId')
-      if (!location.ok) return badRequest(location.message)
+      const locationIds = parseIdsArg(args.locationIds, 'locationIds')
+      if (!locationIds.ok) return badRequest(locationIds.message)
       const cap = clampLimit(args.limit, ASSET_CAP)
 
       // The same filter set applies to the head-only count and the row pages.
@@ -252,7 +252,7 @@ export const resolvers = {
       const filtered = (query: any): any => {
         let q = query.in('registration_id', scopedIds)
         if (typeIds !== null) q = q.in('type_id', typeIds)
-        if (location.id !== null) q = q.eq('location_id', location.id)
+        if (locationIds.ids !== null) q = q.in('location_id', locationIds.ids)
         return q
       }
 

--- a/src/app/api/graphql/resolvers.ts
+++ b/src/app/api/graphql/resolvers.ts
@@ -18,16 +18,18 @@ import { uniq } from 'ramda'
 
 import { guessLocationRef, resolveTypeFilter } from '@/app/api/mcp/lib'
 import { resolveLocations, type LocationRef, type ResolvedLocations } from '@/app/resolveLocations'
-import { getSdeTypes, type SdeType } from '@/sdeTypes'
+import { getSdeTypes, searchSdeTypesAll, type SdeType } from '@/sdeTypes'
 import {
   ASSET_CAP,
   LIST_CAP,
   clampLimit,
   matchCharacterFilter,
-  parseIdsArg,
+  matchExactNames,
+  parseRefFilter,
   parseSince,
-  parseTypeIdsArg,
+  splitRefEntries,
 } from './filters'
+import { searchLocationCandidates } from './locationSearch'
 import type { GraphqlContext } from './context'
 
 const badRequest = (message: string): never => {
@@ -54,19 +56,65 @@ const scopeIds = (
   return match.ids ?? ctx.registrationIds
 }
 
-// The item-type filter → SDE type ids, or null for no filter. Exact `typeIds`
-// win outright; otherwise the fuzzy name search runs, with the MCP layer's
-// "too many matches" guard. parseTypeIdsArg rejects passing both.
+// The item-type dimension → SDE type ids, or null for no filter. `type` runs
+// the fuzzy SDE search (with the MCP layer's "too many matches" guard);
+// `types` takes exact type ids and whole type names, mixed. parseRefFilter
+// rejects passing both.
 const typeIdsFor = async (args: {
-  typeIds?: readonly string[] | null
-  typeName?: string | null
+  type?: string | null
+  types?: readonly string[] | null
 }): Promise<number[] | null> => {
-  const exact = parseTypeIdsArg(args.typeIds, args.typeName)
-  if (!exact.ok) return badRequest(exact.message)
-  if (exact.ids !== null) return exact.ids
-  const filter = await resolveTypeFilter(args.typeName ?? undefined)
-  if (!filter.ok) return badRequest(filter.message)
-  return filter.matches === null ? null : filter.matches.map((m) => m.typeID)
+  const parsed = parseRefFilter(args.type, args.types, 'type')
+  if (!parsed.ok) return badRequest(parsed.message)
+  const query = parsed.query
+  if (query.kind === 'none') return null
+  if (query.kind === 'search') {
+    const filter = await resolveTypeFilter(query.term)
+    if (!filter.ok) return badRequest(filter.message)
+    return filter.matches === null ? null : filter.matches.map((m) => m.typeID)
+  }
+
+  // A name in the exact list still goes through the ranked SDE search — it's
+  // the only name index there is — but only a WHOLE-name hit counts.
+  const { ids, names } = splitRefEntries(query.entries)
+  const found = await Promise.all(names.map(async (name) => [name, await searchSdeTypesAll(name)] as const))
+  const byName = new Map(
+    found.map(([name, matches]) => [name, matches.map((m) => ({ id: String(m.typeID), name: m.name }))])
+  )
+  const matched = matchExactNames(names, (name) => byName.get(name) ?? [])
+  if (matched.unmatched.length > 0) {
+    return badRequest(`No item type matched ${matched.unmatched.map((u) => `"${u}"`).join(', ')}.`)
+  }
+  return [...new Set([...ids, ...matched.ids])].map(Number)
+}
+
+// The location dimension → location ids, or null for no filter. `location`
+// searches names (station, structure or system — see locationSearch.ts) and
+// keeps everything it matched; `locations` takes exact ids and whole names.
+const locationIdsFor = async (
+  ctx: GraphqlContext,
+  args: { location?: string | null; locations?: readonly string[] | null }
+): Promise<string[] | null> => {
+  const parsed = parseRefFilter(args.location, args.locations, 'location')
+  if (!parsed.ok) return badRequest(parsed.message)
+  const query = parsed.query
+  if (query.kind === 'none') return null
+  if (query.kind === 'search') {
+    const candidates = await searchLocationCandidates(query.term, ctx.supabase)
+    if (candidates.length === 0) return badRequest(`No location matched "${query.term}".`)
+    return candidates.map((c) => c.id)
+  }
+
+  const { ids, names } = splitRefEntries(query.entries)
+  const found = await Promise.all(
+    names.map(async (name) => [name, await searchLocationCandidates(name, ctx.supabase)] as const)
+  )
+  const byName = new Map(found)
+  const matched = matchExactNames(names, (name) => byName.get(name) ?? [])
+  if (matched.unmatched.length > 0) {
+    return badRequest(`No location matched ${matched.unmatched.map((u) => `"${u}"`).join(', ')}.`)
+  }
+  return [...new Set([...ids, ...matched.ids])]
 }
 
 // Page a filtered select up to `cap` rows — PostgREST caps a single request at
@@ -223,9 +271,10 @@ export const resolvers = {
     assets: async (
       _parent: unknown,
       args: {
-        typeIds?: readonly string[] | null
-        typeName?: string | null
-        locationIds?: readonly string[] | null
+        type?: string | null
+        types?: readonly string[] | null
+        location?: string | null
+        locations?: readonly string[] | null
         character?: string | null
         characters?: readonly string[] | null
         limit?: number | null
@@ -243,8 +292,7 @@ export const resolvers = {
       const sharedIds = args.includeShared ? await grantorRegistrationIds(ctx) : []
       const scopedIds = [...ownerIds, ...sharedIds]
       const typeIds = await typeIdsFor(args)
-      const locationIds = parseIdsArg(args.locationIds, 'locationIds')
-      if (!locationIds.ok) return badRequest(locationIds.message)
+      const locationIds = await locationIdsFor(ctx, args)
       const cap = clampLimit(args.limit, ASSET_CAP)
 
       // The same filter set applies to the head-only count and the row pages.
@@ -252,7 +300,7 @@ export const resolvers = {
       const filtered = (query: any): any => {
         let q = query.in('registration_id', scopedIds)
         if (typeIds !== null) q = q.in('type_id', typeIds)
-        if (locationIds.ids !== null) q = q.in('location_id', locationIds.ids)
+        if (locationIds !== null) q = q.in('location_id', locationIds)
         return q
       }
 
@@ -362,8 +410,8 @@ export const resolvers = {
     blueprints: async (
       _parent: unknown,
       args: {
-        typeIds?: readonly string[] | null
-        typeName?: string | null
+        type?: string | null
+        types?: readonly string[] | null
         character?: string | null
         characters?: readonly string[] | null
         limit?: number | null
@@ -613,8 +661,8 @@ export const resolvers = {
     walletTransactions: async (
       _parent: unknown,
       args: {
-        typeIds?: readonly string[] | null
-        typeName?: string | null
+        type?: string | null
+        types?: readonly string[] | null
         character?: string | null
         characters?: readonly string[] | null
         since?: string | null

--- a/src/app/api/graphql/schema.graphql.ts
+++ b/src/app/api/graphql/schema.graphql.ts
@@ -28,25 +28,31 @@
 // Every entity field is ALSO reachable as a flat scalar on the row itself
 // (ownerName beside owner { name }, typeName beside type { name }). Pick the
 // scalars for a CSV-shaped query, the edges for exploring; both cost the same.
+//
+// FILTERS COME IN SINGULAR/PLURAL PAIRS, one pair per entity type: character/
+// characters, location/locations, type/types. The singular is a
+// case-insensitive substring SEARCH over names; the plural is an EXACT list
+// whose entries are ids or whole names, mixed freely. The two are mutually
+// exclusive, an entry matching nothing is an error, and each entity type's
+// description says which of its fields the pair accepts. See filters.ts.
 export const typeDefs = /* GraphQL */ `
   type Query {
     "Your linked characters. ownerId on every row below is one of these ids."
     owners: [Owner!]!
 
     """
-    Current asset rows (live inventory) across your characters. typeIds filters
-    on exact SDE type ids; typeName is a fuzzy name search — pass one or the
-    other, never both. Likewise characters is an exact list and character a
-    name search — pass one or the other. locationIds pins the rows to one or
-    more station, structure or system ids. includeShared additionally returns
-    rows other users have shared with you (session auth only — the api_token
-    path is own-data only; a Lens is the way to hand shared data to external
-    tools).
+    Current asset rows (live inventory) across your characters. Filters are the
+    schema's singular/plural pairs — type/types, location/locations,
+    character/characters (see each entity type). includeShared additionally
+    returns rows other users have shared with you (session auth only — the
+    api_token path is own-data only; a Lens is the way to hand shared data to
+    external tools).
     """
     assets(
-      typeIds: [String!]
-      typeName: String
-      locationIds: [String!]
+      type: String
+      types: [String!]
+      location: String
+      locations: [String!]
       character: String
       characters: [String!]
       limit: Int
@@ -56,14 +62,8 @@ export const typeDefs = /* GraphQL */ `
     "Asset shares other users have aimed at you (corporation/alliance/public). Session auth only."
     sharedWithMe: [ShareGrant!]!
 
-    "Current blueprint rows (BPOs and BPCs) across your characters. typeIds and typeName are mutually exclusive, as are characters and character."
-    blueprints(
-      typeIds: [String!]
-      typeName: String
-      character: String
-      characters: [String!]
-      limit: Int
-    ): BlueprintPage!
+    "Current blueprint rows (BPOs and BPCs) across your characters, filtered by item type and character."
+    blueprints(type: String, types: [String!], character: String, characters: [String!], limit: Int): BlueprintPage!
 
     "Open market orders across your characters."
     marketOrders(character: String, characters: [String!]): [MarketOrder!]!
@@ -74,10 +74,10 @@ export const typeDefs = /* GraphQL */ `
     "Latest known wallet balance per character."
     walletBalances: [WalletBalance!]!
 
-    "Market transaction history across your characters, newest first. typeIds and typeName are mutually exclusive, as are characters and character."
+    "Market transaction history across your characters, newest first, filtered by item type and character."
     walletTransactions(
-      typeIds: [String!]
-      typeName: String
+      type: String
+      types: [String!]
       character: String
       characters: [String!]
       since: String
@@ -86,19 +86,19 @@ export const typeDefs = /* GraphQL */ `
   }
 
   """
-  The character a row belongs to. Reached as \`owner\` from every row type, and
-  listed on its own by the \`owners\` query. Leaf-only, so \`owner { … }\` still
-  flattens to one CSV line.
+    The character a row belongs to. Reached as \`owner\` from every row type, and
+    listed on its own by the \`owners\` query. Leaf-only, so \`owner { … }\` still
+    flattens to one CSV line.
 
-  \`id\` is this site's registration id (the id \`ownerId\` carries), NOT the EVE
-  character id — that's \`characterId\`. The corp/alliance fields load only when
-  you select them.
+    \`id\` is this site's registration id (the id \`ownerId\` carries), NOT the EVE
+    character id — that's \`characterId\`. The corp/alliance fields load only when
+    you select them.
 
-  The two character filters name a row's character differently. \`character:\`
-  is a case-insensitive substring of \`name\`. \`characters:\` is an exact list,
-  and each entry may be any of the three ids on this type: a whole \`name\`, an
-  EVE \`characterId\`, or a registration \`id\` — mix them freely. An entry that
-  matches nothing is an error, never a silently narrower result.
+  FILTERS: \`character:\` is a case-insensitive substring of \`name\`.
+    \`characters:\` is an exact list, and each entry may be any of the three ids
+    on this type: a whole \`name\`, an EVE \`characterId\`, or a registration
+    \`id\` — mix them freely. An entry that matches nothing is an error, never a
+    silently narrower result.
   """
   type Owner {
     "This site's registration id — what ownerId carries, and one of the forms the characters: filter accepts. NOT the EVE character id."
@@ -119,6 +119,11 @@ export const typeDefs = /* GraphQL */ `
   \`blueprintType\`/\`productType\`) from every row that names an item.
   Leaf-only. Nothing here needs an extra query — the row's \`typeName\` was
   already read from these same SDE rows.
+
+  FILTERS: \`type:\` searches \`name\` the way the site's item search does, and
+  keeps everything it matched (so "Fuel Block" catches all four, and the
+  blueprints); it refuses a term matching too many types to be a filter.
+  \`types:\` is an exact list of \`typeId\`s and whole \`name\`s, mixed.
   """
   type ItemType {
     typeId: String!
@@ -143,6 +148,13 @@ export const typeDefs = /* GraphQL */ `
 
   \`systemId\`/\`systemName\` are the solar system the location is in — null for a
   container or ship whose own location we couldn't walk up to a system.
+
+  FILTERS: \`location:\` substring-searches names across all three sources at
+  once — your corp's structures, the ESI-resolved structure cache, NPC stations
+  and solar systems — and keeps every id it matched, so a system name pulls in
+  that system's rows and a station name that station's. \`locations:\` is an
+  exact list of \`locationId\`s and whole names, mixed. Neither widens what you
+  can read: a name you don't own resolves to an id none of your rows carry.
   """
   type Location {
     locationId: String!

--- a/src/app/api/graphql/schema.graphql.ts
+++ b/src/app/api/graphql/schema.graphql.ts
@@ -36,8 +36,8 @@ export const typeDefs = /* GraphQL */ `
     """
     Current asset rows (live inventory) across your characters. typeIds filters
     on exact SDE type ids; typeName is a fuzzy name search — pass one or the
-    other, never both. Likewise owners is an exact list of characters and owner
-    a name search — pass one or the other. locationId pins one station,
+    other, never both. Likewise characters is an exact list and character a
+    name search — pass one or the other. locationId pins one station,
     structure or system id. includeShared additionally returns rows other users
     have shared with you (session auth only — the api_token path is own-data
     only; a Lens is the way to hand shared data to external tools).
@@ -46,8 +46,8 @@ export const typeDefs = /* GraphQL */ `
       typeIds: [String!]
       typeName: String
       locationId: String
-      owner: String
-      owners: [String!]
+      character: String
+      characters: [String!]
       limit: Int
       includeShared: Boolean = false
     ): AssetPage!
@@ -55,24 +55,30 @@ export const typeDefs = /* GraphQL */ `
     "Asset shares other users have aimed at you (corporation/alliance/public). Session auth only."
     sharedWithMe: [ShareGrant!]!
 
-    "Current blueprint rows (BPOs and BPCs) across your characters. typeIds and typeName are mutually exclusive, as are owners and owner."
-    blueprints(typeIds: [String!], typeName: String, owner: String, owners: [String!], limit: Int): BlueprintPage!
+    "Current blueprint rows (BPOs and BPCs) across your characters. typeIds and typeName are mutually exclusive, as are characters and character."
+    blueprints(
+      typeIds: [String!]
+      typeName: String
+      character: String
+      characters: [String!]
+      limit: Int
+    ): BlueprintPage!
 
     "Open market orders across your characters."
-    marketOrders(owner: String, owners: [String!]): [MarketOrder!]!
+    marketOrders(character: String, characters: [String!]): [MarketOrder!]!
 
     "Industry jobs across your characters. Delivered jobs are excluded unless includeDelivered."
-    industryJobs(owner: String, owners: [String!], includeDelivered: Boolean = false): [IndustryJob!]!
+    industryJobs(character: String, characters: [String!], includeDelivered: Boolean = false): [IndustryJob!]!
 
     "Latest known wallet balance per character."
     walletBalances: [WalletBalance!]!
 
-    "Market transaction history across your characters, newest first. typeIds and typeName are mutually exclusive, as are owners and owner."
+    "Market transaction history across your characters, newest first. typeIds and typeName are mutually exclusive, as are characters and character."
     walletTransactions(
       typeIds: [String!]
       typeName: String
-      owner: String
-      owners: [String!]
+      character: String
+      characters: [String!]
       since: String
       limit: Int
     ): [WalletTransaction!]!
@@ -87,18 +93,18 @@ export const typeDefs = /* GraphQL */ `
   character id — that's \`characterId\`. The corp/alliance fields load only when
   you select them.
 
-  The two owner filters name characters differently. \`owner:\` is a
-  case-insensitive substring of \`name\`. \`owners:\` is an exact list, and each
-  entry may be any of the three ids on this type: a whole \`name\`, an EVE
-  \`characterId\`, or a registration \`id\` — mix them freely. An entry that
+  The two character filters name a row's character differently. \`character:\`
+  is a case-insensitive substring of \`name\`. \`characters:\` is an exact list,
+  and each entry may be any of the three ids on this type: a whole \`name\`, an
+  EVE \`characterId\`, or a registration \`id\` — mix them freely. An entry that
   matches nothing is an error, never a silently narrower result.
   """
   type Owner {
-    "This site's registration id — what ownerId carries, and one of the forms the owners: filter accepts. NOT the EVE character id."
+    "This site's registration id — what ownerId carries, and one of the forms the characters: filter accepts. NOT the EVE character id."
     id: String!
-    "The character's name. The owner: filter substring-matches it; the owners: filter matches it whole."
+    "The character's name. The character: filter substring-matches it; the characters: filter matches it whole."
     name: String!
-    "The EVE character id (what zKillboard, ESI and the image server use), and one of the forms the owners: filter accepts."
+    "The EVE character id (what zKillboard, ESI and the image server use), and one of the forms the characters: filter accepts."
     characterId: String
     corporationId: String
     corporationName: String

--- a/src/app/api/graphql/schema.graphql.ts
+++ b/src/app/api/graphql/schema.graphql.ts
@@ -37,15 +37,16 @@ export const typeDefs = /* GraphQL */ `
     Current asset rows (live inventory) across your characters. typeIds filters
     on exact SDE type ids; typeName is a fuzzy name search — pass one or the
     other, never both. Likewise characters is an exact list and character a
-    name search — pass one or the other. locationId pins one station,
-    structure or system id. includeShared additionally returns rows other users
-    have shared with you (session auth only — the api_token path is own-data
-    only; a Lens is the way to hand shared data to external tools).
+    name search — pass one or the other. locationIds pins the rows to one or
+    more station, structure or system ids. includeShared additionally returns
+    rows other users have shared with you (session auth only — the api_token
+    path is own-data only; a Lens is the way to hand shared data to external
+    tools).
     """
     assets(
       typeIds: [String!]
       typeName: String
-      locationId: String
+      locationIds: [String!]
       character: String
       characters: [String!]
       limit: Int

--- a/src/app/graphql/queryEditor.tsx
+++ b/src/app/graphql/queryEditor.tsx
@@ -29,7 +29,7 @@ const EXAMPLES: Array<{ label: string; query: string }> = [
   {
     label: 'Stockpile by item',
     query: `query Stockpile($item: String!) {
-  assets(typeName: $item) {
+  assets(type: $item) {
     totalCount
     truncated
     rows {
@@ -49,7 +49,7 @@ const EXAMPLES: Array<{ label: string; query: string }> = [
     // what else hangs off them.
     label: 'Stockpile by group (nested)',
     query: `{
-  assets(typeName: "Tritanium") {
+  assets(type: "Tritanium") {
     rows {
       quantity
       type {

--- a/src/app/lens/lensEditor.tsx
+++ b/src/app/lens/lensEditor.tsx
@@ -7,7 +7,7 @@ import { deleteLens, previewLens, saveLens } from './actions'
 import styles from './lens.module.css'
 
 const DEFAULT_QUERY = `{
-  assets(typeName: "Tritanium") {
+  assets(type: "Tritanium") {
     totalCount
     rows {
       typeName

--- a/test/graphqlFilters.test.ts
+++ b/test/graphqlFilters.test.ts
@@ -13,9 +13,10 @@ import {
   matchCharacterFilter,
   matchCharacterName,
   matchCharacterRefs,
-  parseIdsArg,
+  matchExactNames,
+  parseRefFilter,
   parseSince,
-  parseTypeIdsArg,
+  splitRefEntries,
 } from '../src/app/api/graphql/filters.ts'
 
 test('clampLimit defaults to the cap when absent or not a number', () => {
@@ -131,44 +132,51 @@ test('parseSince accepts ISO timestamps and date prefixes, rejects junk', () => 
   assert.equal(parseSince('yesterday-ish').ok, false)
 })
 
-test('parseIdsArg returns null when no ids are given', () => {
-  assert.deepEqual(parseIdsArg(undefined, 'locationIds'), { ok: true, ids: null })
-  assert.deepEqual(parseIdsArg([], 'locationIds'), { ok: true, ids: null })
-  assert.deepEqual(parseIdsArg(['  '], 'locationIds'), { ok: true, ids: null })
+// The shape every filter dimension shares (character, location, type): a
+// singular name search, a plural exact list, never both.
+test('parseRefFilter reads an absent filter as none', () => {
+  assert.deepEqual(parseRefFilter(undefined, undefined, 'type'), { ok: true, query: { kind: 'none' } })
+  assert.deepEqual(parseRefFilter('  ', [], 'type'), { ok: true, query: { kind: 'none' } })
+  assert.deepEqual(parseRefFilter(null, ['  '], 'type'), { ok: true, query: { kind: 'none' } })
 })
 
-test('parseIdsArg trims and dedupes bare positive integer literals', () => {
-  assert.deepEqual(parseIdsArg([' 60003760 ', '1040000000001', '60003760'], 'locationIds'), {
+test('parseRefFilter reads the singular as a search and the plural as an exact list', () => {
+  assert.deepEqual(parseRefFilter(' Fuel Block ', null, 'type'), {
     ok: true,
-    ids: ['60003760', '1040000000001'],
+    query: { kind: 'search', term: 'Fuel Block' },
+  })
+  assert.deepEqual(parseRefFilter(null, [' 4051 ', 'Nitrogen Fuel Block', '4051'], 'type'), {
+    ok: true,
+    query: { kind: 'exact', entries: ['4051', 'Nitrogen Fuel Block'] },
   })
 })
 
-test('parseIdsArg rejects anything that is not a plain id, rather than widening', () => {
-  assert.equal(parseIdsArg(['60003760; drop table'], 'locationIds').ok, false)
-  assert.equal(parseIdsArg(['-1'], 'locationIds').ok, false)
-  assert.equal(parseIdsArg(['1e9'], 'locationIds').ok, false)
-  assert.equal(parseIdsArg(['60003760', 'Jita'], 'locationIds').ok, false)
-})
-
-test('parseTypeIdsArg returns null when no ids are given', () => {
-  assert.deepEqual(parseTypeIdsArg(undefined, undefined), { ok: true, ids: null })
-  assert.deepEqual(parseTypeIdsArg([], 'Fuel Block'), { ok: true, ids: null })
-  assert.deepEqual(parseTypeIdsArg(['  '], undefined), { ok: true, ids: null })
-})
-
-test('parseTypeIdsArg parses, trims and dedupes exact ids', () => {
-  assert.deepEqual(parseTypeIdsArg([' 4051 ', '4246', '4051'], undefined), { ok: true, ids: [4051, 4246] })
-})
-
-test('parseTypeIdsArg refuses typeIds and typeName together', () => {
-  const both = parseTypeIdsArg(['4051'], 'Fuel Block')
+test('parseRefFilter refuses both, naming the pair it was given', () => {
+  const both = parseRefFilter('jita', ['60003760'], 'location')
   assert.equal(both.ok, false)
-  assert.match(!both.ok ? both.message : '', /not both/)
+  assert.match(!both.ok ? both.message : '', /Pass location or locations, not both/)
 })
 
-test('parseTypeIdsArg rejects non-numeric ids rather than widening', () => {
-  assert.equal(parseTypeIdsArg(['4051', 'Tritanium'], undefined).ok, false)
-  assert.equal(parseTypeIdsArg(['-4051'], undefined).ok, false)
-  assert.equal(parseTypeIdsArg(['4051; drop table'], undefined).ok, false)
+test('splitRefEntries calls a bare integer an id and everything else a name', () => {
+  assert.deepEqual(splitRefEntries(['4051', 'Tritanium', '60003760', '1MN Afterburner II']), {
+    ids: ['4051', '60003760'],
+    names: ['Tritanium', '1MN Afterburner II'],
+  })
+})
+
+test('matchExactNames takes whole names only, keeping every candidate that matches', () => {
+  const candidates = {
+    Tritanium: [
+      { id: '34', name: 'Tritanium' },
+      { id: '35', name: 'Tritanium Bar' },
+    ],
+    jita: [{ id: '30000142', name: 'Jita' }],
+  }
+  const matched = matchExactNames(['Tritanium', 'jita'], (name) => candidates[name] ?? [])
+  assert.deepEqual(matched, { ids: ['34', '30000142'], unmatched: [] })
+})
+
+test('matchExactNames reports what matched nothing, rather than dropping it', () => {
+  const matched = matchExactNames(['Trit'], () => [{ id: '34', name: 'Tritanium' }])
+  assert.deepEqual(matched, { ids: [], unmatched: ['Trit'] })
 })

--- a/test/graphqlFilters.test.ts
+++ b/test/graphqlFilters.test.ts
@@ -1,8 +1,8 @@
 // Unit coverage for the GraphQL resolvers' pure argument shaping
 // (src/app/api/graphql/filters.ts). What matters here is what the resolvers
 // can't get wrong quietly: limit clamping against the hard caps (the request
-// bound), owner matching (the same substring semantics as the MCP layer), and
-// the argument parsers rejecting rather than silently widening a filter.
+// bound), character matching (the same substring semantics as the MCP layer),
+// and the argument parsers rejecting rather than silently widening a filter.
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
@@ -10,9 +10,9 @@ import {
   ASSET_CAP,
   LIST_CAP,
   clampLimit,
-  matchOwnerFilter,
-  matchOwnerIds,
-  matchOwnerRefs,
+  matchCharacterFilter,
+  matchCharacterName,
+  matchCharacterRefs,
   parseIdArg,
   parseSince,
   parseTypeIdsArg,
@@ -38,21 +38,21 @@ const OWNERS = new Map([
   ['reg-c', 'Someone Else'],
 ])
 
-test('matchOwnerIds passes null through as no filter', () => {
-  assert.deepEqual(matchOwnerIds(undefined, OWNERS), { ok: true, ids: null })
-  assert.deepEqual(matchOwnerIds('   ', OWNERS), { ok: true, ids: null })
+test('matchCharacterName passes null through as no filter', () => {
+  assert.deepEqual(matchCharacterName(undefined, OWNERS), { ok: true, ids: null })
+  assert.deepEqual(matchCharacterName('   ', OWNERS), { ok: true, ids: null })
 })
 
-test('matchOwnerIds matches case-insensitive substrings, possibly several', () => {
-  const match = matchOwnerIds('philihp', OWNERS)
+test('matchCharacterName matches case-insensitive substrings, possibly several', () => {
+  const match = matchCharacterName('philihp', OWNERS)
   assert.ok(match.ok)
   assert.deepEqual(match.ok && match.ids, ['reg-a', 'reg-b'])
-  const exact = matchOwnerIds('someone else', OWNERS)
+  const exact = matchCharacterName('someone else', OWNERS)
   assert.deepEqual(exact.ok && exact.ids, ['reg-c'])
 })
 
-test('matchOwnerIds rejects an unknown owner, listing what exists', () => {
-  const match = matchOwnerIds('nobody', OWNERS)
+test('matchCharacterName rejects an unknown character, listing what exists', () => {
+  const match = matchCharacterName('nobody', OWNERS)
   assert.equal(match.ok, false)
   assert.match(!match.ok ? match.message : '', /Philihp Alt, Philihp Busby, Someone Else/)
 })
@@ -76,48 +76,48 @@ const DIRECTORY = {
   ]),
 }
 
-test('matchOwnerRefs passes an absent or empty list through as no filter', () => {
-  assert.deepEqual(matchOwnerRefs(undefined, DIRECTORY), { ok: true, ids: null })
-  assert.deepEqual(matchOwnerRefs([], DIRECTORY), { ok: true, ids: null })
-  assert.deepEqual(matchOwnerRefs(['  '], DIRECTORY), { ok: true, ids: null })
+test('matchCharacterRefs passes an absent or empty list through as no filter', () => {
+  assert.deepEqual(matchCharacterRefs(undefined, DIRECTORY), { ok: true, ids: null })
+  assert.deepEqual(matchCharacterRefs([], DIRECTORY), { ok: true, ids: null })
+  assert.deepEqual(matchCharacterRefs(['  '], DIRECTORY), { ok: true, ids: null })
 })
 
-test('matchOwnerRefs takes whole names, EVE character ids and registration ids, mixed', () => {
-  const byName = matchOwnerRefs(['philihp busby', 'Someone Else'], DIRECTORY)
+test('matchCharacterRefs takes whole names, EVE character ids and registration ids, mixed', () => {
+  const byName = matchCharacterRefs(['philihp busby', 'Someone Else'], DIRECTORY)
   assert.deepEqual(byName.ok && byName.ids, [REG_A, REG_C])
-  const byCharacterId = matchOwnerRefs(['95465499'], DIRECTORY)
+  const byCharacterId = matchCharacterRefs(['95465499'], DIRECTORY)
   assert.deepEqual(byCharacterId.ok && byCharacterId.ids, [REG_A])
-  const mixed = matchOwnerRefs([REG_B, '95465499', 'Someone Else'], DIRECTORY)
+  const mixed = matchCharacterRefs([REG_B, '95465499', 'Someone Else'], DIRECTORY)
   assert.deepEqual(mixed.ok && mixed.ids, [REG_B, REG_A, REG_C])
 })
 
-test('matchOwnerRefs dedupes a character named twice', () => {
-  const match = matchOwnerRefs(['Philihp Busby', '95465499', REG_A], DIRECTORY)
+test('matchCharacterRefs dedupes a character named twice', () => {
+  const match = matchCharacterRefs(['Philihp Busby', '95465499', REG_A], DIRECTORY)
   assert.deepEqual(match.ok && match.ids, [REG_A])
 })
 
-test('matchOwnerRefs matches names whole, not by substring — that is what owner: is for', () => {
-  const partial = matchOwnerRefs(['philihp'], DIRECTORY)
+test('matchCharacterRefs matches names whole, not by substring — that is what character: is for', () => {
+  const partial = matchCharacterRefs(['philihp'], DIRECTORY)
   assert.equal(partial.ok, false)
   assert.match(!partial.ok ? partial.message : '', /"philihp"/)
 })
 
-test('matchOwnerRefs rejects unknown entries, listing names with their character ids', () => {
-  const match = matchOwnerRefs(['Someone Else', 'Nobody', '12345'], DIRECTORY)
+test('matchCharacterRefs rejects unknown entries, listing names with their character ids', () => {
+  const match = matchCharacterRefs(['Someone Else', 'Nobody', '12345'], DIRECTORY)
   assert.equal(match.ok, false)
   const message = !match.ok ? match.message : ''
   assert.match(message, /"Nobody", "12345"/)
   assert.match(message, /Philihp Busby \(95465499\)/)
 })
 
-test('matchOwnerFilter routes to the fuzzy or the exact matcher, never both', () => {
-  const none = matchOwnerFilter(null, null, DIRECTORY)
+test('matchCharacterFilter routes to the fuzzy or the exact matcher, never both', () => {
+  const none = matchCharacterFilter(null, null, DIRECTORY)
   assert.deepEqual(none, { ok: true, ids: null })
-  const fuzzy = matchOwnerFilter('philihp', null, DIRECTORY)
+  const fuzzy = matchCharacterFilter('philihp', null, DIRECTORY)
   assert.deepEqual(fuzzy.ok && fuzzy.ids, [REG_A, REG_B])
-  const exact = matchOwnerFilter(null, ['Philihp Alt'], DIRECTORY)
+  const exact = matchCharacterFilter(null, ['Philihp Alt'], DIRECTORY)
   assert.deepEqual(exact.ok && exact.ids, [REG_B])
-  const both = matchOwnerFilter('philihp', ['Philihp Alt'], DIRECTORY)
+  const both = matchCharacterFilter('philihp', ['Philihp Alt'], DIRECTORY)
   assert.equal(both.ok, false)
   assert.match(!both.ok ? both.message : '', /not both/)
 })

--- a/test/graphqlFilters.test.ts
+++ b/test/graphqlFilters.test.ts
@@ -13,7 +13,7 @@ import {
   matchCharacterFilter,
   matchCharacterName,
   matchCharacterRefs,
-  parseIdArg,
+  parseIdsArg,
   parseSince,
   parseTypeIdsArg,
 } from '../src/app/api/graphql/filters.ts'
@@ -131,12 +131,24 @@ test('parseSince accepts ISO timestamps and date prefixes, rejects junk', () => 
   assert.equal(parseSince('yesterday-ish').ok, false)
 })
 
-test('parseIdArg accepts only bare positive integer literals', () => {
-  assert.deepEqual(parseIdArg(undefined, 'locationId'), { ok: true, id: null })
-  assert.deepEqual(parseIdArg(' 60003760 ', 'locationId'), { ok: true, id: '60003760' })
-  assert.equal(parseIdArg('60003760; drop table', 'locationId').ok, false)
-  assert.equal(parseIdArg('-1', 'locationId').ok, false)
-  assert.equal(parseIdArg('1e9', 'locationId').ok, false)
+test('parseIdsArg returns null when no ids are given', () => {
+  assert.deepEqual(parseIdsArg(undefined, 'locationIds'), { ok: true, ids: null })
+  assert.deepEqual(parseIdsArg([], 'locationIds'), { ok: true, ids: null })
+  assert.deepEqual(parseIdsArg(['  '], 'locationIds'), { ok: true, ids: null })
+})
+
+test('parseIdsArg trims and dedupes bare positive integer literals', () => {
+  assert.deepEqual(parseIdsArg([' 60003760 ', '1040000000001', '60003760'], 'locationIds'), {
+    ok: true,
+    ids: ['60003760', '1040000000001'],
+  })
+})
+
+test('parseIdsArg rejects anything that is not a plain id, rather than widening', () => {
+  assert.equal(parseIdsArg(['60003760; drop table'], 'locationIds').ok, false)
+  assert.equal(parseIdsArg(['-1'], 'locationIds').ok, false)
+  assert.equal(parseIdsArg(['1e9'], 'locationIds').ok, false)
+  assert.equal(parseIdsArg(['60003760', 'Jita'], 'locationIds').ok, false)
 })
 
 test('parseTypeIdsArg returns null when no ids are given', () => {

--- a/test/graphqlSchema.test.ts
+++ b/test/graphqlSchema.test.ts
@@ -123,7 +123,7 @@ test('the flat scalar beside each edge survives', () => {
 test('Owner exposes the EVE character id distinctly from the registration id', () => {
   const schema = buildSchema(typeDefs)
   const owner = objectType(schema, 'Owner').getFields()
-  // id is the registration uuid (what ownerId carries and `owner:` filters on);
+  // id is the registration uuid (what ownerId carries and `characters:` accepts);
   // characterId is the EVE numeric id. Conflating them is the legacy wart
   // docs/registration-id-rename.md exists to unwind — the schema states it.
   assert.equal(String(owner.id.type), 'String!')
@@ -131,15 +131,19 @@ test('Owner exposes the EVE character id distinctly from the registration id', (
   assert.ok(owner.id.description?.includes('registration id'))
 })
 
-test('every owner-filtered field carries both the fuzzy owner and the exact owners list', () => {
+test('every character-filtered field carries both the fuzzy character and the exact characters list', () => {
   const schema = buildSchema(typeDefs)
   const fields = (schema.getQueryType() as GraphQLObjectType).getFields()
   for (const name of ['assets', 'blueprints', 'industryJobs', 'marketOrders', 'walletTransactions']) {
     const args = new Map(fields[name].args.map((a) => [a.name, String(a.type)]))
-    assert.equal(args.get('owner'), 'String', `${name}.owner`)
+    assert.equal(args.get('character'), 'String', `${name}.character`)
     // A list of characters — names, EVE character ids or registration ids —
     // and String for the same reason typeIds is: EVE ids overflow Int.
-    assert.equal(args.get('owners'), '[String!]', `${name}.owners`)
+    assert.equal(args.get('characters'), '[String!]', `${name}.characters`)
+    // The rows still say owner/ownerId/ownerName; only the FILTER is named for
+    // what it takes. `owner:` as an argument is gone, not deprecated.
+    assert.equal(args.get('owner'), undefined, `${name}.owner`)
+    assert.equal(args.get('owners'), undefined, `${name}.owners`)
   }
 })
 

--- a/test/graphqlSchema.test.ts
+++ b/test/graphqlSchema.test.ts
@@ -131,39 +131,29 @@ test('Owner exposes the EVE character id distinctly from the registration id', (
   assert.ok(owner.id.description?.includes('registration id'))
 })
 
-test('every character-filtered field carries both the fuzzy character and the exact characters list', () => {
+test('every filter dimension is a singular/plural pair, and the old names are gone', () => {
   const schema = buildSchema(typeDefs)
   const fields = (schema.getQueryType() as GraphQLObjectType).getFields()
-  for (const name of ['assets', 'blueprints', 'industryJobs', 'marketOrders', 'walletTransactions']) {
-    const args = new Map(fields[name].args.map((a) => [a.name, String(a.type)]))
-    assert.equal(args.get('character'), 'String', `${name}.character`)
-    // A list of characters — names, EVE character ids or registration ids —
-    // and String for the same reason typeIds is: EVE ids overflow Int.
-    assert.equal(args.get('characters'), '[String!]', `${name}.characters`)
-    // The rows still say owner/ownerId/ownerName; only the FILTER is named for
-    // what it takes. `owner:` as an argument is gone, not deprecated.
-    assert.equal(args.get('owner'), undefined, `${name}.owner`)
-    assert.equal(args.get('owners'), undefined, `${name}.owners`)
+  // Which dimensions each field filters on — the pairs are uniform, the set of
+  // dimensions is per field (only assets carries a location).
+  const dimensions: Record<string, string[]> = {
+    assets: ['type', 'location', 'character'],
+    blueprints: ['type', 'character'],
+    industryJobs: ['character'],
+    marketOrders: ['character'],
+    walletTransactions: ['type', 'character'],
   }
-})
-
-test('assets filters locations by a list of ids, not a single one', () => {
-  const schema = buildSchema(typeDefs)
-  const args = new Map(
-    (schema.getQueryType() as GraphQLObjectType).getFields().assets.args.map((a) => [a.name, String(a.type)])
-  )
-  assert.equal(args.get('locationIds'), '[String!]')
-  assert.equal(args.get('locationId'), undefined)
-})
-
-test('the type-filtered fields all carry typeIds as a String list', () => {
-  const schema = buildSchema(typeDefs)
-  const fields = (schema.getQueryType() as GraphQLObjectType).getFields()
-  for (const name of ['assets', 'blueprints', 'walletTransactions']) {
-    const arg = fields[name].args.find((a) => a.name === 'typeIds')
-    assert.ok(arg, `${name} has a typeIds arg`)
-    // String, not Int: EVE type ids are small today but the schema keeps one
-    // id representation, and Int is 32-bit.
-    assert.equal(String(arg.type), '[String!]')
+  for (const [field, dims] of Object.entries(dimensions)) {
+    const args = new Map(fields[field].args.map((a) => [a.name, String(a.type)]))
+    for (const dim of dims) {
+      assert.equal(args.get(dim), 'String', `${field}.${dim}`)
+      // A list of ids or whole names — String for the same reason every id in
+      // this schema is: EVE ids overflow GraphQL's 32-bit Int.
+      assert.equal(args.get(`${dim}s`), '[String!]', `${field}.${dim}s`)
+    }
+    // The pre-pairing spellings, all removed rather than deprecated.
+    for (const gone of ['owner', 'owners', 'typeIds', 'typeName', 'locationId', 'locationIds']) {
+      assert.equal(args.get(gone), undefined, `${field}.${gone}`)
+    }
   }
 })

--- a/test/graphqlSchema.test.ts
+++ b/test/graphqlSchema.test.ts
@@ -147,6 +147,15 @@ test('every character-filtered field carries both the fuzzy character and the ex
   }
 })
 
+test('assets filters locations by a list of ids, not a single one', () => {
+  const schema = buildSchema(typeDefs)
+  const args = new Map(
+    (schema.getQueryType() as GraphQLObjectType).getFields().assets.args.map((a) => [a.name, String(a.type)])
+  )
+  assert.equal(args.get('locationIds'), '[String!]')
+  assert.equal(args.get('locationId'), undefined)
+})
+
 test('the type-filtered fields all carry typeIds as a String list', () => {
   const schema = buildSchema(typeDefs)
   const fields = (schema.getQueryType() as GraphQLObjectType).getFields()

--- a/test/lensValidate.test.ts
+++ b/test/lensValidate.test.ts
@@ -13,7 +13,7 @@ test('a plain single-field query passes', () => {
 
 test('a named query with variables passes', () => {
   const result = validateLensQuery(`query Stockpile($item: String!) {
-    assets(typeName: $item) { totalCount rows { typeName quantity } }
+    assets(type: $item) { totalCount rows { typeName quantity } }
   }`)
   assert.deepEqual(result, { ok: true })
 })


### PR DESCRIPTION
Follow-up to #858. Filtering had grown three different shapes: characters took `character`/`characters`, locations took a `locationId` (one id, no way to name a place), and item types took `typeIds` **or** `typeName` — an id list and a name search spelled as two arguments rather than one dimension.

All three now take the same pair, so knowing one filter is knowing all of them:

- the **singular** (`character:`, `location:`, `type:`) is a case-insensitive substring **search** over names, keeping everything it matched;
- the **plural** (`characters:`, `locations:`, `types:`) is an **exact list** whose entries are ids or whole names, mixed freely.

```graphql
{
  assets(types: ["4051", "Nitrogen Fuel Block"], location: "1DQ1-A", characters: ["Philihp Busby", "95465499"]) {
    rows { typeName quantity locationName ownerName }
  }
}
```

The two are mutually exclusive per dimension, and an entry matching nothing is an error rather than a silently narrower result.

## Where each dimension resolves names

| dimension | singular search | plural entries |
| --- | --- | --- |
| `character` | the caller's own character names | name, EVE character id, or registration id |
| `location` | corp structures, the ESI-resolved structure cache, NPC stations, solar systems | name or location id |
| `type` | the SDE search the site's item lookup uses (refuses a term matching too many types) | name or type id |

Which fields carry which dimension is unchanged: `assets` filters on all three, `blueprints`/`walletTransactions` on type and character, `marketOrders`/`industryJobs` on character.

## Searching locations is not reading them

New `locationSearch.ts` maps a name to an id, which the caller then filters their **own** rows by. The resolvers' `.in('registration_id', …)` leak guard is untouched, a name you don't own resolves to an id none of your rows carry, and candidate names are never echoed back — an error repeats only what was typed.

## Breaking

`owner`, `owners`, `locationId`, `locationIds`, `typeIds` and `typeName` are all gone rather than deprecated; a query passing one fails validation with GraphQL's unknown-argument message. Everything except `typeIds`/`typeName` was introduced in #858, which merged today; `typeIds`/`typeName` predate it, so the sample queries on `/graphql`, in the lens editor, and in `docs/sharing-layer/07-lens.md` are updated to `type:`.

Row fields are untouched throughout — `ownerId`, `ownerName`, `owner { … }`, `typeName`, `locationId`, and the `Owner`/`ItemType`/`Location` types all keep their names, so selection sets and CSV columns are unaffected. Only the filters were renamed.

## Testing

- `pnpm test` — 232 pass; new coverage for the shared parser (`parseRefFilter`, `splitRefEntries`, `matchExactNames`) and a drift guard asserting every field's dimensions are present as a pair **and** that all six old argument names are gone
- `pnpm run build` (typecheck), `pnpm run lint`, prettier clean