### PR TITLE
Attribute tenants' tax revenue on the structures list too

### DIFF
--- a/src/app/structure/page.tsx
+++ b/src/app/structure/page.tsx
@@ -186,6 +186,38 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
       .range(from, to)
   )
 
+  // Both job tables above are RLS-scoped to the caller, so a job installed by another player who
+  // uses this site — a renting corp's rows live under their own registration — resolves to nothing
+  // here and its tax lands in "unaccounted", even though it ran in one of these structures and the
+  // tax is sitting in this caller's wallet. industry_job_tax_facility (security definer) closes
+  // that gap the same way /structure/revenue and structure_tax_revenue() already do: it discloses
+  // only the location, and only for a job the caller can prove they were taxed for.
+  //
+  // Only context_ids may be asked about — never the description tokens scraped below. A loose token
+  // colliding with a real job id would turn the function into an oracle for jobs the caller was
+  // never taxed for (see the migration comment).
+  const unresolvedJobIds = [
+    ...new Set(
+      (journal ?? [])
+        .map((entry) => (entry.context_id == null ? null : String(entry.context_id)))
+        .filter((id): id is string => id != null && !structureByJob.has(id))
+    ),
+  ]
+  if (unresolvedJobIds.length > 0) {
+    const { data: taxedJobs } = await supabase.rpc('industry_job_tax_facility', { job_ids: unresolvedJobIds })
+    // Keep the invariant the structure-seeded queries above establish: every value in the map is a
+    // structure on this page. A job taxed into our wallet from somewhere not in `list` (an NPC
+    // station, a structure we've stopped monitoring) stays unaccounted rather than accruing to a
+    // row nothing renders.
+    const onPage = new Set(structureIds.map(String))
+    for (const j of (taxedJobs ?? []) as JobRow[]) {
+      const structureId = j.station_id ?? j.facility_id
+      if (structureId != null && onPage.has(String(structureId))) {
+        structureByJob.set(String(j.job_id), String(structureId))
+      }
+    }
+  }
+
   const totalByStructure = new Map<string, number>()
   // Unaccounted tax broken down by the party that paid it (the character/corp that ran the job).
   const unaccountedByParty = new Map<string, number>()


### PR DESCRIPTION
## The bug

Isk Lemmings' industry tax shows up correctly on `/structure/revenue` and in the per-structure breakdown on `/structure/[structureId]`, but on the `/structure` list its ISK sits in **Unaccounted tax revenue** instead of on the structure that earned it.

`src/app/structure/page.tsx` resolves each `industry_job_tax` journal entry to a structure by looking the job up in `character_industry_job` / `corp_industry_job`. Both are RLS-scoped to the caller, so a job installed by another corp renting a slot — their rows live under their own registration — resolves to nothing, and the tax falls through to "unaccounted" even though it ran in one of the structures on the page and the ISK is in the caller's own wallet.

#846 added `industry_job_tax_facility()` for exactly this and wired it into `/structure/revenue`; #850 reached it from `/structure/[structureId]` via `structure_tax_revenue()`. The list page was never updated, so the three views disagree with each other.

## The fix

Call the same security-definer function for the `context_id`s the RLS lookup missed, and merge the results into `structureByJob`.

- It discloses only the location, and only for a job the caller can prove they were taxed for — nothing new crosses the boundary.
- Only `context_id`s are passed, never the description tokens scraped as a fallback below: a loose token colliding with a real job id would make the function an oracle for jobs the caller was never taxed for.
- Results are filtered to structures on the page, keeping the invariant the structure-seeded queries establish. Tax from a location not in the list (an NPC station, a structure no longer monitored) stays unaccounted rather than accruing to a row nothing renders.

## Verified against production

Default 30-day window, as the reporting account. **1.18B ISK moves out of unaccounted onto four structures:**

| Structure | Before | After |
| --- | ---: | ---: |
| EKPB-3 - CUDDLES T2 Structure+Fuel | 26.4M | 992.8M |
| TK-DLH - CUDDLES T2 Cap+Adv Components | 78.5M | 186.0M |
| TK-DLH - CUDDLES T2 Composite Reactions | 28.7M | 131.6M |
| EKPB-3 - CUDDLES T2 Hybrid+Bio Reactions | 21.4M | 21.9M |

Isk Lemmings alone is ~963M of that: 208/208 of their tax entries resolve through the function, all to EKPB-3 - CUDDLES T2 Structure+Fuel. The 600M that remains unaccounted is jobs by players who don't use the site — genuinely unresolvable.

Cost: the widest offered window (90 days, ~6.4k job ids) resolves in 46 ms, so no new index is needed.

`pnpm run lint` and `tsc --noEmit` are clean; prettier reports no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HG6pBa6KogDf5cAwjs6XKK

---
_Generated by [Claude Code](https://claude.ai/code/session_01HG6pBa6KogDf5cAwjs6XKK)_