### PR TITLE
Type-check the test files Next 16.3.0 started including

### DIFF
--- a/src/jobs/denReinforcement.js
+++ b/src/jobs/denReinforcement.js
@@ -78,6 +78,18 @@ export const composeDenPing = ({ planet, planetId, reinforcementEnd }) => {
 // The whole decision: [] unless the den just entered reinforcement, else one
 // insert-ready notification row per linked channel (delivery state is
 // per-message, so detection fans out here rather than in the sender).
+/**
+ * @param {{
+ *   userId: string,
+ *   denId: number,
+ *   planetId: number,
+ *   planet: { system_name?: string | null, celestial_index?: number | null } | null,
+ *   prevObservation: { reinforcement_end?: string | null } | null,
+ *   newObservation: { reinforcement_end?: string | null },
+ *   channels: { id: string }[],
+ *   now?: Date,
+ * }} params
+ */
 export const planDenNotifications = ({
   userId,
   denId,

--- a/src/jobs/industryJobReconcile.js
+++ b/src/jobs/industryJobReconcile.js
@@ -51,6 +51,13 @@ export const jobSignature = (j) =>
 // again with a changed signature, and it will never appear again. That is why
 // month-old finished research kept rendering on /industry. Terminal rows are
 // still left alone, so the view keeps every job we did see finish.
+/**
+ * @typedef {{ job_id: number, status: string, [column: string]: any }} EsiJob
+ * @typedef {EsiJob & { id: number }} JobRow
+ *
+ * @param {JobRow[]} current
+ * @param {EsiJob[]} fetched
+ */
 export const partitionJobs = (current, fetched) => {
   const currentByJob = new Map(current.map((c) => [Number(c.job_id), c]))
   // ESI could report the same job twice if the set shifts mid-response;
@@ -70,7 +77,12 @@ export const partitionJobs = (current, fetched) => {
       }
       return a
     },
-    { touchIds: [], closeIds: [], openJobs: [], agedOutIds: [] },
+    /** @type {{ touchIds: number[], closeIds: number[], openJobs: EsiJob[], agedOutIds: number[] }} */ ({
+      touchIds: [],
+      closeIds: [],
+      openJobs: [],
+      agedOutIds: [],
+    }),
     [...fetchedByJob.values()]
   )
 

--- a/src/jobs/structureFuel.js
+++ b/src/jobs/structureFuel.js
@@ -73,12 +73,28 @@ export const composeFuelPing = ({ name, systemName, structureId, fuelExpires }) 
   }
 }
 
+/**
+ * @typedef {{ structure_id: number, system_id?: number | null, name?: string | null, fuel_expires?: string | null }} FuelStructure
+ * @typedef {{ fuel_expires?: string | null, updated_at?: string | null }} FuelReading
+ * @typedef {{ id: string, user_id: string }} FuelChannel
+ */
+
 // The whole decision for one structure: [] unless it just crossed under the
 // threshold, else one insert-ready notification row per listening channel
 // (delivery state is per-message, so detection fans out here rather than in the
 // sender). Unlike the den equivalent the channels span *several* accounts —
 // structures are corp-scoped, so every corp member listening gets told — hence
 // user_id comes off each channel rather than being passed in.
+/**
+ * @param {{
+ *   structure: FuelStructure,
+ *   prev: FuelReading | null,
+ *   systemName: string | null,
+ *   channels: FuelChannel[],
+ *   now?: Date,
+ *   thresholdMs?: number,
+ * }} params
+ */
 export const planFuelNotifications = ({
   structure,
   prev,
@@ -105,6 +121,16 @@ export const planFuelNotifications = ({
 // Every row for a run's worth of structures. `prevById` / `systemNames` are
 // Maps keyed by structure id and system id; a miss in either is fine (the
 // former means "never seen", the latter falls back to the bare name).
+/**
+ * @param {{
+ *   structures: FuelStructure[],
+ *   prevById: Map<number, FuelReading>,
+ *   systemNames: Map<number, string>,
+ *   channels: FuelChannel[],
+ *   now?: Date,
+ *   thresholdMs?: number,
+ * }} params
+ */
 export const planAllFuelNotifications = ({
   structures,
   prevById,

--- a/test/contractFields.test.ts
+++ b/test/contractFields.test.ts
@@ -10,7 +10,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-// @ts-expect-error — plain JS module with no types, imported by the extracts.
 import { contractFields, contractItemFields, ITEMISED_TYPES } from '../src/jobs/contractFields.js'
 
 const SEEN_AT = '2026-08-09T12:00:00.000Z'

--- a/test/graphqlFilters.test.ts
+++ b/test/graphqlFilters.test.ts
@@ -73,7 +73,7 @@ test('splitRefEntries calls a bare integer an id and everything else a name', ()
 })
 
 test('matchExactNames takes whole names only, keeping every candidate that matches', () => {
-  const candidates = {
+  const candidates: Record<string, { id: string; name: string }[]> = {
     Tritanium: [
       { id: '34', name: 'Tritanium' },
       { id: '35', name: 'Tritanium Bar' },

--- a/test/planetQuery.test.ts
+++ b/test/planetQuery.test.ts
@@ -55,7 +55,8 @@ test('matchPlanetTypes is case-insensitive and accepts the full name', () => {
     typeIDs: [LAVA],
     names: ['Planet (Lava)'],
   })
-  assert.deepEqual(matchPlanetTypes(PLANET_TYPES, 'LAVA').typeIDs, [LAVA])
+  const lava = matchPlanetTypes(PLANET_TYPES, 'LAVA')
+  assert.deepEqual(lava.ok ? lava.typeIDs : null, [LAVA])
 })
 
 test('matchPlanetTypes treats a missing query as no filter, not as no matches', () => {
@@ -73,7 +74,8 @@ test('matchPlanetTypes fails a typo and lists what exists', () => {
 
 test('matchPlanetTypes keeps a deliberately broad query broad', () => {
   // "planet" is in every name — the caller asked for everything, so give it.
-  assert.equal(matchPlanetTypes(PLANET_TYPES, 'planet').typeIDs?.length, PLANET_TYPES.length)
+  const broad = matchPlanetTypes(PLANET_TYPES, 'planet')
+  assert.equal(broad.ok ? broad.typeIDs?.length : null, PLANET_TYPES.length)
 })
 
 test('planetTypeName falls back rather than dropping an unmirrored type', () => {

--- a/test/shipMatrix.test.ts
+++ b/test/shipMatrix.test.ts
@@ -29,8 +29,10 @@ const type = (
   groupID: 0,
   categoryID: 6,
   groupName,
+  categoryName: 'Ship',
   raceID,
   metaGroupID,
+  volume: null,
 })
 
 const fit = (fittingId: number, shipTypeId: number, name: string, owner?: string): MatrixEntry => ({


### PR DESCRIPTION
Unblocks #845 (renovate's `next` 16.2.12 → 16.3.0), whose only failing check is the Vercel deployment — eleven `tsc` errors, all in `test/**`.

16.2.12's build type-checked only the modules reachable from the app; 16.3.0 checks everything `tsconfig.json` includes, and that include list has always covered `test/`. So the errors are long-standing on `main` (`npx tsc --noEmit` reproduces every one of them without the bump) — 16.3.0 just stopped hiding them.

None of them were the tests being wrong about behaviour. They split three ways:

**Inference at the untyped-JS boundary.** `planDenNotifications`, `planFuelNotifications`/`planAllFuelNotifications` and `partitionJobs` take implicitly-`any` params, so ramda's `map`/`chain` resolved to the Functor overload and callers saw `never[] | {…}` instead of a row array — not callable, and every callback param implicitly `any`. `partitionJobs`'s accumulator literal inferred `never[]` the same way, which is why `openJobs[0].status` was an error on `never`. Fixed with JSDoc `@param` types on those four seams plus a `@type` on the accumulator, rather than casting at the call sites, so the types benefit the extracts that import them too. No runtime change.

**Reaching through a discriminated union.** `matchPlanetTypes` returns `{ ok: true; typeIDs } | { ok: false; message }`; two assertions read `.typeIDs` without narrowing. They now check `ok` first, which is also what the neighbouring assertions in the same file already do.

**Stale fixtures.** `shipMatrix`'s `SdeType` fixture predates `categoryName` and `volume`; `graphqlFilters`' `candidates` lookup is indexed by an arbitrary name so it's a `Record`, not an object literal of its two sample keys; and `contractFields`' `@ts-expect-error` is unused now that `allowJs` resolves the module it was suppressing.

## Verification

- `pnpm run build` against `next@16.3.0` (temporarily installed from #845's branch) — green, type check included.
- `pnpm test` — 269 passing.
- `pnpm run lint` — clean.

Once this lands, #845 should go green on a rebase.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLr9hCeiYM1U3gXF3YEpHT)_