### PR TITLE
Count corp industry jobs in character slot bubbles

### DIFF
--- a/src/app/api/mcp/industryTools.ts
+++ b/src/app/api/mcp/industryTools.ts
@@ -9,14 +9,15 @@ import { z } from 'zod'
 import { fetchType, resolveProductTypeID } from '@/app/blueprint/api'
 import { rigsForProduct } from '@/app/blueprint/rigs'
 import {
-  ACTIVITY_FAMILY,
   baseSlotMax,
+  countJobSlots,
   emptyCounts,
   SKILL_FAMILY,
   SKILL_NAME,
   SLOT_FAMILIES,
   SLOT_SKILL_IDS,
-  type SlotCounts,
+  type CharacterJobRow,
+  type CorpJobRow,
   type SlotMax,
 } from '@/app/industry/jobSlots'
 import {
@@ -161,31 +162,35 @@ export const registerIndustryTools = (server: McpServer): void => {
       if (!supabase) return textResult('Missing bearer token.')
 
       const owners = await fetchOwnerContext(supabase)
-      const [{ data: jobRows }, { data: skillRows }] = await Promise.all([
-        // Jobs holding a slot: running, or finished but not yet delivered.
-        supabase
-          .from('character_industry_job')
-          .select('registration_id, activity_id, status, end_date')
-          .in('status', ['active', 'ready']),
-        supabase
-          .from('character_skill')
-          .select('registration_id, skill_id, active_skill_level')
-          .in('skill_id', SLOT_SKILL_IDS),
-      ])
+      // Jobs holding a slot: running, or finished but not yet delivered. Corp
+      // jobs consume the installing character's slots too, so both listings are
+      // folded together (cf. /character); `registration` supplies the
+      // installer's EVE id → registration uuid translation.
+      const [{ data: jobRows }, { data: corpJobRows }, { data: registrations }, { data: skillRows }] =
+        await Promise.all([
+          supabase
+            .from('character_industry_job')
+            .select('job_id, registration_id, activity_id, status, end_date')
+            .in('status', ['active', 'ready']),
+          supabase
+            .from('corp_industry_job')
+            .select('job_id, installer_id, activity_id, status, end_date')
+            .in('status', ['active', 'ready']),
+          supabase.from('registration').select('id, character_id'),
+          supabase
+            .from('character_skill')
+            .select('registration_id, skill_id, active_skill_level')
+            .in('skill_id', SLOT_SKILL_IDS),
+        ])
 
-      const now = Date.now()
-      const counts = new Map<string, SlotCounts>()
-      ;(
-        (jobRows ?? []) as Array<{ registration_id: string; activity_id: number; status: string; end_date: string }>
-      ).forEach((j) => {
-        const family = ACTIVITY_FAMILY[Number(j.activity_id)]
-        if (!family) return
-        const entry = counts.get(j.registration_id) ?? emptyCounts()
-        // A job whose timer elapsed still holds its slot until delivered, even
-        // if ESI hasn't flipped its status yet (cf. /character).
-        const finished = j.status === 'ready' || new Date(j.end_date).getTime() <= now
-        entry[family][finished ? 'finished' : 'running'] += 1
-        counts.set(j.registration_id, entry)
+      const counts = countJobSlots({
+        characterJobs: (jobRows ?? []) as CharacterJobRow[],
+        corpJobs: (corpJobRows ?? []) as CorpJobRow[],
+        registrationByCharacterId: new Map(
+          ((registrations ?? []) as Array<{ id: string; character_id: number | null }>)
+            .filter((r) => r.character_id != null)
+            .map((r) => [String(r.character_id), r.id])
+        ),
       })
 
       const maxes = new Map<string, SlotMax>()
@@ -240,7 +245,11 @@ export const registerIndustryTools = (server: McpServer): void => {
         characters,
         total_free_slots: characters.reduce((sum, c) => sum + c.total_free, 0),
         note: "Corporation-installed jobs occupy the installing character's slots, so they are counted here too when that character is one of yours.",
-        data_refreshed: await dataFreshness(supabase, ['character-industry-jobs', 'character-status']),
+        data_refreshed: await dataFreshness(supabase, [
+          'character-industry-jobs',
+          'corp-industry-jobs',
+          'character-status',
+        ]),
       })
     }
   )

--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -4,11 +4,13 @@ import { ascend, range, reduce, sort, uniq } from 'ramda'
 
 import { createClient } from '@/utils/supabase/server'
 import {
-  ACTIVITY_FAMILY,
   baseSlotMax,
+  countJobSlots,
   emptyCounts,
   SKILL_FAMILY,
   SLOT_SKILL_IDS,
+  type CharacterJobRow,
+  type CorpJobRow,
   type SlotCounts,
   type SlotFamily,
   type SlotMax,
@@ -131,28 +133,26 @@ const CharacterPage = async () => {
   )
 
   // Jobs that still hold a slot: running (status 'active') or ready to deliver
-  // (status 'ready'). A job whose timer elapsed but that ESI still reports as
-  // 'active' is treated as ready too, so the pulsing "deliver me" state doesn't
-  // wait on ESI flipping the status.
-  const nowMs = Date.now()
-  const { data: industryJobs } = await supabase
-    .from('character_industry_job')
-    .select('registration_id, activity_id, status, end_date')
-    .in('status', ['active', 'ready'])
-  const jobSlotCounts = reduce(
-    (acc, j) => {
-      const family = ACTIVITY_FAMILY[Number(j.activity_id)]
-      if (family) {
-        const counts = acc.get(j.registration_id as string) ?? emptyCounts()
-        const finished = j.status === 'ready' || new Date(j.end_date as string).getTime() <= nowMs
-        counts[family][finished ? 'finished' : 'running'] += 1
-        acc.set(j.registration_id as string, counts)
-      }
-      return acc
-    },
-    new Map<string, SlotCounts>(),
-    industryJobs ?? []
-  )
+  // (status 'ready'). Corp jobs count against the installing character's slots
+  // as well, so both listings feed the shared fold; RLS already scopes the corp
+  // view to the caller's corporations.
+  const [{ data: industryJobs }, { data: corpIndustryJobs }] = await Promise.all([
+    supabase
+      .from('character_industry_job')
+      .select('job_id, registration_id, activity_id, status, end_date')
+      .in('status', ['active', 'ready']),
+    supabase
+      .from('corp_industry_job')
+      .select('job_id, installer_id, activity_id, status, end_date')
+      .in('status', ['active', 'ready']),
+  ])
+  const jobSlotCounts = countJobSlots({
+    characterJobs: (industryJobs ?? []) as CharacterJobRow[],
+    corpJobs: (corpIndustryJobs ?? []) as CorpJobRow[],
+    registrationByCharacterId: new Map(
+      (characters ?? []).filter((c) => c.character_id != null).map((c) => [String(c.character_id), c.id as string])
+    ),
+  })
 
   // Per-character slot ceilings, derived from the two skills behind each family.
   const { data: skillRows } = await supabase

--- a/src/app/industry/jobSlots.ts
+++ b/src/app/industry/jobSlots.ts
@@ -52,3 +52,56 @@ export const emptyCounts = (): SlotCounts => ({
 
 // One slot per family before any skill is trained.
 export const baseSlotMax = (): SlotMax => ({ manufacturing: 1, research: 1, reaction: 1 })
+
+// A job still holding a slot, from either the character or the corp listing.
+// Only the columns the count needs; both views carry them under these names.
+type JobRow = {
+  job_id: number | string
+  activity_id: number | string
+  status: string
+  end_date: string
+}
+export type CharacterJobRow = JobRow & { registration_id: string }
+export type CorpJobRow = JobRow & { installer_id: number | string }
+
+// Occupied slots per character, folding in corp-owned jobs: a job installed
+// from the corp hangar still consumes the *installing character's* personal
+// slots, so a character running nothing but corp jobs must not read as idle.
+// Corp jobs identify the installer by EVE character id, hence the map back to
+// the registration uuid the callers key on; jobs installed by someone who
+// isn't one of ours drop out. Both callers pass rows already filtered to
+// status active/ready.
+export const countJobSlots = ({
+  characterJobs = [],
+  corpJobs = [],
+  registrationByCharacterId,
+  now = Date.now(),
+}: {
+  characterJobs?: CharacterJobRow[]
+  corpJobs?: CorpJobRow[]
+  registrationByCharacterId: Map<string, string>
+  now?: number
+}): Map<string, SlotCounts> => {
+  const byCharacter = new Map<string, SlotCounts>()
+  // job_id is unique game-wide, so a job appearing in both listings counts once.
+  const seen = new Set<string>()
+
+  const add = (registrationId: string, job: JobRow) => {
+    const family = ACTIVITY_FAMILY[Number(job.activity_id)]
+    if (!family || seen.has(String(job.job_id))) return
+    seen.add(String(job.job_id))
+    const counts = byCharacter.get(registrationId) ?? emptyCounts()
+    // A job whose timer elapsed still holds its slot until delivered, even if
+    // ESI hasn't flipped its status to 'ready' yet.
+    const finished = job.status === 'ready' || new Date(job.end_date).getTime() <= now
+    counts[family][finished ? 'finished' : 'running'] += 1
+    byCharacter.set(registrationId, counts)
+  }
+
+  characterJobs.forEach((j) => add(j.registration_id, j))
+  corpJobs.forEach((j) => {
+    const registrationId = registrationByCharacterId.get(String(j.installer_id))
+    if (registrationId) add(registrationId, j)
+  })
+  return byCharacter
+}

--- a/test/jobSlots.test.ts
+++ b/test/jobSlots.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { countJobSlots, emptyCounts, type CharacterJobRow, type CorpJobRow } from '../src/app/industry/jobSlots.ts'
+
+const NOW = Date.parse('2026-08-11T12:00:00Z')
+const LATER = '2026-08-11T18:00:00Z'
+const EARLIER = '2026-08-11T06:00:00Z'
+
+const REGISTRATIONS = new Map([
+  ['90000001', 'reg-a'],
+  ['90000002', 'reg-b'],
+])
+
+const characterJob = (over: Partial<CharacterJobRow> = {}): CharacterJobRow => ({
+  job_id: 1,
+  registration_id: 'reg-a',
+  activity_id: 1,
+  status: 'active',
+  end_date: LATER,
+  ...over,
+})
+
+const corpJob = (over: Partial<CorpJobRow> = {}): CorpJobRow => ({
+  job_id: 2,
+  installer_id: 90000001,
+  activity_id: 1,
+  status: 'active',
+  end_date: LATER,
+  ...over,
+})
+
+test('counts a corp job against the installing character', () => {
+  const counts = countJobSlots({
+    corpJobs: [corpJob()],
+    registrationByCharacterId: REGISTRATIONS,
+    now: NOW,
+  })
+  assert.deepEqual(counts.get('reg-a')?.manufacturing, { running: 1, finished: 0 })
+})
+
+test('sums character and corp jobs into one occupancy', () => {
+  const counts = countJobSlots({
+    characterJobs: [characterJob({ job_id: 10 }), characterJob({ job_id: 11, activity_id: 4 })],
+    corpJobs: [corpJob({ job_id: 20 }), corpJob({ job_id: 21, activity_id: 9 })],
+    registrationByCharacterId: REGISTRATIONS,
+    now: NOW,
+  })
+  assert.deepEqual(counts.get('reg-a'), {
+    manufacturing: { running: 2, finished: 0 },
+    research: { running: 1, finished: 0 },
+    reaction: { running: 1, finished: 0 },
+  })
+})
+
+test('counts a job listed by both endpoints once', () => {
+  const counts = countJobSlots({
+    characterJobs: [characterJob({ job_id: 42 })],
+    corpJobs: [corpJob({ job_id: 42 })],
+    registrationByCharacterId: REGISTRATIONS,
+    now: NOW,
+  })
+  assert.deepEqual(counts.get('reg-a')?.manufacturing, { running: 1, finished: 0 })
+})
+
+test('drops corp jobs installed by characters we do not track', () => {
+  const counts = countJobSlots({
+    corpJobs: [corpJob({ installer_id: 90009999 })],
+    registrationByCharacterId: REGISTRATIONS,
+    now: NOW,
+  })
+  assert.equal(counts.size, 0)
+})
+
+test('an elapsed corp job is ready to deliver, not running', () => {
+  const counts = countJobSlots({
+    corpJobs: [corpJob({ end_date: EARLIER }), corpJob({ job_id: 3, status: 'ready' })],
+    registrationByCharacterId: REGISTRATIONS,
+    now: NOW,
+  })
+  assert.deepEqual(counts.get('reg-a')?.manufacturing, { running: 0, finished: 2 })
+})
+
+test('ignores activities that consume no slot family', () => {
+  const counts = countJobSlots({
+    characterJobs: [characterJob({ activity_id: 11 })],
+    registrationByCharacterId: REGISTRATIONS,
+    now: NOW,
+  })
+  assert.equal(counts.size, 0)
+})
+
+test('keeps installers apart', () => {
+  const counts = countJobSlots({
+    corpJobs: [corpJob({ job_id: 1 }), corpJob({ job_id: 2, installer_id: 90000002 })],
+    registrationByCharacterId: REGISTRATIONS,
+    now: NOW,
+  })
+  assert.deepEqual(counts.get('reg-a')?.manufacturing, { running: 1, finished: 0 })
+  assert.deepEqual(counts.get('reg-b')?.manufacturing, { running: 1, finished: 0 })
+})
+
+test('emptyCounts is a fresh object each call', () => {
+  const a = emptyCounts()
+  a.manufacturing.running = 5
+  assert.equal(emptyCounts().manufacturing.running, 0)
+})


### PR DESCRIPTION
A job installed from the corp hangar consumes the *installing character's* personal job slots, but `/character` only read `character_industry_job`. A character running nothing but corp jobs showed as fully idle — the bubbles said "start another job" when the game would refuse.

## Changes

- **`src/app/industry/jobSlots.ts`** — new pure `countJobSlots({ characterJobs, corpJobs, registrationByCharacterId, now })`, folding both listings into one per-character occupancy. Corp jobs identify the installer by EVE character id, so callers pass a `character_id → registration.id` map; installers who aren't one of our characters drop out. Rows are deduped on the game-wide-unique `job_id`, so a job appearing in both listings counts once. The elapsed-timer-still-holds-the-slot rule moves in here with it.
- **`src/app/character/page.tsx`** — queries `corp_industry_job` alongside the character view (both in one `Promise.all`) and delegates to the shared fold. RLS already scopes the corp view to the caller's corporations, so no new access is opened.
- **`src/app/api/mcp/industryTools.ts`** — `list_job_slots` carried a copy of the same fold, and its response `note` already told callers that corp jobs were counted when they weren't. It now goes through the same seam and reports `corp-industry-jobs` freshness alongside the character jobs.
- **`test/jobSlots.test.ts`** — new: corp job attributed to its installer, character + corp summed per family, dedupe on shared `job_id`, untracked installers dropped, elapsed/`ready` jobs counted as ready-to-deliver, non-slot activities ignored, installers kept apart.

## Verification

`pnpm test` (240 pass), `pnpm run lint`, and `pnpm run build` all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QmA99Hkm7LyQgtACjy7Zf2)_