### PR TITLE
Make Supabase session cookies httpOnly, drop the unused browser client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ Functions take `(accessToken, id, ...)`; return raw ESI JSON (paged wrappers ret
 - `queue.ts` — region-pinned `@vercel/queue` client (default `sfo1`) + `send`/`handleCallback`
 - `cron.ts` — `requireCronSecret`; `runDirectCronJob` kept only for the `esf-data`/`sheet-csv` bootstrap routes
 - `escapeLike.ts` — escapes `%`/`_`/`\` before `.ilike()`; `sdeCategories.ts` — `BLUEPRINT_CATEGORY_ID` (9). Both in `utils/` because their callers sit in layers that must not import each other (`structureQuery.ts` re-exports `escapeLike`)
-- `supabase/client.ts`/`server.ts`/`service.ts`/`bearer.ts`/`sde.ts` — browser / server-cookie / service-role / OAuth-bearer client factories; `sde.ts` is a lazy **anon** client for the public-read `sde_*` tables, usable in every context, never for writes
+- `supabase/server.ts`/`service.ts`/`bearer.ts`/`sde.ts` — server-cookie / service-role / OAuth-bearer client factories; `sde.ts` is a lazy **anon** client for the public-read `sde_*` tables, usable in every context, never for writes. **There is no browser client** — session cookies are httpOnly (`supabase/cookieOptions.ts`, applied by `server.ts` and `src/proxy.ts`), so `createBrowserClient` would see no session. Every Supabase call is server-side
 
 ## App routes → files
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,8 @@
 import { createServerClient } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
 
+import { sessionCookieOptions } from '@/utils/supabase/cookieOptions'
+
 export async function proxy(request: NextRequest) {
   let response = NextResponse.next({
     request: { headers: request.headers },
@@ -24,7 +26,9 @@ export async function proxy(request: NextRequest) {
           response = NextResponse.next({
             request: { headers: request.headers },
           })
-          cookiesToSet.forEach(({ name, value, options }) => response.cookies.set(name, value, options))
+          cookiesToSet.forEach(({ name, value, options }) =>
+            response.cookies.set(name, value, sessionCookieOptions(options))
+          )
         },
       },
     })

--- a/src/utils/supabase/client.ts
+++ b/src/utils/supabase/client.ts
@@ -1,5 +1,0 @@
-import { createBrowserClient } from '@supabase/ssr'
-
-export function createClient() {
-  return createBrowserClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!)
-}

--- a/src/utils/supabase/cookieOptions.ts
+++ b/src/utils/supabase/cookieOptions.ts
@@ -1,0 +1,26 @@
+// Session cookies are httpOnly.
+//
+// A Supabase access token is a bearer JWT — no origin, audience or domain
+// claim ties it to this site, and the Data API never inspects Origin or
+// Referer. So anything that can read the cookie can replay the session
+// against /rest/v1 and /graphql/v1 from anywhere, and the refresh token
+// riding in the same payload mints fresh access tokens indefinitely until
+// it is revoked. httpOnly takes JS-side theft (XSS, a hostile extension)
+// off the table; it does nothing about a user exporting their own token,
+// which is harmless anyway since RLS hands them exactly their own rows.
+//
+// @supabase/ssr cannot default to this, because createBrowserClient reads
+// the cookies from document.cookie. This app never runs that client — every
+// Supabase call is server-side (the cookie-bound client here, the bearer
+// client for MCP, the service client for cron, the anon client for the
+// public sde_* mirror), which is why src/utils/supabase/client.ts was
+// deleted rather than left dormant. Reintroducing a browser client would
+// silently break auth: it would see no session at all. Use the server
+// client from a server component or action instead.
+//
+// Only httpOnly is forced. Everything else — path, sameSite, maxAge,
+// secure — is whatever @supabase/ssr computed for that cookie.
+export const sessionCookieOptions = <T>(options: T): T & { httpOnly: true } => ({
+  ...options,
+  httpOnly: true,
+})

--- a/src/utils/supabase/server.ts
+++ b/src/utils/supabase/server.ts
@@ -1,6 +1,8 @@
 import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
+import { sessionCookieOptions } from './cookieOptions'
+
 export const createClient = async () => {
   const cookieStore = await cookies()
   return createServerClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!, {
@@ -10,10 +12,12 @@ export const createClient = async () => {
       },
       setAll(cookiesToSet) {
         try {
-          cookiesToSet.forEach(({ name, value, options }) => cookieStore.set(name, value, options))
+          cookiesToSet.forEach(({ name, value, options }) =>
+            cookieStore.set(name, value, sessionCookieOptions(options))
+          )
         } catch {
           // The setAll method was called from a Server Component.
-          // This can be ignored if middleware is refreshing user sessions.
+          // This can be ignored if src/proxy.ts is refreshing user sessions.
         }
       },
     },


### PR DESCRIPTION
A Supabase access token is a bearer JWT — `sub`, `role`, `aud: "authenticated"`, `exp`. Nothing in it ties the session to edencom.link, and the Data API never inspects `Origin` or `Referer`. So anything that can read the session cookie can replay it against `/rest/v1` and `/graphql/v1` from anywhere, and the refresh token riding in the same cookie payload mints fresh access tokens indefinitely, from any IP, until someone revokes it.

`@supabase/ssr` can't default to `httpOnly`, because `createBrowserClient` reads the cookies out of `document.cookie`. **This app never runs that client.** `src/utils/supabase/client.ts` defined one and nothing imported it — every Supabase call already goes through the cookie-bound server client, the bearer client (MCP), the service client (cron), or the anon SDE client. So the flag is free here.

`src/app/account/debug/impersonate.ts` already asserted the invariant in a comment — *"nothing session-related ever reaches client-side JS"* — but no cookie flag enforced it. Now one does.

## What changed

- **`src/utils/supabase/cookieOptions.ts`** (new) — one `sessionCookieOptions()` helper forcing only `httpOnly`, leaving `path`/`sameSite`/`maxAge`/`secure` exactly as `@supabase/ssr` computed them.
- **`src/utils/supabase/server.ts`** — applies it in `setAll`.
- **`src/proxy.ts`** — applies it in `setAll` too. This is the one that actually matters: it's Next 16's rename of `middleware.ts`, and it's where the session gets refreshed on every matched request. Patching only `server.ts` would have left most cookie writes unflagged.
- **`src/utils/supabase/client.ts`** — deleted. Left dormant it becomes a trap: wiring up a browser client after this change would silently break auth, because it would see no session at all. The helper's comment and CLAUDE.md both say so.
- **`CLAUDE.md`** — the client-factory line drops `client.ts` and records that there is no browser client by design.

## What this does and doesn't buy

Takes JS-side token theft off the table — XSS on the origin, a hostile browser extension. Does **not** stop a user exporting their own token from devtools and using it elsewhere; that's unfixable with a bearer scheme and harmless anyway, since RLS hands them exactly their own rows either way.

Two related knobs live in the Supabase dashboard, not in this diff, and are worth checking separately: **refresh-token rotation with reuse detection** (what turns a stolen refresh token from permanent access into a detectable, self-revoking incident), and **JWT expiry**.

## Verification

`pnpm run lint` clean, `pnpm run build` passes, `pnpm test` 263/263. `npx tsc --noEmit` reports zero errors under `src/` (the pre-existing `test/` errors are untouched and outside what `next build` typechecks).

Not verified by automated tests: no test covers cookie flags. Worth a manual check after deploy that the `sb-*` cookies come back with `HttpOnly` and that login, logout, email confirm, password reset, GICE SSO, and Chancellor impersonate all still work — all of them redeem through the server client, so they should, but the session path is the one thing here you don't want to take on faith.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVuyNgKVuCSy2PJZPfZskQ)_