### PR TITLE
Custom fit UI, stage 0: prove the non-UI stack

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ honest when a project ships or a new doc lands.
 | Project | What it will be | Notes |
 |---|---|---|
 | [asset-proximity/](asset-proximity/) | Sort `/asset` by stargate jumps from the main character's location | Feasibility validated (the SDE stargate graph is mirrored); no code yet |
-| [custom-fit-ui.md](custom-fit-ui.md) | Replace `@eveshipfit/react` rendering with our own components, keeping the dogma-engine math | Feasibility assessed; stage 0 (proof-out) not started |
+| [custom-fit-ui.md](custom-fit-ui.md) | Replace `@eveshipfit/react` rendering with our own components, keeping the dogma-engine math | Stage 0 (proof-out) done — decoder, engine glue, flag mapping and skills all verified; stages 1–5 not started |
 | [fitting-paging.md](fitting-paging.md) | Treat the game's 500-fit cap as a resident set and this site as the backing store (page fits in/out via ESI) | Plan only; builds on the shipped fittings feature |
 | [fluid-compute-memory-plan/](fluid-compute-memory-plan/) | Reduce Vercel Fluid Compute memory costs | Multi-stage plan; discovery not started |
 | [open-registration.md](open-registration.md) | Drop the invite-code gate: anonymous users on first visit, invites become referral attribution, identities (email / EVE SSO / Discord / GICE) affix in any order | Plan merged 2026-08-12 (#860); implementation not started. Its stage 5 delivers discord-bot stage 06 |

--- a/docs/custom-fit-ui.md
+++ b/docs/custom-fit-ui.md
@@ -2,8 +2,8 @@
 
 Feasibility assessment and staged plan for rendering the ship-fitting view
 (wheel + statistics) with our own components and look & feel, while keeping
-eveship.fit's calculation model. Nothing here is implemented yet; stage 0 is
-the proof-out.
+eveship.fit's calculation model. **Stage 0 is done** (see its section below);
+stages 1–5 are not started.
 
 ## Verdict
 
@@ -137,6 +137,53 @@ drones, T3 with subsystems), the dumped numbers match what `/ship/[itemId]`
 shows today. That validates decoder, glue, flag mapping, and skills shape in
 one shot. If this fails in a way we can't fix, we stop here having written no
 UI.
+
+#### Outcome — done, no showstoppers
+
+Shipped as `src/app/item/[itemId]/` (page + `fitDebug.tsx`) over
+`src/app/item/[itemId]/esf/`: `protobuf.ts` (schema-driven reader),
+`schema.ts` (the six messages of `src/esf.proto` as data), `eveData.ts`
+(fetch + decode + name→id indexes, cached per page load), `dogma.ts` (the
+seven data callbacks, WASM load, all-V skills), `fit.ts` (flag → slot, ESI fit
+→ engine fit) and `attributes.ts` (the readout's formatting rules and the slot
+count, ported from `ShipAttribute`/`StatisticsProvider`).
+
+Every listed risk cleared, and the proof was stronger than a page dump: the
+whole stack runs headless under Node (the engine's bindings read the callbacks
+off `window`, so a harness only has to alias it), which let the decoder be
+diffed **entry by entry** against `@eveshipfit/react`'s own generated decoder
+over the live `/esf/*.pb2`.
+
+- **Protobuf decode:** all 89 783 entries across the six files decode
+  identically to the vendored decoder (52 848 types, 26 846 typeDogma, 3 454
+  dogmaEffects, 2 919 dogmaAttributes, 2 106 marketGroups, 1 610 groups), down
+  to prototype-vs-own-property placement. The only differences are 321 names
+  that upstream mojibakes — it builds strings byte-per-char, ours decodes UTF-8.
+- **WASM under Turbopack without the react wrapper:** `next build` compiles the
+  route; the existing `turbopack: {}` config was all it needed.
+- **The window-globals ABI:** all seven callbacks are one-line reads, and
+  `type_name_to_id`/`attribute_name_to_id` become index lookups instead of
+  upstream's linear scan per call.
+- **Skills shape:** 588 skill types at L5, and calculated stats land where
+  they should (a 5×HML II Caracal: 18 515 ehp, 9 919 shield, 426.8 dps).
+
+Two things came out of it that weren't in the plan:
+
+- **The current viewer under-reports damage.** Loaded ammunition is a hangar
+  row carrying its *slot's* flag, so a launcher and its missiles both arrive as
+  `HiSlot0`; upstream's ESI import turns each into a module, landing two
+  "modules" in one slot and leaving the weapon unarmed. A fitted, loaded Rifter
+  reads **0 dps** in today's embed and 116.9 dps once the charge is routed onto
+  the module sharing its slot, which `fit.ts` now does. (The claim in
+  `esfFit.ts` that the hook disambiguates charges is wrong — it doesn't.)
+- **Slot counts are not a hull attribute alone.** A T3's slots come entirely
+  from its subsystems' `*SlotModifier` attributes, so anything reading only
+  `calculation.hull` reports a Tengu with zero slots. `calculateSlots` in
+  `attributes.ts` folds in the per-item modifiers, as upstream does.
+
+Left for stage 1: the harness is a scratch script, not a checked-in test — the
+decode comparison needs the multi-MB `.pb2` files, so it wants a fixture
+strategy (or a small hand-built fixture) rather than a copy of the SDE in git.
 
 ### Stage 1 — extract the engine layer into a real module
 

--- a/src/app/item/[itemId]/esf/attributes.ts
+++ b/src/app/item/[itemId]/esf/attributes.ts
@@ -1,0 +1,136 @@
+import type { Calculation } from './dogma'
+import type { EveData } from './eveData'
+
+// Reading and formatting attributes out of a Calculation, ported from
+// @eveshipfit/react's ShipAttribute + StatisticsProvider (MIT).
+//
+// Stage 0 only needs enough of this to *compare* against the current viewer,
+// so the rules that matter are the ones that change a displayed number: the
+// fall back to the attribute's SDE default when the engine didn't produce one,
+// resistances as percentages, and the round-down/round-up asymmetry (an EHP of
+// 18 519.9 shows as 18 519, a resist of 55.01% shows as 56%).
+
+export type AttributeSource = 'hull' | 'char'
+
+export const attributeValue = (
+  eveData: EveData,
+  calculation: Calculation,
+  name: string,
+  source: AttributeSource = 'hull'
+): number => {
+  const id = eveData.attributeMapping[name]
+  if (id === undefined) return 0
+  // `||` not `??`, matching upstream: an attribute the engine computed as 0
+  // falls back to the SDE default too.
+  return calculation[source].attributes.get(id)?.value || eveData.dogmaAttributes[id]?.defaultValue || 0
+}
+
+export type AttributeFormat = {
+  name: string
+  label: string
+  fixed: number
+  unit?: string
+  divideBy?: number
+  roundDown?: boolean
+  isResistance?: boolean
+  source?: AttributeSource
+}
+
+export const formatAttribute = (eveData: EveData, calculation: Calculation, format: AttributeFormat): string => {
+  let value = attributeValue(eveData, calculation, format.name, format.source ?? 'hull')
+
+  // Resonances are stored as the fraction that gets *through*, and shown as
+  // the fraction stopped.
+  if (format.isResistance) value = 100 - value * 100
+  if (format.divideBy) value /= format.divideBy
+
+  const k = Math.pow(10, format.fixed)
+  if (format.isResistance) {
+    value -= 1 / k / 10
+    value = Math.ceil(value * k) / k
+  } else if (format.roundDown) {
+    value = Math.floor(value * k) / k
+  } else {
+    value = Math.round(value * k) / k
+  }
+
+  if (Object.is(value, -0)) value = 0
+  if (format.isResistance) value = Math.max(value, 0)
+
+  return value.toLocaleString('en', { minimumFractionDigits: format.fixed, maximumFractionDigits: format.fixed })
+}
+
+// The readout the current viewer shows, in its order — the checklist the
+// stage-0 comparison runs down. Stage 2 replaces this with a laid-out panel;
+// here it's deliberately a flat list of label/value pairs.
+export const HEADLINE: AttributeFormat[] = [
+  { name: 'ehp', label: 'EHP', fixed: 0, roundDown: true, unit: 'ehp' },
+  { name: 'shieldCapacity', label: 'Shield', fixed: 0, roundDown: true, unit: 'hp' },
+  { name: 'armorHP', label: 'Armor', fixed: 0, roundDown: true, unit: 'hp' },
+  { name: 'hp', label: 'Hull', fixed: 0, roundDown: true, unit: 'hp' },
+  { name: 'shieldEmDamageResonance', label: 'Shield EM resist', fixed: 1, isResistance: true, unit: '%' },
+  { name: 'shieldThermalDamageResonance', label: 'Shield thermal resist', fixed: 1, isResistance: true, unit: '%' },
+  { name: 'shieldKineticDamageResonance', label: 'Shield kinetic resist', fixed: 1, isResistance: true, unit: '%' },
+  { name: 'shieldExplosiveDamageResonance', label: 'Shield explosive resist', fixed: 1, isResistance: true, unit: '%' },
+  { name: 'armorEmDamageResonance', label: 'Armor EM resist', fixed: 1, isResistance: true, unit: '%' },
+  { name: 'armorThermalDamageResonance', label: 'Armor thermal resist', fixed: 1, isResistance: true, unit: '%' },
+  { name: 'armorKineticDamageResonance', label: 'Armor kinetic resist', fixed: 1, isResistance: true, unit: '%' },
+  { name: 'armorExplosiveDamageResonance', label: 'Armor explosive resist', fixed: 1, isResistance: true, unit: '%' },
+  { name: 'damagePerSecondWithoutReload', label: 'DPS', fixed: 1, unit: 'dps' },
+  { name: 'damagePerSecondWithReload', label: 'DPS (with reload)', fixed: 1, unit: 'dps' },
+  { name: 'damageAlpha', label: 'Alpha', fixed: 0, unit: 'HP' },
+  { name: 'droneDamagePerSecond', label: 'Drone DPS', fixed: 1, unit: 'dps' },
+  { name: 'droneBandwidthLoad', label: 'Drone bandwidth used', fixed: 0 },
+  { name: 'droneBandwidth', label: 'Drone bandwidth', fixed: 0 },
+  { name: 'capacitorCapacity', label: 'Capacitor', fixed: 1, unit: 'GJ' },
+  { name: 'rechargeRate', label: 'Capacitor recharge', fixed: 2, divideBy: 1000, unit: 's' },
+  { name: 'capacitorPeakDelta', label: 'Capacitor delta', fixed: 1, unit: 'GJ/s' },
+  { name: 'capacitorPeakDeltaPercentage', label: 'Capacitor delta', fixed: 1, unit: '%' },
+  { name: 'capacitorDepletesIn', label: 'Capacitor depletes in', fixed: 1, unit: 's' },
+  { name: 'maxVelocity', label: 'Max velocity', fixed: 1, unit: 'm/s' },
+  { name: 'warpSpeedMultiplier', label: 'Warp speed', fixed: 2, unit: 'AU/s' },
+  { name: 'alignTime', label: 'Align time', fixed: 2, unit: 's' },
+  { name: 'agility', label: 'Inertia modifier', fixed: 4, unit: 'x' },
+  { name: 'mass', label: 'Mass', fixed: 2, divideBy: 1000, unit: 't' },
+  { name: 'maxTargetRange', label: 'Targeting range', fixed: 2, divideBy: 1000, unit: 'km' },
+  { name: 'scanStrength', label: 'Sensor strength', fixed: 2, unit: 'points' },
+  { name: 'scanResolution', label: 'Scan resolution', fixed: 0, unit: 'mm' },
+  { name: 'signatureRadius', label: 'Signature radius', fixed: 0, unit: 'm' },
+  { name: 'maxLockedTargets', label: 'Max locked targets', fixed: 0, unit: 'x' },
+  { name: 'cpuFree', label: 'CPU free', fixed: 2, unit: 'tf' },
+  { name: 'cpuOutput', label: 'CPU total', fixed: 2, unit: 'tf' },
+  { name: 'powerFree', label: 'Powergrid free', fixed: 2, unit: 'MW' },
+  { name: 'powerOutput', label: 'Powergrid total', fixed: 2, unit: 'MW' },
+]
+
+export type SlotCounts = Record<'High' | 'Medium' | 'Low' | 'SubSystem' | 'Rig' | 'Launcher' | 'Turret', number>
+
+// [hull attribute, per-item modifier attribute]. A T3's slots come entirely
+// from its subsystems' modifiers, so reading only the hull reports zero slots
+// on the one hull family where the count is most interesting.
+const SLOT_ATTRIBUTES: [keyof SlotCounts, string, string | null][] = [
+  ['High', 'hiSlots', 'hiSlotModifier'],
+  ['Medium', 'medSlots', 'medSlotModifier'],
+  ['Low', 'lowSlots', 'lowSlotModifier'],
+  ['SubSystem', 'maxSubSystems', null],
+  ['Rig', 'rigSlots', null],
+  ['Launcher', 'launcherSlotsLeft', 'launcherHardPointModifier'],
+  ['Turret', 'turretSlotsLeft', 'turretHardPointModifier'],
+]
+
+export const calculateSlots = (eveData: EveData, calculation: Calculation): SlotCounts => {
+  const slots = { High: 0, Medium: 0, Low: 0, SubSystem: 0, Rig: 0, Launcher: 0, Turret: 0 }
+
+  for (const [slot, hullAttribute, itemAttribute] of SLOT_ATTRIBUTES) {
+    const id = eveData.attributeMapping[hullAttribute]
+    slots[slot] += calculation.hull.attributes.get(id)?.value ?? 0
+    if (itemAttribute === null) continue
+    const modifierId = eveData.attributeMapping[itemAttribute]
+    for (const item of calculation.items) slots[slot] += item.attributes.get(modifierId)?.value ?? 0
+  }
+
+  // EVE went from five subsystems to four; the attribute never followed.
+  if (slots.SubSystem === 5) slots.SubSystem = 4
+
+  return slots
+}

--- a/src/app/item/[itemId]/esf/dogma.ts
+++ b/src/app/item/[itemId]/esf/dogma.ts
@@ -1,0 +1,99 @@
+import { SKILL_CATEGORY_ID, type EveData } from './eveData'
+import { esfFitToDogmaFit, type EsfFit } from './fit'
+
+// Our own replacement for @eveshipfit/react's DogmaEngineProvider: load the
+// WASM engine and wire up the seven data callbacks it reads the SDE through.
+//
+// Those globals are the engine's real ABI — undocumented, and the thing most
+// likely to drift on a version bump. They're all one-line reads of the decoded
+// EveData, which is why porting this layer is cheap; ./verify.ts is what tells
+// us the contract still holds.
+
+export type CalculationItemAttribute = {
+  base_value: number
+  value: number
+  effects: unknown[]
+}
+
+export type CalculationItem = {
+  type_id: number
+  slot: { type: string; index?: number }
+  charge: CalculationItem | undefined
+  state: string
+  // The engine returns a JS Map keyed by attribute id, not a plain object.
+  attributes: Map<number, CalculationItemAttribute>
+  effects: unknown[]
+}
+
+export type Calculation = {
+  hull: CalculationItem
+  items: CalculationItem[]
+  skills: CalculationItem[]
+  char: CalculationItem
+  structure: CalculationItem
+  target: CalculationItem
+}
+
+export type Skills = Record<string, number>
+
+type DogmaEngineModule = {
+  init: () => void
+  calculate: (fit: unknown, skills: Skills) => Calculation
+}
+
+declare global {
+  interface Window {
+    get_dogma_attributes?: unknown
+    get_dogma_attribute?: unknown
+    get_dogma_effects?: unknown
+    get_dogma_effect?: unknown
+    get_type?: unknown
+    type_name_to_id?: unknown
+    attribute_name_to_id?: unknown
+  }
+}
+
+// The engine's generated bindings call these synchronously, by name, off
+// `window` during calculate() — the reason this whole layer is browser-only.
+// Assigned through `globalThis` (the same object in a browser) so a Node
+// harness can stand `window` up as an alias and exercise the engine headless.
+export const installDataCallbacks = (eveData: EveData): void => {
+  const target = globalThis as typeof globalThis & Window
+
+  target.get_dogma_attributes = (typeId: number) => eveData.typeDogma[typeId]?.dogmaAttributes
+  target.get_dogma_attribute = (attributeId: number) => eveData.dogmaAttributes[attributeId]
+  target.get_dogma_effects = (typeId: number) => eveData.typeDogma[typeId]?.dogmaEffects
+  target.get_dogma_effect = (effectId: number) => eveData.dogmaEffects[effectId]
+  target.get_type = (typeId: number) => eveData.types[typeId]
+  target.type_name_to_id = (name: string) => eveData.typeMapping[name]
+  target.attribute_name_to_id = (name: string) => eveData.attributeMapping[name]
+}
+
+let engine: Promise<DogmaEngineModule> | null = null
+
+// Dynamic import: the WASM chunk is only fetched on a page that actually
+// renders a fit (next.config.mjs already carries the turbopack config this
+// package needs).
+export const loadDogmaEngine = (): Promise<DogmaEngineModule> => {
+  engine ??= import('@eveshipfit/dogma-engine').then((module) => {
+    module.init()
+    return module as unknown as DogmaEngineModule
+  })
+  return engine
+}
+
+// The engine assumes an *unlisted* skill is trained to level 1 rather than
+// untrained, so a baseline has to name every skill explicitly. All-V is the
+// standard "what can this hull do" assumption every fitting tool shows, and
+// the one the current eveship.fit embed is pinned to.
+export const allSkillsAtLevel = (eveData: EveData, level = 5): Skills => {
+  const skills: Skills = {}
+  for (const typeId in eveData.types) {
+    if (eveData.types[typeId].categoryID !== SKILL_CATEGORY_ID) continue
+    skills[typeId] = level
+  }
+  return skills
+}
+
+export const calculateFit = (dogma: DogmaEngineModule, fit: EsfFit, skills: Skills): Calculation =>
+  dogma.calculate(esfFitToDogmaFit(fit), skills)

--- a/src/app/item/[itemId]/esf/eveData.ts
+++ b/src/app/item/[itemId]/esf/eveData.ts
@@ -1,0 +1,136 @@
+import { decodeEntries } from './protobuf'
+import * as schema from './schema'
+
+// Our own replacement for @eveshipfit/react's EveDataProvider: fetch the six
+// `.pb2` files from /esf/ and decode them into the `EveData` shape the WASM
+// dogma engine's data callbacks read (see ./dogma.ts). No React involved — a
+// module-level promise, so the several-MB decode happens once per page load
+// and any second caller awaits the same result.
+
+export type EsfType = {
+  name: string
+  groupID: number
+  categoryID: number
+  published: boolean
+  factionID?: number
+  marketGroupID?: number
+  metaGroupID?: number
+  capacity?: number
+  mass?: number
+  radius?: number
+  volume?: number
+}
+
+export type EsfGroup = { name: string; categoryID: number; published: boolean }
+export type EsfMarketGroup = { name: string; parentGroupID?: number; iconID?: number }
+
+export type EsfTypeDogmaAttribute = { attributeID: number; value: number }
+export type EsfTypeDogmaEffect = { effectID: number; isDefault: boolean }
+export type EsfTypeDogma = {
+  dogmaAttributes: EsfTypeDogmaAttribute[]
+  dogmaEffects: EsfTypeDogmaEffect[]
+}
+
+export type EsfDogmaAttribute = {
+  name: string
+  published: boolean
+  defaultValue: number
+  highIsGood: boolean
+  stackable: boolean
+}
+
+export type EsfModifierInfo = {
+  domain: number
+  func: number
+  modifiedAttributeID?: number
+  modifyingAttributeID?: number
+  operation?: number
+  groupID?: number
+  skillTypeID?: number
+}
+
+export type EsfDogmaEffect = {
+  name: string
+  effectCategory: number
+  electronicChance: boolean
+  isAssistance: boolean
+  isOffensive: boolean
+  isWarpSafe: boolean
+  propulsionChance: boolean
+  rangeChance: boolean
+  dischargeAttributeID?: number
+  durationAttributeID?: number
+  rangeAttributeID?: number
+  falloffAttributeID?: number
+  trackingSpeedAttributeID?: number
+  fittingUsageChanceAttributeID?: number
+  resistanceAttributeID?: number
+  modifierInfo?: EsfModifierInfo[]
+}
+
+export type EveData = {
+  types: Record<string, EsfType>
+  groups: Record<string, EsfGroup>
+  marketGroups: Record<string, EsfMarketGroup>
+  typeDogma: Record<string, EsfTypeDogma>
+  dogmaAttributes: Record<string, EsfDogmaAttribute>
+  dogmaEffects: Record<string, EsfDogmaEffect>
+  // name → id reverse indexes, built once here so neither the stats readout
+  // nor the engine's `*_name_to_id` callbacks have to scan.
+  attributeMapping: Record<string, number>
+  effectMapping: Record<string, number>
+  typeMapping: Record<string, number>
+}
+
+// The SDE category id for skills — every type in it is passed to the engine as
+// a trained skill (see ./dogma.ts).
+export const SKILL_CATEGORY_ID = 16
+
+const fetchEntries = async <T>(dataUrl: string, name: string, spec: (typeof schema)[keyof typeof schema]) => {
+  const response = await fetch(`${dataUrl}${name}.pb2`)
+  if (!response.ok) throw new Error(`esf: fetching ${name}.pb2 failed with ${response.status}`)
+  return decodeEntries<T>(new Uint8Array(await response.arrayBuffer()), spec)
+}
+
+// First id wins for a duplicated name — the same thing the upstream provider's
+// scan-and-return-first does, since integer-like keys iterate ascending.
+const invert = (entries: Record<string, { name: string }>): Record<string, number> => {
+  const mapping: Record<string, number> = {}
+  for (const id in entries) {
+    const { name } = entries[id]
+    if (mapping[name] === undefined) mapping[name] = parseInt(id)
+  }
+  return mapping
+}
+
+const load = async (dataUrl: string): Promise<EveData> => {
+  const [types, groups, marketGroups, typeDogma, dogmaAttributes, dogmaEffects] = await Promise.all([
+    fetchEntries<EsfType>(dataUrl, 'types', schema.type),
+    fetchEntries<EsfGroup>(dataUrl, 'groups', schema.group),
+    fetchEntries<EsfMarketGroup>(dataUrl, 'marketGroups', schema.marketGroup),
+    fetchEntries<EsfTypeDogma>(dataUrl, 'typeDogma', schema.typeDogmaEntry),
+    fetchEntries<EsfDogmaAttribute>(dataUrl, 'dogmaAttributes', schema.dogmaAttribute),
+    fetchEntries<EsfDogmaEffect>(dataUrl, 'dogmaEffects', schema.dogmaEffect),
+  ])
+
+  return {
+    types,
+    groups,
+    marketGroups,
+    typeDogma,
+    dogmaAttributes,
+    dogmaEffects,
+    attributeMapping: invert(dogmaAttributes),
+    effectMapping: invert(dogmaEffects),
+    typeMapping: invert(types),
+  }
+}
+
+let cached: Promise<EveData> | null = null
+
+// `/esf/` serves the .pb2 from the esf_data table (refreshed by the sde-mirror
+// workflow), not the build-time static files — see src/app/esf/[file]/route.ts.
+export const loadEveData = (dataUrl = '/esf/'): Promise<EveData> => {
+  cached ??= load(dataUrl)
+  return cached
+}

--- a/src/app/item/[itemId]/esf/fit.ts
+++ b/src/app/item/[itemId]/esf/fit.ts
@@ -1,0 +1,199 @@
+import type { EveData } from './eveData'
+
+// ESI's fitting JSON, as `toEsiFit` in ../../ship/[itemId]/esfFit.ts builds it
+// from a ship's asset rows. Declared here rather than imported from
+// @eveshipfit/react: it's ESI's shape, not that package's, and this stack is
+// meant to outlive the dependency (docs/custom-fit-ui.md, stage 4).
+export type EsiFit = {
+  name: string
+  description: string
+  ship_type_id: number
+  items: { item_id: number; type_id: number; flag: number | string; quantity: number }[]
+}
+
+// Ported from @eveshipfit/react's ImportEsiFitting hook (MIT): turn the ESI
+// fitting JSON we build from a ship's asset rows into the fit shape the WASM
+// dogma engine takes.
+//
+// Two conversions live here because they're two halves of one mapping and
+// neither is useful alone: ESI location flags → slot type + index, and the
+// resulting fit → the engine's snake_case input.
+
+export type SlotType = 'High' | 'Medium' | 'Low' | 'Rig' | 'SubSystem'
+export type Slot = { type: SlotType; index: number }
+
+export type EsfModule = { typeId: number; slot: Slot; charge?: { typeId: number } }
+export type EsfDrone = { typeId: number; active: number; passive: number }
+export type EsfCargo = { typeId: number; quantity: number }
+
+export type EsfFit = {
+  name: string
+  shipTypeId: number
+  modules: EsfModule[]
+  drones: EsfDrone[]
+  cargo: EsfCargo[]
+}
+
+// ESI reports a flag as a name on assets and as a number on saved fittings;
+// both forms appear in our data, so both resolve here.
+const FLAG_ID_TO_NAME: Record<number, string> = {
+  5: 'Cargo',
+  11: 'LoSlot0',
+  12: 'LoSlot1',
+  13: 'LoSlot2',
+  14: 'LoSlot3',
+  15: 'LoSlot4',
+  16: 'LoSlot5',
+  17: 'LoSlot6',
+  18: 'LoSlot7',
+  19: 'MedSlot0',
+  20: 'MedSlot1',
+  21: 'MedSlot2',
+  22: 'MedSlot3',
+  23: 'MedSlot4',
+  24: 'MedSlot5',
+  25: 'MedSlot6',
+  26: 'MedSlot7',
+  27: 'HiSlot0',
+  28: 'HiSlot1',
+  29: 'HiSlot2',
+  30: 'HiSlot3',
+  31: 'HiSlot4',
+  32: 'HiSlot5',
+  33: 'HiSlot6',
+  34: 'HiSlot7',
+  87: 'DroneBay',
+  92: 'RigSlot0',
+  93: 'RigSlot1',
+  94: 'RigSlot2',
+  125: 'SubSystemSlot0',
+  126: 'SubSystemSlot1',
+  127: 'SubSystemSlot2',
+  128: 'SubSystemSlot3',
+}
+
+// Flag prefix → slot type. The trailing digit is the zero-based slot number;
+// the engine's indexes are one-based, hence the +1 below.
+const SLOT_PREFIXES: [string, SlotType][] = [
+  ['LoSlot', 'Low'],
+  ['MedSlot', 'Medium'],
+  ['HiSlot', 'High'],
+  ['RigSlot', 'Rig'],
+  ['SubSystemSlot', 'SubSystem'],
+]
+
+export type Placement = { kind: 'module'; slot: Slot } | { kind: 'cargo' } | { kind: 'drone' }
+
+// Anything not fitted, carried or in the drone bay (a ship maintenance bay,
+// fuel bay, fleet hangar, …) has no bearing on the fit and returns undefined.
+export const placementForFlag = (flag: number | string): Placement | undefined => {
+  const name = typeof flag === 'number' ? FLAG_ID_TO_NAME[flag] : flag
+  if (name === undefined) return undefined
+  if (name === 'Cargo') return { kind: 'cargo' }
+  if (name === 'DroneBay') return { kind: 'drone' }
+
+  for (const [prefix, type] of SLOT_PREFIXES) {
+    if (!name.startsWith(prefix)) continue
+    const index = Number(name.slice(prefix.length))
+    // Guard the suffix rather than trusting the prefix: `RigSlotX` from a
+    // future flag would otherwise land in slot NaN.
+    if (!Number.isInteger(index) || index < 0) return undefined
+    return { kind: 'module', slot: { type, index: index + 1 } }
+  }
+
+  return undefined
+}
+
+// A ship's rows carry one item per stack, so the same drone type or cargo item
+// can appear more than once (two stacks of the same drone in the bay). The
+// engine wants one entry per type, as upstream's CleanImportFit does.
+const accumulate = <T extends { typeId: number }>(items: T[], merge: (into: T, from: T) => void): T[] =>
+  items.reduce<T[]>((acc, item) => {
+    const existing = acc.find((candidate) => candidate.typeId === item.typeId)
+    if (existing) merge(existing, item)
+    else acc.push({ ...item })
+    return acc
+  }, [])
+
+// The SDE category id for Charge — ammunition, scripts, probes.
+export const CHARGE_CATEGORY_ID = 8
+
+// Loaded ammunition is a hangar row like any other, carrying the *slot's* flag
+// rather than one of its own, so a loaded launcher and its missiles both come
+// through as `HiSlot0`. Upstream's ESI import maps each of them to a module,
+// which lands two "modules" in one slot and makes the engine report the weapon
+// as unarmed — a fitted, loaded Rifter reads 0 dps in the current viewer.
+// Route a charge onto the module sharing its slot instead. A charge whose slot
+// holds no module (ammo left behind by an unfitted weapon) is dropped: it isn't
+// loaded into anything, so it changes nothing.
+const attachCharges = (
+  modules: { typeId: number; slot: Slot; charge?: { typeId: number } }[],
+  charges: { typeId: number; slot: Slot }[]
+): EsfModule[] => {
+  for (const charge of charges) {
+    const module = modules.find(
+      (candidate) => candidate.slot.type === charge.slot.type && candidate.slot.index === charge.slot.index
+    )
+    // Multiple charges in one slot (a partly-swapped ammo load) can't be
+    // represented; the first one wins, as the module can only hold one.
+    if (module && module.charge === undefined) module.charge = { typeId: charge.typeId }
+  }
+  return modules
+}
+
+export const esiFitToEsfFit = (esiFit: EsiFit, eveData: EveData): EsfFit => {
+  const placed = esiFit.items.map((item) => ({
+    item,
+    placement: placementForFlag(item.flag),
+    isCharge: eveData.types[item.type_id]?.categoryID === CHARGE_CATEGORY_ID,
+  }))
+
+  const modules = placed.flatMap(({ item, placement, isCharge }) =>
+    placement?.kind === 'module' && !isCharge ? [{ typeId: item.type_id, slot: placement.slot }] : []
+  )
+  const charges = placed.flatMap(({ item, placement, isCharge }) =>
+    placement?.kind === 'module' && isCharge ? [{ typeId: item.type_id, slot: placement.slot }] : []
+  )
+  const drones = placed.flatMap(({ item, placement }) =>
+    placement?.kind === 'drone' ? [{ typeId: item.type_id, active: item.quantity, passive: 0 }] : []
+  )
+  const cargo = placed.flatMap(({ item, placement }) =>
+    placement?.kind === 'cargo' ? [{ typeId: item.type_id, quantity: item.quantity }] : []
+  )
+
+  return {
+    name: esiFit.name,
+    shipTypeId: esiFit.ship_type_id,
+    modules: attachCharges(modules, charges),
+    drones: accumulate(drones, (into, from) => {
+      into.active += from.active
+      into.passive += from.passive
+    }),
+    cargo: accumulate(cargo, (into, from) => {
+      into.quantity += from.quantity
+    }),
+  }
+}
+
+export type DogmaFit = {
+  ship_type_id: number
+  modules: { type_id: number; slot: Slot; state: string; charge?: { type_id: number } }[]
+  drones: { type_id: number; state: string }[]
+}
+
+// The engine takes one entry per drone rather than a count, and every module
+// online-and-running: we render a ship as it sits, and nothing in this view
+// can offline a module or change its state.
+export const esfFitToDogmaFit = (fit: EsfFit): DogmaFit => ({
+  ship_type_id: fit.shipTypeId,
+  modules: fit.modules.map((module) => ({
+    type_id: module.typeId,
+    slot: module.slot,
+    state: 'Active',
+    charge: module.charge === undefined ? undefined : { type_id: module.charge.typeId },
+  })),
+  drones: fit.drones.flatMap((drone) => [
+    ...Array.from({ length: drone.active }, () => ({ type_id: drone.typeId, state: 'Active' })),
+    ...Array.from({ length: drone.passive }, () => ({ type_id: drone.typeId, state: 'Passive' })),
+  ]),
+})

--- a/src/app/item/[itemId]/esf/protobuf.ts
+++ b/src/app/item/[itemId]/esf/protobuf.ts
@@ -1,0 +1,179 @@
+// A minimal protobuf reader, enough for the six `.pb2` files `/esf/[file]`
+// serves (see src/esf.proto). Written rather than pulled in: protobufjs is
+// ~100KB for a wire format we only ever *read*, in exactly one schema shape —
+// a top-level `map<int32, Message>` of flat messages, at most three levels
+// deep, using only varints, floats, bools, strings and nested messages.
+//
+// Schema-driven instead of code-generated: the six messages are declared as
+// data in ./schema.ts, so the decoder itself is ~100 lines and the schema
+// diffs against src/esf.proto by eye.
+//
+// Defaults follow proto2 (and thus the generated decoder @eveshipfit/react
+// vendors, which this replaces): a *required* field that somehow didn't make
+// it into the file reads back as its type's zero, an absent *optional* field
+// reads back `undefined`. Both come from a per-message prototype rather than
+// own properties, exactly like the generated code — so `Object.keys()` of a
+// decoded message lists only the fields actually on the wire, which is what
+// the WASM engine's deserializer sees when it reads these objects back.
+
+const WIRE_VARINT = 0
+const WIRE_64BIT = 1
+const WIRE_LENGTH = 2
+const WIRE_32BIT = 5
+
+export type ScalarKind = 'int32' | 'float' | 'bool' | 'string'
+
+export type Field =
+  { name: string; kind: ScalarKind } | { name: string; kind: 'message'; of: MessageSpec; repeated?: boolean }
+
+// `fields` is keyed by protobuf field number; `defaults` becomes the prototype
+// of every decoded instance (so absent fields resolve to the proto2 default
+// without ever being own properties).
+export type MessageSpec = {
+  fields: Record<number, Field>
+  defaults: Record<string, unknown>
+}
+
+// A cursor over the whole file. The upstream reader streams chunks as they
+// arrive; we read the complete response first — these files are a few MB and
+// come from a CDN-cached route, and decoding all six takes well under the time
+// the fetches themselves do.
+class Reader {
+  readonly bytes: Uint8Array
+  pos = 0
+  private readonly view: DataView
+
+  constructor(bytes: Uint8Array) {
+    this.bytes = bytes
+    this.view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  }
+
+  // Varints are little-endian base-128. Read at most 10 bytes (the encoding of
+  // a negative int32, sign-extended to 64 bits) and keep the low 32 — the same
+  // truncation `int32` does upstream.
+  varint(): number {
+    let value = 0
+    let shift = 0
+    for (let i = 0; i < 10; i++) {
+      const byte = this.bytes[this.pos++]
+      if (shift < 32) value |= (byte & 0x7f) << shift
+      shift += 7
+      if (byte < 0x80) break
+    }
+    return value
+  }
+
+  int32(): number {
+    return this.varint() | 0
+  }
+
+  bool(): boolean {
+    return this.varint() !== 0
+  }
+
+  float(): number {
+    const value = this.view.getFloat32(this.pos, true)
+    this.pos += 4
+    return value
+  }
+
+  // Every string in these files is a type/attribute/effect/group name: ASCII
+  // in practice, but decoded as UTF-8 so a non-ASCII name survives intact
+  // (the vendored reader's byte-per-char loop would mangle it).
+  string(): string {
+    const length = this.varint()
+    const bytes = this.bytes.subarray(this.pos, this.pos + length)
+    this.pos += length
+    return new TextDecoder().decode(bytes)
+  }
+
+  // Unknown field: step over it so a file written by a newer schema still
+  // decodes the fields we do know (the vendored reader throws here).
+  skip(wireType: number): void {
+    if (wireType === WIRE_VARINT) this.varint()
+    else if (wireType === WIRE_64BIT) this.pos += 8
+    else if (wireType === WIRE_32BIT) this.pos += 4
+    else if (wireType === WIRE_LENGTH) this.pos += this.varint()
+    else throw new Error(`esf: unsupported wire type ${wireType}`)
+  }
+}
+
+// A repeated field is always an own array, empty when nothing was on the wire
+// — the generated decoder assigns one in its constructor, so a consumer can
+// iterate without a presence check. Derived once per spec.
+const repeatedFields = new WeakMap<MessageSpec, string[]>()
+const repeatedNames = (spec: MessageSpec): string[] => {
+  let names = repeatedFields.get(spec)
+  if (names === undefined) {
+    names = Object.values(spec.fields)
+      .filter((field) => field.kind === 'message' && field.repeated)
+      .map((field) => field.name)
+    repeatedFields.set(spec, names)
+  }
+  return names
+}
+
+const decodeMessage = (reader: Reader, end: number, spec: MessageSpec): Record<string, unknown> => {
+  const message: Record<string, unknown> = Object.create(spec.defaults)
+  for (const name of repeatedNames(spec)) message[name] = []
+
+  while (reader.pos < end) {
+    const tag = reader.varint()
+    const field = spec.fields[tag >>> 3]
+    if (field === undefined) {
+      reader.skip(tag & 7)
+      continue
+    }
+
+    if (field.kind === 'message') {
+      const length = reader.varint()
+      const value = decodeMessage(reader, reader.pos + length, field.of)
+      if (field.repeated) {
+        ;(message[field.name] as unknown[]).push(value)
+      } else {
+        message[field.name] = value
+      }
+    } else if (field.kind === 'int32') {
+      message[field.name] = reader.int32()
+    } else if (field.kind === 'float') {
+      message[field.name] = reader.float()
+    } else if (field.kind === 'bool') {
+      message[field.name] = reader.bool()
+    } else {
+      message[field.name] = reader.string()
+    }
+  }
+
+  return message
+}
+
+// Each file is a single message whose only field is `map<int32, V> entries = 1`.
+// A protobuf map is repeated `{ key = 1, value = 2 }` entry messages, so the
+// map is read here rather than declared in the schema: the result is the plain
+// `Record<id, V>` object every consumer (and the WASM engine's data callbacks)
+// expects, keyed by the id as a string.
+export const decodeEntries = <T>(bytes: Uint8Array, value: MessageSpec): Record<string, T> => {
+  const reader = new Reader(bytes)
+  const entries: Record<string, T> = {}
+
+  while (reader.pos < bytes.length) {
+    const tag = reader.varint()
+    if (tag >>> 3 !== 1) {
+      reader.skip(tag & 7)
+      continue
+    }
+
+    const end = reader.varint() + reader.pos
+    let key = 0
+    let entry: unknown = null
+    while (reader.pos < end) {
+      const entryTag = reader.varint()
+      if (entryTag >>> 3 === 1) key = reader.int32()
+      else if (entryTag >>> 3 === 2) entry = decodeMessage(reader, reader.varint() + reader.pos, value)
+      else reader.skip(entryTag & 7)
+    }
+    entries[key] = entry as T
+  }
+
+  return entries
+}

--- a/src/app/item/[itemId]/esf/schema.ts
+++ b/src/app/item/[itemId]/esf/schema.ts
@@ -1,0 +1,129 @@
+import type { MessageSpec } from './protobuf'
+
+// The six messages of src/esf.proto, as data for ./protobuf.ts. Field numbers
+// and names must track that file exactly — it's the schema src/buildEsfData.js
+// encodes with, and the field *names* are the contract with the WASM engine
+// (it reads `groupID`, `attributeID`, `modifierInfo`, … off these objects by
+// name). Keep the declarations in the same order as the .proto so the two can
+// be diffed side by side.
+//
+// `defaults` holds only what proto2 gives a value to when it's missing: the
+// zero of each *required* field. Optional fields are deliberately absent —
+// they must read back `undefined`, not a zero. Repeated fields need no entry:
+// the decoder always materializes them as an (own) array.
+
+const typeDogmaAttribute: MessageSpec = {
+  fields: {
+    1: { name: 'attributeID', kind: 'int32' },
+    2: { name: 'value', kind: 'float' },
+  },
+  defaults: { attributeID: 0, value: 0 },
+}
+
+const typeDogmaEffect: MessageSpec = {
+  fields: {
+    1: { name: 'effectID', kind: 'int32' },
+    2: { name: 'isDefault', kind: 'bool' },
+  },
+  defaults: { effectID: 0, isDefault: false },
+}
+
+export const typeDogmaEntry: MessageSpec = {
+  fields: {
+    1: { name: 'dogmaAttributes', kind: 'message', of: typeDogmaAttribute, repeated: true },
+    2: { name: 'dogmaEffects', kind: 'message', of: typeDogmaEffect, repeated: true },
+  },
+  defaults: {},
+}
+
+export const type: MessageSpec = {
+  fields: {
+    1: { name: 'name', kind: 'string' },
+    2: { name: 'groupID', kind: 'int32' },
+    3: { name: 'categoryID', kind: 'int32' },
+    4: { name: 'published', kind: 'bool' },
+    5: { name: 'factionID', kind: 'int32' },
+    6: { name: 'marketGroupID', kind: 'int32' },
+    7: { name: 'metaGroupID', kind: 'int32' },
+    8: { name: 'capacity', kind: 'float' },
+    9: { name: 'mass', kind: 'float' },
+    10: { name: 'radius', kind: 'float' },
+    11: { name: 'volume', kind: 'float' },
+  },
+  defaults: { name: '', groupID: 0, categoryID: 0, published: false },
+}
+
+export const group: MessageSpec = {
+  fields: {
+    1: { name: 'name', kind: 'string' },
+    2: { name: 'categoryID', kind: 'int32' },
+    3: { name: 'published', kind: 'bool' },
+  },
+  defaults: { name: '', categoryID: 0, published: false },
+}
+
+export const marketGroup: MessageSpec = {
+  fields: {
+    1: { name: 'name', kind: 'string' },
+    2: { name: 'parentGroupID', kind: 'int32' },
+    3: { name: 'iconID', kind: 'int32' },
+  },
+  defaults: { name: '' },
+}
+
+export const dogmaAttribute: MessageSpec = {
+  fields: {
+    1: { name: 'name', kind: 'string' },
+    2: { name: 'published', kind: 'bool' },
+    3: { name: 'defaultValue', kind: 'float' },
+    4: { name: 'highIsGood', kind: 'bool' },
+    5: { name: 'stackable', kind: 'bool' },
+  },
+  defaults: { name: '', published: false, defaultValue: 0, highIsGood: false, stackable: false },
+}
+
+// Domain and Func are proto enums, i.e. varints on the wire; the engine reads
+// them as the numbers the generated decoder also produces.
+const modifierInfo: MessageSpec = {
+  fields: {
+    1: { name: 'domain', kind: 'int32' },
+    2: { name: 'func', kind: 'int32' },
+    3: { name: 'modifiedAttributeID', kind: 'int32' },
+    4: { name: 'modifyingAttributeID', kind: 'int32' },
+    5: { name: 'operation', kind: 'int32' },
+    6: { name: 'groupID', kind: 'int32' },
+    7: { name: 'skillTypeID', kind: 'int32' },
+  },
+  defaults: { domain: 0, func: 0 },
+}
+
+export const dogmaEffect: MessageSpec = {
+  fields: {
+    1: { name: 'name', kind: 'string' },
+    2: { name: 'effectCategory', kind: 'int32' },
+    3: { name: 'electronicChance', kind: 'bool' },
+    4: { name: 'isAssistance', kind: 'bool' },
+    5: { name: 'isOffensive', kind: 'bool' },
+    6: { name: 'isWarpSafe', kind: 'bool' },
+    7: { name: 'propulsionChance', kind: 'bool' },
+    8: { name: 'rangeChance', kind: 'bool' },
+    9: { name: 'dischargeAttributeID', kind: 'int32' },
+    10: { name: 'durationAttributeID', kind: 'int32' },
+    11: { name: 'rangeAttributeID', kind: 'int32' },
+    12: { name: 'falloffAttributeID', kind: 'int32' },
+    13: { name: 'trackingSpeedAttributeID', kind: 'int32' },
+    14: { name: 'fittingUsageChanceAttributeID', kind: 'int32' },
+    15: { name: 'resistanceAttributeID', kind: 'int32' },
+    16: { name: 'modifierInfo', kind: 'message', of: modifierInfo, repeated: true },
+  },
+  defaults: {
+    name: '',
+    effectCategory: 0,
+    electronicChance: false,
+    isAssistance: false,
+    isOffensive: false,
+    isWarpSafe: false,
+    propulsionChance: false,
+    rangeChance: false,
+  },
+}

--- a/src/app/item/[itemId]/fitDebug.tsx
+++ b/src/app/item/[itemId]/fitDebug.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+
+import { HEADLINE, calculateSlots, formatAttribute, type SlotCounts } from './esf/attributes'
+import { allSkillsAtLevel, calculateFit, installDataCallbacks, loadDogmaEngine, type Calculation } from './esf/dogma'
+import { loadEveData } from './esf/eveData'
+import { esiFitToEsfFit, type EsfFit, type EsiFit } from './esf/fit'
+
+// Stage 0 of docs/custom-fit-ui.md: no UI, just evidence. Everything the
+// eventual fitting view needs that *isn't* look & feel — protobuf decode,
+// the WASM engine's data callbacks, the all-skills-V baseline, the ESI
+// flag → slot mapping — runs here and dumps what it produced, so the numbers
+// can be read side by side with the eveship.fit embed on /ship/[itemId].
+//
+// Client-only by construction: the engine reads its data off `window`.
+
+type Loaded = {
+  fit: EsfFit
+  calculation: Calculation
+  slots: SlotCounts
+  headline: { label: string; value: string; unit?: string }[]
+  timings: { data: number; engine: number; calculate: number }
+  typeNames: Record<number, string>
+}
+
+const useFitCalculation = (esiFit: EsiFit) => {
+  const [loaded, setLoaded] = useState<Loaded | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let live = true
+
+    const run = async () => {
+      const dataStart = performance.now()
+      const eveData = await loadEveData()
+      const engineStart = performance.now()
+
+      installDataCallbacks(eveData)
+      const dogma = await loadDogmaEngine()
+      const skills = allSkillsAtLevel(eveData, 5)
+
+      const calculateStart = performance.now()
+      const fit = esiFitToEsfFit(esiFit, eveData)
+      const calculation = calculateFit(dogma, fit, skills)
+      const done = performance.now()
+
+      if (!live) return
+      setLoaded({
+        fit,
+        calculation,
+        slots: calculateSlots(eveData, calculation),
+        headline: HEADLINE.map((format) => ({
+          label: format.label,
+          value: formatAttribute(eveData, calculation, format),
+          unit: format.unit,
+        })),
+        timings: {
+          data: engineStart - dataStart,
+          engine: calculateStart - engineStart,
+          calculate: done - calculateStart,
+        },
+        typeNames: Object.fromEntries(
+          [fit.shipTypeId, ...fit.modules.flatMap((m) => [m.typeId, ...(m.charge ? [m.charge.typeId] : [])])].map(
+            (typeId) => [typeId, eveData.types[typeId]?.name ?? `#${typeId}`]
+          )
+        ),
+      })
+    }
+
+    run().catch((thrown) => {
+      if (live) setError(thrown instanceof Error ? thrown.message : String(thrown))
+    })
+
+    return () => {
+      live = false
+    }
+  }, [esiFit])
+
+  return { loaded, error }
+}
+
+// The engine returns attributes as a Map keyed by id, and each carries the
+// effects that produced it — the provenance a stats panel will want later.
+// JSON.stringify sees a Map as `{}`, so it's reshaped for the dump.
+const dumpable = (calculation: Calculation) => {
+  const item = (entry: Calculation['hull']) => ({
+    ...entry,
+    attributes: Object.fromEntries(entry.attributes),
+    charge: entry.charge === undefined ? undefined : { ...entry.charge, attributes: undefined },
+  })
+  return {
+    hull: item(calculation.hull),
+    items: calculation.items.map(item),
+    char: item(calculation.char),
+    // Skills are 588 near-identical entries; the count is the interesting part.
+    skills: calculation.skills.length,
+  }
+}
+
+export const FitDebug = ({ esiFit, itemId }: { esiFit: EsiFit; itemId: string }) => {
+  const { loaded, error } = useFitCalculation(esiFit)
+
+  if (error) return <pre>Failed: {error}</pre>
+  if (!loaded) return <pre>Loading /esf/ data and the dogma engine…</pre>
+
+  return (
+    <>
+      <h2>Fit</h2>
+      <p>
+        {loaded.typeNames[loaded.fit.shipTypeId]} — {loaded.fit.modules.length} modules, {loaded.fit.drones.length}{' '}
+        drone type(s), {loaded.fit.cargo.length} cargo stack(s). Slots: {loaded.slots.High} high / {loaded.slots.Medium}{' '}
+        mid / {loaded.slots.Low} low / {loaded.slots.Rig} rig / {loaded.slots.SubSystem} subsystem,{' '}
+        {loaded.slots.Turret} turret and {loaded.slots.Launcher} launcher hardpoints.
+      </p>
+      <p>
+        Decoded 6 protobuf files in {loaded.timings.data.toFixed(0)}ms, loaded the engine in{' '}
+        {loaded.timings.engine.toFixed(0)}ms, calculated in {loaded.timings.calculate.toFixed(0)}ms. Skills: all V.
+      </p>
+      <ul>
+        {loaded.fit.modules.map((module, index) => (
+          <li key={index}>
+            {module.slot.type} {module.slot.index}: {loaded.typeNames[module.typeId]}
+            {module.charge ? ` — loaded with ${loaded.typeNames[module.charge.typeId]}` : ''}
+          </li>
+        ))}
+      </ul>
+
+      <h2>Headline attributes</h2>
+      <p>
+        These are the numbers to read against the eveship.fit embed on{' '}
+        <Link href={`/ship/${itemId}`}>/ship/{itemId}</Link>. Damage is the known exception: this stack loads a
+        weapon&apos;s ammunition into it, the embed does not (see esf/fit.ts), so a loaded ship reads 0 dps there and a
+        real figure here.
+      </p>
+      <table>
+        <tbody>
+          {loaded.headline.map((row) => (
+            <tr key={row.label}>
+              <td>{row.label}</td>
+              <td>
+                {row.value}
+                {row.unit ? ` ${row.unit}` : ''}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h2>Raw calculation</h2>
+      <pre style={{ overflow: 'auto', maxHeight: '40rem' }}>
+        {JSON.stringify(dumpable(loaded.calculation), null, 2)}
+      </pre>
+    </>
+  )
+}

--- a/src/app/item/[itemId]/fitDebugDynamic.tsx
+++ b/src/app/item/[itemId]/fitDebugDynamic.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+// Same shape as shipFitViewDynamic.tsx, and for the same two reasons:
+// `dynamic(..., { ssr: false })` has to be called from a Client Component, and
+// isolating it keeps the WASM engine and the several-MB protobuf decode out of
+// every other route's bundle. There's nothing to hold space for here — the
+// page renders text — so the loading state is a line of text.
+export const FitDebugDynamic = dynamic(() => import('./fitDebug').then((m) => m.FitDebug), {
+  ssr: false,
+  loading: () => <pre>Loading the fit engine…</pre>,
+})

--- a/src/app/item/[itemId]/page.tsx
+++ b/src/app/item/[itemId]/page.tsx
@@ -1,0 +1,106 @@
+import Link from 'next/link'
+import { notFound, redirect } from 'next/navigation'
+
+import { FIT_UI_FLAG, hasFlag } from '@/flags'
+import { getSdeType } from '@/sdeTypes'
+import { createClient } from '@/utils/supabase/server'
+import { toEsiFit } from '../../ship/[itemId]/esfFit'
+import { SHIP_CATEGORY_ID, fittingOrder } from '../../ship/[itemId]/shipRows'
+import { FitDebugDynamic } from './fitDebugDynamic'
+
+// Stage 0 of docs/custom-fit-ui.md: the same ship /ship/[itemId] renders,
+// fed through our own fitting stack instead of @eveshipfit/react, rendering
+// no fitting UI at all — just what the stack produced, to be read against the
+// embed on /ship/[itemId].
+//
+// Dark-launched: nothing links here, and the `fit-ui` flag gates it, so
+// obscurity isn't the only gate. Access is otherwise exactly /ship's
+// signed-in path — the same RLS-scoped queries, so this route can't see a
+// ship its owner couldn't. The share-token path is deliberately not mirrored:
+// an unfinished debug page has no business being anonymously reachable.
+
+type ShipRow = {
+  item_id: number | string
+  type_id: number | string
+  name: string | null
+  registration_id?: string
+  corporation_id?: number | string
+}
+
+// A row inside the ship: a fitted module, its ammunition, a drone, or cargo.
+type FittedRow = {
+  item_id: number | string
+  type_id: number | string
+  location_flag: string | null
+  quantity: number | string | null
+}
+
+const ItemFitPage = async ({ params }: { params: Promise<{ itemId: string }> }) => {
+  const { itemId } = await params
+
+  const supabase = await createClient()
+  const { data: auth, error: authError } = await supabase.auth.getUser()
+  if (authError || !auth?.user) redirect('/')
+  // A visitor without the flag gets the same answer as a visitor to a route
+  // that doesn't exist.
+  if (!(await hasFlag(auth.user.id, FIT_UI_FLAG))) notFound()
+
+  // Both hangars probed at once, character wins — the same shape /ship uses,
+  // minus everything this page doesn't render (owner, location, breadcrumb).
+  const [{ data: characterSelf }, { data: corpSelf }] = await Promise.all([
+    supabase
+      .from('character_asset')
+      .select('item_id, registration_id, type_id, name')
+      .eq('item_id', itemId)
+      .maybeSingle<ShipRow>(),
+    supabase.from('corp_asset').select('item_id, corporation_id, type_id').eq('item_id', itemId).maybeSingle<ShipRow>(),
+  ])
+  const self = characterSelf ?? corpSelf
+  if (!self) notFound()
+
+  const selfType = await getSdeType(Number(self.type_id))
+  if (selfType?.categoryID !== SHIP_CATEGORY_ID) notFound()
+
+  const [{ data: characterChildren }, { data: corpChildren }] = await Promise.all([
+    supabase
+      .from('character_asset')
+      .select('item_id, type_id, location_flag, quantity')
+      .eq('location_id', itemId)
+      .returns<FittedRow[]>(),
+    supabase
+      .from('corp_asset')
+      .select('item_id, type_id, location_flag, quantity')
+      .eq('location_id', itemId)
+      .returns<FittedRow[]>(),
+  ])
+  const children = [...(characterChildren ?? []), ...(corpChildren ?? [])]
+
+  // The same rows /ship feeds its viewer, in the same fitting-window order, so
+  // the two pages are demonstrably looking at one fit. Only the four fields
+  // toEsiFit reads are built — the rest of an ItemRow describes a table this
+  // page doesn't render.
+  const rows = fittingOrder(
+    children.map((child) => ({
+      itemId: String(child.item_id),
+      typeId: Number(child.type_id),
+      flag: child.location_flag,
+      quantity: child.quantity,
+    }))
+  )
+
+  const typeName = selfType?.name ?? `#${self.type_id}`
+
+  return (
+    <>
+      <h1>{self.name && self.name !== typeName ? `${self.name} (${typeName})` : typeName}</h1>
+      <p>
+        Fitting-stack spike (docs/custom-fit-ui.md, stage 0). No fitting UI here — this page exists to prove the
+        non-visual half works: our protobuf decoder over <Link href="/esf/types.pb2">/esf/</Link>, the dogma
+        engine&apos;s data callbacks, the all-skills-V baseline, and the ESI flag → slot mapping.
+      </p>
+      <FitDebugDynamic esiFit={toEsiFit(Number(self.type_id), self.name ?? null, rows)} itemId={itemId} />
+    </>
+  )
+}
+
+export default ItemFitPage

--- a/src/app/ship/[itemId]/shipRows.ts
+++ b/src/app/ship/[itemId]/shipRows.ts
@@ -32,11 +32,11 @@ export type Hull = { item_id: number | string; type_id: number | string; name?: 
 // string within a family (HiSlot0 before HiSlot1), then type id. This is the
 // server order the unsorted table shows, so the listing reads top-to-bottom
 // the way the ship does.
-export const fittingOrder = sortWith<ItemRow>([
-  ascend((r) => flagSortKey(r.flag ?? '')),
-  ascend((r) => r.flag ?? ''),
-  ascend((r) => r.typeId),
-])
+// Generic over the row: the callers that render the module table pass full
+// ItemRows, while a caller that only needs the fit order (the /item spike)
+// passes the handful of fields the comparator actually reads.
+export const fittingOrder = <T extends Pick<ItemRow, 'flag' | 'typeId'>>(rows: T[]): T[] =>
+  sortWith<T>([ascend((r) => flagSortKey(r.flag ?? '')), ascend((r) => r.flag ?? ''), ascend((r) => r.typeId)])(rows)
 
 // The hull as a row of its own, heading the module table.
 //

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -3,6 +3,7 @@ import { createServiceClient } from '@/utils/supabase/service'
 // Dark-launch flag names live here so callers can't typo them apart.
 export const GRAPHQL_FLAG = 'graphql'
 export const LENS_FLAG = 'lens'
+export const FIT_UI_FLAG = 'fit-ui'
 
 // Every flag the Chancellor tools offer as a checkbox, with the copy shown
 // beside it. A flag an account already carries that isn't listed here still
@@ -11,6 +12,7 @@ export const LENS_FLAG = 'lens'
 export const KNOWN_FLAGS: { flag: string; label: string }[] = [
   { flag: GRAPHQL_FLAG, label: 'GraphQL API and its playground (/graphql)' },
   { flag: LENS_FLAG, label: 'Lenses — saved, shareable GraphQL queries (/lens)' },
+  { flag: FIT_UI_FLAG, label: 'Our own ship-fitting stack, in progress (/item/[itemId])' },
 ]
 
 // user_settings.flags is the per-user dark-launch flag list (see the


### PR DESCRIPTION
Stage 0 of `docs/custom-fit-ui.md` — the spike that decides whether we can render fits ourselves. **It works**, and it turned up two bugs in what we ship today.

A dark-launched `/item/[itemId]` (gated on the new `fit-ui` flag, `notFound()` otherwise, nothing links to it) renders no fitting UI at all — just what the non-visual half of the stack produced, to be read side by side with the eveship.fit embed on `/ship/[itemId]`.

## What's here

The three layers of `@eveshipfit/react` we'd have to own, under `src/app/item/[itemId]/esf/`. The dogma-engine WASM — the part that does the actual math — is untouched.

| File | What it replaces |
| --- | --- |
| `protobuf.ts` + `schema.ts` | the vendored protobufjs-derived reader and generated decoder; the six messages of `src/esf.proto` are declared as data, so the decoder itself is ~100 lines |
| `eveData.ts` | `EveDataProvider` — fetch, decode and index the six `.pb2` files once per page load |
| `dogma.ts` | `DogmaEngineProvider` — the engine's seven `window` data callbacks, the WASM load, the all-skills-V baseline |
| `fit.ts` | `useImportEsiFitting` — ESI location flag → slot, ESI fit → engine fit |
| `attributes.ts` | `ShipAttribute` + `StatisticsProvider`'s numeric rules (fallbacks, resistances, rounding, slot counts) |

## Verification

The engine's bindings read their callbacks off `window`, so a harness only has to alias it — the whole stack runs headless under Node. That let the decoder be diffed **entry by entry** against `@eveshipfit/react`'s own generated decoder over the live `/esf/*.pb2`:

| file | entries | result |
| --- | ---: | --- |
| types | 52,848 | identical |
| typeDogma | 26,846 | identical |
| dogmaEffects | 3,454 | identical |
| dogmaAttributes | 2,919 | identical |
| marketGroups | 2,106 | identical |
| groups | 1,610 | identical |

Identical down to prototype-vs-own-property placement (which is what the WASM deserializer sees). The only differences are 321 names upstream mojibakes — it builds strings byte-per-char, ours decodes UTF-8.

Every risk the doc listed cleared: `next build` compiles the route (the existing `turbopack: {}` was all the WASM needed), 588 skills at L5 feed in, and calculated stats land where they should — a 5×HML II Caracal reads 18,515 ehp / 9,919 shield / 426.8 dps.

## Two findings

- **Today's viewer under-reports damage.** Loaded ammunition is a hangar row carrying its *slot's* flag, so a launcher and its missiles both arrive as `HiSlot0`; upstream's import turns each into a module, landing two "modules" in one slot and leaving the weapon unarmed. A fitted, loaded Rifter reads **0 dps** in the current embed and **116.9** once the charge is routed onto the module sharing its slot, which `fit.ts` now does. (The comment in `esfFit.ts` claiming the hook disambiguates charges is wrong.)
- **Slot counts aren't a hull attribute alone.** A T3's slots come entirely from its subsystems' `*SlotModifier` attributes, so reading only `calculation.hull` reports a Tengu with zero slots. `calculateSlots` folds in the per-item modifiers.

## Also

`fittingOrder` is now generic over its row, so a caller that only needs the fit order doesn't have to fabricate a whole `ItemRow`.

## Not done

The comparison harness is a scratch script, not a checked-in test — it needs the multi-MB `.pb2` files, so it wants a fixture strategy rather than a copy of the SDE in git. That's stage 1's job, along with moving these modules out of the route.

---
_Generated by [Claude Code](https://claude.ai/code/session_019dCxyHYjiZA2ay5oq4TLmm)_