### PR TITLE
Declare MCP cache hints so tools/list is cacheable

### DIFF
--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -28,7 +28,23 @@ const handler = createMcpHandler(
     registerExploreTools(server)
     registerLensTools(server)
   },
-  { serverInfo: { name: 'edencom-link', version: '1.0.0' } }
+  {
+    serverInfo: { name: 'edencom-link', version: '1.0.0' },
+    // SEP-2549 cache hints. The SDK emits every cacheable 2026-07-28 result
+    // with `ttlMs: 0` (immediately stale) and `cacheScope: 'private'` unless
+    // told otherwise, so without this every client re-fetches the tool list on
+    // every use. Both of these results are the same for every caller: tools are
+    // registered unconditionally above — the `lens` dark-launch flag is checked
+    // inside the lens handlers, not at registration — so nothing here varies by
+    // who is asking, and `public` is honest even though the endpoint is
+    // authenticated. RLS, not the cache scope, is what scopes the *data* a tool
+    // returns. The TTL is how long a deploy that changes the tool list can take
+    // to reach a client, since we send no `listChanged` notifications.
+    cacheHints: {
+      'tools/list': { ttlMs: 300_000, cacheScope: 'public' },
+      'server/discover': { ttlMs: 300_000, cacheScope: 'public' },
+    },
+  }
 )
 
 // Point the 401 WWW-Authenticate challenge at the path-suffixed protected-


### PR DESCRIPTION
## What

Declares SEP-2549 cache hints on the MCP server so `tools/list` and `server/discover` are actually cacheable by clients.

## Why

I went looking for what the 2026-07-28 MCP spec still asks of us. The short answer is: almost nothing — `mcp-handler` 2.1.0 over `@modelcontextprotocol/server` 2.0.0 (both already the latest published versions) implement the whole wire contract, and the server was already stateless, already Streamable-HTTP-only, and already using no removed features.

The one real gap was caching. The spec requires `ttlMs` and `cacheScope` on every cacheable result, and the SDK does emit them — but its defaults are the pessimistic pair, `ttlMs: 0` (immediately stale) and `cacheScope: "private"`. Verified against the wire with a scratch handler:

```
DEFAULT : ..."resultType":"complete","ttlMs":0,"cacheScope":"private"...
HINTED  : ..."resultType":"complete","ttlMs":300000,"cacheScope":"public"...
```

So every client re-fetched the full tool list on every use, for a list that only changes on deploy.

## How

`public` is honest here even though the endpoint is authenticated: all five `register*Tools` calls are unconditional, and the `lens` dark-launch flag is checked inside the lens handlers rather than at registration, so the tool list is byte-identical for every caller. The spec explicitly allows a list to vary by authorization, but ours doesn't. RLS on the bearer client — not the cache scope — is what scopes the *data* a tool returns; `cacheScope` only covers the tool list itself, which carries no user data.

The 5-minute TTL bounds how long a deploy that changes the tool list takes to reach a client, since the server sends no `listChanged` notifications.

## Not included

- **`additionalProperties: false` on the two no-parameter tools** (`lens_schema`, and the one at `tools.ts:554`). The spec lists it as the recommended spelling, but zod currently emits `{"type":"object","properties":{}}` and making it strict would start rejecting stray arguments from sloppy clients. Happy to add it if you'd rather match the recommendation.
- **Dynamic Client Registration.** Now deprecated in favor of Client ID Metadata Documents, but it remains supported for backwards compatibility and the migration is Supabase's side of the handshake, not ours.
- Tasks, MCP Apps, and the other extensions — all optional, and nothing here needs them.

## Testing

- `pnpm run lint` — clean
- `pnpm test` — 263 pass
- `pnpm run build` — passes
- Wire output verified directly against a scratch handler (above); the same probe confirmed the SDK already emits `resultType: "complete"` and the `io.modelcontextprotocol/serverInfo` `_meta` on its own

---
_Generated by [Claude Code](https://claude.ai/code/session_013hyDVYwVJKKuy4mZfnnyRw)_