### PR TITLE
Alert linked Discord channels when structure fuel runs low

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ honest when a project ships or a new doc lands.
 
 | Project | What it is | Where it stands |
 |---|---|---|
-| [discord-bot/](discord-bot/) | Discord sign-in + a bot posting alerts to configured channels | Stages 01–05 shipped (legal pages, interactions endpoint, `/edencom link`, reinforcement detection, notification sender — the MVP alert loop is closed). Stages 06 (Discord sign-in) and 07 (fuel alerts) not started; 06 is folded into [open-registration.md](open-registration.md)'s stage 5 |
+| [discord-bot/](discord-bot/) | Discord sign-in + a bot posting alerts to configured channels | Stages 01–05 and 07 shipped (legal pages, interactions endpoint, `/edencom link`, reinforcement detection, notification sender, low-fuel alerts — the alert loop is closed and proven to carry a second source). Only stage 06 (Discord sign-in) is left, folded into [open-registration.md](open-registration.md)'s stage 5 |
 | [jobs-page.md](jobs-page.md) | `/jobs`: one page for job freshness, live activity, next scheduled run; replaces `/character/refresh` | `/jobs` page exists but renders stub data (`src/app/jobs/stubData.ts`); the real queries and the `/character/refresh` replacement are still to come |
 | [mcp-search-exploration.md](mcp-search-exploration.md) | MCP static-data exploration tools (planets, regions, type taxonomy) | DB views + the planet slice shipped (`list_planets`, `sdeRegions.ts`); type-taxonomy tools (`get_type`, `list_item_groups`, `list_types`), `explore_region`, and PR 4 still open |
 | [mcp-tools-spec.md](mcp-tools-spec.md) | Tool gaps found by real MCP sessions: blueprint scoping, structures, readiness | §1 `list_blueprints`/`blueprint_search` and §3 `list_structures` shipped; §2 `research_backlog` and §4 `build_readiness` not built |

--- a/docs/discord-bot/07-structure-fuel-alerts.md
+++ b/docs/discord-bot/07-structure-fuel-alerts.md
@@ -1,7 +1,38 @@
 # Stage 07 — Low structure fuel alerts
 
 **PR size:** small · **Depends on:** 04 (outbox table), 05 (sender), 03
-(linked channels)
+(linked channels) · **Status: shipped**
+
+## Implementation notes (what the code does differently)
+
+The scoping below is accurate except on three points the code had to settle:
+
+- **`fuel_expires` moved.** It now lives in `corp_structure_status`
+  (own-corp-only, while `corp_structure` opened up to alliance-mates), not
+  on `corp_structure`. Detection reads that table's previous row — before
+  the extract's upsert overwrites it — and enqueues after the write lands,
+  so a failed upsert can't leave an alert whose dedupe state was never
+  stored.
+- **The dedup rule needed a second clock.** "Compare against the previous
+  observation" is not enough on its own: while nobody refuels, the stored
+  `fuel_expires` and the fresh one are the *same instant*, so both sides of
+  a naive comparison read the same remaining time and the alert never
+  fires. The previous reading has to be judged against
+  `corp_structure_status.updated_at` — the time it was taken. Yesterday's
+  "7.5 days left" over today's "6.5 days left" is the crossing. The
+  `structure-fuel:<structure_id>:<expiry unix>` source key is a backstop
+  under that, not a substitute: the outbox's unique index only guards rows
+  that haven't been sent yet.
+- **Formatting lives with detection**, not with the sender as suggested
+  below. Stage 04 set that precedent and the outbox stores a fully composed
+  `body`, so the sender stays source-agnostic — it posts rows, it doesn't
+  know what a mercenary den or a fuel bay is.
+
+Silent by design: a structure with no fuel timer at all, and one already
+dry. A daily extract against a 7-day threshold always warns a live
+structure first, so reaching "expired" unannounced means nobody was
+listening yet — and back-dated obituaries for long-dead structures are
+noise on the first run after a channel is linked.
 
 ## Goal
 

--- a/docs/discord-bot/README.md
+++ b/docs/discord-bot/README.md
@@ -14,7 +14,7 @@ Scope for making edencom.link double as a Discord application. Two goals
    `/mercenary-dens` 📋 button, `copyDiscordPing.tsx`) and low structure
    fuel (promoted from the follow-ups list to stage 07).
 
-## Status (2026-08-01)
+## Status (2026-08-12)
 
 - **Stage 01 — shipped.** `/privacy` and `/terms` are live
   (`src/app/privacy/`, `src/app/terms/`), linked from the footer.
@@ -51,7 +51,21 @@ Scope for making edencom.link double as a Discord application. Two goals
   cron → Workflows migration. Settings grew a per-channel "Send test
   message" button. Sending needs `DISCORD_BOT_TOKEN` set in Vercel; without
   it the sweep is a logged no-op.
-- **Stages 06–07 — not started.**
+- **Stage 06 — superseded, not started.** Its invite-gating question was
+  answered elsewhere: [open-registration.md](../open-registration.md) drops
+  the invite gate entirely, and its stage 5 now delivers Discord sign-in on
+  top of an anonymous-session bootstrap that doesn't exist yet. Implement it
+  from there, not from 06-discord-sign-in.md alone — that doc stands as the
+  provider-configuration reference.
+- **Stage 07 — shipped.** Low-fuel detection rides inside the
+  `corp-structures` extract (`src/jobs/corpStructures.js` reads the fuel
+  timers the previous run stored before overwriting them; the pure
+  crossing/format seam is `src/jobs/structureFuel.js`, the enqueue I/O is
+  `src/jobs/structureFuelNotification.js`), enqueueing onto the stage-04
+  outbox for the stage-05 sender. Threshold 7 days, corp-wide audience.
+  Formatting lives with detection (as stage 04 does) rather than with the
+  sender as this doc's stage-07 sketch guessed — the outbox stores a composed
+  body, so the sender never needs to know a message's source.
 
 This is a scoping document set, not an implementation spec. Each stage is
 one PR with its own milestone; do them **in order** (each builds on the
@@ -69,9 +83,11 @@ against the code as it stands then.
 | [06-discord-sign-in.md](06-discord-sign-in.md) | medium | Discord as a Supabase Auth provider: sign in / sign up with Discord, link Discord to an email account, add email later | A Discord-only account exists and works; an email account shows a linked Discord identity in settings |
 | [07-structure-fuel-alerts.md](07-structure-fuel-alerts.md) | small | Low-fuel detection on the `corp-structures` extract, riding the stage-04 outbox and stage-05 sender | A structure crossing the fuel threshold produces exactly one channel message |
 
-Stage 06 is independent of 03–05 and can land any time after 02 (it wants
-the same Discord application, plus a second OAuth2 redirect for Supabase).
-Stage 07 depends on 04+05 (outbox + sender).
+Stage 06 was written as independent of 03–05 (it wants the same Discord
+application, plus a second OAuth2 redirect for Supabase) — but it is now
+sequenced behind [open-registration.md](../open-registration.md)'s stages
+1–4, which decide the account model it has to plug into. Stage 07 depended
+on 04+05 (outbox + sender) and shipped after them.
 
 Follow-ups (out of scope for all five stages) are collected at the bottom of
 this file.

--- a/schema.sql
+++ b/schema.sql
@@ -4075,7 +4075,9 @@ grant all            on public.discord_channel to service_role;
 create table public.notification (
   id bigint generated always as identity primary key,
   user_id uuid not null references auth.users(id) on delete cascade,
-  source text not null,                 -- 'mercenary-den:<den_id>:<end unix>'
+  source text not null,                 -- '<kind>:<subject>:<timer unix>', e.g.
+                                        -- 'mercenary-den:<den_id>:<end unix>'
+                                        -- 'structure-fuel:<structure_id>:<expiry unix>'
   transport text not null,              -- 'discord' | (future) 'ntfy'
   discord_channel_id uuid references public.discord_channel(id) on delete cascade,
   subject text not null,

--- a/src/jobs/corpStructures.js
+++ b/src/jobs/corpStructures.js
@@ -1,6 +1,11 @@
 import { corpStructures } from '../esi.js'
 import { sudoSupabase } from '../supabase.js'
 import { cli, fetchAllPages, forEachCorporation } from './lib.js'
+import {
+  enqueueLowFuelAlerts,
+  selectCorpDiscordChannels,
+  selectPreviousFuelStatuses,
+} from './structureFuelNotification.js'
 
 const TAG = 'corp-structures'
 const SCOPE = 'esi-corporations.read_structures.v1'
@@ -41,6 +46,14 @@ export const runCorpStructures = ({ registrationIds } = {}) =>
       updated_at: now,
     }))
 
+    // Low-fuel detection (docs/discord-bot/07-structure-fuel-alerts.md) judges
+    // the fresh fuel timer against the one the previous run stored, so read the
+    // old statuses before the upsert below overwrites them — and only when
+    // someone in the corp is actually listening.
+    const channels = await selectCorpDiscordChannels(corporation_id)
+    const prevById =
+      channels.length > 0 ? await selectPreviousFuelStatuses(statusRows.map((s) => s.structure_id)) : new Map()
+
     if (rows.length > 0) {
       const { error } = await sudoSupabase.from('corp_structure').upsert(rows, { onConflict: 'structure_id' })
       if (error) throw error
@@ -49,7 +62,28 @@ export const runCorpStructures = ({ registrationIds } = {}) =>
         .upsert(statusRows, { onConflict: 'structure_id' })
       if (statusError) throw statusError
     }
-    console.log(`[${TAG}] ${ctx}: corp ${corporation_id} ${rows.length} structure(s) in ${Date.now() - t0}ms`)
+
+    // After the upsert: an alert must never outlive a failed write of the state
+    // that makes it dedupe (a re-run would then ping the same crossing twice).
+    const alerts =
+      channels.length > 0
+        ? await enqueueLowFuelAlerts({
+            structures: all.map((s) => ({
+              structure_id: s.structure_id,
+              system_id: s.system_id,
+              name: s.name ?? null,
+              fuel_expires: s.fuel_expires ?? null,
+            })),
+            prevById,
+            channels,
+            now: new Date(now),
+          })
+        : 0
+
+    const alertNote = alerts > 0 ? `, ${alerts} low-fuel alert(s)` : ''
+    console.log(
+      `[${TAG}] ${ctx}: corp ${corporation_id} ${rows.length} structure(s)${alertNote} in ${Date.now() - t0}ms`
+    )
   })
 
 cli(import.meta.url, TAG, runCorpStructures)

--- a/src/jobs/mercenaryDenNotification.js
+++ b/src/jobs/mercenaryDenNotification.js
@@ -4,28 +4,16 @@
 // insert them into the notification outbox. Called from
 // characterMercenaryDens.js at extract time, so the cron, queue, and CLI paths
 // all detect for free.
-import { createClient } from '@supabase/supabase-js'
-
 import { sudoSupabase } from '../supabase.js'
 import { isNewlyReinforced, planDenNotifications } from './denReinforcement.js'
 import { forEachSequential } from './lib.js'
+import { sdeAnon } from './sdeAnon.js'
 
-// Lazy anon client for the public-read sde_planet view (same env fallbacks as
-// src/buildEsfData.js). Missing env or a failed lookup degrades to the
-// planet-id fallback body rather than failing the extract — a ping with a raw
-// id beats no ping.
-let sdeClient
-const sde = () => {
-  if (sdeClient === undefined) {
-    const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL
-    const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? process.env.SUPABASE_KEY
-    sdeClient = url && key ? createClient(url, key, { auth: { persistSession: false, autoRefreshToken: false } }) : null
-  }
-  return sdeClient
-}
-
+// The public-read sde_planet view. Missing env or a failed lookup degrades to
+// the planet-id fallback body rather than failing the extract — a ping with a
+// raw id beats no ping.
 const selectPlanet = async (planetId) => {
-  const client = sde()
+  const client = sdeAnon()
   if (!client) return null
   const { data, error } = await client
     .from('sde_planet')

--- a/src/jobs/sdeAnon.js
+++ b/src/jobs/sdeAnon.js
@@ -1,0 +1,20 @@
+// Lazy anon Supabase client for the public-read `sde_*` tables and views, for
+// use from the plain-JS extract jobs. src/utils/supabase/sde.ts is the same
+// idea for the app, but it imports via `@/` and so can't load under `node
+// src/jobs/<job>.js`; the env fallbacks mirror src/buildEsfData.js.
+//
+// Callers treat a missing client (unset env) as "no name available" and fall
+// back to raw ids rather than failing the extract — a ping naming a structure
+// id beats no ping at all.
+import { createClient } from '@supabase/supabase-js'
+
+let client
+
+export const sdeAnon = () => {
+  if (client === undefined) {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL
+    const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? process.env.SUPABASE_KEY
+    client = url && key ? createClient(url, key, { auth: { persistSession: false, autoRefreshToken: false } }) : null
+  }
+  return client
+}

--- a/src/jobs/structureFuel.js
+++ b/src/jobs/structureFuel.js
@@ -1,0 +1,127 @@
+// Pure decision logic for low-structure-fuel notifications
+// (docs/discord-bot/07-structure-fuel-alerts.md): given a structure's stored
+// fuel timer and the fresh one, decide whether it just crossed under the
+// threshold and compose the outbox rows. Ramda-only and I/O-free so node --test
+// can exercise it directly (test/structureFuel.test.ts); the reads/writes live
+// in src/jobs/structureFuelNotification.js.
+//
+// The sibling of src/jobs/denReinforcement.js, and deliberately shaped like it
+// — same transition-plus-source-key dedupe, same insert-ready row fan-out.
+import { chain } from 'ramda'
+
+// How much fuel is "low". Seven days is the spec's starting point: long enough
+// that a weekend of inattention is still recoverable, short enough that a
+// well-stocked structure never nags. Per-user thresholds are a follow-up.
+export const LOW_FUEL_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000
+
+// A timestamp as epoch millis, or null for missing/unparsable — timers are
+// compared numerically, never as strings (ISO spellings of the same instant
+// differ between ESI and Postgres round-trips).
+const toEpoch = (timestamp) => {
+  if (timestamp == null) return null
+  const ms = new Date(timestamp).getTime()
+  return Number.isNaN(ms) ? null : ms
+}
+
+// The outbox dedupe key: one alert per structure per distinct fuel timer.
+// Refuelling pushes fuel_expires forward, minting a new source — which is the
+// backstop under the crossing test below, not a replacement for it (the pending
+// unique index only guards rows that haven't been sent yet).
+export const structureFuelSource = (structureId, fuelExpires) =>
+  `structure-fuel:${structureId}:${Math.floor(toEpoch(fuelExpires) / 1000)}`
+
+// Did this structure just cross under the threshold?
+//
+// The subtlety is what "previously" means. While nobody refuels, the stored
+// fuel_expires and the fresh one are the *same instant* — so comparing both
+// against `now` can never show a crossing, and the alert would never fire.
+// The previous reading has to be judged against the time it was taken, which
+// is what corp_structure_status.updated_at records. Yesterday's "7.5 days
+// left" is above the line; today's "6.5 days left" is below it, and that pair
+// is the crossing. Run again tomorrow and the previous reading is itself below
+// the line, so it stays quiet until a refuel lifts it back over.
+export const isNewlyLowFuel = ({ prev, next, now = new Date(), thresholdMs = LOW_FUEL_THRESHOLD_MS }) => {
+  const nextMs = toEpoch(next?.fuel_expires)
+  if (nextMs === null) return false // no fuel timer at all (unfuelled or unanchoring)
+  const nowMs = now.getTime()
+  // Already dry: this alert warns, it doesn't write obituaries. A daily extract
+  // against a 7-day threshold means a live structure always gets warned first.
+  if (nextMs <= nowMs) return false
+  if (nextMs - nowMs > thresholdMs) return false // still comfortably fuelled
+
+  const prevMs = toEpoch(prev?.fuel_expires)
+  const prevAtMs = toEpoch(prev?.updated_at)
+  // Never seen before (newly anchored, or the first run after linking a
+  // channel) and already low — worth saying once.
+  if (prevMs === null || prevAtMs === null) return true
+  return prevMs - prevAtMs > thresholdMs
+}
+
+// The channel message. <t:…:s> / <t:…:R> are Discord timestamp markup: viewer-
+// local wall clock plus a live countdown, the same pair the den ping uses.
+// `name` is corp_structure.name (ESI omits it for structures the token can't
+// name) and `systemName` comes from the SDE mirror; either may be missing, and
+// the id is the last resort. ESI structure names usually already carry the
+// system as a prefix, so the parenthetical is only added when it isn't there.
+export const composeFuelPing = ({ name, systemName, structureId, fuelExpires }) => {
+  const unix = Math.floor(toEpoch(fuelExpires) / 1000)
+  const label = name?.trim() || `structure ${structureId}`
+  const place = systemName && !label.includes(systemName) ? `${label} (${systemName})` : label
+  return {
+    subject: 'Structure Fuel Low',
+    body: `Structure Low On Fuel - ${place} runs dry at <t:${unix}:s> <t:${unix}:R>`,
+  }
+}
+
+// The whole decision for one structure: [] unless it just crossed under the
+// threshold, else one insert-ready notification row per listening channel
+// (delivery state is per-message, so detection fans out here rather than in the
+// sender). Unlike the den equivalent the channels span *several* accounts —
+// structures are corp-scoped, so every corp member listening gets told — hence
+// user_id comes off each channel rather than being passed in.
+export const planFuelNotifications = ({
+  structure,
+  prev,
+  systemName,
+  channels,
+  now = new Date(),
+  thresholdMs = LOW_FUEL_THRESHOLD_MS,
+}) => {
+  if (!isNewlyLowFuel({ prev, next: structure, now, thresholdMs })) return []
+  const { structure_id: structureId, fuel_expires: fuelExpires, name } = structure
+  const { subject, body } = composeFuelPing({ name, systemName, structureId, fuelExpires })
+  const source = structureFuelSource(structureId, fuelExpires)
+  return channels.map((channel) => ({
+    user_id: channel.user_id,
+    source,
+    transport: 'discord',
+    discord_channel_id: channel.id,
+    subject,
+    body,
+    scheduled_at: now.toISOString(),
+  }))
+}
+
+// Every row for a run's worth of structures. `prevById` / `systemNames` are
+// Maps keyed by structure id and system id; a miss in either is fine (the
+// former means "never seen", the latter falls back to the bare name).
+export const planAllFuelNotifications = ({
+  structures,
+  prevById,
+  systemNames,
+  channels,
+  now = new Date(),
+  thresholdMs = LOW_FUEL_THRESHOLD_MS,
+}) =>
+  chain(
+    (structure) =>
+      planFuelNotifications({
+        structure,
+        prev: prevById.get(Number(structure.structure_id)) ?? null,
+        systemName: systemNames.get(Number(structure.system_id)) ?? null,
+        channels,
+        now,
+        thresholdMs,
+      }),
+    structures
+  )

--- a/src/jobs/structureFuelNotification.js
+++ b/src/jobs/structureFuelNotification.js
@@ -1,0 +1,88 @@
+// I/O side of low-structure-fuel notifications
+// (docs/discord-bot/07-structure-fuel-alerts.md): read the fuel timers the
+// previous run stored, resolve system names, plan the rows via the pure seam
+// (structureFuel.js), and insert them into the notification outbox. Called from
+// corpStructures.js at extract time, so the cron, workflow and CLI paths all
+// detect for free — the same shape mercenaryDenNotification.js has for dens.
+import { uniq } from 'ramda'
+
+import { sdeAnon } from './sdeAnon.js'
+import { sudoSupabase } from '../supabase.js'
+import { forEachSequential } from './lib.js'
+import { isNewlyLowFuel, planAllFuelNotifications } from './structureFuel.js'
+
+// Who hears about a corp's structures: every account with a live linked channel
+// that has a character registered to this corporation — not just the director
+// whose token happened to pull the extract. Mirrors what the /structure page's
+// RLS implies (corp members see their corp's structures).
+export const selectCorpDiscordChannels = async (corporationId) => {
+  if (!corporationId) return []
+
+  const { data: registrations, error: regError } = await sudoSupabase
+    .from('registration')
+    .select('user_id')
+    .eq('corporation_id', corporationId)
+  if (regError) throw regError
+
+  const userIds = uniq((registrations ?? []).map((r) => r.user_id).filter(Boolean))
+  if (userIds.length === 0) return []
+
+  const { data, error } = await sudoSupabase
+    .from('discord_channel')
+    .select('id, user_id')
+    .in('user_id', userIds)
+    .is('disabled_at', null)
+  if (error) throw error
+  return data ?? []
+}
+
+// The fuel timers as of the previous run, keyed by structure id. Must be read
+// *before* corpStructures upserts the fresh ones over them — updated_at is what
+// dates the reading, and the upsert stamps it with this run's clock.
+export const selectPreviousFuelStatuses = async (structureIds) => {
+  if (structureIds.length === 0) return new Map()
+  const { data, error } = await sudoSupabase
+    .from('corp_structure_status')
+    .select('structure_id, fuel_expires, updated_at')
+    .in('structure_id', structureIds)
+  if (error) throw error
+  return new Map((data ?? []).map((row) => [Number(row.structure_id), row]))
+}
+
+// System names from the SDE mirror, keyed by system id. Best-effort: no client
+// or a failed lookup degrades to the bare structure name rather than failing
+// the extract.
+const selectSystemNames = async (systemIds) => {
+  const client = sdeAnon()
+  if (!client || systemIds.length === 0) return new Map()
+  const { data, error } = await client.from('sde_kspace_system').select('system_id, name').in('system_id', systemIds)
+  if (error) return new Map()
+  return new Map((data ?? []).map((row) => [Number(row.system_id), row.name]))
+}
+
+// Enqueue one pending notification per listening channel for every structure
+// that just crossed under the fuel threshold. Returns the number of rows
+// actually inserted. Per-row inserts so a 23505 (the pending unique index —
+// this timer was already enqueued) is swallowed as success without poisoning
+// the rest of the fan-out, exactly as den detection does.
+export const enqueueLowFuelAlerts = async ({ structures, prevById, channels, now = new Date() }) => {
+  if (channels.length === 0) return 0
+
+  // Resolve names only for the structures that will actually ping — the common
+  // path is "everything is fuelled" and shouldn't cost an SDE round trip.
+  const crossing = structures.filter((structure) =>
+    isNewlyLowFuel({ prev: prevById.get(Number(structure.structure_id)) ?? null, next: structure, now })
+  )
+  if (crossing.length === 0) return 0
+
+  const systemNames = await selectSystemNames(uniq(crossing.map((s) => Number(s.system_id)).filter(Boolean)))
+  const rows = planAllFuelNotifications({ structures: crossing, prevById, systemNames, channels, now })
+
+  let inserted = 0
+  await forEachSequential(rows, async (row) => {
+    const { error } = await sudoSupabase.from('notification').insert(row)
+    if (error && error.code !== '23505') throw error
+    if (!error) inserted += 1
+  })
+  return inserted
+}

--- a/test/structureFuel.test.ts
+++ b/test/structureFuel.test.ts
@@ -1,0 +1,196 @@
+// Unit coverage for the pure low-fuel detection seam
+// (docs/discord-bot/07-structure-fuel-alerts.md). The crossing rule is the part
+// a live structure can't be arranged to exercise on demand — and the part with
+// a real trap in it: while nobody refuels, the stored fuel timer and the fresh
+// one are the same instant, so a naive "is it low now, was it high before"
+// written against a single clock never fires at all. These tests pin that the
+// previous reading is judged against the time it was taken.
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  composeFuelPing,
+  isNewlyLowFuel,
+  LOW_FUEL_THRESHOLD_MS,
+  planAllFuelNotifications,
+  planFuelNotifications,
+  structureFuelSource,
+} from '../src/jobs/structureFuel.js'
+
+const now = new Date('2026-08-12T12:00:00Z')
+const day = 24 * 60 * 60 * 1000
+const at = (offsetMs: number) => new Date(now.getTime() + offsetMs).toISOString()
+
+const channels = [
+  { id: 'chan-a', user_id: 'user-1' },
+  { id: 'chan-b', user_id: 'user-2' },
+]
+
+test('threshold is seven days', () => {
+  assert.equal(LOW_FUEL_THRESHOLD_MS, 7 * day)
+})
+
+test('crossing: yesterday above the line, today below it', () => {
+  // The no-refuel case: fuel_expires is unchanged, only the clock moved.
+  const fuelExpires = at(6.5 * day)
+  assert.equal(
+    isNewlyLowFuel({
+      prev: { fuel_expires: fuelExpires, updated_at: at(-day) }, // 7.5 days left when read
+      next: { fuel_expires: fuelExpires }, // 6.5 days left now
+      now,
+    }),
+    true
+  )
+})
+
+test('quiet: still low the next run, with no refuel in between', () => {
+  const fuelExpires = at(5.5 * day)
+  assert.equal(
+    isNewlyLowFuel({
+      prev: { fuel_expires: fuelExpires, updated_at: at(-day) }, // already 6.5 days left
+      next: { fuel_expires: fuelExpires },
+      now,
+    }),
+    false
+  )
+})
+
+test('quiet: comfortably fuelled', () => {
+  assert.equal(
+    isNewlyLowFuel({
+      prev: { fuel_expires: at(31 * day), updated_at: at(-day) },
+      next: { fuel_expires: at(30 * day) },
+      now,
+    }),
+    false
+  )
+})
+
+test('re-arms: refuelled above the line, then drained back under it', () => {
+  const refuelled = { fuel_expires: at(30 * day), updated_at: at(-day) }
+  // Straight after the refuel, nothing to say.
+  assert.equal(isNewlyLowFuel({ prev: refuelled, next: { fuel_expires: at(30 * day) }, now }), false)
+  // Weeks later it crosses again, and the alert fires a second time.
+  const drained = at(6.5 * day)
+  assert.equal(
+    isNewlyLowFuel({
+      prev: { fuel_expires: drained, updated_at: at(-day) }, // 7.5 days left when read
+      next: { fuel_expires: drained },
+      now,
+    }),
+    true
+  )
+})
+
+test('first sighting already low alerts once', () => {
+  assert.equal(isNewlyLowFuel({ prev: null, next: { fuel_expires: at(2 * day) }, now }), true)
+})
+
+test('no fuel timer at all is silent', () => {
+  assert.equal(isNewlyLowFuel({ prev: null, next: { fuel_expires: null }, now }), false)
+  assert.equal(isNewlyLowFuel({ prev: null, next: {}, now }), false)
+})
+
+test('already dry is silent — this alert warns, it does not write obituaries', () => {
+  assert.equal(isNewlyLowFuel({ prev: null, next: { fuel_expires: at(-day) }, now }), false)
+})
+
+test('exactly at the threshold counts as low', () => {
+  assert.equal(
+    isNewlyLowFuel({
+      prev: { fuel_expires: at(7 * day), updated_at: at(-day) },
+      next: { fuel_expires: at(7 * day) },
+      now,
+    }),
+    true
+  )
+})
+
+test('source key is per structure per distinct timer', () => {
+  const fuelExpires = at(3 * day)
+  const unix = Math.floor(new Date(fuelExpires).getTime() / 1000)
+  assert.equal(structureFuelSource(1035466617946, fuelExpires), `structure-fuel:1035466617946:${unix}`)
+  // A refuel moves the timer, so the source changes and the alert can fire again.
+  assert.notEqual(structureFuelSource(1035466617946, fuelExpires), structureFuelSource(1035466617946, at(30 * day)))
+})
+
+test('ping names the structure, its system, and the countdown', () => {
+  const fuelExpires = at(3 * day)
+  const unix = Math.floor(new Date(fuelExpires).getTime() / 1000)
+  assert.deepEqual(composeFuelPing({ name: 'The Vault', systemName: 'RXA-W1', structureId: 42, fuelExpires }), {
+    subject: 'Structure Fuel Low',
+    body: `Structure Low On Fuel - The Vault (RXA-W1) runs dry at <t:${unix}:s> <t:${unix}:R>`,
+  })
+})
+
+test('ping does not repeat a system already in the structure name', () => {
+  const { body } = composeFuelPing({
+    name: 'RXA-W1 - The Vault',
+    systemName: 'RXA-W1',
+    structureId: 42,
+    fuelExpires: at(3 * day),
+  })
+  assert.match(body, /- RXA-W1 - The Vault runs dry/)
+})
+
+test('ping falls back to the raw id when ESI gave no name', () => {
+  const { body } = composeFuelPing({ name: null, systemName: null, structureId: 42, fuelExpires: at(3 * day) })
+  assert.match(body, /- structure 42 runs dry/)
+})
+
+test('one row per listening channel, each attributed to its own account', () => {
+  const fuelExpires = at(6.5 * day)
+  const rows = planFuelNotifications({
+    structure: { structure_id: 42, system_id: 30000142, name: 'The Vault', fuel_expires: fuelExpires },
+    prev: { fuel_expires: fuelExpires, updated_at: at(-day) },
+    systemName: 'Jita',
+    channels,
+    now,
+  })
+  assert.equal(rows.length, 2)
+  assert.deepEqual(
+    rows.map((r) => [r.user_id, r.discord_channel_id]),
+    [
+      ['user-1', 'chan-a'],
+      ['user-2', 'chan-b'],
+    ]
+  )
+  assert.equal(rows[0].transport, 'discord')
+  assert.equal(rows[0].source, structureFuelSource(42, fuelExpires))
+  assert.equal(rows[0].scheduled_at, now.toISOString())
+})
+
+test('a structure that did not cross produces nothing', () => {
+  assert.deepEqual(
+    planFuelNotifications({
+      structure: { structure_id: 42, system_id: 30000142, name: 'The Vault', fuel_expires: at(30 * day) },
+      prev: { fuel_expires: at(31 * day), updated_at: at(-day) },
+      systemName: 'Jita',
+      channels,
+      now,
+    }),
+    []
+  )
+})
+
+test('a run plans only its crossing structures', () => {
+  const crossing = at(6.5 * day)
+  const rows = planAllFuelNotifications({
+    structures: [
+      { structure_id: 42, system_id: 30000142, name: 'The Vault', fuel_expires: crossing },
+      { structure_id: 43, system_id: 30000142, name: 'The Annex', fuel_expires: at(30 * day) },
+      { structure_id: 44, system_id: 30000999, name: null, fuel_expires: null },
+    ],
+    prevById: new Map([
+      [42, { fuel_expires: crossing, updated_at: at(-day) }],
+      [43, { fuel_expires: at(31 * day), updated_at: at(-day) }],
+    ]),
+    systemNames: new Map([[30000142, 'Jita']]),
+    channels,
+    now,
+  })
+  // Only structure 42, fanned out across both channels.
+  assert.equal(rows.length, 2)
+  assert.ok(rows.every((r) => r.source === structureFuelSource(42, crossing)))
+  assert.match(rows[0].body, /The Vault \(Jita\)/)
+})


### PR DESCRIPTION
Discord **stage 07** — the first alert source beyond den reinforcement, and the proof that the stage-04 outbox generalizes. A structure crossing under seven days of fuel enqueues one notification per listening channel; the stage-05 sweep posts it.

Detection rides inside the `corp-structures` extract, mirroring how stage 04 hooks `character-mercenary-dens`: pure crossing/format seam in `structureFuel.js`, enqueue I/O in `structureFuelNotification.js`.

### Why stage 07 and not stage 06

Stage 06 (Discord sign-in) is next by number but is no longer implementable as written. `docs/README.md` (#862) records it as folded into `open-registration.md`'s stage 5, which sits on an anonymous-session bootstrap that doesn't exist yet and answers 06's open invite-gating question differently (no gate at all). Building 06 standalone now would implement a design the project just superseded. Stage 07 depends only on 03–05, all shipped.

### Three things the scoping doc left open

- **`fuel_expires` moved.** It now lives in `corp_structure_status`, not `corp_structure`. Detection reads the previous run's row *before* the extract's upsert overwrites it, and enqueues only *after* that write lands — an alert must not outlive the state that dedupes it, or a re-run pings the same crossing twice.
- **The dedup rule needed a second clock.** "Compare against the previous observation" doesn't hold unqualified: while nobody refuels, the stored fuel timer and the fresh one are the *same instant*, so both sides of a naive comparison read the same remaining time and the alert never fires at all. The previous reading is judged against `updated_at`, the time it was taken — yesterday's "7.5 days left" over today's "6.5 days left" is the crossing. The `structure-fuel:<id>:<expiry unix>` source key is a backstop under that, not a substitute: the outbox's unique index only guards rows not yet sent, so it alone would re-alert daily forever.
- **Formatting stays with detection**, as stage 04 established, rather than with the sender as the stage-07 sketch guessed. The outbox stores a composed `body`, so the sender never needs to know what a fuel bay is.

### Behaviour

- Threshold 7 days; refuelling above the line re-arms it, so a refuel-then-drain alerts again.
- Audience is corp-wide: every account with a live linked channel and a character registered to the structure's corporation, not just the director whose token pulled the extract. Rows are attributed per recipient, since one crossing now fans out across several accounts.
- Silent for a structure with no fuel timer, and for one already dry — a daily extract against a 7-day threshold always warns a live structure first, so back-dated obituaries would just be noise on the first run after a channel is linked.
- No new tables or columns, so no migration; the `notification.source` comment in `schema.sql` gains the second key format.

### Drive-by

Lifts the lazy anon SDE client that `mercenaryDenNotification.js` had inlined into a shared `src/jobs/sdeAnon.js`, now used by both notifiers instead of duplicated.

### Testing

- `test/structureFuel.test.ts` — 16 cases over the pure seam, pinning the crossing rule (including the same-instant trap above), threshold boundary, re-arm sequence, source key, and message formatting. Full suite: 256 pass.
- `pnpm run lint` and `pnpm run build` both pass.
- Not exercised against live ESI — a real crossing can't be arranged on demand, which is why the decision logic is a tested pure seam.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASgksLCipJEQKzxH2BYkZc)_