### PR TITLE
Treat a corp role denial as a recorded no-op, not a failed extract

### DIFF
--- a/docs/jobs-page.md
+++ b/docs/jobs-page.md
@@ -74,8 +74,9 @@ per-character detail is a nested expansion.
   one lagging character must not make the schedule itself look broken.
 - Expanding a row (`<details>`, server-rendered — no client JS needed to open
   it) reveals today's matrix column: one line per registration with its own
-  freshness `Cell` and refresh button. Nothing about per-character refresh
-  changes; it just stops being the page's top-level axis.
+  freshness `Cell` and refresh button, plus a **refresh everyone** button above
+  them that kicks the job for every character in one batch. Nothing about
+  per-character refresh changes; it just stops being the page's top-level axis.
 
 ### 2. Corporations
 
@@ -132,11 +133,14 @@ account-wide jobs that today sit in the refresh page's "Account-wide" table.
   ignore the color. Plain relative text plus the next-run countdown carries it
   — and the countdown is the honest health signal here anyway (a job whose
   _next_ run is in the past is a job that didn't fire).
-- Refresh buttons: `character-directory` and `universe-names` keep theirs
-  (they're in `ACCOUNT_JOBS` today and cheap). `industry-systems` keeps its
-  Chancellor gate (`isChancellor` server-side, per today's `refreshCell`).
-  `sde-mirror`, `universe-structures` get none — the `?force=1` /
-  `CRON_SECRET` cron routes stay operator tools.
+- Refresh buttons: **Chancellor-only, for every job in this section that has
+  one at all.** `character-directory` and `universe-names` shipped as
+  `kickable: 'always'` (they're cheap and were in `ACCOUNT_JOBS`), but cheap
+  isn't the test — these pulls are game-wide, so one account's button spends
+  everyone's rate limit and moves data nobody else asked to move. They now sit
+  behind the same `isChancellor` gate `industry-systems` always had, re-checked
+  server-side in `refreshCell`. `sde-mirror` and `universe-structures` still get
+  none — the `?force=1` / `CRON_SECRET` cron routes stay operator tools.
 - Because these rows are shared, a run kicked by another account shows up
   here as `running` for everyone. That is correct and worth a line of UI copy.
 
@@ -262,23 +266,23 @@ account-independent number that means less.
 
 ## Files
 
-| File                                                       | Change                                                                                                        |
-| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| File                                                             | Change                                                                                                                                       |
+| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `src/app/jobs/registry.ts`                                       | Job catalog: label, section, kickable, `cronFor()` over the `vercel.json` import, plus `jobEntry()` — the allow-list `refreshCell` gates on. |
-| `src/app/jobs/schedule.ts`                                       | Pure `parseCron` / `nextCronRun` / `previousCronRun`, UTC.                                                                                  |
+| `src/app/jobs/schedule.ts`                                       | Pure `parseCron` / `nextCronRun` / `previousCronRun`, UTC.                                                                                   |
 | `src/app/jobs/rows.ts`                                           | Pure reductions: oldest/newest run, lagging count, status precedence, activity grouping, the abandoned-task rule.                            |
-| `src/app/jobs/page.tsx`                                          | The four sections, over live queries.                                                                                                       |
-| `src/app/jobs/jobs.module.css`                                   | Table/status/countdown styles, lifted from `refresh.module.css`.                                                                            |
-| `src/app/jobs/actions.ts`                                        | `refreshCell`, allow-list rebuilt from the registry.                                                                                        |
-| `src/app/jobs/refreshButton.tsx`, `poller.tsx`, `loading.tsx`    | Moved from `src/app/character/refresh/`.                                                                                                    |
-| `src/app/character/refresh/*`                                    | Deleted.                                                                                                                                    |
-| `next.config.mjs`                                                | `/character/refresh` → `/jobs` permanent; `/characters/refresh` retargeted straight at `/jobs`.                                             |
+| `src/app/jobs/page.tsx`                                          | The four sections, over live queries.                                                                                                        |
+| `src/app/jobs/jobs.module.css`                                   | Table/status/countdown styles, lifted from `refresh.module.css`.                                                                             |
+| `src/app/jobs/actions.ts`                                        | `refreshCell`, allow-list rebuilt from the registry.                                                                                         |
+| `src/app/jobs/refreshButton.tsx`, `poller.tsx`, `loading.tsx`    | Moved from `src/app/character/refresh/`.                                                                                                     |
+| `src/app/character/refresh/*`                                    | Deleted.                                                                                                                                     |
+| `next.config.mjs`                                                | `/character/refresh` → `/jobs` permanent; `/characters/refresh` retargeted straight at `/jobs`.                                              |
 | `src/app/layout/header.tsx`, `src/app/page.tsx`, `fittingMatrix` | Refresh links point at `/jobs`; the character callback lands there after adding a character.                                                 |
-| `test/schedule.test.ts`, `test/jobsRows.test.ts`                 | Cron parsing/next-fire assertions; the row reductions.                                                                                      |
+| `test/schedule.test.ts`, `test/jobsRows.test.ts`                 | Cron parsing/next-fire assertions; the row reductions.                                                                                       |
 
 One migration, `20260812000000_latest_heartbeats_outcome`: `latest_heartbeats()`
 now returns `ok` and `error` alongside `ended_at`, which is what lets a cell
-render `✗ failed` for a *scheduled* run rather than an undifferentiated stale
+render `✗ failed` for a _scheduled_ run rather than an undifferentiated stale
 dot. Adding OUT columns changes the return type, so the function is dropped and
 recreated (as in #754); the only other caller reads `job`/`ended_at` and is
 unaffected.
@@ -299,6 +303,54 @@ unaffected.
   the per-cell status overlay reads only the last 10 minutes, so an on-demand
   error from this morning doesn't outrank a scheduled pull that has since
   succeeded.
+
+### Closed gap: a corp you don't direct is a no-op, not a failure ✅
+
+The corp endpoints need an **in-game role** (director, accountant, station
+manager) on top of the OAuth scope, and ESI answers a character without it with
+`403 Character does not have required role(s)`. That threw, so the per-corp
+heartbeat closed `ok = false` and the row read `✗ failed` every six hours — for
+something that never was a failure. Nothing broke; the pilot was simply never
+allowed to ask, and re-running earns the same 403.
+
+That outcome is now its own thing, end to end:
+
+- `src/esi.js` throws `EsiError` (status + body) instead of a bare `Error`, and
+  `isRoleDenial(e)` recognises the role 403. Matched on the **body**, not on the
+  bare status: a 403 also covers an expired or revoked token, which _is_ a
+  failure and keeps surfacing as one.
+- `forEachCorporation` (`src/jobs/lib.js`) closes that character's heartbeat
+  `ok = true` with **`heartbeat.skipped_reason`** naming them, logs it as a skip
+  rather than a FAILED, and still leaves the corp unclaimed so a corpmate with
+  the role gets their turn in the same run. `withHeartbeat` takes a
+  `skipReasonOf(e)` classifier for this; nothing else uses it yet.
+- Migration `20260812120000_heartbeat_skipped_reason` adds the column and carries
+  it through `latest_heartbeats()`.
+- The page renders `— not a director` (the reason on hover), offers no refresh
+  button for it, and — the part that matters beyond the label — **excludes
+  skipped entities from `oldestRun` and `laggingCount`**, so a corp nobody on the
+  account directs stops pinning its job's row at "never" forever. A row reads
+  `skipped` only when _every_ entity is one; one unreachable corp doesn't relabel
+  a job that ran fine for the other.
+
+Known limit: the on-demand path still records `refresh_task` as `✓ done` for such
+a run, since nothing threw. Recent activity has no column for "did nothing, on
+purpose"; the cell carries that fact instead.
+
+### Also shipped: two refresh-button changes
+
+- **Shared universe kicks are Chancellor-only.** `universe-names` and
+  `character-directory` were `kickable: 'always'`; both are now `'chancellor'`,
+  like `industry-systems`. These pulls are game-wide — one account's button
+  spends everyone's rate limit and moves data nobody else asked to move —
+  so every kickable job in that section is now gated the same way, and
+  `refreshCell` re-checks server-side.
+- **"Refresh everyone" per character job.** The Characters expansion carries one
+  button that kicks the job for every registered character (`refreshAllCharacters`
+  → `dispatchJobForCharacters`), under a single `batch_id` so Recent activity
+  reads it as the one action it was. Per-character jobs only: a corp job's unit
+  of work is the corporation, and fanning one run per character is the
+  concurrent-reconcile race `PER_CORPORATION_JOBS` exists to avoid.
 
 ## Verification (no test runner for pages; gates are lint + build + manual)
 

--- a/schema.sql
+++ b/schema.sql
@@ -747,6 +747,13 @@ create table public.heartbeat (
   ok boolean,
   -- The failure's message (truncated), null when ok.
   error text,
+  -- Why the run was a permitted no-op rather than a pull: a corp endpoint needs
+  -- an in-game role (director, accountant) on top of the OAuth scope, and a
+  -- character without it gets a 403 that means "you were never allowed to ask",
+  -- not "the extract broke". Those rows close with ok=true, error null and this
+  -- sentence set, so /jobs can say "not a director" instead of "✗ failed".
+  -- Null on real runs, open rows, and rows predating the column.
+  skipped_reason text,
   started_at timestamptz,
   ended_at timestamptz,
   -- How long the run took for that job/entity; null until ended_at lands.
@@ -917,13 +924,14 @@ returns table (
   corporation_id bigint,
   ended_at timestamptz,
   ok boolean,
-  error text
+  error text,
+  skipped_reason text
 )
 language sql
 stable
 as $$
   select distinct on (h.job, h.owner_key)
-    h.job, h.registration_id, h.corporation_id, h.ended_at, h.ok, h.error
+    h.job, h.registration_id, h.corporation_id, h.ended_at, h.ok, h.error, h.skipped_reason
   from public.heartbeat h
   where h.ended_at is not null
     and h.ended_at > now() - interval '30 days'

--- a/src/app/character/dispatchRefresh.ts
+++ b/src/app/character/dispatchRefresh.ts
@@ -217,6 +217,44 @@ export const dispatchRefresh = async (userId: string, characters: Character[]): 
   return batchId
 }
 
+// One *row* of the /jobs Characters section: the same per-character work
+// dispatchSingleJob does, for every one of the caller's characters at once,
+// under a single batch_id so Recent activity reads it as the one action it was
+// rather than as N unrelated kicks. Per-character jobs only — a corp job's unit
+// of work is the corporation, not the character, and fanning one run per
+// character is exactly the concurrent-reconcile race PER_CORPORATION_JOBS
+// exists to avoid. Uses the service role, so callers must pass a userId they've
+// already authorized, and characters they've confirmed belong to it.
+export const dispatchJobForCharacters = async (
+  userId: string,
+  job: string,
+  characters: Character[]
+): Promise<string> => {
+  const batchId = randomUUID()
+  const { sudoSupabase } = await import('@/supabase.js')
+
+  const { data: inserted, error } = await sudoSupabase
+    .from('refresh_task')
+    .insert(
+      characters.map((c) => ({
+        batch_id: batchId,
+        user_id: userId,
+        job,
+        registration_id: c.id,
+        character_name: c.name,
+      }))
+    )
+    .select('id, registration_id')
+  if (error) throw error
+
+  const started = await Promise.all(
+    (inserted ?? []).map((t) => startJobWorkflow(job, { registrationIds: [t.registration_id], taskId: t.id }))
+  )
+  console.log(`[dispatchJobForCharacters] started ${started.length} ${job} runs`)
+
+  return batchId
+}
+
 // One cell of the /jobs page: insert a single refresh_task row
 // and start its one workflow run. `character` is null for the account-wide
 // jobs. For a corp-scoped job the target carries every scoped character in the

--- a/src/app/jobs/actions.ts
+++ b/src/app/jobs/actions.ts
@@ -6,7 +6,7 @@ import { redirect } from 'next/navigation'
 import { createClient } from '@/utils/supabase/server'
 
 import { isChancellor } from '../account/settings/chancellor/chancellor'
-import { dispatchSingleJob } from '../character/dispatchRefresh'
+import { PER_CHARACTER_JOBS, dispatchJobForCharacters, dispatchSingleJob } from '../character/dispatchRefresh'
 import { jobEntry } from './registry'
 
 // Kick one cell of /jobs: one job for one character (or for one corporation,
@@ -50,5 +50,42 @@ export const refreshCell = async (job: string, characterId: string | null) => {
   }
 
   await dispatchSingleJob(user.id, job, character)
+  revalidatePath('/jobs')
+}
+
+// Kick one job for every character the caller has registered — the "refresh
+// all" button inside a Characters row's expansion, for when the answer to "why
+// is this stale" is "all of them", and clicking four cells in turn is just
+// clicking four cells in turn. One batch, so Recent activity groups it.
+//
+// Per-character jobs only: a corp job is dispatched per corporation (see
+// dispatchJobForCharacters), and the shared jobs have a single cell already.
+export const refreshAllCharacters = async (job: string) => {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user?.id) {
+    redirect('/account/login')
+  }
+
+  const entry = jobEntry(job)
+  if (!entry || entry.section !== 'character' || entry.kickable === 'never') {
+    throw new Error(`not an on-demand per-character job: ${job}`)
+  }
+  if (!(PER_CHARACTER_JOBS as readonly string[]).includes(job)) {
+    throw new Error(`no per-character dispatch for: ${job}`)
+  }
+
+  // RLS scopes this to the caller's own registrations, which is what makes the
+  // service-role dispatch below safe.
+  const { data: characters } = await supabase
+    .from('registration')
+    .select('id, name')
+    .order('created_at', { ascending: true })
+  if (!characters?.length) return
+
+  await dispatchJobForCharacters(user.id, job, characters)
   revalidatePath('/jobs')
 }

--- a/src/app/jobs/jobs.module.css
+++ b/src/app/jobs/jobs.module.css
@@ -62,6 +62,13 @@
   color: #ff4040;
 }
 
+/* A run that was permitted to do nothing (no in-game role). Deliberately the
+   same muted grey as idle rather than the failure red: nothing is wrong. */
+.status[data-status='skipped'] {
+  color: var(--ink-faint, #888);
+  font-style: italic;
+}
+
 .status[data-status='idle'] {
   color: var(--ink-faint, #888);
 }
@@ -92,6 +99,12 @@
 .breakdown summary {
   cursor: pointer;
   white-space: nowrap;
+}
+
+/* The row-wide "refresh everyone" button, above the per-character lines it
+   stands in for. */
+.breakdownActions {
+  margin: 0.4rem 0 0;
 }
 
 .breakdownList {

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -21,7 +21,7 @@ import { CharacterName, Name } from '../names'
 import styles from './jobs.module.css'
 import { NextRun } from './nextRun'
 import { RefreshPoller } from './poller'
-import { RefreshButton } from './refreshButton'
+import { RefreshAllButton, RefreshButton } from './refreshButton'
 import { type JobEntry, type Kickable, isOverdue, jobsInSection, nextRunFor } from './registry'
 import {
   type ActivityTask,
@@ -47,6 +47,9 @@ type Beat = {
   ended_at: string
   ok: boolean | null
   error: string | null
+  // Set (with ok true) when the run was a permitted no-op: a corp endpoint the
+  // character holds no in-game role for. See heartbeat.skipped_reason.
+  skipped_reason: string | null
 }
 
 type OpenBeat = { job: string; registration_id: string | null; corporation_id: number | null }
@@ -59,6 +62,9 @@ const STATUS_LABEL: Record<string, string> = {
   running: '● running',
   queued: '· queued',
   failed: '✗ failed',
+  // Not a failure: nothing was pulled because nothing was permitted to be. The
+  // reason (which character, which role) rides along as the title.
+  skipped: '— not a director',
   idle: 'idle',
   pending: '· pending',
   done: '✓ done',
@@ -100,10 +106,12 @@ const Cell = ({
   const offerRefresh =
     kickable !== 'never' &&
     !inFlight &&
+    // Re-kicking a run we're not permitted to make just re-earns the same 403.
+    entity.status !== 'skipped' &&
     (!showFreshness || entity.status === 'failed' || freshnessLevel(entity.lastRunAt) !== 'fresh')
   return (
     <span className={styles.cell}>
-      {inFlight || entity.status === 'failed' ? (
+      {inFlight || entity.status === 'failed' || entity.status === 'skipped' ? (
         <Status status={entity.status} error={entity.error} />
       ) : showFreshness ? (
         <Freshness at={entity.lastRunAt} />
@@ -128,6 +136,7 @@ const EntityJobTable = ({
   entityNoun,
   kickableOf,
   showRunsAs = false,
+  offerRefreshAll = false,
 }: {
   entries: readonly JobEntry[]
   entitiesByJob: Record<string, EntityRun[]>
@@ -136,6 +145,10 @@ const EntityJobTable = ({
   entityNoun: string
   kickableOf: (entry: JobEntry) => Kickable
   showRunsAs?: boolean
+  // Characters only: offer one button that kicks the job for every character,
+  // so the answer to "they're all stale" isn't four clicks. Corp jobs dispatch
+  // per corporation, which the per-corp cells already do one at a time.
+  offerRefreshAll?: boolean
 }) => (
   <table className={styles.table}>
     <thead>
@@ -164,6 +177,11 @@ const EntityJobTable = ({
                   {entities.length} {entityNoun}
                   {lagging > 0 && <span className={styles.lagging}> · {lagging} lagging</span>}
                 </summary>
+                {offerRefreshAll && kickable === 'always' && entities.length > 1 && (
+                  <div className={styles.breakdownActions}>
+                    <RefreshAllButton job={entry.job} />
+                  </div>
+                )}
                 <ul className={styles.breakdownList}>
                   {entities.map((entity) => (
                     <li key={entity.id}>
@@ -279,8 +297,13 @@ const JobsPage = async () => {
         const key = `${b.job}:${b.corporation_id}`
         const prev = acc.corpBeats.get(key)
         if (!prev || prev.ended_at < b.ended_at) acc.corpBeats.set(key, b)
-        const prevRun = acc.corpRunsAs.get(b.corporation_id)
-        if (!prevRun || prevRun.ended_at < b.ended_at) acc.corpRunsAs.set(b.corporation_id, b)
+        // Whose token *worked*. A skipped row names a character who was turned
+        // away for want of the in-game role, which is precisely who didn't run
+        // it, so those never claim the Runs as column.
+        if (b.skipped_reason == null) {
+          const prevRun = acc.corpRunsAs.get(b.corporation_id)
+          if (!prevRun || prevRun.ended_at < b.ended_at) acc.corpRunsAs.set(b.corporation_id, b)
+        }
       } else if (b.registration_id != null) {
         acc.charBeats.set(`${b.job}:${b.registration_id}`, b)
       } else {
@@ -337,7 +360,11 @@ const JobsPage = async () => {
 
   const runFor = (job: string, key: string, beat: Beat | undefined): Omit<EntityRun, 'id' | 'name'> => ({
     lastRunAt: beat?.ended_at ?? null,
-    ...statusOf({ task: taskByCell.get(`${job}:${key}`), open: openCells.has(`${job}:${key}`), beat }),
+    ...statusOf({
+      task: taskByCell.get(`${job}:${key}`),
+      open: openCells.has(`${job}:${key}`),
+      beat: beat && { ok: beat.ok, error: beat.error, skippedReason: beat.skipped_reason },
+    }),
   })
 
   const characterEntities: Record<string, EntityRun[]> = Object.fromEntries(
@@ -398,13 +425,15 @@ const JobsPage = async () => {
           <h2>Characters</h2>
           <p>
             Last run is <em>the oldest of your characters</em>&nbsp;— one character that hasn&apos;t pulled is what
-            makes the data stale, even when the others just ran. Open a row for the per-character breakdown.
+            makes the data stale, even when the others just ran. Open a row for the per-character breakdown, and for the
+            button that refreshes every character at once.
           </p>
           <EntityJobTable
             entries={jobsInSection('character')}
             entitiesByJob={characterEntities}
             entityNoun="characters"
             kickableOf={(entry) => entry.kickable}
+            offerRefreshAll
           />
 
           {corporations.size > 0 && (
@@ -414,6 +443,8 @@ const JobsPage = async () => {
                 Corp extracts run once per corporation, under the token of a character holding the in-game role —
                 director, accountant — that the endpoint requires. <em>Runs as</em> names whose token the last pull
                 actually used, so a corp going stale because its only director token stopped working is visible as such.
+                A corp where none of your characters holds the role reads <em>not a director</em>: nothing was pulled,
+                but nothing failed either, and there is nothing to retry.
               </p>
               <EntityJobTable
                 entries={jobsInSection('corporation')}
@@ -431,7 +462,8 @@ const JobsPage = async () => {
       <p>
         Game-wide data every account shares — the SDE mirror, structure and name resolution, industry cost indices.
         These run once for everyone, so a run someone else kicked shows here as running for you too. Relative times
-        only: a nightly job would sit permanently red against the six-hourly freshness scale.
+        only: a nightly job would sit permanently red against the six-hourly freshness scale. Kicking one of these is a
+        Chancellor's call — the pull is game-wide, not yours.
       </p>
       <table className={styles.table}>
         <thead>

--- a/src/app/jobs/refreshButton.tsx
+++ b/src/app/jobs/refreshButton.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from 'next/navigation'
 import { useTransition } from 'react'
 
-import { refreshCell } from './actions'
+import { refreshAllCharacters, refreshCell } from './actions'
 import styles from './jobs.module.css'
 
 // Kicks one job for one cell without leaving the page. The follow-up
@@ -25,6 +25,29 @@ export const RefreshButton = ({ job, characterId }: { job: string; characterId: 
       }
     >
       {pending ? 'refreshing…' : 'refresh'}
+    </button>
+  )
+}
+
+// The same thing for a whole Characters row: one click kicks the job for every
+// registered character instead of one cell at a time. Lives inside the row's
+// expansion, next to the per-character cells it stands in for.
+export const RefreshAllButton = ({ job }: { job: string }) => {
+  const router = useRouter()
+  const [pending, startTransition] = useTransition()
+  return (
+    <button
+      type="button"
+      className={styles.refreshButton}
+      disabled={pending}
+      onClick={() =>
+        startTransition(async () => {
+          await refreshAllCharacters(job)
+          router.refresh()
+        })
+      }
+    >
+      {pending ? 'refreshing everyone…' : 'refresh everyone'}
     </button>
   )
 }

--- a/src/app/jobs/registry.ts
+++ b/src/app/jobs/registry.ts
@@ -17,8 +17,10 @@ export type JobSection = 'character' | 'corporation' | 'universe'
 
 // Whether this page offers a refresh button for the job:
 //   always     — anyone may kick it for their own characters/corps
-//   chancellor — gated on isChancellor() server-side (whole-universe pull with
-//                no per-character reason to run it; see refreshCell today)
+//   chancellor — gated on isChancellor() server-side. Every shared-universe job
+//                that can be kicked at all is this: those pulls are game-wide,
+//                so one account's button spends everyone's rate limit and moves
+//                data nobody asked to move. refreshCell re-checks server-side.
 //   never      — whole-corp/whole-universe work whose only trigger is the cron
 //                (its ?force=1 / CRON_SECRET route stays an operator tool)
 export type Kickable = 'always' | 'chancellor' | 'never'
@@ -56,9 +58,9 @@ export const JOBS: readonly JobEntry[] = [
   { job: 'corp-wallet-journal', label: 'wallet journal', section: 'corporation', kickable: 'never' },
 
   { job: 'sde-mirror', label: 'SDE mirror', section: 'universe', kickable: 'never' },
-  { job: 'universe-names', label: 'names', section: 'universe', kickable: 'always' },
+  { job: 'universe-names', label: 'names', section: 'universe', kickable: 'chancellor' },
   { job: 'universe-structures', label: 'structures', section: 'universe', kickable: 'never' },
-  { job: 'character-directory', label: 'character directory', section: 'universe', kickable: 'always' },
+  { job: 'character-directory', label: 'character directory', section: 'universe', kickable: 'chancellor' },
   { job: 'industry-systems', label: 'industry indexes', section: 'universe', kickable: 'chancellor' },
 ]
 

--- a/src/app/jobs/rows.ts
+++ b/src/app/jobs/rows.ts
@@ -5,7 +5,10 @@
 
 import { freshnessLevel } from '../freshness.ts'
 
-export type EntityStatus = 'running' | 'queued' | 'failed' | 'idle'
+// 'skipped' is a run that was allowed to do nothing: a corp endpoint the
+// character holds no in-game role for. Not a failure and not a pull — see
+// forEachCorporation (src/jobs/lib.js) and heartbeat.skipped_reason.
+export type EntityStatus = 'running' | 'queued' | 'failed' | 'skipped' | 'idle'
 
 // One owner of a job's data — a registered character, a corporation, or (for
 // the shared jobs) the single implicit account-wide owner.
@@ -17,6 +20,7 @@ export type EntityRun = {
   status: EntityStatus
   // The failure's message, from whichever of the two sources set the status to
   // 'failed' — a refresh_task the caller kicked, or the job's own end heartbeat.
+  // For 'skipped' it's the reason the run was a permitted no-op instead.
   error: string | null
   // Corp rows only: whose token the last pull ran under. runsAsCorpmate means a
   // director on another account in the same corp, visible as a corp-scoped
@@ -25,11 +29,18 @@ export type EntityRun = {
   runsAsCorpmate?: boolean
 }
 
+// An entity we're not permitted to pull has no freshness to speak of: a corp
+// nobody on this account directs would otherwise pin its job's row at "never"
+// forever, which reads as broken data rather than as data that was never ours.
+const pullable = (entities: readonly EntityRun[]): EntityRun[] =>
+  entities.filter((entity) => entity.status !== 'skipped')
+
 // The row's headline freshness is the OLDEST of the caller's entities, not the
 // newest: the question is "is my data fresh", and one character that hasn't
 // pulled since yesterday is the answer even when the other three ran minutes
 // ago. A never-run entity is older than any timestamp.
-export const oldestRun = (entities: readonly EntityRun[]): string | null => {
+export const oldestRun = (all: readonly EntityRun[]): string | null => {
+  const entities = pullable(all)
   if (entities.length === 0) return null
   if (entities.some((entity) => entity.lastRunAt === null)) return null
   return entities.reduce<string | null>(
@@ -55,7 +66,10 @@ const LEVEL_RANK: Record<string, number> = { fresh: 0, aging: 1, stale: 2, none:
 // normal state for a six-hourly job and teaches nothing; what's worth a note is
 // one character lagging the others, which is a real symptom (dead token, missing
 // scope) rather than the cadence doing its job.
-export const laggingCount = (entities: readonly EntityRun[], now: number = Date.now()): number => {
+export const laggingCount = (all: readonly EntityRun[], now: number = Date.now()): number => {
+  // Skipped entities are excluded for the same reason as in oldestRun: never
+  // being allowed to pull isn't lagging behind.
+  const entities = pullable(all)
   if (entities.length === 0) return 0
   const ranks = entities.map((entity) => LEVEL_RANK[freshnessLevel(entity.lastRunAt, now)])
   const best = Math.min(...ranks)
@@ -68,6 +82,9 @@ export const rowStatus = (entities: readonly EntityRun[]): EntityStatus => {
   if (entities.some((e) => e.status === 'running')) return 'running'
   if (entities.some((e) => e.status === 'queued')) return 'queued'
   if (entities.some((e) => e.status === 'failed')) return 'failed'
+  // Only when *every* entity is a no-op: one corp we can't pull shouldn't
+  // relabel a job that ran fine for the other one.
+  if (entities.length > 0 && entities.every((e) => e.status === 'skipped')) return 'skipped'
   return 'idle'
 }
 
@@ -79,8 +96,9 @@ export type StatusInputs = {
   // only ever returns completed rows.
   open?: boolean
   // The newest completed heartbeat's outcome. ok === false is a run that threw;
-  // null means "unknown" (rows predating the column, CLI runs).
-  beat?: { ok: boolean | null; error: string | null }
+  // null means "unknown" (rows predating the column, CLI runs). skippedReason
+  // set (with ok true) is a run that was permitted to do nothing.
+  beat?: { ok: boolean | null; error: string | null; skippedReason?: string | null }
 }
 
 export const statusOf = ({ task, open, beat }: StatusInputs): { status: EntityStatus; error: string | null } => {
@@ -90,6 +108,9 @@ export const statusOf = ({ task, open, beat }: StatusInputs): { status: EntitySt
   // A scheduled run that failed is a failure too, and it's the only way a dead
   // token on one character is distinguishable from a job that simply runs daily.
   if (beat?.ok === false) return { status: 'failed', error: beat.error }
+  // A no-op the character was never permitted to perform. Below 'failed' on
+  // purpose: if the last run actually threw, that's the more urgent fact.
+  if (beat?.skippedReason != null) return { status: 'skipped', error: beat.skippedReason }
   return { status: 'idle', error: null }
 }
 

--- a/src/esi.js
+++ b/src/esi.js
@@ -2,6 +2,37 @@ export const userAgent = 'philihp@gmail.com edencom-link discord:philihp'
 
 const ESI_BASE = 'https://esi.evetech.net/latest'
 
+// Every failing ESI response throws this rather than a bare Error, so callers
+// can branch on the status and body instead of regexing a message. The message
+// is byte-for-byte what the plain Error carried before, since it's what lands in
+// heartbeat.error and the logs.
+export class EsiError extends Error {
+  constructor(label, status, statusText, body) {
+    super(`${label}: ${status} ${statusText} body=${body}`)
+    this.name = 'EsiError'
+    this.status = status
+    this.body = body
+  }
+}
+
+const esiError = async (response, path, label) => {
+  const text = await response.text().catch(() => '')
+  return new EsiError(label ?? path, response.status, response.statusText, text.slice(0, 500))
+}
+
+// A 403 that means "this character isn't allowed to ask", not "something broke".
+// The corp endpoints require an in-game role (director, accountant, station
+// manager…) *on top of* the OAuth scope, and CCP answers a role-less character
+// with 403 and a body naming the missing role. That is a permission fact about
+// the pilot, not a failure of the extract — see forEachCorporation in
+// src/jobs/lib.js, which turns it into a recorded no-op.
+//
+// Deliberately matched on the body rather than on the bare status: a 403 also
+// covers an expired or revoked token, which *is* a failure and must keep
+// surfacing as one.
+export const isRoleDenial = (e) =>
+  e instanceof EsiError && e.status === 403 && /role|not in (the |that )?corporation/i.test(e.body ?? '')
+
 const esiFetch = async (path, { access_token, params = {}, method = 'GET', body, label } = {}) => {
   const search = new URLSearchParams({ ...(access_token ? { token: access_token } : {}), ...params })
   const headers = { 'User-Agent': userAgent }
@@ -15,8 +46,7 @@ const esiFetch = async (path, { access_token, params = {}, method = 'GET', body,
     body: body !== undefined ? JSON.stringify(body) : undefined,
   })
   if (!response.ok) {
-    const text = await response.text().catch(() => '')
-    throw new Error(`${label ?? path}: ${response.status} ${response.statusText} body=${text.slice(0, 500)}`)
+    throw await esiError(response, path, label)
   }
   return response
 }
@@ -43,8 +73,7 @@ const esiConditionalJson = async (path, { access_token, params = {}, ifNoneMatch
   const etag = response.headers.get('etag')
   if (response.status === 304) return { status: 304, json: null, etag }
   if (!response.ok) {
-    const text = await response.text().catch(() => '')
-    throw new Error(`${label ?? path}: ${response.status} ${response.statusText} body=${text.slice(0, 500)}`)
+    throw await esiError(response, path, label)
   }
   return { status: 200, json: await response.json(), etag }
 }
@@ -63,8 +92,7 @@ const esiJsonTolerant = async (path, { access_token, params = {}, tolerate = [],
   })
   if (tolerate.includes(response.status)) return { status: response.status, json: null }
   if (!response.ok) {
-    const text = await response.text().catch(() => '')
-    throw new Error(`${label ?? path}: ${response.status} ${response.statusText} body=${text.slice(0, 500)}`)
+    throw await esiError(response, path, label)
   }
   return { status: response.status, json: await response.json() }
 }
@@ -89,8 +117,7 @@ const esiCompatJson = async (path, { access_token, params = {}, label } = {}) =>
   if (access_token) headers.Authorization = `Bearer ${access_token}`
   const response = await fetch(`${ESI_BASE_COMPAT}${path}${qs ? `?${qs}` : ''}`, { headers })
   if (!response.ok) {
-    const text = await response.text().catch(() => '')
-    throw new Error(`${label ?? path}: ${response.status} ${response.statusText} body=${text.slice(0, 500)}`)
+    throw await esiError(response, path, label)
   }
   return response.json()
 }

--- a/src/jobs/lib.js
+++ b/src/jobs/lib.js
@@ -2,7 +2,7 @@ import { randomInt } from 'node:crypto'
 import { fileURLToPath } from 'node:url'
 import { range, reduce } from 'ramda'
 
-import { character as fetchCharacter } from '../esi.js'
+import { character as fetchCharacter, isRoleDenial } from '../esi.js'
 import { recordHeartbeat, sudoSupabase } from '../supabase.js'
 import { refreshAccessToken } from '../tokenRefresh.js'
 
@@ -14,7 +14,13 @@ import { refreshAccessToken } from '../tokenRefresh.js'
 // (a GitHub Actions cron) or just one (a Vercel queue message dispatched for a
 // single character). Runs fn even if the heartbeat write fails; always records
 // the end heartbeat, success or failure, so a thrown error still has a duration.
-const withHeartbeat = async (tag, owner, fn) => {
+//
+// `skipReasonOf(e)` lets a caller classify some throws as *not failures*: return
+// a reason string and the end row lands with ok=true and skipped_reason set,
+// instead of ok=false. The error still propagates — forEachCorporation uses this
+// for the in-game-role denial, where the corp must stay unclaimed so a later
+// character can try, but nothing has actually gone wrong.
+const withHeartbeat = async (tag, owner, fn, { skipReasonOf } = {}) => {
   const runId = randomInt(1, 2 ** 48)
   await recordHeartbeat(tag, 'start', { runId, ...owner })
   try {
@@ -22,9 +28,17 @@ const withHeartbeat = async (tag, owner, fn) => {
     await recordHeartbeat(tag, 'end', { runId, ...owner, ok: true })
     return result
   } catch (e) {
-    // Stamp the failure on the end row (heartbeat.ok/error) and rethrow — the
-    // caller's catch still logs and skips to the next character/corp as before.
-    await recordHeartbeat(tag, 'end', { runId, ...owner, ok: false, error: e?.message ?? e })
+    const skippedReason = skipReasonOf?.(e) ?? null
+    // Stamp the outcome on the end row (heartbeat.ok/error/skipped_reason) and
+    // rethrow — the caller's catch still logs and skips to the next
+    // character/corp as before.
+    await recordHeartbeat(
+      tag,
+      'end',
+      skippedReason !== null
+        ? { runId, ...owner, ok: true, skippedReason }
+        : { runId, ...owner, ok: false, error: e?.message ?? e }
+    )
     throw e
   }
 }
@@ -170,12 +184,19 @@ export const forEachCharacterAnyScope = async (tag, { scopes, registrationIds, h
 // the character whose token authorized the pull, so "which user" is derivable
 // too); the inner forEachCharacter's own per-character heartbeat is disabled to
 // avoid a redundant second row for the same unit of work.
+//
+// A role denial is a **no-op, not a failure**: a pilot who isn't a director
+// simply can't be asked for the corp's hangar, which is a fact about the pilot
+// rather than a broken extract. Its heartbeat closes ok=true with a
+// skipped_reason naming the character, so /jobs can say "not a director"
+// instead of "✗ failed" (docs/jobs-page.md), and the corp is still left
+// unclaimed so the next character in the group gets its turn.
 export const forEachCorporation = async (tag, { scope, registrationIds }, handler) => {
   const seenCorps = new Set()
   await forEachCharacter(
     tag,
     { scope, registrationIds, heartbeat: false },
-    async ({ access_token, characterID, registration_id, userId, ctx }) => {
+    async ({ access_token, characterID, registration_id, userId, name, ctx }) => {
       const info = await fetchCharacter(access_token, characterID)
       const corporation_id = info?.corporation_id
       if (!corporation_id) {
@@ -193,9 +214,24 @@ export const forEachCorporation = async (tag, { scope, registrationIds }, handle
         console.log(`[${tag}] ${ctx}: corp ${corporation_id} already pulled this run, skipping`)
         return
       }
-      await withHeartbeat(tag, { registrationId: registration_id, corporationId: corporation_id, userId }, () =>
-        handler({ access_token, corporation_id, registration_id, ctx })
-      )
+      const skipReasonOf = (e) =>
+        isRoleDenial(e) ? `${name} doesn't hold the in-game role this corp endpoint requires` : null
+      try {
+        await withHeartbeat(
+          tag,
+          { registrationId: registration_id, corporationId: corporation_id, userId },
+          () => handler({ access_token, corporation_id, registration_id, ctx }),
+          { skipReasonOf }
+        )
+      } catch (e) {
+        const skipped = skipReasonOf(e)
+        if (skipped === null) throw e
+        // Swallowed rather than rethrown: runTokenLoop's catch would log this
+        // as FAILED, and it isn't. The corp stays out of seenCorps either way,
+        // so a corpmate with the role still gets a turn this run.
+        console.log(`[${tag}] ${ctx}: ${skipped} — recorded as a skip, not a failure`)
+        return
+      }
       // Only mark the corp as handled once the pull actually succeeds.
       seenCorps.add(corporation_id)
     }

--- a/src/supabase.js
+++ b/src/supabase.js
@@ -87,6 +87,13 @@ export const recordHeartbeat = async (job, phase = 'end', opts = {}) => {
     ...(phase === 'end' && opts.ok != null
       ? { ok: opts.ok, error: opts.error != null ? String(opts.error).slice(0, 500) : null }
       : {}),
+    // A run that didn't do the work because the caller isn't permitted to (a
+    // corp endpoint the character lacks the in-game role for). Not a failure —
+    // ok stays true — but not a pull either, so the reason is recorded and /jobs
+    // renders it instead of an undifferentiated stale dot.
+    ...(phase === 'end' && opts.skippedReason != null
+      ? { skipped_reason: String(opts.skippedReason).slice(0, 500) }
+      : {}),
   }
   const table = sudoSupabase.from('heartbeat')
   const { error } =

--- a/supabase/migrations/20260812120000_heartbeat_skipped_reason.sql
+++ b/supabase/migrations/20260812120000_heartbeat_skipped_reason.sql
@@ -1,0 +1,49 @@
+-- Tell "the extract broke" apart from "this pilot was never allowed to ask".
+--
+-- The corp endpoints need an in-game role (director, accountant, …) on top of
+-- the OAuth scope, so a corp job run under a character who doesn't hold it gets
+-- a 403. Until now that closed the heartbeat with ok=false, and /jobs rendered
+-- the corp as '✗ failed' every six hours — for something that is not a failure
+-- at all but a permission fact about the character. It is a no-op: nothing was
+-- pulled, nothing went wrong, and re-running it will do exactly the same thing.
+--
+-- skipped_reason records that outcome as its own thing (ok stays true, error
+-- stays null) with the sentence the page shows on hover. Null on every other
+-- row: a real run, an open row, or anything written before this column.
+
+alter table public.heartbeat
+  add column skipped_reason text;
+
+comment on column public.heartbeat.skipped_reason is
+  'Why the run was a permitted no-op rather than a pull (e.g. the character holds no director role); null for real runs. ok stays true.';
+
+-- latest_heartbeats() is what /jobs reads, so the new outcome has to travel
+-- through it. Adding an OUT column changes the return type, which CREATE OR
+-- REPLACE cannot do (same reason as #754 and 20260812000000), so drop first.
+-- Callers reading fewer columns — the MCP data_refreshed stamp in
+-- src/app/api/mcp/lib.ts — are unaffected; the argument list is unchanged.
+
+drop function if exists public.latest_heartbeats();
+
+create function public.latest_heartbeats()
+returns table (
+  job text,
+  registration_id uuid,
+  corporation_id bigint,
+  ended_at timestamptz,
+  ok boolean,
+  error text,
+  skipped_reason text
+)
+language sql
+stable
+as $$
+  select distinct on (h.job, h.owner_key)
+    h.job, h.registration_id, h.corporation_id, h.ended_at, h.ok, h.error, h.skipped_reason
+  from public.heartbeat h
+  where h.ended_at is not null
+    and h.ended_at > now() - interval '30 days'
+  order by h.job, h.owner_key, h.ended_at desc;
+$$;
+
+grant execute on function public.latest_heartbeats() to authenticated;

--- a/test/jobsRows.test.ts
+++ b/test/jobsRows.test.ts
@@ -144,3 +144,36 @@ test('a task stuck non-terminal is abandoned, a terminal one never is', () => {
   assert.equal(isAbandoned(task({ status: 'error', created_at: minutesAgo(600) }), NOW), false)
   assert.equal(isAbandoned(task({ status: 'done', created_at: minutesAgo(600) }), NOW), false)
 })
+
+test('a corp nobody directs reads as a no-op, not a failure', () => {
+  // The heartbeat closed ok=true with a reason: the character was never
+  // permitted to ask, so nothing ran and nothing broke.
+  assert.deepEqual(
+    statusOf({ beat: { ok: true, error: null, skippedReason: "Philihp Boeing doesn't hold the in-game role" } }),
+    { status: 'skipped', error: "Philihp Boeing doesn't hold the in-game role" }
+  )
+  // A run that actually threw still outranks it.
+  assert.deepEqual(statusOf({ beat: { ok: false, error: '500', skippedReason: 'stale note' } }), {
+    status: 'failed',
+    error: '500',
+  })
+})
+
+test('a skipped entity drags neither the row freshness nor the lagging count', () => {
+  const entities = [
+    run({ id: 'ours', lastRunAt: minutesAgo(5) }),
+    // Never pulled and never will be — without the exclusion this pins the row
+    // at "never" for good, which reads as broken rather than as not ours.
+    run({ id: 'theirs', lastRunAt: null, status: 'skipped', error: 'no director role' }),
+  ]
+  assert.equal(oldestRun(entities), minutesAgo(5))
+  assert.equal(laggingCount(entities, NOW), 0)
+  // One skipped corp doesn't relabel a job that ran fine for the other.
+  assert.equal(rowStatus(entities), 'idle')
+})
+
+test('the row reads skipped only when every entity is one', () => {
+  const skipped = (id: string) => run({ id, lastRunAt: minutesAgo(30), status: 'skipped', error: 'no role' })
+  assert.equal(rowStatus([skipped('a'), skipped('b')]), 'skipped')
+  assert.equal(rowStatus([skipped('a'), run({ id: 'b', status: 'failed', error: 'boom' })]), 'failed')
+})


### PR DESCRIPTION
A corp ESI endpoint needs an **in-game role** (director, accountant, station manager) on top of the OAuth scope, so a pull run under a character without it gets `403 Character does not have required role(s)`. That threw, closing the per-corp heartbeat `ok = false`, and `/jobs` rendered the corp as `✗ failed` every six hours — for something that never was a failure. Nothing broke; the pilot was simply never allowed to ask, and re-running earns the same 403.

That outcome is now its own thing, end to end.

## The no-op

- **`src/esi.js`** throws an `EsiError` carrying `status` and `body` instead of a bare `Error` (the message is byte-for-byte what it was, since it lands in `heartbeat.error` and the logs), and `isRoleDenial(e)` recognises the role 403. Matched on the **body**, not the bare status — a 403 also covers an expired or revoked token, which *is* a failure and keeps surfacing as one.
- **`forEachCorporation`** (`src/jobs/lib.js`) closes that character's heartbeat `ok = true` with `heartbeat.skipped_reason` naming them, logs it as a skip rather than a FAILED, and still leaves the corp unclaimed so a corpmate holding the role gets their turn in the same run. `withHeartbeat` gained a `skipReasonOf(e)` classifier for this; nothing else uses it yet.
- **Migration `20260812120000_heartbeat_skipped_reason`** adds the column (nullable; `ok` stays true, `error` stays null) and carries it through `latest_heartbeats()` — drop-and-recreate, since adding an OUT column changes the return type. `schema.sql` updated to match.
- **`/jobs`** renders `— not a director` with the reason on hover, offers no refresh button for it (re-kicking just re-earns the 403), and keeps such a character out of the **Runs as** column. The part that matters beyond the label: skipped entities are excluded from `oldestRun` and `laggingCount`, so a corp nobody on the account directs stops pinning its job's row at "never" forever. A row reads `skipped` only when *every* entity is one.

Known limit, documented: the on-demand path still records `refresh_task` as `✓ done` for such a run, since nothing throws. Recent activity has no column for "did nothing, on purpose"; the cell carries that fact instead.

## Two refresh-button changes alongside

- **Shared universe kicks are Chancellor-only.** `universe-names` and `character-directory` were `kickable: 'always'`; both join `industry-systems` at `'chancellor'`. Those pulls are game-wide — one account's button spends everyone's rate limit and moves data nobody else asked to move — and `refreshCell` re-checks server-side.
- **"Refresh everyone" per character job.** A Characters row's expansion now carries one button that kicks the job for every registered character (`refreshAllCharacters` → `dispatchJobForCharacters`) under a single `batch_id`, so Recent activity reads it as the one action it was. Per-character jobs only: a corp job's unit of work is the corporation, and fanning one run per character is the concurrent-reconcile race `PER_CORPORATION_JOBS` exists to avoid.

## Verification

`pnpm run lint`, `pnpm run build`, `pnpm test` (266 pass, including new cases in `test/jobsRows.test.ts` for the skipped status precedence and its exclusion from the freshness reductions). `docs/jobs-page.md` records all of the above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3AKx4Z74S8WLTYXarhDin)_