### PR TITLE
feat(structure): favorites, director-driven refresh, hourly directory

### DIFF
--- a/docs/structure-universe/design.md
+++ b/docs/structure-universe/design.md
@@ -1,13 +1,13 @@
 # Per-account structure universe
 
-Status: design, not built.
+Status: built (PR #879).
 
 ## Problem
 
 `/structure` today lists exactly one thing: `corp_structure`, the Upwell
 structures owned by corporations the account has a character in (widened to
 alliance-mates by a second policy). That is the set of structures the account
-*owns*, not the set it can *see*.
+_owns_, not the set it can _see_.
 
 Two things are missing: a per-account lever to refresh that set on demand, and
 a name for every structure that shows up elsewhere in the app.
@@ -17,12 +17,12 @@ a name for every structure that shows up elsewhere in the app.
 A genuinely complete list of player-anchored structures **does not exist in any
 data source we can reach**. Measured 2026-08-12:
 
-| Source | Structures |
-|---|---|
-| ESI `GET /universe/structures` | 886 ids, no names |
+| Source                              | Structures                    |
+| ----------------------------------- | ----------------------------- |
+| ESI `GET /universe/structures`      | 886 ids, no names             |
 | EVE Ref `structures-latest.v2.json` | 2,374 rows, 1,444 with a name |
 
-ESI's public list is documented as *fully public* only — "a completely open
+ESI's public list is documented as _fully public_ only — "a completely open
 Access Control List". Everything else in New Eden is invisible to ESI unless one
 of our own characters has access.
 
@@ -72,21 +72,22 @@ For each of the account's characters that holds the in-game role, scan that
 character's corp. This is where everything beyond a name comes from: state,
 services, reinforcement windows, fuel, rigs.
 
-**The trap:** rigs and fuel come from *different jobs*.
+**The trap:** rigs and fuel come from _different jobs_.
 
-| Data | Table | Job |
-|---|---|---|
-| state, services, reinforce, unanchors_at | `corp_structure` | `corp-structures` |
-| **fuel_expires, profile_id** | `corp_structure_status` | `corp-structures` |
-| **fitted rigs** | `corp_structure_rig` | **`corp-assets`** |
+| Data                                     | Table                   | Job               |
+| ---------------------------------------- | ----------------------- | ----------------- |
+| state, services, reinforce, unanchors_at | `corp_structure`        | `corp-structures` |
+| **fuel_expires, profile_id**             | `corp_structure_status` | `corp-structures` |
+| **fitted rigs**                          | `corp_structure_rig`    | **`corp-assets`** |
 
-ESI has no structure-fitting endpoint; rigs are inferred from corp *assets*
+ESI has no structure-fitting endpoint; rigs are inferred from corp _assets_
 whose `location_flag` is a RigSlot (`src/jobs/corpAssets.js`). So a "refresh my
 structures" lever must fan out **both** `corp-structures` and `corp-assets`, or
 the rigs silently stay stale while everything beside them updates.
 
-`corp-assets` is already in `PER_CORPORATION_JOBS`; `corp-structures` is not,
-and needs adding. Both stay **per-corporation, one run per corp** — never one
+`corp-assets` was already in `PER_CORPORATION_JOBS`; `corp-structures` joined it
+(and its workflow moved from the single-step shape to the per-corporation
+fan-out). Both stay **per-corporation, one run per corp** — never one
 run per director. Two directors in the same corp would race a concurrent
 reconcile, which is the failure `dispatchRefresh.ts` already documents at
 length: the loser's INSERT collides with the winner's committed row and can
@@ -104,18 +105,24 @@ this** — it is the path that writes `heartbeat.skipped_reason` so `/jobs` can
 say "not a director" instead of "✗ failed" — and then discards the fact.
 
 ```sql
-create table public.corp_role_grant (
+create table public.corp_job_access (
   registration_id uuid   not null references public.registration (id) on delete cascade,
   corporation_id  bigint not null,
-  role text not null,          -- 'station_manager', later 'director', 'accountant', …
+  job  text not null,          -- the extract tag that proved it, e.g. 'corp-structures'
   observed_at timestamptz not null default now(),
-  primary key (registration_id, corporation_id, role)
+  primary key (registration_id, corporation_id, job)
 );
 ```
 
-Written on success, deleted on role-denial. No new ESI scope, no re-auth. If
-`esi-characters.read_corporation_roles.v1` is ever added it can fill the same
-table with stated rather than inferred roles, and no policy changes.
+Written on success, deleted on role-denial, in `forEachCorporation` itself so
+every corp job records it — best-effort, since bookkeeping must not fail an
+extract that succeeded. No new ESI scope, no re-auth.
+
+Keyed on the **job tag rather than a role name** on purpose: ESI never tells us
+which role the pilot holds, only whether the call was allowed. "Can pull
+`corp-structures` for corp X" is exactly what we observed, and exactly what the
+fuel policy needs. If `esi-characters.read_corporation_roles.v1` is ever added
+it can fill the same table with stated roles and no policy changes.
 
 ### 2. Names — universal, hourly
 
@@ -182,50 +189,58 @@ structure the directory has not learned about yet.
 
 ### Visibility ladder
 
-| Table | Contents | Audience | Change |
-|---|---|---|---|
-| `universe_structure` | name, system, type, owner | any established account | populate far wider |
-| `structure_favorite` | pinned structures | the owning user | **new** |
-| `corp_structure` | state, services, reinforce | own corp + alliance | none — already correct |
-| `corp_structure_rig` | fitted rigs | own corp → **+ alliance** | widen |
-| `corp_structure_status` | fuel, profile_id | own corp → **directors only** | narrow |
+| Table                   | Contents                   | Audience                      | Change                 |
+| ----------------------- | -------------------------- | ----------------------------- | ---------------------- |
+| `universe_structure`    | name, system, type, owner  | any established account       | populate far wider     |
+| `structure_favorite`    | pinned structures          | the owning user               | **new**                |
+| `corp_structure`        | state, services, reinforce | own corp + alliance           | none — already correct |
+| `corp_structure_rig`    | fitted rigs                | own corp → **+ alliance**     | widen                  |
+| `corp_structure_status` | fuel, profile_id           | own corp → **directors only** | narrow                 |
 
 Widening the rigs is a copy of the existing "Alliance members read corp
 structures" policy onto `corp_structure_rig`; a fitted rig is inferable from the
 structure's bonuses in space, so it was never really corp-private.
 
-Narrowing the status gates on `corp_role_grant`. **Consequence to accept:**
+Narrowing the status gates on `corp_job_access`. **Consequence to accept:**
 rank-and-file corp members lose the fuel column. The low-fuel Discord alerts are
 unaffected — that job runs service-role and never sees RLS.
 
 ## Page
 
-`/structure` sorts favorites to the top, then degrades by tier:
+Two tiers, and deliberately no third:
 
-1. **Favorites** — `structure_favorite`, `position` order, whatever tier.
-2. **Ours** — corp/alliance structures, full columns; fuel only for directors.
-3. **Everything else we can name** — identity from `universe_structure`. No
-   state, no revenue, no rigs; we have no data for someone else's structure.
+1. **Favorites** — `structure_favorite`, `position` order.
+2. **Everything else in the alliance** — which is exactly what the existing
+   `corp_structure` select already returns, since its RLS is own-corps OR
+   alliance-mates. Fuel only for directors; rigs now visible alliance-wide.
+3. ~~Everything else we can name~~ — **not shown.** Structures outside the
+   alliance don't belong on this page.
 
-The revenue/index/sparkline machinery stays keyed to tier 2 only.
+Because tier 3 is empty, a favorite is always something the caller can already
+see, and the star only ever re-sorts this list — no "pinned a structure you
+can't view" state to design around.
+
+That does _not_ make the directory pointless: naming structures is what it is
+for. Asset paths, market orders, industry job locations and contract endpoints
+all render structure ids elsewhere in the app, and the hourly job is what turns
+those into names.
 
 NPC stations are excluded by id range, not by a lookup: player structures are
 `>= 100_000_000_000`, NPC stations `<= 64_000_000`. `universeStructures.js`
 already carries the floor as `STRUCTURE_ID_FLOOR`.
 
-## Open questions
+## Decisions
 
-1. Do we take the EVE Ref dependency? It is the only way to name a structure no
-   token can reach, but it is a third-party feed with no SLA — the same bet
+1. **EVE Ref: taken.** It is the only way to name a structure no token of ours
+   can reach. The risk is a third-party feed with no SLA — the same bet
    jEveAssets made, and the same bet that left it with a dead Hammertime source.
-   The fallback is showing the raw id, which is what the SDE rule in `CLAUDE.md`
-   already prescribes for unresolvable lookups.
-2. Does tier 3 mean *every* structure in the directory (~2.4k rows, universe-wide)
-   or only ones the account has touched? "A name for every location that
-   matters" suggests the directory is for resolution and the page stays scoped —
-   worth confirming before building the query.
-3. Do the reinforcement hours in `corp_structure` stay alliance-visible? They are
-   shown in-game to anyone who can see the structure, so probably yes — worth
-   stating deliberately rather than inheriting.
-4. Should a user be able to add a structure id by hand (jEveAssets' `USER`
-   source) for the case where they know a structure exists but nothing resolves it?
+   Contained by `source` precedence: if the feed dies, the rows it wrote stay,
+   and everything a token resolved is untouched.
+2. **Page scope: alliance only.** See above.
+3. **Docking probes: not built.** Dockability is not what the page needs.
+4. Reinforcement hours stay alliance-visible (unchanged from today — they are
+   shown in-game to anyone who can see the structure).
+
+Still open: whether a user should be able to add a structure id by hand
+(jEveAssets' `USER` source) for the case where they know a structure exists but
+nothing resolves it.

--- a/docs/structure-universe/design.md
+++ b/docs/structure-universe/design.md
@@ -15,6 +15,57 @@ and, strictly, per character, since docking is an ACL evaluated per pilot. It
 overlaps heavily between accounts in the same alliance but is never identical,
 so it cannot be a single global table.
 
+## What is actually obtainable
+
+A genuinely complete list of player-anchored structures **does not exist in any
+data source we can reach**, and it is worth stating that before designing
+around it.
+
+Measured 2026-08-12:
+
+| Source | Structures |
+|---|---|
+| ESI `GET /universe/structures` | 886 ids |
+| EVE Ref `structures-latest.v2.json` | 2,374 rows, 1,444 with a name |
+
+ESI's public list is documented as *fully public* only — "a completely open
+Access Control List". Everything else in New Eden is invisible to ESI unless one
+of your own characters has access to it. EVE Ref does better (it scrapes the
+public endpoints continuously and backfills from Adam4EVE) but is still under
+2.5k rows, which is nowhere near the anchored total.
+
+So "complete" has to be redefined as **everything your characters can see**,
+which *is* obtainable and is what the job should target:
+
+    own corp + alliance structures
+  ∪ every structure id already present in the account's extracted data
+  ∪ the publicly-listed structures
+  ∪ EVE Ref's snapshot, as an identity fallback only
+
+### How jEveAssets does it
+
+It does not enumerate. `CitadelSource` is a **prioritised resolver**, not a
+discovery mechanism — ESI corp structures ("certified fresh") over ESI
+locations ("good source") over planet/moon derivation over user-entered data,
+with zKillboard and the Hammertime Citadel Hunt API ranked last and explicitly
+labelled "outdated source". It learns about a structure because an id showed up
+in the player's own data, then races several sources to put a name on it.
+
+The Hammertime API is dead as of this writing (connection refused), which is
+why jEveAssets demoted it. EVE Ref is its live successor.
+
+### The search endpoint is off the table
+
+`GET /characters/{id}/search?categories=structure` is ACL-filtered and looks
+like the answer. It is not, for two reasons:
+
+- `minLength: 3` makes exhaustive enumeration combinatorially impossible.
+- **CCP has publicly warned that using `/search/` as a discovery endpoint —
+  citadel discovery named specifically — is an API-policy violation that gets
+  developers banned from ESI.**
+
+Do not add `esi-search.search_structures.v1` for this.
+
 ## The three axes the current schema conflates
 
 A structure carries three independent kinds of fact, each with its own
@@ -168,36 +219,65 @@ service-role and never sees RLS.
 
 ## Jobs
 
-Split by cost and by who owns the result:
+Two jobs, split by who owns the result and what it costs.
 
-- **`structure-directory`** — account-wide, daily. Pulls `GET /universe/structures`
-  (no auth, ~9k ids), upserts identity rows into `universe_structure`, flags
-  `is_public`. Single-step workflow; cheap; shared by every account.
-- **`structure-access`** — **per-character**, the lever. Probes candidates with
-  `GET /universe/structures/{id}` per token; a 200 writes `can_dock = true` plus
-  refreshed identity, a 403 writes `can_dock = false`. Per-character fan-out
-  shape, so it lands in `PER_CHARACTER_JOBS` and inherits a `/jobs` row and a
-  per-cell refresh button for free — that *is* the "refresh my universe" lever,
-  plus a shortcut button on `/structure` itself.
+### `structure-directory` — account-wide, daily
 
-Candidate pool per character, in priority order: own corp + alliance structures
-→ locations of their assets, clones, orders, industry jobs and contracts →
-public structures in systems they have ever been in → the rest of the public
-list.
+Identity only, shared by every account, no per-character work:
+
+- `GET /universe/structures` → upsert ids, set `is_public`.
+- EVE Ref `structures-latest.v2.json` → name, owner, system, type, region for
+  ids ESI will not resolve for us. Lowest priority: never overwrite a field we
+  resolved ourselves from ESI, exactly as jEveAssets ranks its sources.
+
+Single-step workflow, cheap, one heartbeat. Nothing here is per-user, so it does
+not need a refresh lever.
+
+### `structure-access` — per-character, daily, **and the lever**
+
+This is the job the user pulls. Per-character fan-out shape, so registering it
+in `PER_CHARACTER_JOBS` gives it a `/jobs` row with a per-character refresh
+button and `refresh_task` tracking for free — that is the "refresh my
+structures" control, with a shortcut button on `/structure` pointing at the same
+dispatch. Daily on the cron otherwise.
+
+For each of the account's characters:
+
+1. **Harvest candidates from data we already hold.** No ESI calls at all — every
+   one of these tables is already extracted and sitting in Postgres, and a
+   structure id in them is proof the character has been there:
+   - `character_asset` / `corp_asset` — `location_id`
+   - `character_clone_over_time` — `location_id` where `location_type='structure'`
+   - `character_order` / market orders — `location_id`
+   - `character_industry_job` / `corp_industry_job` — `station_id`, `facility_id`,
+     `blueprint_location_id`, `output_location_id`
+   - `character_contract` / `corp_contract` — `start_location_id`, `end_location_id`
+   - `character_wallet_transaction` / `corp_wallet_transaction` — `location_id`
+   - `corp_structure` — own corp and alliance
+   This is where the great majority of a real account's universe comes from, and
+   it costs nothing.
+2. **Add the public list** from `universe_structure where is_public`.
+3. **Probe** each candidate not already decided (or past its TTL) with
+   `GET /universe/structures/{id}` on that character's token. 200 → `can_dock =
+   true` plus fresh identity into `universe_structure`; 403 → `can_dock = false`.
+
+Filtering NPC stations out is free: player structures are `structure_id >=
+100_000_000_000` and NPC stations are `<= 64_000_000`. `universeStructures.js`
+already carries that floor as `STRUCTURE_ID_FLOOR`.
 
 ### ESI error budget
 
-**403s count against ESI's 100-errors-per-60s limit.** A blind sweep of the
-public list against a token that can dock at few of them will trip it and get
-the whole app throttled. The probe therefore must:
+**403s count against ESI's 100-errors-per-60s limit.** Probing a large candidate
+set against a token that can dock at few of them will trip it and throttle the
+whole deployment. The probe must:
 
 - read `X-Esi-Error-Limit-Remain` / `-Reset` and back off before exhausting it;
 - run under a bounded per-run probe budget with a persisted cursor, so a large
-  candidate set drains across runs instead of in one burst;
-- never re-probe a `can_dock = false` row inside its TTL.
+  candidate set drains across days rather than in one burst;
+- never re-probe inside its TTL — short for `can_dock = true`, long for `false`.
 
-This is the single hardest constraint in the whole feature, and it is why the
-negative rows exist.
+This is the single hardest constraint in the feature, and it is why
+`structure_access` stores negative rows.
 
 ## Page
 
@@ -213,13 +293,18 @@ The revenue/index/sparkline machinery stays keyed to tier 2 only.
 
 ## Open questions
 
-1. Does "everything" include public structures the account has never been near,
-   or only those in systems it has touched? The former is ~9k probes per
-   character; the latter is a few hundred and covers nearly the same practical
-   set.
-2. Do the reinforcement hours in `corp_structure` stay alliance-visible? They
-   are shown in-game to anyone who can see the structure, so probably yes — but
-   it is worth stating deliberately rather than inheriting.
-3. Is `esi-search.search_structures.v1` worth adding as a fourth candidate
-   source? Its `minLength: 3` makes exhaustive enumeration impossible, so it
-   only helps as a per-system-name sweep, and it costs a re-auth.
+1. Do we take the EVE Ref dependency? It is the only way to name a structure we
+   cannot dock at, but it is a third-party feed with no SLA — the same bet
+   jEveAssets made, and the same bet that left it with a dead Hammertime source.
+   The alternative is showing the raw id, which is what the SDE rule in
+   `CLAUDE.md` already prescribes for unresolvable lookups.
+2. Do the reinforcement hours in `corp_structure` stay alliance-visible? They are
+   shown in-game to anyone who can see the structure, so probably yes — worth
+   stating deliberately rather than inheriting.
+3. Should `structure_access` be probed for *every* character, or only one
+   character per corp? Docking ACLs are usually granted at corp/alliance level,
+   so probing one pilot per corp would cut the ESI cost by the number of alts at
+   the price of missing personally-granted access.
+4. Should a user be able to add a structure id by hand (jEveAssets' `USER`
+   source) for the case where they know a structure exists but nothing can
+   resolve it?

--- a/docs/structure-universe/design.md
+++ b/docs/structure-universe/design.md
@@ -7,57 +7,41 @@ Status: design, not built.
 `/structure` today lists exactly one thing: `corp_structure`, the Upwell
 structures owned by corporations the account has a character in (widened to
 alliance-mates by a second policy). That is the set of structures the account
-*owns*, not the set it can *use*.
+*owns*, not the set it can *see*.
 
-What a player actually wants on that page is their **universe of structures**:
-everywhere any of their characters can dock. That set differs per account —
-and, strictly, per character, since docking is an ACL evaluated per pilot. It
-overlaps heavily between accounts in the same alliance but is never identical,
-so it cannot be a single global table.
+Two things are missing: a per-account lever to refresh that set on demand, and
+a name for every structure that shows up elsewhere in the app.
 
 ## What is actually obtainable
 
 A genuinely complete list of player-anchored structures **does not exist in any
-data source we can reach**, and it is worth stating that before designing
-around it.
-
-Measured 2026-08-12:
+data source we can reach**. Measured 2026-08-12:
 
 | Source | Structures |
 |---|---|
-| ESI `GET /universe/structures` | 886 ids |
+| ESI `GET /universe/structures` | 886 ids, no names |
 | EVE Ref `structures-latest.v2.json` | 2,374 rows, 1,444 with a name |
 
 ESI's public list is documented as *fully public* only — "a completely open
 Access Control List". Everything else in New Eden is invisible to ESI unless one
-of your own characters has access to it. EVE Ref does better (it scrapes the
-public endpoints continuously and backfills from Adam4EVE) but is still under
-2.5k rows, which is nowhere near the anchored total.
-
-So "complete" has to be redefined as **everything your characters can see**,
-which *is* obtainable and is what the job should target:
-
-    own corp + alliance structures
-  ∪ every structure id already present in the account's extracted data
-  ∪ the publicly-listed structures
-  ∪ EVE Ref's snapshot, as an identity fallback only
+of our own characters has access.
 
 ### How jEveAssets does it
 
-It does not enumerate. `CitadelSource` is a **prioritised resolver**, not a
-discovery mechanism — ESI corp structures ("certified fresh") over ESI
-locations ("good source") over planet/moon derivation over user-entered data,
-with zKillboard and the Hammertime Citadel Hunt API ranked last and explicitly
-labelled "outdated source". It learns about a structure because an id showed up
-in the player's own data, then races several sources to put a name on it.
+It does not enumerate. `CitadelSource` is a **prioritised resolver** — ESI corp
+structures ("certified fresh") over ESI locations ("good source") over
+planet/moon derivation over user-entered data, with zKillboard and the
+Hammertime Citadel Hunt API ranked last and explicitly labelled "outdated
+source". It learns about a structure because an id showed up in the player's own
+data, then races several sources to put a name on it.
 
-The Hammertime API is dead as of this writing (connection refused), which is
-why jEveAssets demoted it. EVE Ref is its live successor.
+Hammertime is dead as of this writing (connection refused), which is why
+jEveAssets demoted it. EVE Ref is its live successor.
 
 ### The search endpoint is off the table
 
 `GET /characters/{id}/search?categories=structure` is ACL-filtered and looks
-like the answer. It is not, for two reasons:
+like the answer. It is not:
 
 - `minLength: 3` makes exhaustive enumeration combinatorially impossible.
 - **CCP has publicly warned that using `/search/` as a discovery endpoint —
@@ -66,125 +50,58 @@ like the answer. It is not, for two reasons:
 
 Do not add `esi-search.search_structures.v1` for this.
 
-## The three axes the current schema conflates
+### Docking access is not modelled
 
-A structure carries three independent kinds of fact, each with its own
-audience. `corp_structure` currently holds the first and third together, and
-the second does not exist at all.
+An earlier draft proposed a `structure_access` many-to-many recording, per
+character, whether `GET /universe/structures/{id}` returned 200 or 403 — i.e.
+whether that pilot can dock. **Dropped deliberately.** Docking access is not
+what the page is for, and probing it was by far the most expensive and most
+fragile part of the design: 403s count against ESI's 100-errors-per-60s budget,
+so it needed error-limit backoff, a bounded per-run budget, a persisted cursor,
+and TTL'd negative rows. None of that is needed to name a structure and show
+what we know about it.
 
-1. **Identity** — name, solar system, hull type, owning corporation. Not
-   secret: anyone who warps to the grid reads it off the overview. One global
-   row per structure, shared by every account.
-2. **Reachability** — can *this character* dock here. Per-character truth,
-   presented as a per-account union. This is the missing many-to-many.
-3. **Operator facts** — what the owning corp knows: state, service modules,
-   reinforcement windows, fitted rigs, fuel. Corp-scoped, and itself tiered.
+What remains is the split below: **corp structures via directors** for the rich
+data, and **a universal directory** for names.
 
-## Tables
+## The split
 
-### `universe_structure` — the directory (axis 1)
+### 1. Rich data — director-driven, per account, on demand
 
-Already exists, already has the right RLS ("established accounts read"), and is
-already populated incidentally by the `universe-structures` job from asset and
-clone locations. The rework keeps the table and widens what fills it, adding
-two columns:
+For each of the account's characters that holds the in-game role, scan that
+character's corp. This is where everything beyond a name comes from: state,
+services, reinforcement windows, fuel, rigs.
 
-```sql
-alter table public.universe_structure
-  add column owner_corporation_id bigint,   -- universe/structures/{id}.owner_id
-  add column is_public boolean not null default false;  -- seen in GET /universe/structures
-```
+**The trap:** rigs and fuel come from *different jobs*.
 
-`owner_id` comes back free on every successful `/universe/structures/{id}`
-probe, so ownership no longer needs a corp token to learn.
+| Data | Table | Job |
+|---|---|---|
+| state, services, reinforce, unanchors_at | `corp_structure` | `corp-structures` |
+| **fuel_expires, profile_id** | `corp_structure_status` | `corp-structures` |
+| **fitted rigs** | `corp_structure_rig` | **`corp-assets`** |
 
-Deliberately *not* renamed to `structure`: the name already reads as "the
-player-structure directory", and the rename would touch the market-order join,
-asset location resolution, and the MCP tools for no semantic gain.
+ESI has no structure-fitting endpoint; rigs are inferred from corp *assets*
+whose `location_flag` is a RigSlot (`src/jobs/corpAssets.js`). So a "refresh my
+structures" lever must fan out **both** `corp-structures` and `corp-assets`, or
+the rigs silently stay stale while everything beside them updates.
 
-### `structure_access` — the many-to-many (axis 2)
+`corp-assets` is already in `PER_CORPORATION_JOBS`; `corp-structures` is not,
+and needs adding. Both stay **per-corporation, one run per corp** — never one
+run per director. Two directors in the same corp would race a concurrent
+reconcile, which is the failure `dispatchRefresh.ts` already documents at
+length: the loser's INSERT collides with the winner's committed row and can
+abort partway through with rows closed but never reopened.
 
-```sql
-create table public.structure_access (
-  registration_id uuid   not null references public.registration (id) on delete cascade,
-  structure_id    bigint not null references public.universe_structure (structure_id) on delete cascade,
-  can_dock   boolean     not null,
-  checked_at timestamptz not null default now(),
-  source     text,  -- 'public-list' | 'asset' | 'clone' | 'corp' | 'search' | 'manual'
-  primary key (registration_id, structure_id)
-);
-```
+So: the lever is account-level, the fan-out is per-corp, and the set of corps is
+"corps where this account has a director-capable character".
 
-Keyed on **`registration_id`** (the character), not `user_id`:
-
-- Docking access is a per-character ACL. A character-level key stores the truth
-  and derives the account view as a union; a user-level key stores the union and
-  can never recover the truth.
-- It answers "which of my alts can dock here", which is the question that
-  actually matters when planning a haul.
-- Deleting a character cascades its access away for free.
-- Named `registration_id`, correctly — this is a registration uuid, not an EVE
-  numeric id. (See `docs/registration-id-rename.md` for why most sibling tables
-  get this wrong.)
-
-RLS is the standard character-owned pattern:
-
-```sql
-using (registration_id in (
-  select id from public.registration where user_id = (select auth.uid())
-))
-```
-
-**Negative rows are stored deliberately.** A `can_dock = false` row is the memo
-that stops the probe from re-403ing the same structure every run — see the ESI
-error budget below. Negative rows get a longer re-check TTL than positive ones,
-since access is granted more often than it is revoked.
-
-### `structure_favorite` — pinning (axis 2, user-level)
-
-```sql
-create table public.structure_favorite (
-  user_id      uuid   not null references auth.users (id) on delete cascade,
-  structure_id bigint not null references public.universe_structure (structure_id) on delete cascade,
-  created_at timestamptz not null default now(),
-  position   integer not null default 0,
-  primary key (user_id, structure_id)
-);
-```
-
-A structural copy of `watched_system`, down to the `position` column and the
-"users manage own" policy — same shape, same server-action pattern, same drag
-ordering if it ever wants it. Account-level, not per-character: a favorite is a
-UI preference, not an ACL fact.
-
-## Visibility ladder (axis 3)
-
-| Table | Contents | Audience | Change |
-|---|---|---|---|
-| `universe_structure` | name, system, type, owner | any established account | populate far wider |
-| `structure_access` | can this character dock | the owning account | **new** |
-| `corp_structure` | state, services, reinforce hours, unanchors_at | own corp + alliance | none — already correct |
-| `corp_structure_rig` | fitted rigs | own corp → **+ alliance** | widen |
-| `corp_structure_status` | fuel_expires, profile_id | own corp → **directors only** | narrow |
-
-Widening the rigs is the easy half: copy the "Alliance members read corp
-structures" policy verbatim onto `corp_structure_rig`. The justification is that
-a fitted rig is inferable from the structure's own bonuses in space, so it was
-never really corp-private.
-
-Narrowing the status is the half that needs new data.
-
-## Knowing who is a director
-
-Nothing in the schema records in-game roles today. Two routes:
-
-### (a) Observed capability — free, no re-auth *(recommended)*
+#### Knowing who is a director, for free
 
 `GET /corporations/{id}/structures` requires the Station_Manager role. A token
-that pulls it successfully has proven the role; a token that 403s has proven the
-absence. `forEachCorporation` already distinguishes exactly this case — the
-role-denial path that writes `heartbeat.skipped_reason` — so the signal is
-already being computed and then thrown away.
+that pulls it successfully has proven the role; one that gets the role-denial
+403 has proven its absence. `forEachCorporation` **already classifies exactly
+this** — it is the path that writes `heartbeat.skipped_reason` so `/jobs` can
+say "not a director" instead of "✗ failed" — and then discards the fact.
 
 ```sql
 create table public.corp_role_grant (
@@ -196,115 +113,119 @@ create table public.corp_role_grant (
 );
 ```
 
-Written by `corp-structures` on success, deleted on a role-denial 403. The
-`corp_structure_status` policy becomes "the caller has a registration holding a
-`station_manager` grant for this corporation".
+Written on success, deleted on role-denial. No new ESI scope, no re-auth. If
+`esi-characters.read_corporation_roles.v1` is ever added it can fill the same
+table with stated rather than inferred roles, and no policy changes.
 
-Costs nothing and prompts nobody. Its limit is that it only knows about
-characters the app actually uses for a pull.
+### 2. Names — universal, hourly
 
-### (b) Real roles pull
+`structure-directory`, a new single-step job with no per-user work at all:
 
-`GET /characters/{id}/roles` under `esi-characters.read_corporation_roles.v1`.
-Truthful and general — it would unlock accountant//hangar-role gating later —
-but it is a **new scope**, so every already-linked character needs re-auth, and
-it reads as invasive on the consent screen.
+- `GET /universe/structures` → ids, set `is_public`.
+- EVE Ref `structures-latest.v2.json` → name, `owner_id`, system, type, region.
 
-Take (a) now, shaped so (b) can later populate the same table with real roles
-and the policies never change.
+Both are small and unauthenticated (~874 KB total), so hourly is comfortable.
+One heartbeat, a `/jobs` "shared universe" row, no refresh lever — nothing about
+it is per-account.
 
-**Consequence to accept:** rank-and-file corp members lose the fuel column on
-`/structure`. The low-fuel Discord alerts are unaffected — that job runs
-service-role and never sees RLS.
+Rows carry a `source` so precedence is explicit, following jEveAssets: a name we
+resolved ourselves from ESI with a real token outranks EVE Ref's, and EVE Ref
+never overwrites it.
 
-## Jobs
+#### `universe-structures` stays
 
-Two jobs, split by who owns the result and what it costs.
+The existing token-probe job still earns its place and should **not** be folded
+into the directory. It is the only thing that can name a **non-public**
+structure — one of ours, or one we hold assets in — because that needs a token
+with access, and EVE Ref by construction only has what is publicly queryable.
 
-### `structure-directory` — account-wide, daily
+It is not a sweep: it only resolves ids that already appear in our own extracted
+data, pooled across characters and tried against each token until one succeeds.
+That is precisely jEveAssets' ESI_LOCATIONS source, and it is already built.
 
-Identity only, shared by every account, no per-character work:
+Between the three sources — corp structures, the token probe, and the hourly
+directory — every structure id the app can display should resolve to a name.
 
-- `GET /universe/structures` → upsert ids, set `is_public`.
-- EVE Ref `structures-latest.v2.json` → name, owner, system, type, region for
-  ids ESI will not resolve for us. Lowest priority: never overwrite a field we
-  resolved ourselves from ESI, exactly as jEveAssets ranks its sources.
+## Schema
 
-Single-step workflow, cheap, one heartbeat. Nothing here is per-user, so it does
-not need a refresh lever.
+### `universe_structure` — the directory
 
-### `structure-access` — per-character, daily, **and the lever**
+Exists, keeps its name, keeps its "established accounts read" RLS. Gains:
 
-This is the job the user pulls. Per-character fan-out shape, so registering it
-in `PER_CHARACTER_JOBS` gives it a `/jobs` row with a per-character refresh
-button and `refresh_task` tracking for free — that is the "refresh my
-structures" control, with a shortcut button on `/structure` pointing at the same
-dispatch. Daily on the cron otherwise.
+```sql
+alter table public.universe_structure
+  add column owner_corporation_id bigint,   -- everef owner_id / universe/structures/{id}
+  add column is_public boolean not null default false,
+  add column source text;                   -- 'esi-token' | 'everef' | 'public-list'
+```
 
-For each of the account's characters:
+Not renamed to `structure`: the name already reads correctly and the rename
+would churn the market-order join, asset location resolution and the MCP tools
+for no semantic gain.
 
-1. **Harvest candidates from data we already hold.** No ESI calls at all — every
-   one of these tables is already extracted and sitting in Postgres, and a
-   structure id in them is proof the character has been there:
-   - `character_asset` / `corp_asset` — `location_id`
-   - `character_clone_over_time` — `location_id` where `location_type='structure'`
-   - `character_order` / market orders — `location_id`
-   - `character_industry_job` / `corp_industry_job` — `station_id`, `facility_id`,
-     `blueprint_location_id`, `output_location_id`
-   - `character_contract` / `corp_contract` — `start_location_id`, `end_location_id`
-   - `character_wallet_transaction` / `corp_wallet_transaction` — `location_id`
-   - `corp_structure` — own corp and alliance
-   This is where the great majority of a real account's universe comes from, and
-   it costs nothing.
-2. **Add the public list** from `universe_structure where is_public`.
-3. **Probe** each candidate not already decided (or past its TTL) with
-   `GET /universe/structures/{id}` on that character's token. 200 → `can_dock =
-   true` plus fresh identity into `universe_structure`; 403 → `can_dock = false`.
+### `structure_favorite` — pinning
 
-Filtering NPC stations out is free: player structures are `structure_id >=
-100_000_000_000` and NPC stations are `<= 64_000_000`. `universeStructures.js`
-already carries that floor as `STRUCTURE_ID_FLOOR`.
+```sql
+create table public.structure_favorite (
+  user_id      uuid   not null references auth.users (id) on delete cascade,
+  structure_id bigint not null,
+  created_at timestamptz not null default now(),
+  position   integer not null default 0,
+  primary key (user_id, structure_id)
+);
+```
 
-### ESI error budget
+A structural copy of `watched_system`, down to `position` and the "users manage
+own" policy. Account-level, not per-character: a favorite is a UI preference,
+not a fact about a pilot. No FK to `universe_structure` — a user may favorite a
+structure the directory has not learned about yet.
 
-**403s count against ESI's 100-errors-per-60s limit.** Probing a large candidate
-set against a token that can dock at few of them will trip it and throttle the
-whole deployment. The probe must:
+### Visibility ladder
 
-- read `X-Esi-Error-Limit-Remain` / `-Reset` and back off before exhausting it;
-- run under a bounded per-run probe budget with a persisted cursor, so a large
-  candidate set drains across days rather than in one burst;
-- never re-probe inside its TTL — short for `can_dock = true`, long for `false`.
+| Table | Contents | Audience | Change |
+|---|---|---|---|
+| `universe_structure` | name, system, type, owner | any established account | populate far wider |
+| `structure_favorite` | pinned structures | the owning user | **new** |
+| `corp_structure` | state, services, reinforce | own corp + alliance | none — already correct |
+| `corp_structure_rig` | fitted rigs | own corp → **+ alliance** | widen |
+| `corp_structure_status` | fuel, profile_id | own corp → **directors only** | narrow |
 
-This is the single hardest constraint in the feature, and it is why
-`structure_access` stores negative rows.
+Widening the rigs is a copy of the existing "Alliance members read corp
+structures" policy onto `corp_structure_rig`; a fitted rig is inferable from the
+structure's bonuses in space, so it was never really corp-private.
+
+Narrowing the status gates on `corp_role_grant`. **Consequence to accept:**
+rank-and-file corp members lose the fuel column. The low-fuel Discord alerts are
+unaffected — that job runs service-role and never sees RLS.
 
 ## Page
 
-`/structure` becomes a union with columns degrading by tier:
+`/structure` sorts favorites to the top, then degrades by tier:
 
-1. **Favorites** first (`structure_favorite`, `position` order), whatever tier.
+1. **Favorites** — `structure_favorite`, `position` order, whatever tier.
 2. **Ours** — corp/alliance structures, full columns; fuel only for directors.
-3. **Dockable** — everything else in `structure_access` where `can_dock`:
-   identity, system, type, owner corp, and which alts can dock. No state, no
-   revenue, no rigs — we have no data for someone else's structure.
+3. **Everything else we can name** — identity from `universe_structure`. No
+   state, no revenue, no rigs; we have no data for someone else's structure.
 
 The revenue/index/sparkline machinery stays keyed to tier 2 only.
 
+NPC stations are excluded by id range, not by a lookup: player structures are
+`>= 100_000_000_000`, NPC stations `<= 64_000_000`. `universeStructures.js`
+already carries the floor as `STRUCTURE_ID_FLOOR`.
+
 ## Open questions
 
-1. Do we take the EVE Ref dependency? It is the only way to name a structure we
-   cannot dock at, but it is a third-party feed with no SLA — the same bet
+1. Do we take the EVE Ref dependency? It is the only way to name a structure no
+   token can reach, but it is a third-party feed with no SLA — the same bet
    jEveAssets made, and the same bet that left it with a dead Hammertime source.
-   The alternative is showing the raw id, which is what the SDE rule in
-   `CLAUDE.md` already prescribes for unresolvable lookups.
-2. Do the reinforcement hours in `corp_structure` stay alliance-visible? They are
+   The fallback is showing the raw id, which is what the SDE rule in `CLAUDE.md`
+   already prescribes for unresolvable lookups.
+2. Does tier 3 mean *every* structure in the directory (~2.4k rows, universe-wide)
+   or only ones the account has touched? "A name for every location that
+   matters" suggests the directory is for resolution and the page stays scoped —
+   worth confirming before building the query.
+3. Do the reinforcement hours in `corp_structure` stay alliance-visible? They are
    shown in-game to anyone who can see the structure, so probably yes — worth
    stating deliberately rather than inheriting.
-3. Should `structure_access` be probed for *every* character, or only one
-   character per corp? Docking ACLs are usually granted at corp/alliance level,
-   so probing one pilot per corp would cut the ESI cost by the number of alts at
-   the price of missing personally-granted access.
 4. Should a user be able to add a structure id by hand (jEveAssets' `USER`
-   source) for the case where they know a structure exists but nothing can
-   resolve it?
+   source) for the case where they know a structure exists but nothing resolves it?

--- a/docs/structure-universe/design.md
+++ b/docs/structure-universe/design.md
@@ -1,0 +1,225 @@
+# Per-account structure universe
+
+Status: design, not built.
+
+## Problem
+
+`/structure` today lists exactly one thing: `corp_structure`, the Upwell
+structures owned by corporations the account has a character in (widened to
+alliance-mates by a second policy). That is the set of structures the account
+*owns*, not the set it can *use*.
+
+What a player actually wants on that page is their **universe of structures**:
+everywhere any of their characters can dock. That set differs per account —
+and, strictly, per character, since docking is an ACL evaluated per pilot. It
+overlaps heavily between accounts in the same alliance but is never identical,
+so it cannot be a single global table.
+
+## The three axes the current schema conflates
+
+A structure carries three independent kinds of fact, each with its own
+audience. `corp_structure` currently holds the first and third together, and
+the second does not exist at all.
+
+1. **Identity** — name, solar system, hull type, owning corporation. Not
+   secret: anyone who warps to the grid reads it off the overview. One global
+   row per structure, shared by every account.
+2. **Reachability** — can *this character* dock here. Per-character truth,
+   presented as a per-account union. This is the missing many-to-many.
+3. **Operator facts** — what the owning corp knows: state, service modules,
+   reinforcement windows, fitted rigs, fuel. Corp-scoped, and itself tiered.
+
+## Tables
+
+### `universe_structure` — the directory (axis 1)
+
+Already exists, already has the right RLS ("established accounts read"), and is
+already populated incidentally by the `universe-structures` job from asset and
+clone locations. The rework keeps the table and widens what fills it, adding
+two columns:
+
+```sql
+alter table public.universe_structure
+  add column owner_corporation_id bigint,   -- universe/structures/{id}.owner_id
+  add column is_public boolean not null default false;  -- seen in GET /universe/structures
+```
+
+`owner_id` comes back free on every successful `/universe/structures/{id}`
+probe, so ownership no longer needs a corp token to learn.
+
+Deliberately *not* renamed to `structure`: the name already reads as "the
+player-structure directory", and the rename would touch the market-order join,
+asset location resolution, and the MCP tools for no semantic gain.
+
+### `structure_access` — the many-to-many (axis 2)
+
+```sql
+create table public.structure_access (
+  registration_id uuid   not null references public.registration (id) on delete cascade,
+  structure_id    bigint not null references public.universe_structure (structure_id) on delete cascade,
+  can_dock   boolean     not null,
+  checked_at timestamptz not null default now(),
+  source     text,  -- 'public-list' | 'asset' | 'clone' | 'corp' | 'search' | 'manual'
+  primary key (registration_id, structure_id)
+);
+```
+
+Keyed on **`registration_id`** (the character), not `user_id`:
+
+- Docking access is a per-character ACL. A character-level key stores the truth
+  and derives the account view as a union; a user-level key stores the union and
+  can never recover the truth.
+- It answers "which of my alts can dock here", which is the question that
+  actually matters when planning a haul.
+- Deleting a character cascades its access away for free.
+- Named `registration_id`, correctly — this is a registration uuid, not an EVE
+  numeric id. (See `docs/registration-id-rename.md` for why most sibling tables
+  get this wrong.)
+
+RLS is the standard character-owned pattern:
+
+```sql
+using (registration_id in (
+  select id from public.registration where user_id = (select auth.uid())
+))
+```
+
+**Negative rows are stored deliberately.** A `can_dock = false` row is the memo
+that stops the probe from re-403ing the same structure every run — see the ESI
+error budget below. Negative rows get a longer re-check TTL than positive ones,
+since access is granted more often than it is revoked.
+
+### `structure_favorite` — pinning (axis 2, user-level)
+
+```sql
+create table public.structure_favorite (
+  user_id      uuid   not null references auth.users (id) on delete cascade,
+  structure_id bigint not null references public.universe_structure (structure_id) on delete cascade,
+  created_at timestamptz not null default now(),
+  position   integer not null default 0,
+  primary key (user_id, structure_id)
+);
+```
+
+A structural copy of `watched_system`, down to the `position` column and the
+"users manage own" policy — same shape, same server-action pattern, same drag
+ordering if it ever wants it. Account-level, not per-character: a favorite is a
+UI preference, not an ACL fact.
+
+## Visibility ladder (axis 3)
+
+| Table | Contents | Audience | Change |
+|---|---|---|---|
+| `universe_structure` | name, system, type, owner | any established account | populate far wider |
+| `structure_access` | can this character dock | the owning account | **new** |
+| `corp_structure` | state, services, reinforce hours, unanchors_at | own corp + alliance | none — already correct |
+| `corp_structure_rig` | fitted rigs | own corp → **+ alliance** | widen |
+| `corp_structure_status` | fuel_expires, profile_id | own corp → **directors only** | narrow |
+
+Widening the rigs is the easy half: copy the "Alliance members read corp
+structures" policy verbatim onto `corp_structure_rig`. The justification is that
+a fitted rig is inferable from the structure's own bonuses in space, so it was
+never really corp-private.
+
+Narrowing the status is the half that needs new data.
+
+## Knowing who is a director
+
+Nothing in the schema records in-game roles today. Two routes:
+
+### (a) Observed capability — free, no re-auth *(recommended)*
+
+`GET /corporations/{id}/structures` requires the Station_Manager role. A token
+that pulls it successfully has proven the role; a token that 403s has proven the
+absence. `forEachCorporation` already distinguishes exactly this case — the
+role-denial path that writes `heartbeat.skipped_reason` — so the signal is
+already being computed and then thrown away.
+
+```sql
+create table public.corp_role_grant (
+  registration_id uuid   not null references public.registration (id) on delete cascade,
+  corporation_id  bigint not null,
+  role text not null,          -- 'station_manager', later 'director', 'accountant', …
+  observed_at timestamptz not null default now(),
+  primary key (registration_id, corporation_id, role)
+);
+```
+
+Written by `corp-structures` on success, deleted on a role-denial 403. The
+`corp_structure_status` policy becomes "the caller has a registration holding a
+`station_manager` grant for this corporation".
+
+Costs nothing and prompts nobody. Its limit is that it only knows about
+characters the app actually uses for a pull.
+
+### (b) Real roles pull
+
+`GET /characters/{id}/roles` under `esi-characters.read_corporation_roles.v1`.
+Truthful and general — it would unlock accountant//hangar-role gating later —
+but it is a **new scope**, so every already-linked character needs re-auth, and
+it reads as invasive on the consent screen.
+
+Take (a) now, shaped so (b) can later populate the same table with real roles
+and the policies never change.
+
+**Consequence to accept:** rank-and-file corp members lose the fuel column on
+`/structure`. The low-fuel Discord alerts are unaffected — that job runs
+service-role and never sees RLS.
+
+## Jobs
+
+Split by cost and by who owns the result:
+
+- **`structure-directory`** — account-wide, daily. Pulls `GET /universe/structures`
+  (no auth, ~9k ids), upserts identity rows into `universe_structure`, flags
+  `is_public`. Single-step workflow; cheap; shared by every account.
+- **`structure-access`** — **per-character**, the lever. Probes candidates with
+  `GET /universe/structures/{id}` per token; a 200 writes `can_dock = true` plus
+  refreshed identity, a 403 writes `can_dock = false`. Per-character fan-out
+  shape, so it lands in `PER_CHARACTER_JOBS` and inherits a `/jobs` row and a
+  per-cell refresh button for free — that *is* the "refresh my universe" lever,
+  plus a shortcut button on `/structure` itself.
+
+Candidate pool per character, in priority order: own corp + alliance structures
+→ locations of their assets, clones, orders, industry jobs and contracts →
+public structures in systems they have ever been in → the rest of the public
+list.
+
+### ESI error budget
+
+**403s count against ESI's 100-errors-per-60s limit.** A blind sweep of the
+public list against a token that can dock at few of them will trip it and get
+the whole app throttled. The probe therefore must:
+
+- read `X-Esi-Error-Limit-Remain` / `-Reset` and back off before exhausting it;
+- run under a bounded per-run probe budget with a persisted cursor, so a large
+  candidate set drains across runs instead of in one burst;
+- never re-probe a `can_dock = false` row inside its TTL.
+
+This is the single hardest constraint in the whole feature, and it is why the
+negative rows exist.
+
+## Page
+
+`/structure` becomes a union with columns degrading by tier:
+
+1. **Favorites** first (`structure_favorite`, `position` order), whatever tier.
+2. **Ours** — corp/alliance structures, full columns; fuel only for directors.
+3. **Dockable** — everything else in `structure_access` where `can_dock`:
+   identity, system, type, owner corp, and which alts can dock. No state, no
+   revenue, no rigs — we have no data for someone else's structure.
+
+The revenue/index/sparkline machinery stays keyed to tier 2 only.
+
+## Open questions
+
+1. Does "everything" include public structures the account has never been near,
+   or only those in systems it has touched? The former is ~9k probes per
+   character; the latter is a few hundred and covers nearly the same practical
+   set.
+2. Do the reinforcement hours in `corp_structure` stay alliance-visible? They
+   are shown in-game to anyone who can see the structure, so probably yes — but
+   it is worth stating deliberately rather than inheriting.
+3. Is `esi-search.search_structures.v1` worth adding as a fourth candidate
+   source? Its `minLength: 3` makes exhaustive enumeration impossible, so it
+   only helps as a per-system-name sweep, and it costs a re-auth.

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "anon-sweep": "node src/jobs/anonSweep.js",
     "industry-systems": "node src/jobs/industrySystems.js",
     "universe-names": "node src/jobs/universeNames.js",
+    "structure-directory": "node src/jobs/structureDirectory.js",
     "universe-structures": "node src/jobs/universeStructures.js",
     "sde-mirror": "node src/jobs/sdeMirror.js",
     "esf-data": "node src/jobs/esfData.js",

--- a/schema.sql
+++ b/schema.sql
@@ -86,6 +86,7 @@ drop table if exists public.alliance             cascade;
 drop table if exists public.corp_structure_status cascade;
 drop table if exists public.corp_structure_rig   cascade;
 drop table if exists public.corp_structure       cascade;
+drop table if exists public.corp_job_access      cascade;
 drop table if exists public.corp_wallet_journal  cascade;
 drop table if exists public.corp_wallet_transaction cascade;
 drop table if exists public.corp_contract_item      cascade;
@@ -122,6 +123,7 @@ drop table if exists public.mercenary_den_enemy_intel           cascade;
 drop table if exists public.universe_name        cascade;
 drop table if exists public.universe_structure   cascade;
 drop table if exists public.invite_code          cascade;
+drop table if exists public.structure_favorite   cascade;
 drop table if exists public.watched_system       cascade;
 drop table if exists public.user_settings        cascade;
 drop table if exists public.refresh_task         cascade;
@@ -2881,6 +2883,50 @@ create policy "Users read own clone state"
 grant select on public.character_clone_state to authenticated;
 grant all    on public.character_clone_state to service_role;
 
+-- ── corp_job_access ───────────────────────────────────────────────────────
+-- Observed capability, not a stated role. Every corp ESI endpoint needs an
+-- in-game role on top of the OAuth scope (corp-structures wants Station
+-- Manager, corp-assets wants Director, the wallet endpoints want Accountant),
+-- and forEachCorporation (src/jobs/lib.js) already classifies the role-denial
+-- 403 in order to write heartbeat.skipped_reason — it just discarded the fact
+-- afterwards. This table keeps it, which is what lets the fuel policy below
+-- gate on "is a director" without a new ESI scope.
+--
+-- Keyed on the job tag rather than a role name on purpose: we never learn which
+-- role a character holds, only which endpoint it was able to pull. Reading
+-- roles properly would need esi-characters.read_corporation_roles.v1 and a
+-- re-auth of every already-linked character; if that's ever added it can fill
+-- this same table and no policy has to change.
+--
+-- Defined before corp_structure_status because a policy expression is parsed
+-- and validated at creation time (same reason my_alliance_ids() sits above the
+-- sharing policies).
+create table public.corp_job_access (
+  registration_id uuid   not null references public.registration (id) on delete cascade,
+  corporation_id  bigint not null,
+  -- The extract tag that proved it, e.g. 'corp-structures'.
+  job  text not null,
+  observed_at timestamptz not null default now(),
+  primary key (registration_id, corporation_id, job)
+);
+create index corp_job_access_corporation_id_idx on public.corp_job_access (corporation_id, job);
+
+alter table public.corp_job_access enable row level security;
+-- Users see their own characters' grants; that's all /jobs and the fuel policy
+-- need. Written only by the extract jobs, under the service role.
+create policy "Users read own corp job access"
+  on public.corp_job_access
+  for select
+  to authenticated
+  using (
+    registration_id in (
+      select id from public.registration where user_id = (select auth.uid())
+    )
+  );
+
+grant select on public.corp_job_access to authenticated;
+grant all    on public.corp_job_access to service_role;
+
 -- ── corp_structure ────────────────────────────────────────────────────────
 -- ESI /corporations/{id}/structures/, written by the corp-structures job.
 create table public.corp_structure (
@@ -2955,14 +3001,25 @@ create table public.corp_structure_status (
 create index corp_structure_status_corporation_id_idx on public.corp_structure_status (corporation_id);
 
 alter table public.corp_structure_status enable row level security;
-create policy "Users read structure status for own corps"
+-- Directors only — narrower than the corp_structure policies above. A fuel
+-- expiry is a countdown to when the structure stops shooting back, so it goes
+-- to accounts that actually hold the role on that corp rather than to every
+-- corp member. "Holds the role" is observed capability, not a stated role: see
+-- corp_job_access above. Rank-and-file members lose the fuel column on
+-- /structure as a result; the low-fuel Discord alerts are unaffected, since
+-- that job runs service-role and never sees RLS.
+create policy "Directors read structure status for own corps"
   on public.corp_structure_status
   for select
   to authenticated
   using (
-    corporation_id in (
-      select corporation_id from public.registration
-      where user_id = (select auth.uid()) and corporation_id is not null
+    exists (
+      select 1
+      from public.corp_job_access a
+      join public.registration r on r.id = a.registration_id
+      where a.corporation_id = corp_structure_status.corporation_id
+        and a.job = 'corp-structures'
+        and r.user_id = (select auth.uid())
     )
   );
 
@@ -2993,6 +3050,31 @@ create policy "Users read structure rigs for own corps"
     corporation_id in (
       select corporation_id from public.registration
       where user_id = (select auth.uid()) and corporation_id is not null
+    )
+  );
+
+-- Open rigs to alliance-mates on the same terms as corp_structure itself: a
+-- fitted rig is inferable from the structure's own bonuses in space, so it was
+-- never really corp-private, and the /structure page shows rigs beside
+-- structures the alliance can already see. Additive — OR'd with the own-corps
+-- policy above.
+create policy "Alliance members read corp structure rigs"
+  on public.corp_structure_rig
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.corporation owner_corp
+      where owner_corp.corporation_id = corp_structure_rig.corporation_id
+        and owner_corp.alliance_id is not null
+        and owner_corp.alliance_id in (
+          select member_corp.alliance_id
+          from public.registration r
+          join public.corporation member_corp on member_corp.corporation_id = r.corporation_id
+          where r.user_id = (select auth.uid())
+            and member_corp.alliance_id is not null
+        )
     )
   );
 
@@ -3643,6 +3725,16 @@ create table public.universe_structure (
   name text,
   system_id bigint,
   type_id bigint,
+  -- Free on every /universe/structures/{id} resolve and present in EVE Ref's
+  -- dump, so structure ownership doesn't need a corp token to learn.
+  owner_corporation_id bigint,
+  -- In ESI's public list, i.e. a completely open access control list.
+  is_public boolean not null default false,
+  -- Which of the three feeds last wrote this row: 'esi-token' (resolved by a
+  -- character with docking access), 'everef', or 'public-list'. Makes
+  -- precedence explicit instead of last-write-wins — a name we resolved
+  -- ourselves outranks EVE Ref's copy, and EVE Ref never overwrites it.
+  source text,
   resolved_at timestamptz not null default now()
 );
 
@@ -4351,6 +4443,36 @@ create policy "Users manage own watched systems"
 
 grant select, insert, update, delete on public.watched_system to authenticated;
 grant all                            on public.watched_system to service_role;
+
+-- ── structure_favorite ────────────────────────────────────────────────────
+-- Per-user pinned structures, sorted to the top of /structure. Deliberately
+-- shaped like watched_system above (same key, same position column, same
+-- policy): a favorite is a UI preference belonging to the account, not a fact
+-- about a character, so it keys on user_id rather than registration_id.
+--
+-- No FK to universe_structure on purpose: a user may pin a structure id before
+-- the directory has learned a name for it, and losing the pin when a sweep
+-- drops the directory row would be worse than showing the raw id.
+create table public.structure_favorite (
+  user_id      uuid   not null references auth.users(id) on delete cascade,
+  structure_id bigint not null,
+  created_at timestamptz not null default now(),
+  -- Drag order (lower sorts first), mirroring watched_system.position.
+  position   integer not null default 0,
+  primary key (user_id, structure_id)
+);
+create index structure_favorite_user_id_idx on public.structure_favorite (user_id);
+
+alter table public.structure_favorite enable row level security;
+create policy "Users manage own structure favorites"
+  on public.structure_favorite
+  for all
+  to authenticated
+  using (user_id = (select auth.uid()))
+  with check (user_id = (select auth.uid()));
+
+grant select, insert, update, delete on public.structure_favorite to authenticated;
+grant all                            on public.structure_favorite to service_role;
 
 -- ── invite_code ───────────────────────────────────────────────────────────
 -- Invite-only registration (open registration is staged in

--- a/src/app/api/cron/structure-directory/route.ts
+++ b/src/app/api/cron/structure-directory/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { requireCronSecret } from '@/utils/cron'
+
+// Vercel Cron trigger for structure-directory (hourly). Fire-and-forget: the
+// workflow owns retries, its run/step status shows under Observability →
+// Workflows, and the heartbeat pair is recorded by the workflow's step
+// (source: 'vercel-workflow').
+export const runtime = 'nodejs'
+export const maxDuration = 60
+
+export async function GET(request: NextRequest) {
+  const denied = requireCronSecret(request)
+  if (denied) return denied
+
+  const { start } = await import('workflow/api')
+  const { structureDirectoryWorkflow } = await import('@/workflows/structureDirectory')
+  const run = await start(structureDirectoryWorkflow, [])
+  console.log(`[cron/structure-directory] started workflow run=${run.runId}`)
+
+  return NextResponse.json({ ok: true, runId: run.runId })
+}

--- a/src/app/character/dispatchRefresh.ts
+++ b/src/app/character/dispatchRefresh.ts
@@ -49,6 +49,13 @@ const PER_CORPORATION_JOBS = [
   { job: 'corp-contracts', loadScope: async () => (await import('@/jobs/corpContracts.js')).SCOPE },
   { job: 'corp-assets', loadScope: async () => (await import('@/jobs/corpAssets.js')).SCOPE },
   { job: 'corp-industry-jobs', loadScope: async () => (await import('@/jobs/corpIndustryJobs.js')).SCOPE },
+  // Structures joined the on-demand set with the structure-universe work
+  // (docs/structure-universe/design.md). It has to travel with corp-assets:
+  // this job carries a structure's state, services, reinforcement windows and
+  // fuel timer, while its *rigs* come from corp assets (ESI has no
+  // structure-fitting endpoint), so refreshing one without the other leaves
+  // half the row stale.
+  { job: 'corp-structures', loadScope: async () => (await import('@/jobs/corpStructures.js')).SCOPE },
 ] as const
 
 export const PER_CORPORATION_JOB_NAMES = PER_CORPORATION_JOBS.map(({ job }) => job)
@@ -85,6 +92,8 @@ const JOB_WORKFLOWS: Record<string, () => Promise<(target?: OnDemandTarget) => P
   'character-directory': async () => (await import('@/workflows/characterDirectory')).characterDirectoryWorkflow,
   'universe-names': async () => (await import('@/workflows/universeNames')).universeNamesWorkflow,
   'industry-systems': async () => (await import('@/workflows/industrySystems')).industrySystemsWorkflow,
+  'corp-structures': async () => (await import('@/workflows/corpStructures')).corpStructuresWorkflow,
+  'structure-directory': async () => (await import('@/workflows/structureDirectory')).structureDirectoryWorkflow,
 }
 
 // Start one on-demand workflow run: the job's workflow, given the target that

--- a/src/app/jobs/registry.ts
+++ b/src/app/jobs/registry.ts
@@ -51,15 +51,21 @@ export const JOBS: readonly JobEntry[] = [
   { job: 'corp-industry-jobs', label: 'industry', section: 'corporation', kickable: 'always' },
   { job: 'corp-wallet-transactions', label: 'transactions', section: 'corporation', kickable: 'always' },
   { job: 'corp-contracts', label: 'contracts', section: 'corporation', kickable: 'always' },
-  // The three daily whole-corp pulls a per-character fan-out would only ever
-  // redo once per character, so they're scheduled-only (see dispatchRefresh.ts).
-  { job: 'corp-structures', label: 'structures', section: 'corporation', kickable: 'never' },
+  // Kickable since the structure-universe work: "refresh my structures" is the
+  // lever the /structure page hangs off, and it dispatches this per corporation
+  // alongside corp-assets, which carries the rigs (docs/structure-universe/design.md).
+  { job: 'corp-structures', label: 'structures', section: 'corporation', kickable: 'always' },
+  // The two remaining daily whole-corp pulls a per-character fan-out would only
+  // ever redo once per character, so they're scheduled-only (see dispatchRefresh.ts).
   { job: 'corp-blueprints', label: 'blueprints', section: 'corporation', kickable: 'never' },
   { job: 'corp-wallet-journal', label: 'wallet journal', section: 'corporation', kickable: 'never' },
 
   { job: 'sde-mirror', label: 'SDE mirror', section: 'universe', kickable: 'never' },
   { job: 'universe-names', label: 'names', section: 'universe', kickable: 'chancellor' },
   { job: 'universe-structures', label: 'structures', section: 'universe', kickable: 'never' },
+  // Hourly public-feed pull (ESI's public structure list + EVE Ref). Names
+  // structures no token of ours can reach; see docs/structure-universe/design.md.
+  { job: 'structure-directory', label: 'structure directory', section: 'universe', kickable: 'chancellor' },
   { job: 'character-directory', label: 'character directory', section: 'universe', kickable: 'chancellor' },
   { job: 'industry-systems', label: 'industry indexes', section: 'universe', kickable: 'chancellor' },
 ]

--- a/src/app/structure/favoriteStar.tsx
+++ b/src/app/structure/favoriteStar.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useOptimistic, useTransition } from 'react'
+
+import { toggleFavorite } from './favorites'
+import styles from './structures.module.css'
+
+// The pin control on a structure tile. Favorites sort to the top of the page,
+// so the whole point of the star is that clicking it moves the tile — which
+// makes the round trip very visible. useOptimistic flips the star immediately
+// and React reverts it if the action throws, so the star never sits in the
+// old state while the re-sorted page is on its way.
+export const FavoriteStar = ({ structureId, favorite }: { structureId: string; favorite: boolean }) => {
+  const [pending, startTransition] = useTransition()
+  const [optimistic, setOptimistic] = useOptimistic(favorite)
+
+  return (
+    <button
+      type="button"
+      className={styles.favorite}
+      aria-pressed={optimistic}
+      aria-label={optimistic ? 'Remove from favorites' : 'Add to favorites'}
+      title={optimistic ? 'Remove from favorites' : 'Add to favorites'}
+      data-pending={pending || undefined}
+      onClick={() =>
+        startTransition(async () => {
+          setOptimistic(!optimistic)
+          await toggleFavorite(structureId, !optimistic)
+        })
+      }
+    >
+      {optimistic ? '★' : '☆'}
+    </button>
+  )
+}

--- a/src/app/structure/favorites.ts
+++ b/src/app/structure/favorites.ts
@@ -1,0 +1,55 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+
+import { createClient } from '@/utils/supabase/server'
+
+import { establishedUser } from '../account/lib/establishedUser'
+
+// Pin/unpin a structure so it sorts to the top of /structure. A toggle, not
+// separate add/remove actions: the star is one control and the row either is or
+// isn't pinned.
+//
+// RLS pins the row to the caller (structure_favorite's "Users manage own"
+// policy), so `user_id` here is a filter for the delete, not the security
+// boundary. The structure id isn't validated against corp_structure on purpose:
+// the page only renders a star beside structures the caller can already see, and
+// a favorite that outlives its structure's visibility is a stale row, not a
+// disclosure — nothing about the pin reveals anything the caller didn't supply.
+export const toggleFavorite = async (structureId: string, favorite: boolean) => {
+  const supabase = await createClient()
+
+  const user = await establishedUser(supabase)
+  if (!user) {
+    redirect('/account/login')
+  }
+
+  const id = Number(structureId)
+  if (!Number.isFinite(id)) throw new Error('bad structure id')
+
+  if (favorite) {
+    // Next position, so a newly pinned structure lands at the end of the
+    // favorites block rather than jumping ahead of older pins. Mirrors
+    // watchSystem() on /indexes.
+    const { data: last } = await supabase
+      .from('structure_favorite')
+      .select('position')
+      .eq('user_id', user.id)
+      .order('position', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+    const { error } = await supabase
+      .from('structure_favorite')
+      .upsert(
+        { user_id: user.id, structure_id: id, position: (last?.position ?? -1) + 1 },
+        { onConflict: 'user_id,structure_id' }
+      )
+    if (error) throw error
+  } else {
+    const { error } = await supabase.from('structure_favorite').delete().eq('user_id', user.id).eq('structure_id', id)
+    if (error) throw error
+  }
+
+  revalidatePath('/structure')
+}

--- a/src/app/structure/page.tsx
+++ b/src/app/structure/page.tsx
@@ -6,6 +6,7 @@ import { createClient } from '@/utils/supabase/server'
 
 import { establishedUser } from '../account/lib/establishedUser'
 import { DateTime } from '../DateTime'
+import { FavoriteStar } from './favoriteStar'
 import { formatIsk, formatKisk } from '../isk'
 import { LinkSpinner } from '../linkSpinner'
 import { Name, SystemName } from '../names'
@@ -105,7 +106,36 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
     .order('corporation_id', { ascending: true })
     .order('structure_id', { ascending: true })
 
-  const list = (structures ?? []) as Structure[]
+  // Tier 1 of the page (docs/structure-universe/design.md): the caller's pinned
+  // structures sort above everything else, in their own `position` order.
+  // Tier 2 is every other structure in the alliance — which is exactly what the
+  // select above already returns, since corp_structure's RLS is own-corps OR
+  // alliance-mates. There is no tier 3: structures outside the alliance are
+  // deliberately not shown here, so a favorite is always something the caller
+  // can already see and the star only ever re-sorts this list.
+  const { data: favoriteRows } = await supabase
+    .from('structure_favorite')
+    .select('structure_id, position')
+    .order('position', { ascending: true })
+  const favoritePosition = new Map<string, number>(
+    ((favoriteRows ?? []) as Array<{ structure_id: number | string; position: number }>).map((r) => [
+      String(r.structure_id),
+      r.position,
+    ])
+  )
+  const isFavorite = (s: Structure) => favoritePosition.has(String(s.structure_id))
+
+  // Stable within each block: favorites by their drag order, the rest keeping
+  // the corporation/structure_id order the select asked for.
+  const list = ((structures ?? []) as Structure[]).slice().sort((a, b) => {
+    const aFav = isFavorite(a)
+    const bFav = isFavorite(b)
+    if (aFav !== bFav) return aFav ? -1 : 1
+    if (aFav && bFav) {
+      return (favoritePosition.get(String(a.structure_id)) ?? 0) - (favoritePosition.get(String(b.structure_id)) ?? 0)
+    }
+    return 0
+  })
 
   // Tax revenue each structure generates. Each industry-tax journal entry references its job via
   // context_id (context_id_type = industry_job_id); outer-join those job ids to the industry-job
@@ -382,6 +412,7 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
                       {/* Upwell structures share their structure_id with the station/facility id industry jobs run at. */}
                       <span className={styles.subId}>#{s.structure_id}</span>
                     </div>
+                    <FavoriteStar structureId={String(s.structure_id)} favorite={isFavorite(s)} />
                   </div>
 
                   <div className={styles.fields}>

--- a/src/app/structure/structures.module.css
+++ b/src/app/structure/structures.module.css
@@ -49,6 +49,28 @@
   gap: 8px;
 }
 
+/* The pin control, pushed to the tile's trailing edge by the auto margin so it
+   sits clear of a long structure name rather than wrapping under it. */
+.favorite {
+  margin-left: auto;
+  flex: none;
+  padding: 0 2px;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  color: var(--ink-faint);
+}
+
+.favorite[aria-pressed='true'] {
+  color: var(--accent);
+}
+
+.favorite[data-pending] {
+  opacity: 0.5;
+}
+
 .name {
   font-family: var(--serif);
   font-size: 16px;

--- a/src/esi.js
+++ b/src/esi.js
@@ -306,6 +306,16 @@ export const universeStructure = (access_token, structureID) =>
     label: `universeStructure ${structureID}`,
   })
 
+// Public (no token): every *fully public* player structure id — CCP's wording
+// for a completely open access control list, which is why this is a small
+// fraction of what's anchored in New Eden (886 ids as of 2026-08-12). Ids only;
+// naming them still needs a token with access, or EVE Ref. Feeds the
+// structure-directory job.
+export const universeStructures = () =>
+  esiJson(`/universe/structures/`, {
+    label: 'universeStructures',
+  })
+
 // Public (no token): resolve a single NPC station. Returns { system_id, name,
 // type_id, ... }; used to place clones parked in NPC stations in a solar system.
 export const universeStation = (stationID) =>

--- a/src/jobs/corpStructures.js
+++ b/src/jobs/corpStructures.js
@@ -8,7 +8,10 @@ import {
 } from './structureFuelNotification.js'
 
 const TAG = 'corp-structures'
-const SCOPE = 'esi-corporations.read_structures.v1'
+// Exported for the on-demand dispatch (PER_CORPORATION_JOBS in
+// src/app/character/dispatchRefresh.ts), which groups the account's characters
+// carrying this scope by corporation.
+export const SCOPE = 'esi-corporations.read_structures.v1'
 
 // GET /corporations/{id}/structures/ → corp_structure. Upserts the corp's
 // Upwell structures (state, fuel, reinforcement windows, services).

--- a/src/jobs/lib.js
+++ b/src/jobs/lib.js
@@ -191,6 +191,37 @@ export const forEachCharacterAnyScope = async (tag, { scopes, registrationIds, h
 // skipped_reason naming the character, so /jobs can say "not a director"
 // instead of "✗ failed" (docs/jobs-page.md), and the corp is still left
 // unclaimed so the next character in the group gets its turn.
+// Remember (or forget) that this character was able to pull this corp endpoint.
+// Observed capability, not a stated role: ESI never tells us which role the
+// pilot holds, only whether the call was allowed, and that is exactly what the
+// corp_structure_status fuel policy needs to gate on ("is a director of this
+// corp"). Recording it here rather than in each job module keeps the fact
+// wherever the role denial is already classified.
+//
+// Best-effort on purpose — a bookkeeping failure must not fail an extract that
+// actually succeeded. The worst case is a director briefly losing sight of a
+// fuel timer until the next run.
+const recordCorpJobAccess = async (tag, registration_id, corporation_id, allowed) => {
+  try {
+    const { error } = allowed
+      ? await sudoSupabase
+          .from('corp_job_access')
+          .upsert(
+            { registration_id, corporation_id, job: tag, observed_at: new Date().toISOString() },
+            { onConflict: 'registration_id,corporation_id,job' }
+          )
+      : await sudoSupabase
+          .from('corp_job_access')
+          .delete()
+          .eq('registration_id', registration_id)
+          .eq('corporation_id', corporation_id)
+          .eq('job', tag)
+    if (error) console.warn(`[${tag}] corp_job_access bookkeeping failed: ${error.message}`)
+  } catch (e) {
+    console.warn(`[${tag}] corp_job_access bookkeeping failed: ${e?.message ?? e}`)
+  }
+}
+
 export const forEachCorporation = async (tag, { scope, registrationIds }, handler) => {
   const seenCorps = new Set()
   await forEachCharacter(
@@ -230,10 +261,12 @@ export const forEachCorporation = async (tag, { scope, registrationIds }, handle
         // as FAILED, and it isn't. The corp stays out of seenCorps either way,
         // so a corpmate with the role still gets a turn this run.
         console.log(`[${tag}] ${ctx}: ${skipped} — recorded as a skip, not a failure`)
+        await recordCorpJobAccess(tag, registration_id, corporation_id, false)
         return
       }
       // Only mark the corp as handled once the pull actually succeeds.
       seenCorps.add(corporation_id)
+      await recordCorpJobAccess(tag, registration_id, corporation_id, true)
     }
   )
   return seenCorps

--- a/src/jobs/structureDirectory.js
+++ b/src/jobs/structureDirectory.js
@@ -1,0 +1,147 @@
+import { forEach, map, splitEvery } from 'ramda'
+
+import { universeStructures, userAgent } from '../esi.js'
+import { sudoSupabase } from '../supabase.js'
+import { cli } from './lib.js'
+
+const TAG = 'structure-directory'
+
+// EVE Ref's continuously-scraped dump of everything publicly queryable about
+// player structures — the live successor to the Hammertime Citadel Hunt API
+// jEveAssets used to lean on (docs/structure-universe/design.md). ~874 KB, one
+// JSON object keyed by structure id.
+const EVEREF_URL = 'https://data.everef.net/structures/structures-latest.v2.json'
+
+// Player Upwell structures use ids at or above this; NPC stations (≤64M) and
+// solar systems sit far below it. Same floor universeStructures.js uses.
+const STRUCTURE_ID_FLOOR = 100_000_000_000
+
+// PostgREST caps a single select, and upserting the whole directory in one
+// request would be a needlessly large body.
+const PAGE = 1000
+const CHUNK = 500
+
+// A row we resolved ourselves, with a real token and docking access, is better
+// than EVE Ref's copy of a public scrape: it can name a *private* structure,
+// and it was true for us at the time we read it. So the directory never lets a
+// lower-priority feed overwrite one. Ranked rather than boolean so a third feed
+// can slot in without rewriting the comparison.
+const SOURCE_RANK = { 'esi-token': 3, everef: 2, 'public-list': 1 }
+const outranks = (incoming, existing) => (SOURCE_RANK[incoming] ?? 0) >= (SOURCE_RANK[existing] ?? 0)
+
+// Every directory row we already hold, drained past the PostgREST row cap by
+// recursing to the next page until a short page signals the end. Ordered by the
+// primary key so paging is stable — without an explicit sort PostgREST gives no
+// row order, and an unordered .range() can skip or repeat rows across pages.
+const fetchExisting = async (from = 0, acc = []) => {
+  const { data, error } = await sudoSupabase
+    .from('universe_structure')
+    .select('structure_id, source')
+    .order('structure_id', { ascending: true })
+    .range(from, from + PAGE - 1)
+  if (error) throw new Error(`reading universe_structure failed: ${error.message}`)
+  const page = data ?? []
+  forEach((row) => acc.push(row), page)
+  return page.length < PAGE ? acc : fetchExisting(from + PAGE, acc)
+}
+
+const fetchEveref = async () => {
+  const response = await fetch(EVEREF_URL, { headers: { 'User-Agent': userAgent } })
+  if (!response.ok) throw new Error(`EVE Ref structures fetch failed: ${response.status} ${response.statusText}`)
+  return response.json()
+}
+
+const upsertChunks = async (rows, label) => {
+  if (rows.length === 0) return
+  await splitEvery(CHUNK, rows).reduce(
+    (settled, chunk) =>
+      settled.then(async () => {
+        const { error } = await sudoSupabase.from('universe_structure').upsert(chunk, { onConflict: 'structure_id' })
+        if (error) throw new Error(`upserting ${label} failed: ${error.message}`)
+      }),
+    Promise.resolve()
+  )
+}
+
+// Two public feeds → universe_structure. Names every structure that can be
+// named without a token, so the rest of the app (asset paths, market orders,
+// industry jobs, contract endpoints) has something better than a raw id to
+// show. Hourly: both feeds are small, unauthenticated and cheap.
+//
+// This does NOT replace universe-structures, the token-probe job. That one is
+// the only thing that can name a *non-public* structure — one of ours, or one
+// we hold assets in — because that needs a character with access, and EVE Ref
+// by construction only has what's publicly queryable.
+//
+// Account-wide by construction, so it takes no character scope.
+export const runStructureDirectory = async () => {
+  const [everef, publicIds] = await Promise.all([fetchEveref(), universeStructures()])
+
+  const publicSet = new Set(map(Number, publicIds ?? []))
+  const everefById = new Map()
+  forEach(
+    (entry) => {
+      const id = Number(entry?.structure_id)
+      if (Number.isFinite(id) && id >= STRUCTURE_ID_FLOOR) everefById.set(id, entry)
+    },
+    Object.values(everef ?? {})
+  )
+
+  const existingSource = new Map(map((row) => [Number(row.structure_id), row.source], await fetchExisting()))
+
+  console.log(
+    `[${TAG}] ${everefById.size} EVE Ref structure(s), ${publicSet.size} public id(s), ${existingSource.size} already known`
+  )
+
+  // Three shapes, because a PostgREST bulk upsert builds one INSERT and updates
+  // exactly the columns present in the payload — so rows that must only touch
+  // is_public can't ride along with rows writing full identity.
+  const identity = []
+  const publicOnly = []
+  const now = new Date().toISOString()
+
+  forEach(
+    (id) => {
+      const is_public = publicSet.has(id)
+      const entry = everefById.get(id)
+      const existing = existingSource.get(id)
+      if (entry && outranks('everef', existing)) {
+        identity.push({
+          structure_id: id,
+          name: entry.name ?? null,
+          system_id: entry.solar_system_id ?? null,
+          type_id: entry.type_id ?? null,
+          owner_corporation_id: entry.owner_id ?? null,
+          is_public,
+          source: 'everef',
+          resolved_at: now,
+        })
+      } else if (existingSource.has(id)) {
+        // Known already, and either EVE Ref has nothing to add or the row was
+        // resolved with a token and outranks it. Keep the identity, refresh only
+        // whether it's currently listed as public.
+        publicOnly.push({ structure_id: id, is_public })
+      } else {
+        // In ESI's public list but nowhere else — we have an id and nothing to
+        // call it. The token probe or a later EVE Ref pass may name it.
+        publicOnly.push({ structure_id: id, is_public, source: 'public-list' })
+      }
+    },
+    [...new Set([...everefById.keys(), ...publicSet, ...existingSource.keys()])]
+  )
+
+  // publicOnly holds two column shapes (with and without source), so split it
+  // the same way rather than letting the shorter rows null out `source`.
+  const withSource = publicOnly.filter((row) => row.source !== undefined)
+  const withoutSource = publicOnly.filter((row) => row.source === undefined)
+
+  await upsertChunks(identity, 'EVE Ref identities')
+  await upsertChunks(withSource, 'public-list ids')
+  await upsertChunks(withoutSource, 'public flags')
+
+  console.log(
+    `[${TAG}] wrote ${identity.length} identity row(s), ${withSource.length} new public id(s), ${withoutSource.length} public flag refresh(es)`
+  )
+}
+
+cli(import.meta.url, TAG, runStructureDirectory)

--- a/src/jobs/universeStructures.js
+++ b/src/jobs/universeStructures.js
@@ -13,25 +13,78 @@ const SCOPE = 'esi-universe.read_structures.v1'
 // characters' own items is a ship/container, not a structure.
 const STRUCTURE_ID_FLOOR = 100_000_000_000
 
-// PostgREST caps a single select; page through character_asset_over_time so a
-// large hangar doesn't silently truncate the candidate/own-item sets.
+// PostgREST caps a single select; page through the source tables so a large
+// hangar doesn't silently truncate the candidate/own-item sets.
 const ASSET_PAGE = 1000
 
-// Order by the primary key so range paging is stable: PostgREST gives no row
-// order without an explicit sort, so an unordered .range() can skip or repeat
-// rows across pages and silently drop a structure from the candidate set. The
-// assets extract pages the same table and orders by id for exactly this reason.
-const fetchAssetLocationRows = async (from = 0) => {
-  const { data: rows, error: assetsErr } = await sudoSupabase
+// Every table we already extract that records *where* something was, and the
+// columns holding that location. A structure id in any of them is proof one of
+// our characters has been there, which makes it worth a name — and it costs no
+// ESI calls to harvest, since the rows are already in Postgres
+// (docs/structure-universe/design.md).
+//
+// `orderBy` is the table's primary key (or its first component): range paging
+// without an explicit sort is unstable in PostgREST and can skip or repeat rows
+// across pages, silently dropping a structure from the candidate set.
+// `current` marks the SCD-2 tables, whose live snapshot is is_current rows.
+//
+// Contracts are the quiet win here: a courier contract's start/end locations
+// are often the only record of a structure a character docks at but keeps
+// nothing in.
+const LOCATION_SOURCES = [
+  { table: 'character_asset_over_time', columns: ['location_id'], orderBy: 'id', current: true },
+  { table: 'corp_asset_over_time', columns: ['location_id'], orderBy: 'id', current: true },
+  { table: 'character_order_over_time', columns: ['location_id'], orderBy: 'id', current: true },
+  {
+    table: 'character_industry_job_over_time',
+    columns: ['facility_id', 'station_id', 'blueprint_location_id', 'output_location_id'],
+    orderBy: 'id',
+    current: true,
+  },
+  {
+    table: 'corp_industry_job_over_time',
+    columns: ['facility_id', 'station_id', 'blueprint_location_id', 'output_location_id'],
+    orderBy: 'id',
+    current: true,
+  },
+  {
+    table: 'character_contract',
+    columns: ['start_location_id', 'end_location_id'],
+    orderBy: 'contract_id',
+    current: false,
+  },
+  { table: 'corp_contract', columns: ['start_location_id', 'end_location_id'], orderBy: 'contract_id', current: false },
+  { table: 'character_wallet_transaction', columns: ['location_id'], orderBy: 'transaction_id', current: false },
+  { table: 'corp_wallet_transaction', columns: ['location_id'], orderBy: 'transaction_id', current: false },
+]
+
+// One source table's location columns, drained past the PostgREST row cap by
+// recursing to the next page until a short page signals the end.
+const fetchLocationRows = async ({ table, columns, orderBy, current }, from = 0, acc = []) => {
+  let query = sudoSupabase.from(table).select(columns.join(', '))
+  if (current) query = query.eq('is_current', true)
+  const { data: rows, error } = await query.order(orderBy, { ascending: true }).range(from, from + ASSET_PAGE - 1)
+  if (error) throw new Error(`reading ${table} failed: ${error.message}`)
+  const page = rows ?? []
+  forEach((row) => acc.push(row), page)
+  if (page.length < ASSET_PAGE) return acc
+  return fetchLocationRows({ table, columns, orderBy, current }, from + ASSET_PAGE, acc)
+}
+
+// The item ids of everything our characters own. A location in the structure id
+// range that's also one of these is a ship or container, not a structure.
+const fetchOwnedItemIds = async (from = 0, acc = []) => {
+  const { data: rows, error } = await sudoSupabase
     .from('character_asset_over_time')
-    .select('item_id, location_id')
+    .select('item_id')
     .eq('is_current', true)
     .order('id', { ascending: true })
     .range(from, from + ASSET_PAGE - 1)
-  if (assetsErr) throw assetsErr
+  if (error) throw error
   const page = rows ?? []
-  if (page.length < ASSET_PAGE) return page
-  return [...page, ...(await fetchAssetLocationRows(from + ASSET_PAGE))]
+  forEach((row) => acc.push(Number(row.item_id)), page)
+  if (page.length < ASSET_PAGE) return acc
+  return fetchOwnedItemIds(from + ASSET_PAGE, acc)
 }
 
 // GET /universe/structures/{id} → universe_structure. Resolves and caches the
@@ -52,27 +105,38 @@ export const runUniverseStructures = async () => {
   console.log(`[${TAG}] ${tokens?.length ?? 0} token(s) with ${SCOPE}`)
   if (!tokens || tokens.length === 0) return
 
-  // Ids we don't need to resolve: our own corp structures and anything already cached.
+  // Ids we don't need to resolve: our own corp structures and anything already
+  // *named*. Rows without a name don't count as resolved — the hourly
+  // structure-directory job seeds ids straight from ESI's public list with
+  // nothing to call them, and treating those as done would mean nothing ever
+  // put a name on them.
   const { data: corpStructs } = await sudoSupabase.from('corp_structure').select('structure_id')
-  const { data: knownStructs } = await sudoSupabase.from('universe_structure').select('structure_id')
+  const { data: knownStructs } = await sudoSupabase
+    .from('universe_structure')
+    .select('structure_id')
+    .not('name', 'is', null)
   const resolved = new Set(map(pipe(prop('structure_id'), Number), [...(corpStructs ?? []), ...(knownStructs ?? [])]))
 
-  // Pool candidate structure ids from every character's live assets. itemIds is
-  // the union of all owned item ids across characters: a location in the
-  // structure range that's also someone's item is a ship/container, not a
-  // structure. Read character_asset_over_time (the base table service_role can
-  // reach) filtered to live rows, rather than the character_asset view (granted
-  // to authenticated).
-  const itemIds = new Set()
+  // Pool candidate structure ids from every location column we already extract
+  // (LOCATION_SOURCES). itemIds is the union of all owned item ids across
+  // characters: a location in the structure range that's also someone's item is
+  // a ship/container, not a structure. Read the *_over_time base tables (what
+  // service_role can reach) filtered to live rows, rather than the views
+  // (granted to authenticated).
+  const itemIds = new Set(await fetchOwnedItemIds())
   const locationIds = new Set()
-  forEach(
-    (r) => {
-      itemIds.add(Number(r.item_id))
-      const id = Number(r.location_id)
-      if (Number.isFinite(id) && id >= STRUCTURE_ID_FLOOR) locationIds.add(id)
-    },
-    await fetchAssetLocationRows()
-  )
+  await forEachSequential(LOCATION_SOURCES, async (source) => {
+    const before = locationIds.size
+    forEach(
+      (row) =>
+        forEach((column) => {
+          const id = Number(row[column])
+          if (Number.isFinite(id) && id >= STRUCTURE_ID_FLOOR) locationIds.add(id)
+        }, source.columns),
+      await fetchLocationRows(source)
+    )
+    console.log(`[${TAG}] ${source.table}: ${locationIds.size - before} new candidate id(s)`)
+  })
 
   // Clones parked in player structures are candidates too — the character-clones
   // job resolves what it can with each clone's own token, but only a character
@@ -145,6 +209,11 @@ export const runUniverseStructures = async () => {
         name: info?.name ?? null,
         system_id: info?.solar_system_id ?? null,
         type_id: info?.type_id ?? null,
+        owner_corporation_id: info?.owner_id ?? null,
+        // Outranks 'everef' and 'public-list', so the hourly directory job
+        // never overwrites a name we resolved with real docking access — this
+        // is the only source that can name a *private* structure.
+        source: 'esi-token',
         resolved_at: new Date().toISOString(),
       },
       { onConflict: 'structure_id' }

--- a/src/workflows/corpStructures.ts
+++ b/src/workflows/corpStructures.ts
@@ -1,22 +1,76 @@
-// corp-structures as a Vercel Workflow — phase 1 of the cron → Workflows
-// migration (docs/cron-to-workflows/01-direct-jobs.md). Whole-corp batch work
-// (not per-character), so it stays a single step: runJobWithHeartbeat wraps
-// runCorpStructures in the same start/end heartbeat pair the cron route
-// recorded (source: 'vercel-workflow'). runCorpStructures uses
-// forEachCorporation, which additionally records its own per-corp heartbeat
-// rows — that whole-job + per-corp pairing is unchanged from the runDirectCronJob
-// path and is intentionally preserved (/jobs keys off it). The job
-// module is untouched and still CLI-runnable.
+// corp-structures as a Vercel Workflow, in the per-corporation fan-out shape
+// (docs/cron-to-workflows/04-per-corporation.md), copied from corpAssets.ts.
+//
+// It was a single step for as long as it was scheduled-only. It became
+// on-demand with the structure-universe work (docs/structure-universe/design.md):
+// "refresh my structures" fans this out alongside corp-assets, because the two
+// carry different halves of a structure — this one brings state, services,
+// reinforcement windows and the fuel timer, while the *rigs* come from corp
+// assets (ESI has no structure-fitting endpoint; corpAssets.js reads items
+// whose location_flag is a RigSlot). Dispatching only one of the pair leaves
+// the other half visibly stale.
+//
+// The fan-out unit is the corporation, never the character: a corp's characters
+// ride together in one step so two directors in the same corp can't race a
+// concurrent reconcile, and only *different* corps run concurrently. Both
+// triggers start() this — the cron route bare, the on-demand path with an
+// OnDemandTarget carrying one corp's whole character group plus its
+// refresh_task row. The job module is untouched and still CLI-runnable.
 
-// Both imports live inside the step body on purpose (workflow compiler bans
-// Node modules in workflow context — see src/workflows/lib.ts).
-async function runStep() {
+import { map, reduce, splitEvery, transpose } from 'ramda'
+
+import { enumerateCorporations, type OnDemandTarget } from './lib'
+
+// This job's ESI scope, and the lane count. Two lanes, matching corp-assets:
+// the corp count is small, and one structures pull is far lighter than a
+// paginated hangar.
+const SCOPE = 'esi-corporations.read_structures.v1'
+const LANES = 2
+
+// Step: run the job for one corp group. The lazy import is the usual reason
+// (the job module's top-level supabase/esi setup needs env vars absent at build
+// time). forEachCorporation still refreshes tokens, dedupes to one handler call
+// per corp, falls back through the group on a role denial, records the per-corp
+// heartbeat pair, and now also records corp_job_access — which is what lets the
+// fuel policy tell a director from a rank-and-file member.
+async function syncCorporation(registrationIds: string[], taskId?: string) {
   'use step'
-  const { runJobWithHeartbeat } = await import('./lib')
-  await runJobWithHeartbeat('corp-structures', async () => (await import('@/jobs/corpStructures.js')).runCorpStructures)
+  const { withRefreshTask } = await import('./lib')
+  const { runCorpStructures } = await import('@/jobs/corpStructures.js')
+  await withRefreshTask(taskId, () => runCorpStructures({ registrationIds }))
 }
 
-export async function corpStructuresWorkflow() {
+export async function corpStructuresWorkflow(target?: OnDemandTarget) {
   'use workflow'
-  await runStep()
+  const groups = target?.registrationIds ? [target.registrationIds] : await enumerateCorporations(SCOPE)
+
+  // Round-robin the corp groups into LANES lanes; the mapping is identical on
+  // every replay. Within a lane groups run sequentially; lanes run concurrently,
+  // and only ever parallelize *different* corps.
+  const lanes = transpose(splitEvery(LANES, groups))
+
+  // Drain each lane sequentially, collecting rather than propagating failures so
+  // one bad corp never aborts its lane-mates, then throw them together as an
+  // AggregateError so the run is visibly failed in Observability.
+  const failures: string[][] = []
+  const drainLane = (lane: string[][]): Promise<void> =>
+    reduce(
+      (p, group) =>
+        p.then(() =>
+          syncCorporation(group, target?.taskId).catch((err) => {
+            console.error(`[corp-structures] corp group [${group.join(', ')}] failed:`, err)
+            failures.push(group)
+          })
+        ),
+      Promise.resolve(),
+      lane
+    )
+  await Promise.all(map(drainLane, lanes))
+
+  if (failures.length > 0) {
+    throw new AggregateError(
+      map((group) => new Error(`corp group [${group.join(', ')}] failed`), failures),
+      `corp-structures: ${failures.length} corp step(s) failed`
+    )
+  }
 }

--- a/src/workflows/structureDirectory.ts
+++ b/src/workflows/structureDirectory.ts
@@ -1,0 +1,20 @@
+// structure-directory as a Vercel Workflow. Whole-universe batch work (two
+// public feeds, no tokens, no per-character fan-out), so it's the single-step
+// shape: runJobWithHeartbeat wraps runStructureDirectory in the start/end
+// heartbeat pair, gaining the per-step duration budget and bounded retries.
+//
+// The import lives inside the step body on purpose (the workflow compiler bans
+// Node modules in workflow context — see src/workflows/lib.ts).
+async function runStep() {
+  'use step'
+  const { runJobWithHeartbeat } = await import('./lib')
+  await runJobWithHeartbeat(
+    'structure-directory',
+    async () => (await import('@/jobs/structureDirectory.js')).runStructureDirectory
+  )
+}
+
+export async function structureDirectoryWorkflow() {
+  'use workflow'
+  await runStep()
+}

--- a/supabase/migrations/20260812150000_structure_universe.sql
+++ b/supabase/migrations/20260812150000_structure_universe.sql
@@ -1,0 +1,151 @@
+-- Per-account structure universe (docs/structure-universe/design.md).
+--
+-- Four independent pieces, all additive except the two RLS changes at the end:
+--   1. universe_structure gains the fields the new hourly directory job fills.
+--   2. structure_favorite — per-user pinning, sorted to the top of /structure.
+--   3. corp_job_access — which character proved it can pull which corp endpoint.
+--   4. RLS: structure rigs open to the alliance, fuel narrows to directors.
+
+-- ── 1. universe_structure directory columns ───────────────────────────────
+-- owner_corporation_id comes back free on every /universe/structures/{id}
+-- resolve and is present in EVE Ref's dump, so structure ownership no longer
+-- needs a corp token to learn. is_public marks membership of ESI's public list
+-- (a completely open ACL). source records which of the three feeds last wrote
+-- the row, so precedence is explicit rather than last-write-wins: a name we
+-- resolved ourselves with a real token outranks EVE Ref's copy.
+alter table public.universe_structure
+  add column if not exists owner_corporation_id bigint,
+  add column if not exists is_public boolean not null default false,
+  add column if not exists source text;
+
+comment on column public.universe_structure.source is
+  'Which feed last wrote this row: esi-token (resolved with docking access), everef, or public-list. Precedence order is esi-token > everef > public-list.';
+
+-- ── 2. structure_favorite ─────────────────────────────────────────────────
+-- Per-user pinned structures, sorted to the top of /structure. Deliberately
+-- shaped like watched_system (same key, same position column, same policy):
+-- a favorite is a UI preference belonging to the account, not a fact about a
+-- character, so it keys on user_id rather than registration_id.
+--
+-- No FK to universe_structure: a user may pin a structure id before the
+-- directory has learned a name for it, and losing the pin when a sweep drops
+-- the directory row would be worse than showing the raw id.
+create table if not exists public.structure_favorite (
+  user_id      uuid   not null references auth.users (id) on delete cascade,
+  structure_id bigint not null,
+  created_at timestamptz not null default now(),
+  -- Drag order (lower sorts first), mirroring watched_system.position.
+  position   integer not null default 0,
+  primary key (user_id, structure_id)
+);
+create index if not exists structure_favorite_user_id_idx on public.structure_favorite (user_id);
+
+alter table public.structure_favorite enable row level security;
+
+drop policy if exists "Users manage own structure favorites" on public.structure_favorite;
+create policy "Users manage own structure favorites"
+  on public.structure_favorite
+  for all
+  to authenticated
+  using (user_id = (select auth.uid()))
+  with check (user_id = (select auth.uid()));
+
+grant select, insert, update, delete on public.structure_favorite to authenticated;
+grant all                            on public.structure_favorite to service_role;
+
+-- ── 3. corp_job_access ────────────────────────────────────────────────────
+-- Observed capability, not a stated role. Every corp ESI endpoint needs an
+-- in-game role on top of the OAuth scope (corp-structures wants Station
+-- Manager, corp-assets wants Director, the wallet endpoints want Accountant),
+-- and forEachCorporation already classifies the role-denial 403 to write
+-- heartbeat.skipped_reason — it just discarded the fact afterwards. This table
+-- keeps it.
+--
+-- Keyed on the job tag rather than a role name on purpose: we never learn which
+-- role the character holds, only which endpoint it was able to pull. Recording
+-- "can pull corp-structures for corp X" is exactly what we observed, and it is
+-- what the fuel policy below needs. Reading roles properly would need
+-- esi-characters.read_corporation_roles.v1 and a re-auth of every linked
+-- character; if that is ever added it can fill this same table and no policy
+-- has to change.
+create table if not exists public.corp_job_access (
+  registration_id uuid   not null references public.registration (id) on delete cascade,
+  corporation_id  bigint not null,
+  -- The extract tag that proved it, e.g. 'corp-structures'.
+  job  text not null,
+  observed_at timestamptz not null default now(),
+  primary key (registration_id, corporation_id, job)
+);
+create index if not exists corp_job_access_corporation_id_idx on public.corp_job_access (corporation_id, job);
+
+alter table public.corp_job_access enable row level security;
+
+-- Users see their own characters' grants; that is all the /jobs page and the
+-- fuel policy need. Written only by the extract jobs (service role).
+drop policy if exists "Users read own corp job access" on public.corp_job_access;
+create policy "Users read own corp job access"
+  on public.corp_job_access
+  for select
+  to authenticated
+  using (
+    registration_id in (
+      select id from public.registration where user_id = (select auth.uid())
+    )
+  );
+
+grant select on public.corp_job_access to authenticated;
+grant all    on public.corp_job_access to service_role;
+
+-- ── 4a. Structure rigs open to the alliance ───────────────────────────────
+-- A copy of corp_structure's "Alliance members read corp structures" policy.
+-- A fitted rig is inferable from the structure's own bonuses in space, so it
+-- was never really corp-private, and the /structure page shows rigs beside
+-- structures the alliance can already see. Additive: OR'd with the existing
+-- own-corps policy, which stays.
+drop policy if exists "Alliance members read corp structure rigs" on public.corp_structure_rig;
+create policy "Alliance members read corp structure rigs"
+  on public.corp_structure_rig
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.corporation owner_corp
+      where owner_corp.corporation_id = corp_structure_rig.corporation_id
+        and owner_corp.alliance_id is not null
+        and owner_corp.alliance_id in (
+          select member_corp.alliance_id
+          from public.registration r
+          join public.corporation member_corp on member_corp.corporation_id = r.corporation_id
+          where r.user_id = (select auth.uid())
+            and member_corp.alliance_id is not null
+        )
+    )
+  );
+
+-- ── 4b. Fuel narrows to directors ─────────────────────────────────────────
+-- Fuel timers and the reinforcement profile are the one genuinely sensitive
+-- thing here: a fuel expiry is a countdown to when the structure stops
+-- shooting back. Restricting them to accounts that actually hold the role on
+-- that corp, rather than to every corp member, is the point of the split that
+-- created corp_structure_status in the first place.
+--
+-- Rank-and-file corp members lose the fuel column on /structure as a result.
+-- The low-fuel Discord alerts are unaffected: that job runs service-role and
+-- never sees RLS.
+drop policy if exists "Users read structure status for own corps" on public.corp_structure_status;
+drop policy if exists "Directors read structure status for own corps" on public.corp_structure_status;
+create policy "Directors read structure status for own corps"
+  on public.corp_structure_status
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.corp_job_access a
+      join public.registration r on r.id = a.registration_id
+      where a.corporation_id = corp_structure_status.corporation_id
+        and a.job = 'corp-structures'
+        and r.user_id = (select auth.uid())
+    )
+  );

--- a/vercel.json
+++ b/vercel.json
@@ -82,6 +82,10 @@
       "schedule": "57 9 * * *"
     },
     {
+      "path": "/api/cron/structure-directory",
+      "schedule": "51 * * * *"
+    },
+    {
       "path": "/api/cron/character-directory",
       "schedule": "41 11 * * *"
     },


### PR DESCRIPTION
Implements `docs/structure-universe/design.md`, which is included and records how the design got here.

## The finding that shaped it

A complete list of player-anchored structures **is not obtainable**. Measured 2026-08-12: ESI's public list has **886** ids (fully-open ACL only, no names); EVE Ref's continuously-scraped dump has **2,374** rows, 1,444 named. jEveAssets doesn't enumerate either — `CitadelSource` is a prioritised *resolver*, and its Hammertime source is dead (connection refused). `/search/` is ruled out: `minLength: 3` blocks exhaustive enumeration, and CCP has publicly warned that citadel discovery through it is a policy violation that gets developers banned from ESI.

So "complete" is scoped to what the account can actually see, and the work splits into rich data via directors and names via public feeds. An earlier draft's per-character docking probe (`structure_access`) was dropped — it carried the entire ESI error-budget problem (403s count against 100/60s) for information the page doesn't need.

## Schema — migration `20260812150000_structure_universe.sql`

- **`universe_structure`** gains `owner_corporation_id`, `is_public`, `source`. The last makes feed precedence explicit (`esi-token` &gt; `everef` &gt; `public-list`) so a name resolved with real docking access is never overwritten by a public scrape.
- **`structure_favorite`** — per-user pins, shaped like `watched_system` down to the `position` column. No FK to `universe_structure`: a pin shouldn't die because a sweep dropped the directory row.
- **`corp_job_access`** — which character proved it can pull which corp endpoint. `forEachCorporation` already classified the role-denial 403 to write `heartbeat.skipped_reason`, then discarded the fact; keeping it gives director gating with **no new ESI scope and no re-auth**. Keyed on the job tag, not a role name, because "was allowed to call this" is all ESI actually tells us.
- **RLS:** `corp_structure_rig` opens to alliance-mates on the same terms as `corp_structure` (a fitted rig is inferable from the structure's bonuses in space). `corp_structure_status` narrows from all corp members to directors — a fuel timer is a countdown to when the structure stops shooting back. Rank-and-file members lose the fuel column; the low-fuel Discord alerts are unaffected, since that job runs service-role.

## Jobs

- **`structure-directory`** (new, hourly, single-step): ESI's public list + EVE Ref. ~874 KB, both unauthenticated. Names structures no token of ours can reach, so asset paths, market orders, industry jobs and contract endpoints render a location instead of a bare id.
- **`universe-structures`** now harvests candidates from every location column we already extract — orders, industry jobs, contracts (start *and* end), wallet transactions — not just assets and clones. **No new ESI calls**; the rows are already in Postgres. Contracts are the quiet win: a courier's endpoints are often the only record of a structure a character docks at but keeps nothing in. It also stops treating a nameless directory row as resolved, so ids seeded from the public list still get named.
- **`corp-structures`** becomes on-demand: moved to the per-corporation fan-out shape and joined `PER_CORPORATION_JOBS`, so "refresh my structures" dispatches it **beside `corp-assets`**. The pair is required — this job carries state, services and fuel, while the **rigs come from corp assets** by `location_flag` (ESI has no structure-fitting endpoint), so dispatching one alone leaves the other half visibly stale. Fan-out stays one run per corp, never one per director, to avoid the concurrent-reconcile race `dispatchRefresh.ts` documents.

The lever itself needed no new UI: registering the job makes `/jobs` render a per-corp refresh button with `refresh_task` tracking.

## Page

Favorites first, then everything else in the alliance — which is exactly what `corp_structure`'s existing RLS returns. Nothing outside the alliance is shown, so a favorite is always something the caller can already see and the star only re-sorts the list. Optimistic star, since pinning moves the tile.

## Verification

`pnpm run lint` clean · `pnpm test` 269/269 · `pnpm run build` compiles, `/api/cron/structure-directory` registered · migration ordering guard clean. CI green on all four checks, including `branch` — `test:branch` ran the migration end-to-end against a real Supabase preview branch, since this PR touches `supabase/migrations/**` and `schema.sql`.

Not exercised here: both new pulls (ESI public structure list, EVE Ref snapshot) against production data — those only happen on a real run.