### PR TITLE
chore(structure-directory): run daily instead of hourly

### DIFF
--- a/docs/structure-universe/design.md
+++ b/docs/structure-universe/design.md
@@ -124,16 +124,18 @@ which role the pilot holds, only whether the call was allowed. "Can pull
 fuel policy needs. If `esi-characters.read_corporation_roles.v1` is ever added
 it can fill the same table with stated roles and no policy changes.
 
-### 2. Names — universal, hourly
+### 2. Names — universal, daily
 
 `structure-directory`, a new single-step job with no per-user work at all:
 
 - `GET /universe/structures` → ids, set `is_public`.
 - EVE Ref `structures-latest.v2.json` → name, `owner_id`, system, type, region.
 
-Both are small and unauthenticated (~874 KB total), so hourly is comfortable.
-One heartbeat, a `/jobs` "shared universe" row, no refresh lever — nothing about
-it is per-account.
+Both are small and unauthenticated (~874 KB total). Daily at 09:47, ten minutes
+ahead of `universe-structures`: the directory seeds ids and names what it can,
+so the token probe that follows spends its attempts only on what the public
+feeds couldn't name. One heartbeat, a `/jobs` "shared universe" row, no refresh
+lever — nothing about it is per-account.
 
 Rows carry a `source` so precedence is explicit, following jEveAssets: a name we
 resolved ourselves from ESI with a real token outranks EVE Ref's, and EVE Ref
@@ -150,7 +152,7 @@ It is not a sweep: it only resolves ids that already appear in our own extracted
 data, pooled across characters and tried against each token until one succeeds.
 That is precisely jEveAssets' ESI_LOCATIONS source, and it is already built.
 
-Between the three sources — corp structures, the token probe, and the hourly
+Between the three sources — corp structures, the token probe, and the daily
 directory — every structure id the app can display should resolve to a name.
 
 ## Schema
@@ -222,7 +224,7 @@ can't view" state to design around.
 
 That does _not_ make the directory pointless: naming structures is what it is
 for. Asset paths, market orders, industry job locations and contract endpoints
-all render structure ids elsewhere in the app, and the hourly job is what turns
+all render structure ids elsewhere in the app, and the daily job is what turns
 those into names.
 
 NPC stations are excluded by id range, not by a lookup: player structures are

--- a/src/app/api/cron/structure-directory/route.ts
+++ b/src/app/api/cron/structure-directory/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { requireCronSecret } from '@/utils/cron'
 
-// Vercel Cron trigger for structure-directory (hourly). Fire-and-forget: the
+// Vercel Cron trigger for structure-directory (daily). Fire-and-forget: the
 // workflow owns retries, its run/step status shows under Observability →
 // Workflows, and the heartbeat pair is recorded by the workflow's step
 // (source: 'vercel-workflow').

--- a/src/app/jobs/registry.ts
+++ b/src/app/jobs/registry.ts
@@ -63,7 +63,7 @@ export const JOBS: readonly JobEntry[] = [
   { job: 'sde-mirror', label: 'SDE mirror', section: 'universe', kickable: 'never' },
   { job: 'universe-names', label: 'names', section: 'universe', kickable: 'chancellor' },
   { job: 'universe-structures', label: 'structures', section: 'universe', kickable: 'never' },
-  // Hourly public-feed pull (ESI's public structure list + EVE Ref). Names
+  // Daily public-feed pull (ESI's public structure list + EVE Ref). Names
   // structures no token of ours can reach; see docs/structure-universe/design.md.
   { job: 'structure-directory', label: 'structure directory', section: 'universe', kickable: 'chancellor' },
   { job: 'character-directory', label: 'character directory', section: 'universe', kickable: 'chancellor' },

--- a/src/jobs/structureDirectory.js
+++ b/src/jobs/structureDirectory.js
@@ -66,7 +66,9 @@ const upsertChunks = async (rows, label) => {
 // Two public feeds → universe_structure. Names every structure that can be
 // named without a token, so the rest of the app (asset paths, market orders,
 // industry jobs, contract endpoints) has something better than a raw id to
-// show. Hourly: both feeds are small, unauthenticated and cheap.
+// show. Daily, just ahead of universe-structures: this seeds ids and names
+// them where it can, so the token probe that follows spends its attempts only
+// on what the public feeds couldn't name.
 //
 // This does NOT replace universe-structures, the token-probe job. That one is
 // the only thing that can name a *non-public* structure — one of ours, or one

--- a/vercel.json
+++ b/vercel.json
@@ -83,7 +83,7 @@
     },
     {
       "path": "/api/cron/structure-directory",
-      "schedule": "51 * * * *"
+      "schedule": "47 9 * * *"
     },
     {
       "path": "/api/cron/character-directory",


### PR DESCRIPTION
Follow-up to #879, which shipped `structure-directory` on an hourly cron.

Both feeds are cheap, but nothing they carry changes on an hourly cadence — EVE Ref rescrapes on its own schedule, and ESI's public list only moves when a structure's ACL opens or closes. Hourly was buying nothing.

`51 * * * *` → **`47 9 * * *`**.

The time isn't an arbitrary free slot: it puts the directory **ten minutes ahead of `universe-structures`** (`57 9 * * *`). The directory seeds ids and names whatever the public feeds can, so the token probe that follows spends its attempts only on what's left nameless — rather than the two running in whatever order the hour happened to interleave them.

Also updates the comments that asserted hourly, in the job module, cron route, `/jobs` registry entry, and the design doc. The `/jobs` next-run countdown needs no change — `registry.ts` reads schedules straight out of `vercel.json` precisely so the two can't drift.

## Verification

`pnpm run lint` clean · `pnpm test` 269/269 · prettier clean. No migration or schema change, so the `branch` check won't run on this one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNDmRLJPUGNyMCj1ozGc4V)_