### PR TITLE
feat(graphql): corp-owned rows, under one owner dimension

### DIFF
--- a/src/app/api/graphql/context.ts
+++ b/src/app/api/graphql/context.ts
@@ -30,6 +30,15 @@ export type OwnerIdentity = {
   allianceName: string | null
 }
 
+// The public identity behind a corporation that owns rows, for the
+// Corporation entity edge. World-readable tables only, exactly like
+// OwnerIdentity above.
+export type CorporationIdentity = {
+  name: string | null
+  allianceId: string | null
+  allianceName: string | null
+}
+
 export type GraphqlContext = {
   supabase: SupabaseClient
   mode: 'session' | 'token'
@@ -40,6 +49,17 @@ export type GraphqlContext = {
   // registration uuid → EVE character id, for Owner.characterId on the caller's
   // own characters (free — it rides along on the context's registration read).
   ownerCharacterIdById: Map<string, string>
+  // The corporations the caller's characters belong to. Corp-owned rows
+  // (corp_asset, corp_blueprint, corp_industry_job) are RLS-scoped to exactly
+  // this set in session mode; in token mode the service client bypasses RLS, so
+  // this list IS the leak guard on the corp side — the corp equivalent of
+  // registrationIds. Ids are strings for the same reason every id in the schema
+  // is: EVE ids overflow 32-bit Int.
+  corporationIds: string[]
+  // Lazily load the caller's corporation identities (name, alliance) — only the
+  // Corporation edge reads them, and there are a handful at most, so one memo
+  // per request covers every result set.
+  corporationIdentities: () => Promise<Map<string, CorporationIdentity>>
   // Lazily load the identities for one result set's owners. The Owner type's
   // corp/alliance fields are the only callers, so an unselected edge costs
   // nothing; when they are selected, every row of a result set passes the SAME
@@ -122,6 +142,49 @@ const loadOwnerIdentities = async (
   )
 }
 
+// The caller's corporations, named. `corporation` and `alliance` are both
+// world-readable, so this resolves identically in session and token mode.
+const loadCorporationIdentities = async (
+  supabase: SupabaseClient,
+  corporationIds: readonly string[]
+): Promise<Map<string, CorporationIdentity>> => {
+  if (corporationIds.length === 0) return new Map()
+  const { data } = await supabase
+    .from('corporation')
+    .select('corporation_id, name, alliance_id')
+    .in('corporation_id', corporationIds.map(Number))
+  const rows = (data ?? []) as Array<{
+    corporation_id: number | string
+    name: string | null
+    alliance_id: number | string | null
+  }>
+
+  const allianceIds = [...new Set(rows.map((r) => r.alliance_id).filter((id): id is number | string => id != null))]
+  const { data: alliances } = allianceIds.length
+    ? await supabase.from('alliance').select('alliance_id, name').in('alliance_id', allianceIds.map(Number))
+    : { data: [] }
+  const allianceNames = new Map(
+    ((alliances ?? []) as Array<{ alliance_id: number | string; name: string | null }>).map((a) => [
+      String(a.alliance_id),
+      a.name,
+    ])
+  )
+
+  return new Map(
+    rows.map((r): [string, CorporationIdentity] => {
+      const allianceId = str(r.alliance_id)
+      return [
+        String(r.corporation_id),
+        {
+          name: r.name,
+          allianceId,
+          allianceName: allianceId == null ? null : (allianceNames.get(allianceId) ?? null),
+        },
+      ]
+    })
+  )
+}
+
 // The context for a given user on a given client — the tail every entry point
 // shares once auth has produced a (client, userId) pair. Owner names come from
 // the user's own registration rows, scoped by user_id here rather than through
@@ -134,16 +197,23 @@ const contextFor = async (
 ): Promise<GraphqlContext> => {
   const { data: registrations, error } = await supabase
     .from('registration')
-    .select('id, name, character_id')
+    .select('id, name, character_id, corporation_id')
     .eq('user_id', userId)
   if (error) deny('Lookup failed', 500)
 
-  const rows = (registrations ?? []) as Array<{ id: string; name: string; character_id: number | string | null }>
+  const rows = (registrations ?? []) as Array<{
+    id: string
+    name: string
+    character_id: number | string | null
+    corporation_id: number | string | null
+  }>
+  const corporationIds = [...new Set(rows.map((r) => str(r.corporation_id)).filter((id): id is string => id != null))]
 
   // Per-request memo keyed on the scope array's identity, not its contents: a
   // root resolver hands every Owner in its result set the same array, so the
   // first field resolver to look starts the load and the rest await it.
   const identitiesByScope = new WeakMap<readonly string[], Promise<Map<string, OwnerIdentity>>>()
+  let corporationIdentities: Promise<Map<string, CorporationIdentity>> | null = null
 
   return {
     supabase,
@@ -154,6 +224,11 @@ const contextFor = async (
     ownerCharacterIdById: new Map(
       rows.flatMap((r): Array<[string, string]> => (r.character_id == null ? [] : [[r.id, String(r.character_id)]]))
     ),
+    corporationIds,
+    corporationIdentities: () => {
+      corporationIdentities ??= loadCorporationIdentities(supabase, corporationIds)
+      return corporationIdentities
+    },
     ownerIdentities: (scope) => {
       const inFlight = identitiesByScope.get(scope)
       if (inFlight) return inFlight

--- a/src/app/api/graphql/filters.ts
+++ b/src/app/api/graphql/filters.ts
@@ -55,8 +55,8 @@ export const parseRefFilter = (
 }
 
 // An exact-list entry is an id when it's a bare positive integer, and a name
-// otherwise. (A character may also be named by its registration uuid — see
-// matchCharacterRefs, the one dimension with three id forms.)
+// otherwise. (An owner entry may also be a registration uuid — see
+// matchOwnerFilter, the one dimension with three id forms.)
 export const splitRefEntries = (entries: readonly string[]): { ids: string[]; names: string[] } => ({
   ids: entries.filter((e) => /^\d+$/.test(e)),
   names: entries.filter((e) => !/^\d+$/.test(e)),
@@ -86,37 +86,13 @@ export const matchExactNames = (
   }
 }
 
-// Case-insensitive substring match of the `character:` filter against the
-// caller's characters. Returns the matching registration ids, or an error
-// listing what's available — same semantics as the MCP resolveOwnerFilter.
-export type CharacterMatch = { ok: true; ids: string[] | null } | { ok: false; message: string }
-
-export const matchCharacterName = (
-  character: string | null | undefined,
-  nameById: ReadonlyMap<string, string>
-): CharacterMatch => {
-  const trimmed = (character ?? '').trim().toLowerCase()
-  if (trimmed === '') return { ok: true, ids: null }
-  const ids = [...nameById].filter(([, name]) => name.toLowerCase().includes(trimmed)).map(([id]) => id)
-  if (ids.length === 0) {
-    const available = [...nameById.values()].sort((a, b) => a.localeCompare(b))
-    return { ok: false, message: `No character matched "${character}". Available: ${available.join(', ')}.` }
-  }
-  return { ok: true, ids }
-}
-
-// The exact counterpart of the fuzzy `character:` filter: a LIST of
-// characters, each named by whichever id the caller has to hand. An entry is
+// The caller's characters, by the three ids one can be named by. An exact-list
+// entry resolves against these as:
 //
 //   - all digits          → an EVE character id (Owner.characterId),
 //   - a uuid              → this site's registration id (Owner.id / ownerId),
 //   - anything else       → a character name, matched case-insensitively but
-//                           WHOLE — a list is the exact question, `character`
-//                           is the fuzzy one, as typeIds is to typeName.
-//
-// Every entry must match, and an unmatched one errors listing what exists,
-// rather than quietly narrowing a lens nobody re-reads for a year. The result
-// is the union, deduped, in the caller's order.
+//                           WHOLE (the plural asks the exact question).
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 export type CharacterDirectory = {
@@ -137,90 +113,90 @@ const idsForEntry = (entry: string, { nameById, characterIdById }: CharacterDire
   return [...nameById].filter(([, name]) => name.toLowerCase() === wanted).map(([id]) => id)
 }
 
-const availableCharacters = ({ nameById, characterIdById }: CharacterDirectory): string =>
-  [...nameById]
-    .map(([id, name]) => {
-      const characterId = characterIdById.get(id)
+// THE OWNER DIMENSION covers both kinds of owner at once, because that's how
+// the data reads: an asset, a blueprint or an industry job is owned by a
+// character OR by a corporation, and "show me what these three own" shouldn't
+// care which. `owner:` substring-searches character AND corporation names;
+// `owners:` is an exact list mixing character names, EVE character ids,
+// registration ids, corporation names and corporation ids freely.
+//
+// The result is the two scopes the resolvers read with. `null` means no filter
+// at all (read everything the caller owns); a filter that matched only
+// characters leaves corporationIds EMPTY, and vice versa — naming one side
+// narrows to it, exactly as naming one character narrows to that character.
+export type OwnerScopes = { registrationIds: string[]; corporationIds: string[] }
+export type OwnerMatch = { ok: true; scopes: OwnerScopes | null } | { ok: false; message: string }
+
+export type OwnerDirectory = {
+  characters: CharacterDirectory
+  // EVE corporation id → name. A corporation has no registration uuid behind
+  // it, so it carries two id forms to a character's three.
+  corporations: ReadonlyMap<string, string>
+}
+
+const availableOwners = ({ characters, corporations }: OwnerDirectory): string =>
+  [
+    ...[...characters.nameById].map(([id, name]) => {
+      const characterId = characters.characterIdById.get(id)
       return characterId === undefined ? name : `${name} (${characterId})`
-    })
+    }),
+    ...[...corporations].map(([id, name]) => `${name} (${id}, corporation)`),
+  ]
     .sort((a, b) => a.localeCompare(b))
     .join(', ')
 
-export const matchCharacterRefs = (
-  characters: readonly string[] | null | undefined,
-  directory: CharacterDirectory
-): CharacterMatch => {
-  const entries = (characters ?? []).map((c) => (c ?? '').trim()).filter((c) => c !== '')
-  if (entries.length === 0) return { ok: true, ids: null }
-
-  const matched = entries.map((entry) => ({ entry, ids: idsForEntry(entry, directory) }))
-  const unmatched = matched.filter((m) => m.ids.length === 0).map((m) => m.entry)
-  if (unmatched.length > 0) {
-    return {
-      ok: false,
-      message: `No character matched ${unmatched.map((u) => `"${u}"`).join(', ')}. Available: ${availableCharacters(directory)}.`,
-    }
-  }
-  return { ok: true, ids: [...new Set(matched.flatMap((m) => m.ids))] }
+const corporationIdsForEntry = (entry: string, corporations: ReadonlyMap<string, string>): string[] => {
+  if (corporations.has(entry)) return [entry]
+  const wanted = entry.toLowerCase()
+  return [...corporations].filter(([, name]) => name.toLowerCase() === wanted).map(([id]) => id)
 }
 
-// The character dimension of the two-argument shape above: the singular
-// substring-searches the caller's character names, the plural matches whole
-// names / EVE character ids / registration ids.
-export const matchCharacterFilter = (
-  character: string | null | undefined,
-  characters: readonly string[] | null | undefined,
-  directory: CharacterDirectory
-): CharacterMatch => {
-  const parsed = parseRefFilter(character, characters, 'character')
-  if (!parsed.ok) return { ok: false, message: parsed.message }
-  if (parsed.query.kind === 'none') return { ok: true, ids: null }
-  if (parsed.query.kind === 'search') return matchCharacterName(parsed.query.term, directory.nameById)
-  return matchCharacterRefs(parsed.query.entries, directory)
-}
-
-// The corporation dimension, same shape again over the corporations the
-// caller's characters belong to: the singular substring-searches their names,
-// the plural matches whole names and EVE corporation ids. A corporation has
-// only the two id forms (there's no registration uuid behind one), so this is
-// simpler than the character matcher, but the refusals are identical.
-export const matchCorporationFilter = (
-  corporation: string | null | undefined,
-  corporations: readonly string[] | null | undefined,
-  nameById: ReadonlyMap<string, string>
-): CharacterMatch => {
-  const parsed = parseRefFilter(corporation, corporations, 'corporation')
+export const matchOwnerFilter = (
+  owner: string | null | undefined,
+  owners: readonly string[] | null | undefined,
+  directory: OwnerDirectory
+): OwnerMatch => {
+  const parsed = parseRefFilter(owner, owners, 'owner')
   if (!parsed.ok) return { ok: false, message: parsed.message }
   const query = parsed.query
-  if (query.kind === 'none') return { ok: true, ids: null }
-
-  const available = (): string =>
-    [...nameById]
-      .map(([id, name]) => `${name} (${id})`)
-      .sort((a, b) => a.localeCompare(b))
-      .join(', ')
+  if (query.kind === 'none') return { ok: true, scopes: null }
 
   if (query.kind === 'search') {
     const wanted = query.term.toLowerCase()
-    const ids = [...nameById].filter(([, name]) => name.toLowerCase().includes(wanted)).map(([id]) => id)
-    if (ids.length === 0) {
-      return { ok: false, message: `No corporation matched "${query.term}". Available: ${available()}.` }
+    const registrationIds = [...directory.characters.nameById]
+      .filter(([, name]) => name.toLowerCase().includes(wanted))
+      .map(([id]) => id)
+    const corporationIds = [...directory.corporations]
+      .filter(([, name]) => name.toLowerCase().includes(wanted))
+      .map(([id]) => id)
+    if (registrationIds.length === 0 && corporationIds.length === 0) {
+      return { ok: false, message: `No owner matched "${query.term}". Available: ${availableOwners(directory)}.` }
     }
-    return { ok: true, ids }
+    return { ok: true, scopes: { registrationIds, corporationIds } }
   }
 
-  const { ids, names } = splitRefEntries(query.entries)
-  const candidates = [...nameById].map(([id, name]) => ({ id, name }))
-  const matchedNames = matchExactNames(names, () => candidates)
-  const unknownIds = ids.filter((id) => !nameById.has(id))
-  const unmatched = [...unknownIds, ...matchedNames.unmatched]
+  // An entry can be an id on either side (a bare integer is an EVE character
+  // id OR a corporation id) or a whole name on either side, so each is tried
+  // against both and counts as matched if either bites.
+  const matched = query.entries.map((entry) => ({
+    entry,
+    registrationIds: idsForEntry(entry, directory.characters),
+    corporationIds: corporationIdsForEntry(entry, directory.corporations),
+  }))
+  const unmatched = matched.filter((m) => m.registrationIds.length === 0 && m.corporationIds.length === 0)
   if (unmatched.length > 0) {
     return {
       ok: false,
-      message: `No corporation matched ${unmatched.map((u) => `"${u}"`).join(', ')}. Available: ${available()}.`,
+      message: `No owner matched ${unmatched.map((m) => `"${m.entry}"`).join(', ')}. Available: ${availableOwners(directory)}.`,
     }
   }
-  return { ok: true, ids: [...new Set([...ids, ...matchedNames.ids])] }
+  return {
+    ok: true,
+    scopes: {
+      registrationIds: [...new Set(matched.flatMap((m) => m.registrationIds))],
+      corporationIds: [...new Set(matched.flatMap((m) => m.corporationIds))],
+    },
+  }
 }
 
 // Parse the `since` argument (full ISO timestamp or a date prefix) into an

--- a/src/app/api/graphql/filters.ts
+++ b/src/app/api/graphql/filters.ts
@@ -179,6 +179,50 @@ export const matchCharacterFilter = (
   return matchCharacterRefs(parsed.query.entries, directory)
 }
 
+// The corporation dimension, same shape again over the corporations the
+// caller's characters belong to: the singular substring-searches their names,
+// the plural matches whole names and EVE corporation ids. A corporation has
+// only the two id forms (there's no registration uuid behind one), so this is
+// simpler than the character matcher, but the refusals are identical.
+export const matchCorporationFilter = (
+  corporation: string | null | undefined,
+  corporations: readonly string[] | null | undefined,
+  nameById: ReadonlyMap<string, string>
+): CharacterMatch => {
+  const parsed = parseRefFilter(corporation, corporations, 'corporation')
+  if (!parsed.ok) return { ok: false, message: parsed.message }
+  const query = parsed.query
+  if (query.kind === 'none') return { ok: true, ids: null }
+
+  const available = (): string =>
+    [...nameById]
+      .map(([id, name]) => `${name} (${id})`)
+      .sort((a, b) => a.localeCompare(b))
+      .join(', ')
+
+  if (query.kind === 'search') {
+    const wanted = query.term.toLowerCase()
+    const ids = [...nameById].filter(([, name]) => name.toLowerCase().includes(wanted)).map(([id]) => id)
+    if (ids.length === 0) {
+      return { ok: false, message: `No corporation matched "${query.term}". Available: ${available()}.` }
+    }
+    return { ok: true, ids }
+  }
+
+  const { ids, names } = splitRefEntries(query.entries)
+  const candidates = [...nameById].map(([id, name]) => ({ id, name }))
+  const matchedNames = matchExactNames(names, () => candidates)
+  const unknownIds = ids.filter((id) => !nameById.has(id))
+  const unmatched = [...unknownIds, ...matchedNames.unmatched]
+  if (unmatched.length > 0) {
+    return {
+      ok: false,
+      message: `No corporation matched ${unmatched.map((u) => `"${u}"`).join(', ')}. Available: ${available()}.`,
+    }
+  }
+  return { ok: true, ids: [...new Set([...ids, ...matchedNames.ids])] }
+}
+
 // Parse the `since` argument (full ISO timestamp or a date prefix) into an
 // ISO string usable as a >= bound, or reject with a hint.
 export type SinceParse = { ok: true; iso: string | null } | { ok: false; message: string }

--- a/src/app/api/graphql/resolvers.ts
+++ b/src/app/api/graphql/resolvers.ts
@@ -172,25 +172,19 @@ const locationOf = (locations: ResolvedLocations, ref: LocationRef | null) => {
   }
 }
 
-// The Owner edge. `scope` is the result set's full owner id list, carried on
-// every Owner of that set BY REFERENCE — it's what the context memoizes the
-// corp/alliance load on, so the whole set resolves in one pass. It isn't in the
-// SDL, so it's invisible to callers.
-type OwnerRef = { id: string; name: string; scope: readonly string[] }
+// The Character edge. `scope` is the result set's full registration id list,
+// carried on every Character of that set BY REFERENCE — it's what the context
+// memoizes the corp/alliance load on, so the whole set resolves in one pass. It
+// isn't in the SDL, so it's invisible to callers.
+type CharacterRef = { id: string; name: string; scope: readonly string[] }
 
-const ownerOf = (names: Map<string, string> | ReadonlyMap<string, string>, id: string, scope: readonly string[]) => ({
-  id,
-  name: names.get(id) ?? id,
-  scope,
-})
-
-// The Corporation edge, for rows a CORPORATION owns rather than a character
-// (corp assets, blueprints and industry jobs). Only the id comes from the row;
-// name and alliance load lazily and once per request off the context memo.
+// The Corporation edge, for rows a CORPORATION owns rather than a character.
+// Only the id comes from the row; name and alliance load lazily and once per
+// request off the context memo.
 type CorporationRef = { corporationId: string }
 
 // corporation id → name, off the context's per-request memo. Used both to
-// match the corporation filter and to fill ownerName on corp-owned rows.
+// match the owner filter and to fill the corporation columns on corp rows.
 const corporationNamesFor = async (ctx: GraphqlContext): Promise<Map<string, string>> => {
   const identities = await ctx.corporationIdentities()
   return new Map(
@@ -204,30 +198,65 @@ const corporationNamesFor = async (ctx: GraphqlContext): Promise<Map<string, str
 // two sides are a discriminated union rather than a nullable column.
 type OwnedBy = { kind: 'character'; registrationId: string } | { kind: 'corporation'; corporationId: string }
 
-// The owner block every row type carries. `ownerId`/`ownerName` name WHOEVER
-// owns the row, so a CSV always has one filled owner column; `ownerType` says
-// which side it is, and exactly one of the two edges is non-null.
+// The name and EVE id behind a registration, for the character columns.
+export type CharacterIdentity = { name: string; characterId: string | null }
+
+// The caller's own characters as identities — no query, it's all on the
+// context already. Rows that can only be owned by the caller's characters
+// (everything but a shared asset) resolve their owner block from this.
+const ownCharacters = (ctx: GraphqlContext): ReadonlyMap<string, CharacterIdentity> =>
+  new Map(
+    [...ctx.ownerNameById].map(([id, name]): [string, CharacterIdentity] => [
+      id,
+      { name, characterId: ctx.ownerCharacterIdById.get(id) ?? null },
+    ])
+  )
+
+// THE OWNER BLOCK every row type carries. The character and corporation columns
+// are each filled only on their own side, and the owner columns are the
+// COALESCE of the two — so `ownerName` always has a value while
+// `characterName`/`corporationName` say which kind it is, and `ownerType`
+// states it outright. The two typed edges follow the same split.
+//
+// `characterId` is the EVE character id, not the registration uuid, so
+// `ownerId` is an EVE id whichever side a row came from; the registration uuid
+// is still reachable as `character { id }`. It falls back to the uuid only if
+// a registration somehow has no character id recorded.
 const ownerFieldsOf = (
   owned: OwnedBy,
-  ownerNames: ReadonlyMap<string, string>,
+  characters: ReadonlyMap<string, CharacterIdentity>,
   corporationNames: ReadonlyMap<string, string>,
   ownerScope: readonly string[]
-) =>
-  owned.kind === 'character'
-    ? {
-        ownerType: 'character',
-        ownerId: owned.registrationId,
-        ownerName: ownerNames.get(owned.registrationId) ?? owned.registrationId,
-        owner: ownerOf(ownerNames, owned.registrationId, ownerScope),
-        corporation: null,
-      }
-    : {
-        ownerType: 'corporation',
-        ownerId: owned.corporationId,
-        ownerName: corporationNames.get(owned.corporationId) ?? owned.corporationId,
-        owner: null,
-        corporation: { corporationId: owned.corporationId } as CorporationRef,
-      }
+) => {
+  if (owned.kind === 'corporation') {
+    const name = corporationNames.get(owned.corporationId) ?? owned.corporationId
+    return {
+      ownerType: 'corporation',
+      ownerId: owned.corporationId,
+      ownerName: name,
+      characterId: null,
+      characterName: null,
+      corporationId: owned.corporationId,
+      corporationName: name,
+      character: null,
+      corporation: { corporationId: owned.corporationId } as CorporationRef,
+    }
+  }
+  const identity = characters.get(owned.registrationId)
+  const characterId = identity?.characterId ?? owned.registrationId
+  const characterName = identity?.name ?? owned.registrationId
+  return {
+    ownerType: 'character',
+    ownerId: characterId,
+    ownerName: characterName,
+    characterId,
+    characterName,
+    corporationId: null,
+    corporationName: null,
+    character: { id: owned.registrationId, name: characterName, scope: ownerScope } as CharacterRef,
+    corporation: null,
+  }
+}
 
 // The two owner scopes a field reads, after the owner filter. One filter spans
 // both kinds of owner (filters.ts), so naming a character narrows to that
@@ -286,22 +315,37 @@ const grantorRegistrationIds = async (ctx: GraphqlContext): Promise<string[]> =>
   )
 }
 
-// Owner display names for a mixed set of registration ids: the caller's own
-// from the context, foreign grantors through the world-readable
+// Name and EVE character id for a mixed set of registration ids: the caller's
+// own from the context, foreign grantors through the world-readable
 // character_directory (never registration, which RLS hides to non-owners).
-const ownerNamesFor = async (ctx: GraphqlContext, registrationIds: Iterable<string>): Promise<Map<string, string>> => {
-  const names = new Map(ctx.ownerNameById)
-  const foreign = [...new Set([...registrationIds])].filter((id) => !names.has(id))
+const characterIdentitiesFor = async (
+  ctx: GraphqlContext,
+  registrationIds: Iterable<string>
+): Promise<Map<string, CharacterIdentity>> => {
+  const identities = new Map(
+    [...ctx.ownerNameById].map(([id, name]): [string, CharacterIdentity] => [
+      id,
+      { name, characterId: ctx.ownerCharacterIdById.get(id) ?? null },
+    ])
+  )
+  const foreign = [...new Set([...registrationIds])].filter((id) => !identities.has(id))
   if (foreign.length > 0) {
     const { data } = await ctx.supabase
       .from('character_directory')
-      .select('registration_id, name')
+      .select('registration_id, name, character_id')
       .in('registration_id', foreign)
-    for (const row of (data ?? []) as Array<{ registration_id: string | null; name: string | null }>) {
-      if (row.registration_id != null && row.name != null) names.set(row.registration_id, row.name)
+    const rows = (data ?? []) as Array<{
+      registration_id: string | null
+      name: string | null
+      character_id: number | string | null
+    }>
+    for (const row of rows) {
+      if (row.registration_id != null && row.name != null) {
+        identities.set(row.registration_id, { name: row.name, characterId: str(row.character_id) })
+      }
     }
   }
-  return names
+  return identities
 }
 
 // One shape for both asset sources: character_asset keys on registration_id and
@@ -331,7 +375,7 @@ const assetLocationRef = (row: AssetRow): LocationRef | null =>
 
 export const resolvers = {
   Query: {
-    owners: (_parent: unknown, _args: unknown, ctx: GraphqlContext) => {
+    characters: (_parent: unknown, _args: unknown, ctx: GraphqlContext) => {
       const scope = ctx.registrationIds
       return [...ctx.ownerNameById]
         .map(([id, name]) => ({ id, name, scope }))
@@ -422,13 +466,13 @@ export const resolvers = {
         })),
       ].slice(0, cap)
 
-      const [types, locations, ownerNames, corporationNames] = await Promise.all([
+      const [types, locations, characters, corporationNames] = await Promise.all([
         typesFor(rows.map(({ row }) => row.type_id)),
         locationNamesFor(
           ctx,
           rows.map(({ row }) => assetLocationRef(row))
         ),
-        ownerNamesFor(
+        characterIdentitiesFor(
           ctx,
           own.rows.map((r) => r.registration_id)
         ),
@@ -453,7 +497,7 @@ export const resolvers = {
             isSingleton: r.is_singleton,
             isBlueprintCopy: r.is_blueprint_copy,
             name: r.name ?? null,
-            ...ownerFieldsOf(owned, ownerNames, corporationNames, ownerScope),
+            ...ownerFieldsOf(owned, characters, corporationNames, ownerScope),
             type: itemTypeOf(types, r.type_id),
             location: locationOf(locations, ref),
           }
@@ -492,9 +536,9 @@ export const resolvers = {
           Number(i.type_id),
         ])
       )
-      const [types, ownerNames] = await Promise.all([
+      const [types, characters] = await Promise.all([
         typesFor([...typeByItem.values()]),
-        ownerNamesFor(
+        characterIdentitiesFor(
           ctx,
           grants.map((g) => g.registration_id)
         ),
@@ -507,10 +551,8 @@ export const resolvers = {
           shareId: g.id,
           itemId: String(g.item_id),
           itemTypeName: typeNameOf(types, typeId),
-          ownerId: g.registration_id,
-          ownerName: ownerNames.get(g.registration_id) ?? g.registration_id,
           sharedAt: g.created_at,
-          owner: ownerOf(ownerNames, g.registration_id, ownerScope),
+          ...ownerFieldsOf({ kind: 'character', registrationId: g.registration_id }, characters, new Map(), ownerScope),
           itemType: itemTypeOf(types, typeId),
         }
       })
@@ -607,7 +649,7 @@ export const resolvers = {
             materialEfficiency: r.material_efficiency,
             timeEfficiency: r.time_efficiency,
             runs: r.runs,
-            ...ownerFieldsOf(owned, ctx.ownerNameById, corporationNames, scopes.registrationIds),
+            ...ownerFieldsOf(owned, ownCharacters(ctx), corporationNames, scopes.registrationIds),
             type: itemTypeOf(types, r.type_id),
             location: locationOf(locations, ref),
           }
@@ -667,7 +709,6 @@ export const resolvers = {
           locationId: String(r.location_id),
           locationName: ref ? locations.nameFor(ref) : null,
           regionId: String(r.region_id),
-          owner: ownerOf(ctx.ownerNameById, r.registration_id, ownerIds),
           type: itemTypeOf(types, r.type_id),
           location: locationOf(locations, ref),
           isBuy: r.is_buy,
@@ -767,7 +808,7 @@ export const resolvers = {
           blueprintTypeName: typeNameOf(types, r.blueprint_type_id),
           productTypeId: str(r.product_type_id),
           productTypeName: typeNameOf(types, r.product_type_id),
-          ...ownerFieldsOf(owned, ctx.ownerNameById, corporationNames, scopes.registrationIds),
+          ...ownerFieldsOf(owned, ownCharacters(ctx), corporationNames, scopes.registrationIds),
           blueprintType: itemTypeOf(types, r.blueprint_type_id),
           productType: itemTypeOf(types, r.product_type_id),
           location: locationOf(locations, ref),
@@ -810,11 +851,14 @@ export const resolvers = {
       return latest
         .filter((r): r is NonNullable<typeof r> => r != null)
         .map((r) => ({
-          ownerId: r.registration_id,
-          ownerName: ctx.ownerNameById.get(r.registration_id) ?? r.registration_id,
           balance: Number(r.balance),
           recordedAt: r.recorded_at,
-          owner: ownerOf(ctx.ownerNameById, r.registration_id, ctx.registrationIds),
+          ...ownerFieldsOf(
+            { kind: 'character', registrationId: r.registration_id },
+            ownCharacters(ctx),
+            new Map(),
+            ctx.registrationIds
+          ),
         }))
         .sort((a, b) => a.ownerName.localeCompare(b.ownerName))
     },
@@ -880,9 +924,12 @@ export const resolvers = {
           isBuy: r.is_buy,
           locationId: String(r.location_id),
           locationName: ref ? locations.nameFor(ref) : null,
-          ownerId: r.registration_id,
-          ownerName: ctx.ownerNameById.get(r.registration_id) ?? r.registration_id,
-          owner: ownerOf(ctx.ownerNameById, r.registration_id, ownerIds),
+          ...ownerFieldsOf(
+            { kind: 'character', registrationId: r.registration_id },
+            ownCharacters(ctx),
+            new Map(),
+            ownerIds
+          ),
           type: itemTypeOf(types, r.type_id),
           location: locationOf(locations, ref),
         }
@@ -906,17 +953,17 @@ export const resolvers = {
   // these four read, so they stay lazy — a query that doesn't ask for a corp or
   // alliance issues no query at all, and one that does resolves the whole result
   // set at once off the memoized scope (context.ts).
-  Owner: {
-    characterId: (parent: OwnerRef, _args: unknown, ctx: GraphqlContext) =>
+  Character: {
+    characterId: (parent: CharacterRef, _args: unknown, ctx: GraphqlContext) =>
       ctx.ownerCharacterIdById.get(parent.id) ??
       ctx.ownerIdentities(parent.scope).then((m) => m.get(parent.id)?.characterId ?? null),
-    corporationId: (parent: OwnerRef, _args: unknown, ctx: GraphqlContext) =>
+    corporationId: (parent: CharacterRef, _args: unknown, ctx: GraphqlContext) =>
       ctx.ownerIdentities(parent.scope).then((m) => m.get(parent.id)?.corporationId ?? null),
-    corporationName: (parent: OwnerRef, _args: unknown, ctx: GraphqlContext) =>
+    corporationName: (parent: CharacterRef, _args: unknown, ctx: GraphqlContext) =>
       ctx.ownerIdentities(parent.scope).then((m) => m.get(parent.id)?.corporationName ?? null),
-    allianceId: (parent: OwnerRef, _args: unknown, ctx: GraphqlContext) =>
+    allianceId: (parent: CharacterRef, _args: unknown, ctx: GraphqlContext) =>
       ctx.ownerIdentities(parent.scope).then((m) => m.get(parent.id)?.allianceId ?? null),
-    allianceName: (parent: OwnerRef, _args: unknown, ctx: GraphqlContext) =>
+    allianceName: (parent: CharacterRef, _args: unknown, ctx: GraphqlContext) =>
       ctx.ownerIdentities(parent.scope).then((m) => m.get(parent.id)?.allianceName ?? null),
   },
 }

--- a/src/app/api/graphql/resolvers.ts
+++ b/src/app/api/graphql/resolvers.ts
@@ -5,14 +5,15 @@
 // The `owner`/`type`/`location` entity edges (see the SDL header for why they
 // exist) are built RIGHT HERE, in the root resolver, out of data it already
 // had — the SDE type rows and resolved locations it used to mine for a single
-// name each. So the edges add no queries and cannot fan out per row. The one
-// type-level resolver is Owner's corp/alliance block at the bottom, which loads
-// lazily and once per result set.
+// name each. So the edges add no queries and cannot fan out per row. The only
+// type-level resolvers are Owner's and Corporation's identity blocks at the
+// bottom, which load lazily and once per result set.
 //
-// THE LEAK GUARD (see context.ts): every table read filters
-// .in('registration_id', …) from the context. In session mode that's
-// redundant with RLS; in token mode the client is service-role and the filter
-// is the only barrier between users.
+// THE LEAK GUARD (see context.ts): every table read filters by owner from the
+// context — .in('registration_id', …) on the character tables, and
+// .in('corporation_id', …) from ctx.corporationIds on the corp ones. In session
+// mode that's redundant with RLS; in token mode the client is service-role and
+// these filters are the only barrier between users.
 import { GraphQLError } from 'graphql'
 import { uniq } from 'ramda'
 
@@ -24,6 +25,7 @@ import {
   LIST_CAP,
   clampLimit,
   matchCharacterFilter,
+  matchCorporationFilter,
   matchExactNames,
   parseRefFilter,
   parseSince,
@@ -198,6 +200,85 @@ const ownerOf = (names: Map<string, string> | ReadonlyMap<string, string>, id: s
   scope,
 })
 
+// The Corporation edge, for rows a CORPORATION owns rather than a character
+// (corp assets, blueprints and industry jobs). Only the id comes from the row;
+// name and alliance load lazily and once per request off the context memo.
+type CorporationRef = { corporationId: string }
+
+// corporation id → name, off the context's per-request memo. Used both to
+// match the corporation filter and to fill ownerName on corp-owned rows.
+const corporationNamesFor = async (ctx: GraphqlContext): Promise<Map<string, string>> => {
+  const identities = await ctx.corporationIdentities()
+  return new Map(
+    [...identities].flatMap(([id, identity]): Array<[string, string]> =>
+      identity.name == null ? [] : [[id, identity.name]]
+    )
+  )
+}
+
+// Who owns a row. Corp-owned rows have no registration behind them, so the
+// two sides are a discriminated union rather than a nullable column.
+type OwnedBy = { kind: 'character'; registrationId: string } | { kind: 'corporation'; corporationId: string }
+
+// The owner block every row type carries. `ownerId`/`ownerName` name WHOEVER
+// owns the row, so a CSV always has one filled owner column; `ownerType` says
+// which side it is, and exactly one of the two edges is non-null.
+const ownerFieldsOf = (
+  owned: OwnedBy,
+  ownerNames: ReadonlyMap<string, string>,
+  corporationNames: ReadonlyMap<string, string>,
+  ownerScope: readonly string[]
+) =>
+  owned.kind === 'character'
+    ? {
+        ownerType: 'character',
+        ownerId: owned.registrationId,
+        ownerName: ownerNames.get(owned.registrationId) ?? owned.registrationId,
+        owner: ownerOf(ownerNames, owned.registrationId, ownerScope),
+        corporation: null,
+      }
+    : {
+        ownerType: 'corporation',
+        ownerId: owned.corporationId,
+        ownerName: corporationNames.get(owned.corporationId) ?? owned.corporationId,
+        owner: null,
+        corporation: { corporationId: owned.corporationId } as CorporationRef,
+      }
+
+// The two owner scopes a field reads, after the character and corporation
+// filters. Naming ONE side narrows to it and excludes the other — asking for
+// "my alt's assets" shouldn't hand back the corp hangar — while naming both
+// unions them, and naming neither reads everything the caller owns.
+const ownerScopesFor = async (
+  ctx: GraphqlContext,
+  args: {
+    character?: string | null
+    characters?: readonly string[] | null
+    corporation?: string | null
+    corporations?: readonly string[] | null
+  }
+): Promise<{ registrationIds: string[]; corporationIds: string[] }> => {
+  const character = matchCharacterFilter(args.character, args.characters, {
+    nameById: ctx.ownerNameById,
+    characterIdById: ctx.ownerCharacterIdById,
+  })
+  if (!character.ok) badRequest(character.message)
+  const corporation = matchCorporationFilter(
+    args.corporation,
+    args.corporations,
+    // Only a corporation filter needs the names, so the load stays behind it.
+    args.corporation != null || args.corporations != null ? await corporationNamesFor(ctx) : new Map()
+  )
+  if (!corporation.ok) badRequest(corporation.message)
+
+  const characterIds = character.ok ? character.ids : null
+  const corporationIds = corporation.ok ? corporation.ids : null
+  return {
+    registrationIds: characterIds ?? (corporationIds === null ? ctx.registrationIds : []),
+    corporationIds: corporationIds ?? (characterIds === null ? ctx.corporationIds : []),
+  }
+}
+
 // Session-only guard for the shared-data surfaces: the Bearer path runs on the
 // service client, where RLS can't arbitrate a widened filter — the designed
 // answer for external tools consuming shared data is a Lens (phase 7).
@@ -238,9 +319,13 @@ const ownerNamesFor = async (ctx: GraphqlContext, registrationIds: Iterable<stri
   return names
 }
 
+// One shape for both asset sources: character_asset keys on registration_id and
+// carries a player-assigned name, corp_asset keys on corporation_id and has
+// neither — the columns each source lacks simply arrive undefined.
 type AssetRow = {
   item_id: number
   registration_id: string
+  corporation_id?: number | string
   type_id: number
   location_id: number | null
   location_flag: string | null
@@ -248,7 +333,7 @@ type AssetRow = {
   quantity: number | null
   is_singleton: boolean | null
   is_blueprint_copy: boolean | null
-  name: string | null
+  name?: string | null
 }
 
 const assetLocationRef = (row: AssetRow): LocationRef | null =>
@@ -265,6 +350,13 @@ export const resolvers = {
       const scope = ctx.registrationIds
       return [...ctx.ownerNameById]
         .map(([id, name]) => ({ id, name, scope }))
+        .sort((a, b) => a.name.localeCompare(b.name))
+    },
+
+    corporations: async (_parent: unknown, _args: unknown, ctx: GraphqlContext) => {
+      const names = await corporationNamesFor(ctx)
+      return ctx.corporationIds
+        .map((corporationId) => ({ corporationId, name: names.get(corporationId) ?? corporationId }))
         .sort((a, b) => a.name.localeCompare(b.name))
     },
 
@@ -288,47 +380,81 @@ export const resolvers = {
       // The character filter still narrows only the caller's own characters;
       // shared rows ride along unfiltered.
       if (args.includeShared) requireSession(ctx)
-      const ownerIds = scopeIds(ctx, args)
-      const sharedIds = args.includeShared ? await grantorRegistrationIds(ctx) : []
-      const scopedIds = [...ownerIds, ...sharedIds]
+      const scopes = await ownerScopesFor(ctx, args)
+      // Shared rows ride the character side, so a corporation-only filter (which
+      // empties that side) excludes them along with your own character rows.
+      const sharedIds = args.includeShared && scopes.registrationIds.length > 0 ? await grantorRegistrationIds(ctx) : []
+      const scopedIds = [...scopes.registrationIds, ...sharedIds]
       const typeIds = await typeIdsFor(args)
       const locationIds = await locationIdsFor(ctx, args)
       const cap = clampLimit(args.limit, ASSET_CAP)
 
-      // The same filter set applies to the head-only count and the row pages.
-      // The builder is untyped (no generated DB types in this repo), so `any`.
-      const filtered = (query: any): any => {
-        let q = query.in('registration_id', scopedIds)
+      // The same filter set applies to the head-only count and the row pages,
+      // on both sides — only the owner column differs. The builder is untyped
+      // (no generated DB types in this repo), so `any`.
+      const filtered = (query: any, ownerColumn: string, ownerIds: string[]): any => {
+        let q = query.in(ownerColumn, ownerIds)
         if (typeIds !== null) q = q.in('type_id', typeIds)
         if (locationIds !== null) q = q.in('location_id', locationIds)
         return q
       }
 
-      const { count, error: countError } = await filtered(
-        ctx.supabase.from('character_asset').select('item_id', { count: 'exact', head: true })
-      )
-      if (countError) return queryFailed()
-      const totalCount = count ?? 0
+      // One source per owner side, each skipped entirely when the filters
+      // excluded it. character_asset carries a player-assigned `name`;
+      // corp_asset has no such column, so those rows report null.
+      const read = async (
+        table: string,
+        ownerColumn: string,
+        ownerIds: string[]
+      ): Promise<{ count: number; rows: AssetRow[] }> => {
+        if (ownerIds.length === 0) return { count: 0, rows: [] }
+        const { count, error } = await filtered(
+          ctx.supabase.from(table).select('item_id', { count: 'exact', head: true }),
+          ownerColumn,
+          ownerIds
+        )
+        if (error) return queryFailed()
+        const rows = await fetchCapped<AssetRow>(
+          (from, to) =>
+            filtered(ctx.supabase.from(table).select('*'), ownerColumn, ownerIds).order('item_id').range(from, to),
+          cap
+        )
+        return { count: count ?? 0, rows }
+      }
 
-      const rows = await fetchCapped<AssetRow>(
-        (from, to) => filtered(ctx.supabase.from('character_asset').select('*')).order('item_id').range(from, to),
-        cap
-      )
+      const [own, corp] = await Promise.all([
+        read('character_asset', 'registration_id', scopedIds),
+        read('corp_asset', 'corporation_id', scopes.corporationIds),
+      ])
+      const totalCount = own.count + corp.count
+      // The cap bounds the MERGED set, so a caller asking for 50 rows across
+      // both sides gets 50 rows, not 50 of each.
+      const rows = [
+        ...own.rows.map((r) => ({ row: r, owned: { kind: 'character' as const, registrationId: r.registration_id } })),
+        ...corp.rows.map((r) => ({
+          row: r,
+          owned: { kind: 'corporation' as const, corporationId: String(r.corporation_id) },
+        })),
+      ].slice(0, cap)
 
-      const [types, locations, ownerNames] = await Promise.all([
-        typesFor(rows.map((r) => r.type_id)),
-        locationNamesFor(ctx, rows.map(assetLocationRef)),
+      const [types, locations, ownerNames, corporationNames] = await Promise.all([
+        typesFor(rows.map(({ row }) => row.type_id)),
+        locationNamesFor(
+          ctx,
+          rows.map(({ row }) => assetLocationRef(row))
+        ),
         ownerNamesFor(
           ctx,
-          rows.map((r) => r.registration_id)
+          own.rows.map((r) => r.registration_id)
         ),
+        corp.rows.length > 0 ? corporationNamesFor(ctx) : Promise.resolve(new Map<string, string>()),
       ])
-      const ownerScope = uniq(rows.map((r) => r.registration_id))
+      const ownerScope = uniq(own.rows.map((r) => r.registration_id))
 
       return {
         totalCount,
         truncated: totalCount > rows.length,
-        rows: rows.map((r) => {
+        rows: rows.map(({ row: r, owned }) => {
           const ref = assetLocationRef(r)
           return {
             itemId: String(r.item_id),
@@ -341,10 +467,8 @@ export const resolvers = {
             locationName: ref ? locations.nameFor(ref) : null,
             isSingleton: r.is_singleton,
             isBlueprintCopy: r.is_blueprint_copy,
-            name: r.name,
-            ownerId: r.registration_id,
-            ownerName: ownerNames.get(r.registration_id) ?? r.registration_id,
-            owner: ownerOf(ownerNames, r.registration_id, ownerScope),
+            name: r.name ?? null,
+            ...ownerFieldsOf(owned, ownerNames, corporationNames, ownerScope),
             type: itemTypeOf(types, r.type_id),
             location: locationOf(locations, ref),
           }
@@ -414,17 +538,20 @@ export const resolvers = {
         types?: readonly string[] | null
         character?: string | null
         characters?: readonly string[] | null
+        corporation?: string | null
+        corporations?: readonly string[] | null
         limit?: number | null
       },
       ctx: GraphqlContext
     ) => {
-      const ownerIds = scopeIds(ctx, args)
+      const scopes = await ownerScopesFor(ctx, args)
       const typeIds = await typeIdsFor(args)
       const cap = clampLimit(args.limit, LIST_CAP)
 
       type BlueprintRow = {
         item_id: number
         registration_id: string
+        corporation_id?: number | string
         type_id: number
         location_id: number | null
         location_flag: string | null
@@ -434,34 +561,57 @@ export const resolvers = {
         runs: number | null
       }
 
-      const filtered = (query: any): any => {
-        const q = query.in('registration_id', ownerIds)
+      const filtered = (query: any, ownerColumn: string, ownerIds: string[]): any => {
+        const q = query.in(ownerColumn, ownerIds)
         return typeIds !== null ? q.in('type_id', typeIds) : q
       }
 
-      const { count, error: countError } = await filtered(
-        ctx.supabase.from('character_blueprint').select('item_id', { count: 'exact', head: true })
-      )
-      if (countError) return queryFailed()
-      const totalCount = count ?? 0
+      const read = async (
+        table: string,
+        ownerColumn: string,
+        ownerIds: string[]
+      ): Promise<{ count: number; rows: BlueprintRow[] }> => {
+        if (ownerIds.length === 0) return { count: 0, rows: [] }
+        const { count, error } = await filtered(
+          ctx.supabase.from(table).select('item_id', { count: 'exact', head: true }),
+          ownerColumn,
+          ownerIds
+        )
+        if (error) return queryFailed()
+        const rows = await fetchCapped<BlueprintRow>(
+          (from, to) =>
+            filtered(ctx.supabase.from(table).select('*'), ownerColumn, ownerIds).order('item_id').range(from, to),
+          cap
+        )
+        return { count: count ?? 0, rows }
+      }
 
-      const rows = await fetchCapped<BlueprintRow>(
-        (from, to) => filtered(ctx.supabase.from('character_blueprint').select('*')).order('item_id').range(from, to),
-        cap
-      )
+      const [own, corp] = await Promise.all([
+        read('character_blueprint', 'registration_id', scopes.registrationIds),
+        read('corp_blueprint', 'corporation_id', scopes.corporationIds),
+      ])
+      const totalCount = own.count + corp.count
+      const rows = [
+        ...own.rows.map((r) => ({ row: r, owned: { kind: 'character' as const, registrationId: r.registration_id } })),
+        ...corp.rows.map((r) => ({
+          row: r,
+          owned: { kind: 'corporation' as const, corporationId: String(r.corporation_id) },
+        })),
+      ].slice(0, cap)
 
-      const [types, locations] = await Promise.all([
-        typesFor(rows.map((r) => r.type_id)),
+      const [types, locations, corporationNames] = await Promise.all([
+        typesFor(rows.map(({ row }) => row.type_id)),
         locationNamesFor(
           ctx,
-          rows.map((r) => guessLocationRef(r.location_id))
+          rows.map(({ row }) => guessLocationRef(row.location_id))
         ),
+        corp.rows.length > 0 ? corporationNamesFor(ctx) : Promise.resolve(new Map<string, string>()),
       ])
 
       return {
         totalCount,
         truncated: totalCount > rows.length,
-        rows: rows.map((r) => {
+        rows: rows.map(({ row: r, owned }) => {
           const ref = guessLocationRef(r.location_id)
           return {
             itemId: String(r.item_id),
@@ -474,9 +624,7 @@ export const resolvers = {
             materialEfficiency: r.material_efficiency,
             timeEfficiency: r.time_efficiency,
             runs: r.runs,
-            ownerId: r.registration_id,
-            ownerName: ctx.ownerNameById.get(r.registration_id) ?? r.registration_id,
-            owner: ownerOf(ctx.ownerNameById, r.registration_id, ownerIds),
+            ...ownerFieldsOf(owned, ctx.ownerNameById, corporationNames, scopes.registrationIds),
             type: itemTypeOf(types, r.type_id),
             location: locationOf(locations, ref),
           }
@@ -556,14 +704,22 @@ export const resolvers = {
 
     industryJobs: async (
       _parent: unknown,
-      args: { character?: string | null; characters?: readonly string[] | null; includeDelivered?: boolean | null },
+      args: {
+        character?: string | null
+        characters?: readonly string[] | null
+        corporation?: string | null
+        corporations?: readonly string[] | null
+        includeDelivered?: boolean | null
+      },
       ctx: GraphqlContext
     ) => {
-      const ownerIds = scopeIds(ctx, args)
+      const scopes = await ownerScopesFor(ctx, args)
 
       type JobRow = {
         job_id: number
         registration_id: string
+        corporation_id?: number | string
+        installer_id?: number | string
         activity_id: number
         blueprint_type_id: number
         product_type_id: number | null
@@ -581,24 +737,47 @@ export const resolvers = {
         facility_id: number
       }
 
-      const rows = await fetchCapped<JobRow>((from, to) => {
-        const q = ctx.supabase
-          .from('character_industry_job')
-          .select('*')
-          .in('registration_id', ownerIds)
-          .order('start_date', { ascending: false })
-          .range(from, to)
-        return args.includeDelivered ? q : q.neq('status', 'delivered')
-      }, LIST_CAP)
+      const read = async (table: string, ownerColumn: string, ownerIds: string[]): Promise<JobRow[]> => {
+        if (ownerIds.length === 0) return []
+        return fetchCapped<JobRow>((from, to) => {
+          const q = ctx.supabase
+            .from(table)
+            .select('*')
+            .in(ownerColumn, ownerIds)
+            .order('start_date', { ascending: false })
+            .range(from, to)
+          return args.includeDelivered ? q : q.neq('status', 'delivered')
+        }, LIST_CAP)
+      }
+
+      const [own, corp] = await Promise.all([
+        read('character_industry_job', 'registration_id', scopes.registrationIds),
+        read('corp_industry_job', 'corporation_id', scopes.corporationIds),
+      ])
+      // Newest first across BOTH sides, then capped — each side came back
+      // sorted, so the merged list only needs one sort before the cap.
+      const rows = [
+        ...own.map((r) => ({ row: r, owned: { kind: 'character' as const, registrationId: r.registration_id } })),
+        ...corp.map((r) => ({
+          row: r,
+          owned: { kind: 'corporation' as const, corporationId: String(r.corporation_id) },
+        })),
+      ]
+        .sort((a, b) => b.row.start_date.localeCompare(a.row.start_date))
+        .slice(0, LIST_CAP)
 
       const jobLocationRef = (r: JobRow): LocationRef | null => guessLocationRef(r.station_id ?? r.facility_id)
 
-      const [types, locations] = await Promise.all([
-        typesFor(rows.flatMap((r) => [r.blueprint_type_id, r.product_type_id])),
-        locationNamesFor(ctx, rows.map(jobLocationRef)),
+      const [types, locations, corporationNames] = await Promise.all([
+        typesFor(rows.flatMap(({ row }) => [row.blueprint_type_id, row.product_type_id])),
+        locationNamesFor(
+          ctx,
+          rows.map(({ row }) => jobLocationRef(row))
+        ),
+        corp.length > 0 ? corporationNamesFor(ctx) : Promise.resolve(new Map<string, string>()),
       ])
 
-      return rows.map((r) => {
+      return rows.map(({ row: r, owned }) => {
         const ref = jobLocationRef(r)
         return {
           jobId: String(r.job_id),
@@ -607,7 +786,7 @@ export const resolvers = {
           blueprintTypeName: typeNameOf(types, r.blueprint_type_id),
           productTypeId: str(r.product_type_id),
           productTypeName: typeNameOf(types, r.product_type_id),
-          owner: ownerOf(ctx.ownerNameById, r.registration_id, ownerIds),
+          ...ownerFieldsOf(owned, ctx.ownerNameById, corporationNames, scopes.registrationIds),
           blueprintType: itemTypeOf(types, r.blueprint_type_id),
           productType: itemTypeOf(types, r.product_type_id),
           location: locationOf(locations, ref),
@@ -623,8 +802,9 @@ export const resolvers = {
           completedDate: r.completed_date,
           stationId: str(r.station_id),
           locationName: ref ? locations.nameFor(ref) : null,
-          ownerId: r.registration_id,
-          ownerName: ctx.ownerNameById.get(r.registration_id) ?? r.registration_id,
+          // Corp jobs name the character who installed them; character jobs
+          // are always installed by their owner, so ESI doesn't repeat it.
+          installerId: str(r.installer_id ?? null),
         }
       })
     },
@@ -727,6 +907,18 @@ export const resolvers = {
         }
       })
     },
+  },
+
+  // The Corporation edge's fields, lazy for the same reason Owner's are: a row
+  // hands over only the id, and the identities load once per request off the
+  // context memo — the caller has a handful of corporations at most.
+  Corporation: {
+    name: (parent: CorporationRef, _args: unknown, ctx: GraphqlContext) =>
+      ctx.corporationIdentities().then((m) => m.get(parent.corporationId)?.name ?? null),
+    allianceId: (parent: CorporationRef, _args: unknown, ctx: GraphqlContext) =>
+      ctx.corporationIdentities().then((m) => m.get(parent.corporationId)?.allianceId ?? null),
+    allianceName: (parent: CorporationRef, _args: unknown, ctx: GraphqlContext) =>
+      ctx.corporationIdentities().then((m) => m.get(parent.corporationId)?.allianceName ?? null),
   },
 
   // The only type-level resolvers in the schema. id/name came with the parent;

--- a/src/app/api/graphql/resolvers.ts
+++ b/src/app/api/graphql/resolvers.ts
@@ -24,14 +24,14 @@ import {
   ASSET_CAP,
   LIST_CAP,
   clampLimit,
-  matchCharacterFilter,
-  matchCorporationFilter,
   matchExactNames,
+  matchOwnerFilter,
   parseRefFilter,
   parseSince,
   splitRefEntries,
 } from './filters'
 import { searchLocationCandidates } from './locationSearch'
+import type { OwnerScopes } from './filters'
 import type { GraphqlContext } from './context'
 
 const badRequest = (message: string): never => {
@@ -40,22 +40,6 @@ const badRequest = (message: string): never => {
 
 const queryFailed = (): never => {
   throw new GraphQLError('Query failed', { extensions: { http: { status: 500 } } })
-}
-
-// The registration ids a field should read for, after the optional character
-// filter (`character` fuzzy by name, `characters` an exact list of
-// names/character ids/registration ids) — always a subset of the caller's own
-// registrations.
-const scopeIds = (
-  ctx: GraphqlContext,
-  args: { character?: string | null; characters?: readonly string[] | null }
-): string[] => {
-  const match = matchCharacterFilter(args.character, args.characters, {
-    nameById: ctx.ownerNameById,
-    characterIdById: ctx.ownerCharacterIdById,
-  })
-  if (!match.ok) return badRequest(match.message)
-  return match.ids ?? ctx.registrationIds
 }
 
 // The item-type dimension → SDE type ids, or null for no filter. `type` runs
@@ -245,38 +229,39 @@ const ownerFieldsOf = (
         corporation: { corporationId: owned.corporationId } as CorporationRef,
       }
 
-// The two owner scopes a field reads, after the character and corporation
-// filters. Naming ONE side narrows to it and excludes the other — asking for
-// "my alt's assets" shouldn't hand back the corp hangar — while naming both
-// unions them, and naming neither reads everything the caller owns.
+// The two owner scopes a field reads, after the owner filter. One filter spans
+// both kinds of owner (filters.ts), so naming a character narrows to that
+// character and drops the corp hangar, naming a corporation does the reverse,
+// naming both unions them, and naming neither reads everything the caller owns.
 const ownerScopesFor = async (
   ctx: GraphqlContext,
-  args: {
-    character?: string | null
-    characters?: readonly string[] | null
-    corporation?: string | null
-    corporations?: readonly string[] | null
-  }
-): Promise<{ registrationIds: string[]; corporationIds: string[] }> => {
-  const character = matchCharacterFilter(args.character, args.characters, {
-    nameById: ctx.ownerNameById,
-    characterIdById: ctx.ownerCharacterIdById,
+  args: { owner?: string | null; owners?: readonly string[] | null }
+): Promise<OwnerScopes> => {
+  const filtered = args.owner != null || args.owners != null
+  const match = matchOwnerFilter(args.owner, args.owners, {
+    characters: { nameById: ctx.ownerNameById, characterIdById: ctx.ownerCharacterIdById },
+    // Only a filter needs corporation names, so the load stays behind one.
+    corporations: filtered ? await corporationNamesFor(ctx) : new Map(),
   })
-  if (!character.ok) badRequest(character.message)
-  const corporation = matchCorporationFilter(
-    args.corporation,
-    args.corporations,
-    // Only a corporation filter needs the names, so the load stays behind it.
-    args.corporation != null || args.corporations != null ? await corporationNamesFor(ctx) : new Map()
-  )
-  if (!corporation.ok) badRequest(corporation.message)
+  if (!match.ok) badRequest(match.message)
+  const scopes = match.ok ? match.scopes : null
+  return scopes ?? { registrationIds: ctx.registrationIds, corporationIds: ctx.corporationIds }
+}
 
-  const characterIds = character.ok ? character.ids : null
-  const corporationIds = corporation.ok ? corporation.ids : null
-  return {
-    registrationIds: characterIds ?? (corporationIds === null ? ctx.registrationIds : []),
-    corporationIds: corporationIds ?? (characterIds === null ? ctx.corporationIds : []),
+// The character side alone, for the fields with no corp-owned source behind
+// them (market orders and wallet transactions — ESI's corporation endpoints for
+// those aren't extracted). An owner filter naming ONLY corporations can't be
+// honoured there, and saying so beats returning zero rows as if none existed.
+const characterScopeFor = async (
+  ctx: GraphqlContext,
+  args: { owner?: string | null; owners?: readonly string[] | null },
+  what: string
+): Promise<string[]> => {
+  const scopes = await ownerScopesFor(ctx, args)
+  if (scopes.registrationIds.length === 0 && scopes.corporationIds.length > 0) {
+    badRequest(`${what} are extracted per character only, so a corporation-only owner filter matches nothing here.`)
   }
+  return scopes.registrationIds
 }
 
 // Session-only guard for the shared-data surfaces: the Bearer path runs on the
@@ -367,8 +352,8 @@ export const resolvers = {
         types?: readonly string[] | null
         location?: string | null
         locations?: readonly string[] | null
-        character?: string | null
-        characters?: readonly string[] | null
+        owner?: string | null
+        owners?: readonly string[] | null
         limit?: number | null
         includeShared?: boolean | null
       },
@@ -536,10 +521,8 @@ export const resolvers = {
       args: {
         type?: string | null
         types?: readonly string[] | null
-        character?: string | null
-        characters?: readonly string[] | null
-        corporation?: string | null
-        corporations?: readonly string[] | null
+        owner?: string | null
+        owners?: readonly string[] | null
         limit?: number | null
       },
       ctx: GraphqlContext
@@ -634,10 +617,10 @@ export const resolvers = {
 
     marketOrders: async (
       _parent: unknown,
-      args: { character?: string | null; characters?: readonly string[] | null },
+      args: { owner?: string | null; owners?: readonly string[] | null },
       ctx: GraphqlContext
     ) => {
-      const ownerIds = scopeIds(ctx, args)
+      const ownerIds = await characterScopeFor(ctx, args, 'Market orders')
 
       type OrderRow = {
         order_id: number
@@ -705,10 +688,8 @@ export const resolvers = {
     industryJobs: async (
       _parent: unknown,
       args: {
-        character?: string | null
-        characters?: readonly string[] | null
-        corporation?: string | null
-        corporations?: readonly string[] | null
+        owner?: string | null
+        owners?: readonly string[] | null
         includeDelivered?: boolean | null
       },
       ctx: GraphqlContext
@@ -843,14 +824,14 @@ export const resolvers = {
       args: {
         type?: string | null
         types?: readonly string[] | null
-        character?: string | null
-        characters?: readonly string[] | null
+        owner?: string | null
+        owners?: readonly string[] | null
         since?: string | null
         limit?: number | null
       },
       ctx: GraphqlContext
     ) => {
-      const ownerIds = scopeIds(ctx, args)
+      const ownerIds = await characterScopeFor(ctx, args, 'Wallet transactions')
       const typeIds = await typeIdsFor(args)
       const since = parseSince(args.since)
       if (!since.ok) return badRequest(since.message)

--- a/src/app/api/graphql/schema.graphql.ts
+++ b/src/app/api/graphql/schema.graphql.ts
@@ -8,26 +8,31 @@
 // EVE item ids exceed 2^53, and GraphQL Int is 32-bit. Timestamps are ISO 8601
 // strings.
 //
-// Rows additionally carry ENTITY EDGES (`owner`, `type`, `location`) so the
+// Rows additionally carry ENTITY EDGES (`character`/`corporation`, `type`,
+// `location`) so the
 // GraphiQL docs explorer at GET /api/graphql is navigable — clicking through
 // Asset → ItemType is how you discover that group/category/volume exist at all.
 // Two invariants keep the edges from costing what nested resolvers usually
 // cost, both pinned by test/graphqlSchema.test.ts:
 //
-//  1. THE ENTITY TYPES ARE LEAF-ONLY. Owner, ItemType and Location contain
-//     scalars and nothing else, so a response is at most row → entity → scalar.
-//     Every row therefore flattens to exactly one CSV line (owner { name }
-//     becomes an owner_name column) — see src/app/graphql/flatten.ts, which the
-//     /graphql page's "Copy as CSV" uses. There is no deep-query surface.
+//  1. THE ENTITY TYPES ARE LEAF-ONLY. Character, Corporation, ItemType and
+//     Location contain scalars and nothing else, so a response is at most
+//     row → entity → scalar. Every row therefore flattens to exactly one CSV
+//     line (character { name } becomes a character_name column) — see
+//     src/app/lens/flatten.ts, which the /graphql page's "Copy as CSV" uses.
+//     There is no deep-query surface.
 //  2. NO EDGE FANS OUT PER ROW. `type` and `location` are pure reshapes of data
 //     the root resolver already fetched (it was resolving names from the full
-//     SDE rows and throwing the rest away). Owner's corp/alliance fields are the
-//     one exception that reads: they load lazily and once per result set, memoed
-//     on the scope array in context.ts.
+//     SDE rows and throwing the rest away). The corp/alliance fields on
+//     Character and Corporation are the one exception that reads: they load
+//     lazily and once per result set, memoed in context.ts.
 //
 // Every entity field is ALSO reachable as a flat scalar on the row itself
-// (ownerName beside owner { name }, typeName beside type { name }). Pick the
-// scalars for a CSV-shaped query, the edges for exploring; both cost the same.
+// (characterName beside character { name }, typeName beside type { name }).
+// Pick the scalars for a CSV-shaped query, the edges for exploring; both cost
+// the same. WHO OWNS A ROW is spelled out flat: ownerType says character or
+// corporation, characterId/characterName and corporationId/corporationName are
+// each filled only on their own side, and ownerId/ownerName coalesce the two.
 //
 // FILTERS COME IN SINGULAR/PLURAL PAIRS: owner/owners, location/locations,
 // type/types. An OWNER is a character or a corporation — one dimension, since
@@ -39,10 +44,10 @@
 // description says which of its fields the pair accepts. See filters.ts.
 export const typeDefs = /* GraphQL */ `
   type Query {
-    "Your linked characters. ownerId on a character-owned row below is one of these ids."
-    owners: [Owner!]!
+    "Your linked characters — what characterId/characterName on a row below name, and what an owner filter accepts."
+    characters: [Character!]!
 
-    "The corporations your linked characters belong to — what the corporation filters accept, and what ownerId carries on a corp-owned row."
+    "The corporations your linked characters belong to — what corporationId/corporationName on a corp-owned row name, and what an owner filter accepts."
     corporations: [Corporation!]!
 
     """
@@ -93,13 +98,15 @@ export const typeDefs = /* GraphQL */ `
   }
 
   """
-  The character that owns a row, reached as \`owner\` from every row type, and
-  listed on its own by the \`owners\` query. Leaf-only, so \`owner { … }\` still
-  flattens to one CSV line. Null on a row a CORPORATION owns — see Corporation.
+  A character that owns rows, reached as \`character\` from every row type and
+  listed on its own by the \`characters\` query. Leaf-only, so
+  \`character { … }\` still flattens to one CSV line. Null on a row a
+  CORPORATION owns — see Corporation.
 
-  \`id\` is this site's registration id (the id \`ownerId\` carries), NOT the EVE
-  character id — that's \`characterId\`. The corp/alliance fields load only when
-  you select them.
+  The row already carries \`characterId\`/\`characterName\` as flat columns; this
+  edge is for the rest — the registration \`id\`, and the corp/alliance the
+  character belongs to (which is NOT the row's owner unless \`ownerType\` says
+  corporation). Those load only when you select them.
 
   FILTERS: the \`owner:\`/\`owners:\` pair spans characters and corporations
   alike. \`owner:\` is a case-insensitive substring of either's \`name\`;
@@ -108,13 +115,14 @@ export const typeDefs = /* GraphQL */ `
   mixed freely with the corporation forms. An entry that matches nothing is an
   error, never a silently narrower result.
   """
-  type Owner {
-    "This site's registration id — what ownerId carries, and one of the forms the characters: filter accepts. NOT the EVE character id."
+  type Character {
+    "This site's registration id — one of the forms an owner filter accepts. NOT the EVE character id."
     id: String!
-    "The character's name. The character: filter substring-matches it; the characters: filter matches it whole."
+    "The character's name, as the row's characterName carries it."
     name: String!
-    "The EVE character id (what zKillboard, ESI and the image server use), and one of the forms the characters: filter accepts."
+    "The EVE character id (what zKillboard, ESI and the image server use), as the row's characterId carries it."
     characterId: String
+    "The corporation this CHARACTER belongs to — not the row's owner."
     corporationId: String
     corporationName: String
     allianceId: String
@@ -125,9 +133,10 @@ export const typeDefs = /* GraphQL */ `
   """
   The corporation that owns a row, reached as \`corporation\` from the row types
   a corporation can own (assets, blueprints and industry jobs — the ones with
-  a corp-wide ESI endpoint). Leaf-only, like Owner. Null on a row a CHARACTER
-  owns; \`ownerType\` on the row says which side it is, and \`ownerId\`/
-  \`ownerName\` name whichever it is, so a CSV always has one owner column.
+  a corp-wide ESI endpoint). Leaf-only, like Character. Null on a row a
+  CHARACTER owns; the row's \`corporationId\`/\`corporationName\` carry the flat
+  columns, and \`ownerId\`/\`ownerName\` coalesce the two sides so a CSV always
+  has one filled owner column.
 
   Only corporations your own characters belong to ever appear here — corp rows
   are scoped to exactly that set.
@@ -201,11 +210,19 @@ export const typeDefs = /* GraphQL */ `
     shareId: String!
     itemId: String!
     itemTypeName: String
-    ownerId: String!
-    ownerName: String!
     sharedAt: String!
-    "The sharing character."
-    owner: Owner!
+    "Always character here — a share always comes from a character."
+    ownerType: String!
+    "Same as characterId. The coalesced owner id every row type carries."
+    ownerId: String!
+    "Same as characterName. The coalesced owner name every row type carries."
+    ownerName: String!
+    "The sharing character's EVE id."
+    characterId: String
+    "The sharing character's name."
+    characterName: String
+    "The sharing character, for its registration id and corp/alliance."
+    character: Character
     "The shared root's item type."
     itemType: ItemType
   }
@@ -223,15 +240,23 @@ export const typeDefs = /* GraphQL */ `
     isBlueprintCopy: Boolean
     "Player-assigned name (ship/container custom name), if any."
     name: String
-    "Either character or corporation — which side of the union owns this row."
+    "Either character or corporation — which side owns this row."
     ownerType: String!
-    "The registration id (character-owned) or corporation id (corp-owned)."
+    "characterId or corporationId, whichever this row has — always filled."
     ownerId: String!
-    "The character's or the corporation's name — always filled."
+    "characterName or corporationName, whichever this row has — always filled."
     ownerName: String!
-    "The owning character; null on a corp-owned row."
-    owner: Owner
-    "The owning corporation; null on a character-owned row."
+    "The owning character's EVE id; null when a corporation owns the row."
+    characterId: String
+    "The owning character's name; null when a corporation owns the row."
+    characterName: String
+    "The owning corporation's EVE id; null when a character owns the row."
+    corporationId: String
+    "The owning corporation's name; null when a character owns the row."
+    corporationName: String
+    "The owning character, for its registration id and corp/alliance; null on a corp-owned row."
+    character: Character
+    "The owning corporation, for its alliance; null on a character-owned row."
     corporation: Corporation
     type: ItemType!
     "Null only for a row ESI gave no location_id."
@@ -257,15 +282,25 @@ export const typeDefs = /* GraphQL */ `
     timeEfficiency: Int
     "-1 for an original, remaining licensed runs for a copy."
     runs: Int
-    "Either character or corporation — which side of the union owns this row."
+    "Either character or corporation — which side owns this row."
     ownerType: String!
-    "The registration id (character-owned) or corporation id (corp-owned)."
+    "characterId or corporationId, whichever this row has — always filled."
     ownerId: String!
+    "characterName or corporationName, whichever this row has — always filled."
     ownerName: String!
-    "The owning character; null on a corp-owned row."
-    owner: Owner
-    "The owning corporation; null on a character-owned row."
+    "The owning character's EVE id; null when a corporation owns the row."
+    characterId: String
+    "The owning character's name; null when a corporation owns the row."
+    characterName: String
+    "The owning corporation's EVE id; null when a character owns the row."
+    corporationId: String
+    "The owning corporation's name; null when a character owns the row."
+    corporationName: String
+    "The owning character, for its registration id and corp/alliance; null on a corp-owned row."
+    character: Character
+    "The owning corporation, for its alliance; null on a character-owned row."
     corporation: Corporation
+
     "The blueprint's own item type — the product's type is not on this row."
     type: ItemType!
     location: Location
@@ -293,9 +328,18 @@ export const typeDefs = /* GraphQL */ `
     range: String!
     duration: Int!
     issued: String!
+    "Always character here — nothing else can own this row."
+    ownerType: String!
+    "Same as characterId. The coalesced owner id every row type carries."
     ownerId: String!
+    "Same as characterName. The coalesced owner name every row type carries."
     ownerName: String!
-    owner: Owner!
+    "The owning character's EVE id."
+    characterId: String
+    "The owning character's name."
+    characterName: String
+    "The owning character, for its registration id and corp/alliance."
+    character: Character
     type: ItemType!
     location: Location!
   }
@@ -319,15 +363,25 @@ export const typeDefs = /* GraphQL */ `
     completedDate: String
     stationId: String
     locationName: String
-    "Either character or corporation — which side of the union owns this row."
+    "Either character or corporation — which side owns this row."
     ownerType: String!
-    "The registration id (character-owned) or corporation id (corp-owned)."
+    "characterId or corporationId, whichever this row has — always filled."
     ownerId: String!
+    "characterName or corporationName, whichever this row has — always filled."
     ownerName: String!
-    "The owning character; null on a corp-owned row."
-    owner: Owner
-    "The owning corporation; null on a character-owned row."
+    "The owning character's EVE id; null when a corporation owns the row."
+    characterId: String
+    "The owning character's name; null when a corporation owns the row."
+    characterName: String
+    "The owning corporation's EVE id; null when a character owns the row."
+    corporationId: String
+    "The owning corporation's name; null when a character owns the row."
+    corporationName: String
+    "The owning character, for its registration id and corp/alliance; null on a corp-owned row."
+    character: Character
+    "The owning corporation, for its alliance; null on a character-owned row."
     corporation: Corporation
+
     "The EVE character who installed a CORP job; null on a character's own job, which ESI doesn't stamp."
     installerId: String
     blueprintType: ItemType!
@@ -338,11 +392,20 @@ export const typeDefs = /* GraphQL */ `
   }
 
   type WalletBalance {
-    ownerId: String!
-    ownerName: String!
     balance: Float!
     recordedAt: String!
-    owner: Owner!
+    "Always character here — nothing else can own this row."
+    ownerType: String!
+    "Same as characterId. The coalesced owner id every row type carries."
+    ownerId: String!
+    "Same as characterName. The coalesced owner name every row type carries."
+    ownerName: String!
+    "The owning character's EVE id."
+    characterId: String
+    "The owning character's name."
+    characterName: String
+    "The owning character, for its registration id and corp/alliance."
+    character: Character
   }
 
   type WalletTransaction {
@@ -355,9 +418,18 @@ export const typeDefs = /* GraphQL */ `
     isBuy: Boolean!
     locationId: String!
     locationName: String
+    "Always character here — nothing else can own this row."
+    ownerType: String!
+    "Same as characterId. The coalesced owner id every row type carries."
     ownerId: String!
+    "Same as characterName. The coalesced owner name every row type carries."
     ownerName: String!
-    owner: Owner!
+    "The owning character's EVE id."
+    characterId: String
+    "The owning character's name."
+    characterName: String
+    "The owning character, for its registration id and corp/alliance."
+    character: Character
     type: ItemType!
     location: Location!
   }

--- a/src/app/api/graphql/schema.graphql.ts
+++ b/src/app/api/graphql/schema.graphql.ts
@@ -30,20 +30,24 @@
 // scalars for a CSV-shaped query, the edges for exploring; both cost the same.
 //
 // FILTERS COME IN SINGULAR/PLURAL PAIRS, one pair per entity type: character/
-// characters, location/locations, type/types. The singular is a
+// characters, corporation/corporations, location/locations, type/types. The singular is a
 // case-insensitive substring SEARCH over names; the plural is an EXACT list
 // whose entries are ids or whole names, mixed freely. The two are mutually
 // exclusive, an entry matching nothing is an error, and each entity type's
 // description says which of its fields the pair accepts. See filters.ts.
 export const typeDefs = /* GraphQL */ `
   type Query {
-    "Your linked characters. ownerId on every row below is one of these ids."
+    "Your linked characters. ownerId on a character-owned row below is one of these ids."
     owners: [Owner!]!
 
+    "The corporations your linked characters belong to — what the corporation filters accept, and what ownerId carries on a corp-owned row."
+    corporations: [Corporation!]!
+
     """
-    Current asset rows (live inventory) across your characters. Filters are the
-    schema's singular/plural pairs — type/types, location/locations,
-    character/characters (see each entity type). includeShared additionally
+    Current asset rows (live inventory) across your characters AND the
+    corporations they belong to. Filters are the schema's singular/plural pairs
+    — type/types, location/locations, character/characters,
+    corporation/corporations (see each entity type). includeShared additionally
     returns rows other users have shared with you (session auth only — the
     api_token path is own-data only; a Lens is the way to hand shared data to
     external tools).
@@ -55,6 +59,8 @@ export const typeDefs = /* GraphQL */ `
       locations: [String!]
       character: String
       characters: [String!]
+      corporation: String
+      corporations: [String!]
       limit: Int
       includeShared: Boolean = false
     ): AssetPage!
@@ -62,14 +68,28 @@ export const typeDefs = /* GraphQL */ `
     "Asset shares other users have aimed at you (corporation/alliance/public). Session auth only."
     sharedWithMe: [ShareGrant!]!
 
-    "Current blueprint rows (BPOs and BPCs) across your characters, filtered by item type and character."
-    blueprints(type: String, types: [String!], character: String, characters: [String!], limit: Int): BlueprintPage!
+    "Current blueprint rows (BPOs and BPCs) across your characters and their corporations, filtered by item type and owner."
+    blueprints(
+      type: String
+      types: [String!]
+      character: String
+      characters: [String!]
+      corporation: String
+      corporations: [String!]
+      limit: Int
+    ): BlueprintPage!
 
-    "Open market orders across your characters."
+    "Open market orders across your characters. Character-owned only — corp market orders are not extracted yet, so there is no corporation filter here."
     marketOrders(character: String, characters: [String!]): [MarketOrder!]!
 
-    "Industry jobs across your characters. Delivered jobs are excluded unless includeDelivered."
-    industryJobs(character: String, characters: [String!], includeDelivered: Boolean = false): [IndustryJob!]!
+    "Industry jobs across your characters and their corporations. Delivered jobs are excluded unless includeDelivered."
+    industryJobs(
+      character: String
+      characters: [String!]
+      corporation: String
+      corporations: [String!]
+      includeDelivered: Boolean = false
+    ): [IndustryJob!]!
 
     "Latest known wallet balance per character."
     walletBalances: [WalletBalance!]!
@@ -86,19 +106,19 @@ export const typeDefs = /* GraphQL */ `
   }
 
   """
-    The character a row belongs to. Reached as \`owner\` from every row type, and
-    listed on its own by the \`owners\` query. Leaf-only, so \`owner { … }\` still
-    flattens to one CSV line.
+  The character that owns a row, reached as \`owner\` from every row type, and
+  listed on its own by the \`owners\` query. Leaf-only, so \`owner { … }\` still
+  flattens to one CSV line. Null on a row a CORPORATION owns — see Corporation.
 
-    \`id\` is this site's registration id (the id \`ownerId\` carries), NOT the EVE
-    character id — that's \`characterId\`. The corp/alliance fields load only when
-    you select them.
+  \`id\` is this site's registration id (the id \`ownerId\` carries), NOT the EVE
+  character id — that's \`characterId\`. The corp/alliance fields load only when
+  you select them.
 
   FILTERS: \`character:\` is a case-insensitive substring of \`name\`.
-    \`characters:\` is an exact list, and each entry may be any of the three ids
-    on this type: a whole \`name\`, an EVE \`characterId\`, or a registration
-    \`id\` — mix them freely. An entry that matches nothing is an error, never a
-    silently narrower result.
+  \`characters:\` is an exact list, and each entry may be any of the three ids
+  on this type: a whole \`name\`, an EVE \`characterId\`, or a registration
+  \`id\` — mix them freely. An entry that matches nothing is an error, never a
+  silently narrower result.
   """
   type Owner {
     "This site's registration id — what ownerId carries, and one of the forms the characters: filter accepts. NOT the EVE character id."
@@ -111,6 +131,31 @@ export const typeDefs = /* GraphQL */ `
     corporationName: String
     allianceId: String
     "Null for a character whose corporation is in no alliance."
+    allianceName: String
+  }
+
+  """
+  The corporation that owns a row, reached as \`corporation\` from the row types
+  a corporation can own (assets, blueprints and industry jobs — the ones with
+  a corp-wide ESI endpoint). Leaf-only, like Owner. Null on a row a CHARACTER
+  owns; \`ownerType\` on the row says which side it is, and \`ownerId\`/
+  \`ownerName\` name whichever it is, so a CSV always has one owner column.
+
+  Only corporations your own characters belong to ever appear here — corp rows
+  are scoped to exactly that set.
+
+  FILTERS: \`corporation:\` is a case-insensitive substring of \`name\`.
+  \`corporations:\` is an exact list of whole \`name\`s and \`corporationId\`s,
+  mixed. Naming ONE owner side narrows to it: filtering by corporation drops
+  character-owned rows, filtering by character drops corp-owned rows, giving
+  both unions them, and giving neither returns both.
+  """
+  type Corporation {
+    "The EVE corporation id — what ownerId carries on a corp-owned row."
+    corporationId: String!
+    name: String
+    allianceId: String
+    "Null for a corporation in no alliance."
     allianceName: String
   }
 
@@ -190,9 +235,16 @@ export const typeDefs = /* GraphQL */ `
     isBlueprintCopy: Boolean
     "Player-assigned name (ship/container custom name), if any."
     name: String
+    "Either character or corporation — which side of the union owns this row."
+    ownerType: String!
+    "The registration id (character-owned) or corporation id (corp-owned)."
     ownerId: String!
+    "The character's or the corporation's name — always filled."
     ownerName: String!
-    owner: Owner!
+    "The owning character; null on a corp-owned row."
+    owner: Owner
+    "The owning corporation; null on a character-owned row."
+    corporation: Corporation
     type: ItemType!
     "Null only for a row ESI gave no location_id."
     location: Location
@@ -217,9 +269,15 @@ export const typeDefs = /* GraphQL */ `
     timeEfficiency: Int
     "-1 for an original, remaining licensed runs for a copy."
     runs: Int
+    "Either character or corporation — which side of the union owns this row."
+    ownerType: String!
+    "The registration id (character-owned) or corporation id (corp-owned)."
     ownerId: String!
     ownerName: String!
-    owner: Owner!
+    "The owning character; null on a corp-owned row."
+    owner: Owner
+    "The owning corporation; null on a character-owned row."
+    corporation: Corporation
     "The blueprint's own item type — the product's type is not on this row."
     type: ItemType!
     location: Location
@@ -273,9 +331,17 @@ export const typeDefs = /* GraphQL */ `
     completedDate: String
     stationId: String
     locationName: String
+    "Either character or corporation — which side of the union owns this row."
+    ownerType: String!
+    "The registration id (character-owned) or corporation id (corp-owned)."
     ownerId: String!
     ownerName: String!
-    owner: Owner!
+    "The owning character; null on a corp-owned row."
+    owner: Owner
+    "The owning corporation; null on a character-owned row."
+    corporation: Corporation
+    "The EVE character who installed a CORP job; null on a character's own job, which ESI doesn't stamp."
+    installerId: String
     blueprintType: ItemType!
     "Null for research and copy jobs, which produce no new item type."
     productType: ItemType

--- a/src/app/api/graphql/schema.graphql.ts
+++ b/src/app/api/graphql/schema.graphql.ts
@@ -29,8 +29,10 @@
 // (ownerName beside owner { name }, typeName beside type { name }). Pick the
 // scalars for a CSV-shaped query, the edges for exploring; both cost the same.
 //
-// FILTERS COME IN SINGULAR/PLURAL PAIRS, one pair per entity type: character/
-// characters, corporation/corporations, location/locations, type/types. The singular is a
+// FILTERS COME IN SINGULAR/PLURAL PAIRS: owner/owners, location/locations,
+// type/types. An OWNER is a character or a corporation — one dimension, since
+// a row is owned by one or the other and asking "what do these own" shouldn't
+// care which. The singular is a
 // case-insensitive substring SEARCH over names; the plural is an EXACT list
 // whose entries are ids or whole names, mixed freely. The two are mutually
 // exclusive, an entry matching nothing is an error, and each entity type's
@@ -46,8 +48,9 @@ export const typeDefs = /* GraphQL */ `
     """
     Current asset rows (live inventory) across your characters AND the
     corporations they belong to. Filters are the schema's singular/plural pairs
-    — type/types, location/locations, character/characters,
-    corporation/corporations (see each entity type). includeShared additionally
+    — type/types, location/locations, owner/owners, where an owner is a
+    character OR a corporation (see Owner and Corporation). includeShared
+    additionally
     returns rows other users have shared with you (session auth only — the
     api_token path is own-data only; a Lens is the way to hand shared data to
     external tools).
@@ -57,10 +60,8 @@ export const typeDefs = /* GraphQL */ `
       types: [String!]
       location: String
       locations: [String!]
-      character: String
-      characters: [String!]
-      corporation: String
-      corporations: [String!]
+      owner: String
+      owners: [String!]
       limit: Int
       includeShared: Boolean = false
     ): AssetPage!
@@ -69,37 +70,23 @@ export const typeDefs = /* GraphQL */ `
     sharedWithMe: [ShareGrant!]!
 
     "Current blueprint rows (BPOs and BPCs) across your characters and their corporations, filtered by item type and owner."
-    blueprints(
-      type: String
-      types: [String!]
-      character: String
-      characters: [String!]
-      corporation: String
-      corporations: [String!]
-      limit: Int
-    ): BlueprintPage!
+    blueprints(type: String, types: [String!], owner: String, owners: [String!], limit: Int): BlueprintPage!
 
-    "Open market orders across your characters. Character-owned only — corp market orders are not extracted yet, so there is no corporation filter here."
-    marketOrders(character: String, characters: [String!]): [MarketOrder!]!
+    "Open market orders. Character-owned only: corp market orders are not extracted yet, so an owner filter naming only corporations is refused here rather than silently returning nothing."
+    marketOrders(owner: String, owners: [String!]): [MarketOrder!]!
 
     "Industry jobs across your characters and their corporations. Delivered jobs are excluded unless includeDelivered."
-    industryJobs(
-      character: String
-      characters: [String!]
-      corporation: String
-      corporations: [String!]
-      includeDelivered: Boolean = false
-    ): [IndustryJob!]!
+    industryJobs(owner: String, owners: [String!], includeDelivered: Boolean = false): [IndustryJob!]!
 
     "Latest known wallet balance per character."
     walletBalances: [WalletBalance!]!
 
-    "Market transaction history across your characters, newest first, filtered by item type and character."
+    "Market transaction history across your characters, newest first. Character-owned only, like marketOrders."
     walletTransactions(
       type: String
       types: [String!]
-      character: String
-      characters: [String!]
+      owner: String
+      owners: [String!]
       since: String
       limit: Int
     ): [WalletTransaction!]!
@@ -114,11 +101,12 @@ export const typeDefs = /* GraphQL */ `
   character id — that's \`characterId\`. The corp/alliance fields load only when
   you select them.
 
-  FILTERS: \`character:\` is a case-insensitive substring of \`name\`.
-  \`characters:\` is an exact list, and each entry may be any of the three ids
-  on this type: a whole \`name\`, an EVE \`characterId\`, or a registration
-  \`id\` — mix them freely. An entry that matches nothing is an error, never a
-  silently narrower result.
+  FILTERS: the \`owner:\`/\`owners:\` pair spans characters and corporations
+  alike. \`owner:\` is a case-insensitive substring of either's \`name\`;
+  \`owners:\` is an exact list whose entries may be any of the three ids on this
+  type — a whole \`name\`, an EVE \`characterId\`, or a registration \`id\` —
+  mixed freely with the corporation forms. An entry that matches nothing is an
+  error, never a silently narrower result.
   """
   type Owner {
     "This site's registration id — what ownerId carries, and one of the forms the characters: filter accepts. NOT the EVE character id."
@@ -144,11 +132,11 @@ export const typeDefs = /* GraphQL */ `
   Only corporations your own characters belong to ever appear here — corp rows
   are scoped to exactly that set.
 
-  FILTERS: \`corporation:\` is a case-insensitive substring of \`name\`.
-  \`corporations:\` is an exact list of whole \`name\`s and \`corporationId\`s,
-  mixed. Naming ONE owner side narrows to it: filtering by corporation drops
-  character-owned rows, filtering by character drops corp-owned rows, giving
-  both unions them, and giving neither returns both.
+  FILTERS: the same \`owner:\`/\`owners:\` pair reaches a corporation by whole
+  \`name\` or \`corporationId\`. Naming one side narrows to it: an owner filter
+  that matched only corporations drops character-owned rows, one that matched
+  only characters drops corp-owned rows, one matching both unions them, and no
+  filter returns both.
   """
   type Corporation {
     "The EVE corporation id — what ownerId carries on a corp-owned row."

--- a/src/app/graphql/queryEditor.tsx
+++ b/src/app/graphql/queryEditor.tsx
@@ -62,7 +62,7 @@ const EXAMPLES: Array<{ label: string; query: string }> = [
         name
         systemName
       }
-      owner {
+      character {
         name
         corporationName
       }
@@ -143,7 +143,7 @@ export const QueryEditor = () => {
     }
   }
 
-  // Entity edges nest one level (`owner { name }`), which csvRows joins into
+  // Entity edges nest one level (`character { name }`), which csvRows joins into
   // `owner.name` columns — so a query written by clicking through the docs
   // explorer downloads as a spreadsheet with no rewrite into flat scalars.
   const downloadCsv = () => {

--- a/test/checkMigrations.test.ts
+++ b/test/checkMigrations.test.ts
@@ -65,10 +65,7 @@ test('several migrations added in one PR are fine as long as each sorts after th
 test('ties that already exist on the base branch are not held against a PR', () => {
   // main really does carry two 20260723020000_* and two 20260725000000_* files.
   const tied = [...MERGED, '20260725000000_mercenary_den_alliance_sharing.sql']
-  assert.deepEqual(
-    checkMigrations({ baseFiles: tied, headFiles: [...tied, '20260726000000_new.sql'] }),
-    []
-  )
+  assert.deepEqual(checkMigrations({ baseFiles: tied, headFiles: [...tied, '20260726000000_new.sql'] }), [])
 })
 
 test('an unparseable filename fails', () => {

--- a/test/graphqlFilters.test.ts
+++ b/test/graphqlFilters.test.ts
@@ -10,11 +10,8 @@ import {
   ASSET_CAP,
   LIST_CAP,
   clampLimit,
-  matchCharacterFilter,
-  matchCharacterName,
-  matchCharacterRefs,
-  matchCorporationFilter,
   matchExactNames,
+  matchOwnerFilter,
   parseRefFilter,
   parseSince,
   splitRefEntries,
@@ -32,96 +29,6 @@ test('clampLimit bounds into [1, cap] and floors fractions', () => {
   assert.equal(clampLimit(2.9, LIST_CAP), 2)
   assert.equal(clampLimit(250, LIST_CAP), 250)
   assert.equal(clampLimit(999999, ASSET_CAP), ASSET_CAP)
-})
-
-const OWNERS = new Map([
-  ['reg-a', 'Philihp Busby'],
-  ['reg-b', 'Philihp Alt'],
-  ['reg-c', 'Someone Else'],
-])
-
-test('matchCharacterName passes null through as no filter', () => {
-  assert.deepEqual(matchCharacterName(undefined, OWNERS), { ok: true, ids: null })
-  assert.deepEqual(matchCharacterName('   ', OWNERS), { ok: true, ids: null })
-})
-
-test('matchCharacterName matches case-insensitive substrings, possibly several', () => {
-  const match = matchCharacterName('philihp', OWNERS)
-  assert.ok(match.ok)
-  assert.deepEqual(match.ok && match.ids, ['reg-a', 'reg-b'])
-  const exact = matchCharacterName('someone else', OWNERS)
-  assert.deepEqual(exact.ok && exact.ids, ['reg-c'])
-})
-
-test('matchCharacterName rejects an unknown character, listing what exists', () => {
-  const match = matchCharacterName('nobody', OWNERS)
-  assert.equal(match.ok, false)
-  assert.match(!match.ok ? match.message : '', /Philihp Alt, Philihp Busby, Someone Else/)
-})
-
-// The list filter resolves against both maps the context carries: registration
-// uuid → name, and registration uuid → EVE character id.
-const REG_A = '11111111-1111-4111-8111-111111111111'
-const REG_B = '22222222-2222-4222-8222-222222222222'
-const REG_C = '33333333-3333-4333-8333-333333333333'
-
-const DIRECTORY = {
-  nameById: new Map([
-    [REG_A, 'Philihp Busby'],
-    [REG_B, 'Philihp Alt'],
-    [REG_C, 'Someone Else'],
-  ]),
-  characterIdById: new Map([
-    [REG_A, '95465499'],
-    [REG_B, '90000001'],
-    [REG_C, '90000002'],
-  ]),
-}
-
-test('matchCharacterRefs passes an absent or empty list through as no filter', () => {
-  assert.deepEqual(matchCharacterRefs(undefined, DIRECTORY), { ok: true, ids: null })
-  assert.deepEqual(matchCharacterRefs([], DIRECTORY), { ok: true, ids: null })
-  assert.deepEqual(matchCharacterRefs(['  '], DIRECTORY), { ok: true, ids: null })
-})
-
-test('matchCharacterRefs takes whole names, EVE character ids and registration ids, mixed', () => {
-  const byName = matchCharacterRefs(['philihp busby', 'Someone Else'], DIRECTORY)
-  assert.deepEqual(byName.ok && byName.ids, [REG_A, REG_C])
-  const byCharacterId = matchCharacterRefs(['95465499'], DIRECTORY)
-  assert.deepEqual(byCharacterId.ok && byCharacterId.ids, [REG_A])
-  const mixed = matchCharacterRefs([REG_B, '95465499', 'Someone Else'], DIRECTORY)
-  assert.deepEqual(mixed.ok && mixed.ids, [REG_B, REG_A, REG_C])
-})
-
-test('matchCharacterRefs dedupes a character named twice', () => {
-  const match = matchCharacterRefs(['Philihp Busby', '95465499', REG_A], DIRECTORY)
-  assert.deepEqual(match.ok && match.ids, [REG_A])
-})
-
-test('matchCharacterRefs matches names whole, not by substring — that is what character: is for', () => {
-  const partial = matchCharacterRefs(['philihp'], DIRECTORY)
-  assert.equal(partial.ok, false)
-  assert.match(!partial.ok ? partial.message : '', /"philihp"/)
-})
-
-test('matchCharacterRefs rejects unknown entries, listing names with their character ids', () => {
-  const match = matchCharacterRefs(['Someone Else', 'Nobody', '12345'], DIRECTORY)
-  assert.equal(match.ok, false)
-  const message = !match.ok ? match.message : ''
-  assert.match(message, /"Nobody", "12345"/)
-  assert.match(message, /Philihp Busby \(95465499\)/)
-})
-
-test('matchCharacterFilter routes to the fuzzy or the exact matcher, never both', () => {
-  const none = matchCharacterFilter(null, null, DIRECTORY)
-  assert.deepEqual(none, { ok: true, ids: null })
-  const fuzzy = matchCharacterFilter('philihp', null, DIRECTORY)
-  assert.deepEqual(fuzzy.ok && fuzzy.ids, [REG_A, REG_B])
-  const exact = matchCharacterFilter(null, ['Philihp Alt'], DIRECTORY)
-  assert.deepEqual(exact.ok && exact.ids, [REG_B])
-  const both = matchCharacterFilter('philihp', ['Philihp Alt'], DIRECTORY)
-  assert.equal(both.ok, false)
-  assert.match(!both.ok ? both.message : '', /not both/)
 })
 
 test('parseSince accepts ISO timestamps and date prefixes, rejects junk', () => {
@@ -182,42 +89,65 @@ test('matchExactNames reports what matched nothing, rather than dropping it', ()
   assert.deepEqual(matched, { ids: [], unmatched: ['Trit'] })
 })
 
-// The corporation dimension: same pair, over the corporations the caller's
-// characters belong to. Two id forms only — there's no registration uuid
-// behind a corporation.
-const CORPORATIONS = new Map([
-  ['98000001', 'Sanctuary of Shadows'],
-  ['98000002', 'Shadow Cartel'],
-  ['1000045', 'Deep Core Mining Inc.'],
-])
+// The owner dimension spans both kinds of owner at once: the caller's
+// characters (three id forms) and their corporations (two).
+const REG_A = '11111111-1111-4111-8111-111111111111'
+const REG_B = '22222222-2222-4222-8222-222222222222'
 
-test('matchCorporationFilter passes an absent filter through', () => {
-  assert.deepEqual(matchCorporationFilter(null, null, CORPORATIONS), { ok: true, ids: null })
-  assert.deepEqual(matchCorporationFilter('  ', [], CORPORATIONS), { ok: true, ids: null })
+const DIRECTORY = {
+  characters: {
+    nameById: new Map([
+      [REG_A, 'Philihp Busby'],
+      [REG_B, 'Philihp Alt'],
+    ]),
+    characterIdById: new Map([
+      [REG_A, '95465499'],
+      [REG_B, '90000001'],
+    ]),
+  },
+  corporations: new Map([
+    ['98000001', 'Sanctuary of Shadows'],
+    ['1000045', 'Deep Core Mining Inc.'],
+  ]),
+}
+
+test('matchOwnerFilter passes an absent filter through as no scoping at all', () => {
+  assert.deepEqual(matchOwnerFilter(null, null, DIRECTORY), { ok: true, scopes: null })
+  assert.deepEqual(matchOwnerFilter('  ', [], DIRECTORY), { ok: true, scopes: null })
 })
 
-test('matchCorporationFilter substring-searches names in the singular', () => {
-  const match = matchCorporationFilter('shadow', null, CORPORATIONS)
-  assert.deepEqual(match.ok && match.ids, ['98000001', '98000002'])
+test('matchOwnerFilter searches character and corporation names together', () => {
+  const characters = matchOwnerFilter('philihp', null, DIRECTORY)
+  assert.deepEqual(characters.ok && characters.scopes, { registrationIds: [REG_A, REG_B], corporationIds: [] })
+  const corporations = matchOwnerFilter('sanctuary', null, DIRECTORY)
+  assert.deepEqual(corporations.ok && corporations.scopes, { registrationIds: [], corporationIds: ['98000001'] })
 })
 
-test('matchCorporationFilter takes whole names and corporation ids in the plural', () => {
-  const match = matchCorporationFilter(null, ['shadow cartel', '1000045'], CORPORATIONS)
-  assert.deepEqual(match.ok && match.ids, ['1000045', '98000002'].sort())
+test('matchOwnerFilter mixes characters and corporations in one exact list', () => {
+  const match = matchOwnerFilter(null, ['Philihp Alt', '98000001', '95465499'], DIRECTORY)
+  assert.deepEqual(match.ok && match.scopes, {
+    registrationIds: [REG_B, REG_A],
+    corporationIds: ['98000001'],
+  })
 })
 
-test('matchCorporationFilter rejects unknown entries and a partial name, listing what exists', () => {
-  const unknown = matchCorporationFilter(null, ['98009999'], CORPORATIONS)
-  assert.equal(unknown.ok, false)
-  assert.match(!unknown.ok ? unknown.message : '', /Deep Core Mining Inc\. \(1000045\)/)
-  const partial = matchCorporationFilter(null, ['shadow'], CORPORATIONS)
-  assert.equal(partial.ok, false)
-  const missing = matchCorporationFilter('nobody', null, CORPORATIONS)
-  assert.equal(missing.ok, false)
+test('matchOwnerFilter narrows to the side that matched, leaving the other empty', () => {
+  const match = matchOwnerFilter(null, ['Deep Core Mining Inc.'], DIRECTORY)
+  assert.deepEqual(match.ok && match.scopes, { registrationIds: [], corporationIds: ['1000045'] })
 })
 
-test('matchCorporationFilter refuses the singular and plural together', () => {
-  const both = matchCorporationFilter('shadow', ['Shadow Cartel'], CORPORATIONS)
+test('matchOwnerFilter rejects what matched neither side, listing both', () => {
+  const match = matchOwnerFilter(null, ['Nobody'], DIRECTORY)
+  assert.equal(match.ok, false)
+  const message = !match.ok ? match.message : ''
+  assert.match(message, /"Nobody"/)
+  assert.match(message, /Philihp Busby \(95465499\)/)
+  assert.match(message, /Sanctuary of Shadows \(98000001, corporation\)/)
+  assert.equal(matchOwnerFilter('nobody', null, DIRECTORY).ok, false)
+})
+
+test('matchOwnerFilter refuses the singular and plural together', () => {
+  const both = matchOwnerFilter('philihp', ['Philihp Alt'], DIRECTORY)
   assert.equal(both.ok, false)
-  assert.match(!both.ok ? both.message : '', /Pass corporation or corporations, not both/)
+  assert.match(!both.ok ? both.message : '', /Pass owner or owners, not both/)
 })

--- a/test/graphqlFilters.test.ts
+++ b/test/graphqlFilters.test.ts
@@ -13,6 +13,7 @@ import {
   matchCharacterFilter,
   matchCharacterName,
   matchCharacterRefs,
+  matchCorporationFilter,
   matchExactNames,
   parseRefFilter,
   parseSince,
@@ -179,4 +180,44 @@ test('matchExactNames takes whole names only, keeping every candidate that match
 test('matchExactNames reports what matched nothing, rather than dropping it', () => {
   const matched = matchExactNames(['Trit'], () => [{ id: '34', name: 'Tritanium' }])
   assert.deepEqual(matched, { ids: [], unmatched: ['Trit'] })
+})
+
+// The corporation dimension: same pair, over the corporations the caller's
+// characters belong to. Two id forms only — there's no registration uuid
+// behind a corporation.
+const CORPORATIONS = new Map([
+  ['98000001', 'Sanctuary of Shadows'],
+  ['98000002', 'Shadow Cartel'],
+  ['1000045', 'Deep Core Mining Inc.'],
+])
+
+test('matchCorporationFilter passes an absent filter through', () => {
+  assert.deepEqual(matchCorporationFilter(null, null, CORPORATIONS), { ok: true, ids: null })
+  assert.deepEqual(matchCorporationFilter('  ', [], CORPORATIONS), { ok: true, ids: null })
+})
+
+test('matchCorporationFilter substring-searches names in the singular', () => {
+  const match = matchCorporationFilter('shadow', null, CORPORATIONS)
+  assert.deepEqual(match.ok && match.ids, ['98000001', '98000002'])
+})
+
+test('matchCorporationFilter takes whole names and corporation ids in the plural', () => {
+  const match = matchCorporationFilter(null, ['shadow cartel', '1000045'], CORPORATIONS)
+  assert.deepEqual(match.ok && match.ids, ['1000045', '98000002'].sort())
+})
+
+test('matchCorporationFilter rejects unknown entries and a partial name, listing what exists', () => {
+  const unknown = matchCorporationFilter(null, ['98009999'], CORPORATIONS)
+  assert.equal(unknown.ok, false)
+  assert.match(!unknown.ok ? unknown.message : '', /Deep Core Mining Inc\. \(1000045\)/)
+  const partial = matchCorporationFilter(null, ['shadow'], CORPORATIONS)
+  assert.equal(partial.ok, false)
+  const missing = matchCorporationFilter('nobody', null, CORPORATIONS)
+  assert.equal(missing.ok, false)
+})
+
+test('matchCorporationFilter refuses the singular and plural together', () => {
+  const both = matchCorporationFilter('shadow', ['Shadow Cartel'], CORPORATIONS)
+  assert.equal(both.ok, false)
+  assert.match(!both.ok ? both.message : '', /Pass corporation or corporations, not both/)
 })

--- a/test/graphqlSchema.test.ts
+++ b/test/graphqlSchema.test.ts
@@ -18,7 +18,7 @@ import {
 import { typeDefs } from '../src/app/api/graphql/schema.graphql.ts'
 
 // The leaf-only entity types the row types point at.
-const ENTITY_TYPES = ['Corporation', 'ItemType', 'Location', 'Owner']
+const ENTITY_TYPES = ['Character', 'Corporation', 'ItemType', 'Location']
 
 // Rows a corporation can own: their owner edge is nullable and paired with a
 // corporation edge, with ownerType saying which side a row came from.
@@ -61,10 +61,10 @@ test('the SDL parses and exposes the expected query fields', () => {
   assert.deepEqual(Object.keys(query.getFields()).sort(), [
     'assets',
     'blueprints',
+    'characters',
     'corporations',
     'industryJobs',
     'marketOrders',
-    'owners',
     'sharedWithMe',
     'walletBalances',
     'walletTransactions',
@@ -110,23 +110,31 @@ test('the entity types are leaf-only, which is what keeps rows CSV-flattenable',
   }
 })
 
-test('every row type carries an owner edge, and every object field on one is an entity type', () => {
+test('every row spells out its owner the same way, and points only at entity types', () => {
   const schema = buildSchema(typeDefs)
   for (const name of ROW_TYPES) {
     const fields = objectType(schema, name).getFields()
-    // A row only a character can own keeps a non-null owner; a corp-ownable
-    // row has exactly one of owner/corporation filled, so both are nullable
-    // and ownerType (never null) says which.
+    // The flat block is uniform: ownerType/ownerId/ownerName always filled,
+    // the character columns filled only on a character-owned row.
+    assert.equal(String(fields.ownerType?.type), 'String!', `${name}.ownerType`)
+    assert.equal(String(fields.ownerId?.type), 'String!', `${name}.ownerId`)
+    assert.equal(String(fields.ownerName?.type), 'String!', `${name}.ownerName`)
+    assert.equal(String(fields.characterId?.type), 'String', `${name}.characterId`)
+    assert.equal(String(fields.characterName?.type), 'String', `${name}.characterName`)
+    assert.equal(String(fields.character?.type), 'Character', `${name}.character`)
+    // The corporation columns exist only where a corporation can own the row —
+    // a column that could never be filled would be worse than its absence.
     if (CORP_OWNABLE.includes(name)) {
-      assert.equal(String(fields.owner?.type), 'Owner', `${name}.owner`)
+      assert.equal(String(fields.corporationId?.type), 'String', `${name}.corporationId`)
+      assert.equal(String(fields.corporationName?.type), 'String', `${name}.corporationName`)
       assert.equal(String(fields.corporation?.type), 'Corporation', `${name}.corporation`)
-      assert.equal(String(fields.ownerType?.type), 'String!', `${name}.ownerType`)
-      assert.equal(String(fields.ownerId?.type), 'String!', `${name}.ownerId`)
-      assert.equal(String(fields.ownerName?.type), 'String!', `${name}.ownerName`)
     } else {
-      assert.equal(String(fields.owner?.type), 'Owner!', `${name}.owner`)
+      assert.equal(fields.corporationId, undefined, `${name}.corporationId`)
       assert.equal(fields.corporation, undefined, `${name}.corporation`)
     }
+    // `owner` as an EDGE is gone: it meant the character while ownerName meant
+    // either, one field apart. The scalars are the umbrella now.
+    assert.equal(fields.owner, undefined, `${name}.owner`)
     for (const field of Object.values(fields)) {
       const target = getNamedType(field.type)
       if (!isObjectType(target)) continue
@@ -143,7 +151,7 @@ test('every row type carries an owner edge, and every object field on one is an 
 test('the flat scalar beside each edge survives', () => {
   const schema = buildSchema(typeDefs)
   const asset = objectType(schema, 'Asset').getFields()
-  assert.equal(String(asset.ownerName.type), 'String!')
+  assert.equal(String(asset.characterName.type), 'String')
   assert.equal(String(asset.typeName.type), 'String')
   assert.equal(String(asset.locationName.type), 'String')
   const job = objectType(schema, 'IndustryJob').getFields()
@@ -151,15 +159,16 @@ test('the flat scalar beside each edge survives', () => {
   assert.equal(String(job.productTypeName.type), 'String')
 })
 
-test('Owner exposes the EVE character id distinctly from the registration id', () => {
+test('Character exposes the EVE character id distinctly from the registration id', () => {
   const schema = buildSchema(typeDefs)
-  const owner = objectType(schema, 'Owner').getFields()
-  // id is the registration uuid (what ownerId carries and `characters:` accepts);
-  // characterId is the EVE numeric id. Conflating them is the legacy wart
-  // docs/registration-id-rename.md exists to unwind — the schema states it.
-  assert.equal(String(owner.id.type), 'String!')
-  assert.equal(String(owner.characterId.type), 'String')
-  assert.ok(owner.id.description?.includes('registration id'))
+  const character = objectType(schema, 'Character').getFields()
+  // id is the registration uuid (an owner filter accepts it); characterId is
+  // the EVE numeric id, and what the row's characterId/ownerId carry.
+  // Conflating them is the legacy wart docs/registration-id-rename.md exists to
+  // unwind — the schema states it.
+  assert.equal(String(character.id.type), 'String!')
+  assert.equal(String(character.characterId.type), 'String')
+  assert.ok(character.id.description?.includes('registration id'))
 })
 
 test('every filter dimension is a singular/plural pair, and the old names are gone', () => {

--- a/test/graphqlSchema.test.ts
+++ b/test/graphqlSchema.test.ts
@@ -17,8 +17,12 @@ import {
 
 import { typeDefs } from '../src/app/api/graphql/schema.graphql.ts'
 
-// The three leaf-only entity types the row types point at.
-const ENTITY_TYPES = ['ItemType', 'Location', 'Owner']
+// The leaf-only entity types the row types point at.
+const ENTITY_TYPES = ['Corporation', 'ItemType', 'Location', 'Owner']
+
+// Rows a corporation can own: their owner edge is nullable and paired with a
+// corporation edge, with ownerType saying which side a row came from.
+const CORP_OWNABLE = ['Asset', 'Blueprint', 'IndustryJob']
 
 // Every type whose values are rows of a result set.
 const ROW_TYPES = [
@@ -37,12 +41,27 @@ const objectType = (schema: GraphQLSchema, name: string): GraphQLObjectType => {
   return type
 }
 
+// Corp market orders have no ESI extract behind them (no corp_order table), so
+// marketOrders deliberately carries no corporation filter — an argument that
+// could never match would be worse than its absence.
+test('marketOrders and walletTransactions stay character-only', () => {
+  const schema = buildSchema(typeDefs)
+  const fields = (schema.getQueryType() as GraphQLObjectType).getFields()
+  for (const name of ['marketOrders', 'walletTransactions']) {
+    const args = fields[name].args.map((a) => a.name)
+    assert.ok(args.includes('character'), `${name}.character`)
+    assert.ok(!args.includes('corporation'), `${name}.corporation`)
+    assert.ok(!args.includes('corporations'), `${name}.corporations`)
+  }
+})
+
 test('the SDL parses and exposes the expected query fields', () => {
   const schema = buildSchema(typeDefs)
   const query = schema.getQueryType() as GraphQLObjectType
   assert.deepEqual(Object.keys(query.getFields()).sort(), [
     'assets',
     'blueprints',
+    'corporations',
     'industryJobs',
     'marketOrders',
     'owners',
@@ -95,7 +114,19 @@ test('every row type carries an owner edge, and every object field on one is an 
   const schema = buildSchema(typeDefs)
   for (const name of ROW_TYPES) {
     const fields = objectType(schema, name).getFields()
-    assert.equal(String(fields.owner?.type), 'Owner!', `${name}.owner`)
+    // A row only a character can own keeps a non-null owner; a corp-ownable
+    // row has exactly one of owner/corporation filled, so both are nullable
+    // and ownerType (never null) says which.
+    if (CORP_OWNABLE.includes(name)) {
+      assert.equal(String(fields.owner?.type), 'Owner', `${name}.owner`)
+      assert.equal(String(fields.corporation?.type), 'Corporation', `${name}.corporation`)
+      assert.equal(String(fields.ownerType?.type), 'String!', `${name}.ownerType`)
+      assert.equal(String(fields.ownerId?.type), 'String!', `${name}.ownerId`)
+      assert.equal(String(fields.ownerName?.type), 'String!', `${name}.ownerName`)
+    } else {
+      assert.equal(String(fields.owner?.type), 'Owner!', `${name}.owner`)
+      assert.equal(fields.corporation, undefined, `${name}.corporation`)
+    }
     for (const field of Object.values(fields)) {
       const target = getNamedType(field.type)
       if (!isObjectType(target)) continue
@@ -137,9 +168,9 @@ test('every filter dimension is a singular/plural pair, and the old names are go
   // Which dimensions each field filters on — the pairs are uniform, the set of
   // dimensions is per field (only assets carries a location).
   const dimensions: Record<string, string[]> = {
-    assets: ['type', 'location', 'character'],
-    blueprints: ['type', 'character'],
-    industryJobs: ['character'],
+    assets: ['type', 'location', 'character', 'corporation'],
+    blueprints: ['type', 'character', 'corporation'],
+    industryJobs: ['character', 'corporation'],
     marketOrders: ['character'],
     walletTransactions: ['type', 'character'],
   }

--- a/test/graphqlSchema.test.ts
+++ b/test/graphqlSchema.test.ts
@@ -41,17 +41,17 @@ const objectType = (schema: GraphQLSchema, name: string): GraphQLObjectType => {
   return type
 }
 
-// Corp market orders have no ESI extract behind them (no corp_order table), so
-// marketOrders deliberately carries no corporation filter — an argument that
-// could never match would be worse than its absence.
-test('marketOrders and walletTransactions stay character-only', () => {
+// The owner pair is uniform even where only characters can own a row: corp
+// market orders have no ESI extract behind them (no corp_order table), so
+// marketOrders takes the same owner filter and REFUSES a corporation-only one
+// at run time (resolvers.ts) rather than dropping the argument.
+test('the owner filter is on every list, including the character-only ones', () => {
   const schema = buildSchema(typeDefs)
   const fields = (schema.getQueryType() as GraphQLObjectType).getFields()
-  for (const name of ['marketOrders', 'walletTransactions']) {
-    const args = fields[name].args.map((a) => a.name)
-    assert.ok(args.includes('character'), `${name}.character`)
-    assert.ok(!args.includes('corporation'), `${name}.corporation`)
-    assert.ok(!args.includes('corporations'), `${name}.corporations`)
+  for (const name of ['assets', 'blueprints', 'industryJobs', 'marketOrders', 'walletTransactions']) {
+    const args = new Map(fields[name].args.map((a) => [a.name, String(a.type)]))
+    assert.equal(args.get('owner'), 'String', `${name}.owner`)
+    assert.equal(args.get('owners'), '[String!]', `${name}.owners`)
   }
 })
 
@@ -166,13 +166,14 @@ test('every filter dimension is a singular/plural pair, and the old names are go
   const schema = buildSchema(typeDefs)
   const fields = (schema.getQueryType() as GraphQLObjectType).getFields()
   // Which dimensions each field filters on — the pairs are uniform, the set of
-  // dimensions is per field (only assets carries a location).
+  // dimensions is per field (only assets carries a location). Owner is one
+  // dimension spanning characters and corporations, not two.
   const dimensions: Record<string, string[]> = {
-    assets: ['type', 'location', 'character', 'corporation'],
-    blueprints: ['type', 'character', 'corporation'],
-    industryJobs: ['character', 'corporation'],
-    marketOrders: ['character'],
-    walletTransactions: ['type', 'character'],
+    assets: ['type', 'location', 'owner'],
+    blueprints: ['type', 'owner'],
+    industryJobs: ['owner'],
+    marketOrders: ['owner'],
+    walletTransactions: ['type', 'owner'],
   }
   for (const [field, dims] of Object.entries(dimensions)) {
     const args = new Map(fields[field].args.map((a) => [a.name, String(a.type)]))
@@ -183,7 +184,16 @@ test('every filter dimension is a singular/plural pair, and the old names are go
       assert.equal(args.get(`${dim}s`), '[String!]', `${field}.${dim}s`)
     }
     // The pre-pairing spellings, all removed rather than deprecated.
-    for (const gone of ['owner', 'owners', 'typeIds', 'typeName', 'locationId', 'locationIds']) {
+    for (const gone of [
+      'character',
+      'characters',
+      'corporation',
+      'corporations',
+      'typeIds',
+      'typeName',
+      'locationId',
+      'locationIds',
+    ]) {
       assert.equal(args.get(gone), undefined, `${field}.${gone}`)
     }
   }


### PR DESCRIPTION
Assets, blueprints and industry jobs can be owned by a corporation as well as a character, but the schema only ever read the character tables — a corp hangar was invisible through GraphQL, and through any lens over it.

```graphql
{
  assets(owner: "Sanctuary", type: "Fuel Block") {
    rows { typeName quantity locationName ownerType ownerName }
  }
}
```

## Reading both sides

`assets`, `blueprints` and `industryJobs` now union `corp_asset` / `corp_blueprint` / `corp_industry_job` with their character counterparts. The row cap applies to the merged set, and `totalCount` counts both.

## One owner dimension, not two

An **owner** is a character *or* a corporation — a row is owned by one or the other, and asking "what do these own" shouldn't have to say which kind. The `owner`/`owners` filter pair covers both:

- `owner:` substring-searches character **and** corporation names together;
- `owners:` is an exact list mixing character names, EVE character ids, registration ids, corporation names and corporation ids, freely.

Naming one side narrows to it — a filter that matched only corporations drops character-owned rows, one that matched only characters drops corp-owned rows, one matching both unions them, and no filter returns everything you own.

## Rows spell out ownership flat

| field | filled when |
| --- | --- |
| `ownerType` | always — `character` or `corporation` |
| `ownerId` / `ownerName` | always — the coalesce of the two sides below |
| `characterId` / `characterName` | a character owns the row |
| `corporationId` / `corporationName` | a corporation owns the row |

`characterId` is the EVE character id, so `ownerId` is an EVE id whichever side a row came from. The typed edges follow the same split: `character` (which also carries the registration uuid as `id`, and the character's own corp/alliance) and `corporation`.

This replaces the earlier `owner` edge, which meant two things one field apart — `ownerName` covered either kind while `owner { name }` was null on a corp row. The `Owner` type is renamed **`Character`**, and the `owners` root field becomes **`characters`** (the `owners:` *filter* keeps its name — spanning both kinds is the point of it). Corporation columns appear only where a corporation can actually own the row; on the character-only rows a column that could never be filled would be worse than its absence. Corp industry jobs also expose `installerId`.

## The leak guard grows a second half

Corp reads filter `.in('corporation_id', ctx.corporationIds)` — the corporations the caller's own registrations belong to. In session mode that's redundant with the corp tables' RLS; in token mode, where the client is service-role, it is load-bearing, exactly like `registrationIds`.

## Where corp data doesn't exist yet

`marketOrders` and `walletTransactions` take the same `owner`/`owners` pair, but have no corp-owned source behind them — there is no `corp_order` table, and ESI's corporation orders/transactions endpoints aren't read by any job. An owner filter that matched **only** corporations is refused there with a message saying so, rather than returning zero rows as though the corporation owned none. Wiring corp orders up means a new SCD-2 table + migration, an extract job, a workflow and a cron entry — happy to do that as a follow-up.

## Testing

- `pnpm test` — 238 pass; new coverage for `matchOwnerFilter` (joint search, mixed exact list, one-sided narrowing, unmatched entries listing both kinds, both-at-once) and drift guards pinning the uniform owner block, the entity types staying leaf-only, and the old argument and field names being gone
- `pnpm run build` (typecheck), `pnpm run lint`, prettier clean