### PR TITLE
Create the sheet_csv table its migration never created, and widen the schema-cache retry

### DIFF
--- a/src/jobs/esfData.js
+++ b/src/jobs/esfData.js
@@ -12,7 +12,7 @@
 // and stamps the rows with the latest completed sde_build.
 import { encodeEsfData, ESF_FILE_NAMES } from '../buildEsfData.js'
 import { sudoSupabase } from '../supabase.js'
-import { cli } from './lib.js'
+import { cli, writeWithSchemaRetry } from './lib.js'
 
 // The build the encoded data corresponds to. The workflow passes the build it
 // just ingested; the CLI falls back to the latest fully-mirrored build.
@@ -54,7 +54,11 @@ export const runEsfData = async ({ build, force = false } = {}) => {
     sde_build: sdeBuild,
     updated_at: updatedAt,
   }))
-  const { error } = await sudoSupabase.from('esf_data').upsert(rows, { onConflict: 'name' })
+  // Same schema-cache retry as its sibling tail step (see sheetCsv.js): this
+  // runs inside an sde-mirror run that may be minting tables concurrently.
+  const { error } = await writeWithSchemaRetry('esf_data', () =>
+    sudoSupabase.from('esf_data').upsert(rows, { onConflict: 'name' })
+  )
   if (error) throw new Error(`esf-data: upsert failed: ${error.message}`)
   console.log(`esf-data: upserted ${rows.length} files at sde_build ${sdeBuild}`)
   return { files: rows.length, build: sdeBuild }

--- a/src/jobs/lib.js
+++ b/src/jobs/lib.js
@@ -293,14 +293,18 @@ export const fetchAllPages = async (fetchPage) => {
 //
 //   * writing to a table the same run just minted (sde-mirror creating an
 //     sde_* table for a JSONL file CCP added), and
-//   * writing to a long-standing table while PostgREST is mid-reload, which is
-//     how the sde-mirror run of 2026-08-13 failed on `sheet_csv` — a table
-//     that has existed for months — after minting several new ones earlier in
-//     the same run.
+//   * writing to any table while PostgREST is mid-reload, which minting one of
+//     those tables triggers.
 //
 // Both are transient, so wait the reload out rather than failing the job. The
 // workflow's own step retries don't cover this: they fire within a few seconds
 // of each other and then give up. The backoff sums to ~15s.
+//
+// PGRST205 has a second, non-transient cause worth knowing when reading logs: a
+// table that genuinely does not exist. `sheet_csv` produced this exact error for
+// three weeks because its migration was recorded as applied but never ran (see
+// 20260814000000_repair_sheet_csv.sql). No retry helps there — the ladder just
+// runs out and the caller reports the same failure ~15s later.
 const SCHEMA_CACHE_MISS = 'PGRST205'
 const RELOAD_BACKOFF_MS = [500, 1000, 2000, 4000, 8000]
 

--- a/src/jobs/lib.js
+++ b/src/jobs/lib.js
@@ -287,6 +287,37 @@ export const fetchAllPages = async (fetchPage) => {
   return [...(firstPage ?? []), ...rest]
 }
 
+// PostgREST answers from a cached schema, so a table it hasn't reloaded yet is
+// simply absent — the write comes back as PGRST205, "Could not find the table
+// 'public.<name>' in the schema cache". Two ways to land in that window:
+//
+//   * writing to a table the same run just minted (sde-mirror creating an
+//     sde_* table for a JSONL file CCP added), and
+//   * writing to a long-standing table while PostgREST is mid-reload, which is
+//     how the sde-mirror run of 2026-08-13 failed on `sheet_csv` — a table
+//     that has existed for months — after minting several new ones earlier in
+//     the same run.
+//
+// Both are transient, so wait the reload out rather than failing the job. The
+// workflow's own step retries don't cover this: they fire within a few seconds
+// of each other and then give up. The backoff sums to ~15s.
+const SCHEMA_CACHE_MISS = 'PGRST205'
+const RELOAD_BACKOFF_MS = [500, 1000, 2000, 4000, 8000]
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// Run a PostgREST write, retrying while it reports a schema-cache miss, and
+// return its final result unchanged so the caller keeps its own error message.
+// `write` is a thunk (not a promise) because each attempt needs a fresh request.
+export const writeWithSchemaRetry = async (label, write, attempt = 0) => {
+  const result = await write()
+  if (result.error?.code !== SCHEMA_CACHE_MISS || attempt >= RELOAD_BACKOFF_MS.length) return result
+  const wait = RELOAD_BACKOFF_MS[attempt]
+  console.log(`[schema-cache] ${label} not in PostgREST's schema cache yet, retrying in ${wait}ms`)
+  await sleep(wait)
+  return writeWithSchemaRetry(label, write, attempt + 1)
+}
+
 // Self-run a job when its module is invoked directly as a CLI
 // (npm run <job> / the scheduled workflow). When the module is imported by the
 // Next.js queue consumer instead, the top-level run must not fire.

--- a/src/jobs/sdeMirror.js
+++ b/src/jobs/sdeMirror.js
@@ -31,7 +31,7 @@ import { userAgent } from '../esi.js'
 import { recordPeakRss } from '../observability.js'
 import { resolveAllIds } from '../resolveNames.js'
 import { recordHeartbeat, sudoSupabase } from '../supabase.js'
-import { cli, forEachSequential } from './lib.js'
+import { cli, forEachSequential, writeWithSchemaRetry } from './lib.js'
 
 const SDE_LATEST_URL = 'https://developers.eveonline.com/static-data/eve-online-static-data-latest-jsonl.zip'
 
@@ -281,33 +281,16 @@ const ensureMirrorTable = async (stem, keyType) => {
   if (error) throw new Error(`sde-mirror: ensure_sde_mirror_table(${stem}) failed: ${error.message}`)
 }
 
-// PostgREST answers from a cached schema, so a table ensureMirrorTable() just
-// minted is invisible to it until the cache reloads — the first upsert into a
-// brand-new sde_* table comes back as PGRST205, "Could not find the table
-// 'public.<table>' in the schema cache". ensure_sde_mirror_table() asks for the
-// reload on creation (notify pgrst), but delivery is at commit and the reload
-// itself is asynchronous, so the write has to be prepared to wait for it.
-//
-// Waiting here rather than leaning on the workflow's step retries: those fire
-// within a few seconds of each other and then give up, which is precisely how
-// the nightly mirror spent 20 days dying one new table at a time. The backoff
-// sums to ~15 s, which fits the slice budget — a new table's first chunk is
-// always at the very start of its step.
-const SCHEMA_CACHE_MISS = 'PGRST205'
-const RELOAD_BACKOFF_MS = [500, 1000, 2000, 4000, 8000]
-
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
-
-const upsertChunk = async (table, rows, attempt = 0) => {
-  const { error } = await sudoSupabase.from(table).upsert(rows, { onConflict: '_key' })
-  if (!error) return
-  if (error.code === SCHEMA_CACHE_MISS && attempt < RELOAD_BACKOFF_MS.length) {
-    const wait = RELOAD_BACKOFF_MS[attempt]
-    console.log(`[sde-mirror] ${table} not in PostgREST's schema cache yet, retrying in ${wait}ms`)
-    await sleep(wait)
-    return upsertChunk(table, rows, attempt + 1)
-  }
-  throw new Error(`sde-mirror: upsert into ${table} failed: ${error.message}`)
+// ensure_sde_mirror_table() mints a table over SQL and the very next act is to
+// write its first rows over PostgREST, which can't see it until its schema
+// cache reloads — writeWithSchemaRetry waits that window out. A new table's
+// first chunk is always at the start of its step, so its ~15s ceiling fits the
+// slice budget.
+const upsertChunk = async (table, rows) => {
+  const { error } = await writeWithSchemaRetry(table, () =>
+    sudoSupabase.from(table).upsert(rows, { onConflict: '_key' })
+  )
+  if (error) throw new Error(`sde-mirror: upsert into ${table} failed: ${error.message}`)
 }
 
 // Rows that vanished from the current dump kept their old sde_build stamp;
@@ -454,7 +437,9 @@ export const resolveStationNames = async () => {
   const now = new Date().toISOString()
   const rows = map(({ id, name }) => ({ station_id: id, name, updated_at: now }), resolved)
   await forEachSequential(splitEvery(PAGE, rows), async (batch) => {
-    const { error } = await sudoSupabase.from('sde_npc_station_name').upsert(batch, { onConflict: 'station_id' })
+    const { error } = await writeWithSchemaRetry('sde_npc_station_name', () =>
+      sudoSupabase.from('sde_npc_station_name').upsert(batch, { onConflict: 'station_id' })
+    )
     if (error) throw new Error(`sde-mirror: station name upsert failed: ${error.message}`)
   })
   console.log(`[sde-mirror] station names: ${rows.length} resolved`)
@@ -469,10 +454,14 @@ export const resolveStationNames = async () => {
 export const finalizeBuild = async (build, commit = currentCommitSha()) => {
   const { error: refreshError } = await sudoSupabase.rpc('sde_refresh_views')
   if (refreshError) throw new Error(`sde-mirror: sde_refresh_views failed: ${refreshError.message}`)
-  const { error } = await sudoSupabase
-    .from('sde_mirror_state')
-    .update({ completed_at: new Date().toISOString(), commit_sha: commit })
-    .eq('build_number', build)
+  // Retried too: this is the write that decides whether the whole run counts as
+  // complete, and it lands after a run that may have minted several tables.
+  const { error } = await writeWithSchemaRetry('sde_mirror_state', () =>
+    sudoSupabase
+      .from('sde_mirror_state')
+      .update({ completed_at: new Date().toISOString(), commit_sha: commit })
+      .eq('build_number', build)
+  )
   if (error) throw new Error(`sde-mirror: mirror_state completion failed: ${error.message}`)
   console.log(`[sde-mirror] build ${build} complete (commit ${commit})`)
 }

--- a/src/jobs/sheetCsv.js
+++ b/src/jobs/sheetCsv.js
@@ -15,7 +15,7 @@
 // and stamps the rows with the latest completed sde_build.
 import { encodeSheetCsv, SHEET_FILE_NAMES } from '../buildSheetCsv.js'
 import { sudoSupabase } from '../supabase.js'
-import { cli } from './lib.js'
+import { cli, writeWithSchemaRetry } from './lib.js'
 
 // The build the encoded data corresponds to. The workflow passes the build it
 // just ingested; the CLI falls back to the latest fully-mirrored build.
@@ -57,7 +57,14 @@ export const runSheetCsv = async ({ build, force = false } = {}) => {
     sde_build: sdeBuild,
     updated_at: updatedAt,
   }))
-  const { error } = await sudoSupabase.from('sheet_csv').upsert(rows, { onConflict: 'name' })
+  // Retried on a schema-cache miss like every other PostgREST write here: this
+  // step runs as the tail of an sde-mirror run that may have just minted new
+  // sde_* tables, and a reload triggered by one of those is enough to make even
+  // this long-standing table momentarily invisible (it failed exactly that way
+  // on 2026-08-13, one step from finalize).
+  const { error } = await writeWithSchemaRetry('sheet_csv', () =>
+    sudoSupabase.from('sheet_csv').upsert(rows, { onConflict: 'name' })
+  )
   if (error) throw new Error(`sheet-csv: upsert failed: ${error.message}`)
   console.log(`sheet-csv: upserted ${rows.length} files at sde_build ${sdeBuild}`)
   return { files: rows.length, build: sdeBuild }

--- a/src/jobs/sheetCsv.js
+++ b/src/jobs/sheetCsv.js
@@ -58,10 +58,13 @@ export const runSheetCsv = async ({ build, force = false } = {}) => {
     updated_at: updatedAt,
   }))
   // Retried on a schema-cache miss like every other PostgREST write here: this
-  // step runs as the tail of an sde-mirror run that may have just minted new
-  // sde_* tables, and a reload triggered by one of those is enough to make even
-  // this long-standing table momentarily invisible (it failed exactly that way
-  // on 2026-08-13, one step from finalize).
+  // step is the tail of an sde-mirror run that may have just minted new sde_*
+  // tables, so it can be writing while PostgREST reloads.
+  //
+  // Note this is NOT what broke the 2026-08-13 run. That PGRST205 on sheet_csv
+  // was a missing table, not a stale cache — its migration was recorded as
+  // applied but never ran (20260814000000_repair_sheet_csv.sql). The retry
+  // cannot fix an absent table; it just delays the same failure by ~15s.
   const { error } = await writeWithSchemaRetry('sheet_csv', () =>
     sudoSupabase.from('sheet_csv').upsert(rows, { onConflict: 'name' })
   )

--- a/supabase/migrations/20260814000000_repair_sheet_csv.sql
+++ b/supabase/migrations/20260814000000_repair_sheet_csv.sql
@@ -1,0 +1,51 @@
+-- Create sheet_csv, which 20260723020000_add_sheet_csv.sql was supposed to
+-- create and never did in production.
+--
+-- It was lost to the timestamp collision described in
+-- 20260727000000_migration_history_composite_key.sql: two migrations were minted
+-- in the same second — 20260723020000_add_sheet_csv and
+-- 20260723020000_character_skill — and schema_migrations' primary key was
+-- `(version)` alone, so only one of the pair could ever be recorded. Production
+-- was then repaired by hand to unblock the queue behind it. The repair left the
+-- history consistent (version 20260723020000 present, key widened to
+-- (version, name)) but the add_sheet_csv DDL had never run, and no future
+-- `supabase db push` would ever run it again — the history says it is applied.
+--
+-- Nothing noticed for three weeks because both readers fail quietly:
+-- /sheets/[file] answered 500 to Google Sheets' IMPORTDATA fetcher, which
+-- nobody sees, and the sde-mirror workflow only reaches its encodeSheets step
+-- after a full ingest — which was itself failing earlier, on the schema-cache
+-- bug fixed in #878. The first run that got far enough surfaced it as
+--
+--   sheet-csv: upsert failed:
+--   Could not find the table 'public.sheet_csv' in the schema cache
+--
+-- which reads exactly like the transient PostgREST reload race that #878 dealt
+-- with, and is nothing of the sort: the table simply is not there.
+--
+-- Idempotent throughout, because environments disagree about whether this ever
+-- ran — a database built from schema.sql has the table, production does not.
+-- The shape is copied verbatim from the original migration.
+create table if not exists public.sheet_csv (
+  name text primary key,
+  data text not null,
+  sde_build bigint not null,
+  updated_at timestamptz not null default now()
+);
+
+alter table public.sheet_csv enable row level security;
+
+drop policy if exists "Everyone reads sheet csv" on public.sheet_csv;
+create policy "Everyone reads sheet csv"
+  on public.sheet_csv
+  for select
+  to anon, authenticated
+  using (true);
+
+grant select on public.sheet_csv to anon, authenticated;
+grant all    on public.sheet_csv to service_role;
+
+-- The table is minted here rather than by ensure_sde_mirror_table(), so nothing
+-- has told PostgREST to reload — and the sde-mirror run that writes it may come
+-- long before any other DDL does. Ask directly.
+notify pgrst, 'reload schema';


### PR DESCRIPTION
Follow-up to #878. **The headline finding changed after the first draft of this PR** — the second commit corrects it.

## `sheet_csv` does not exist in production

Not "wasn't in the cache" — does not exist. Live, right now:

```
$ curl -s https://edencom.link/sheets/invention.csv
sheet-csv: Could not find the table 'public.sheet_csv' in the schema cache   (HTTP 500)
```

`20260723020000_add_sheet_csv.sql` was lost to the timestamp collision documented in `20260727000000_migration_history_composite_key.sql`. It shares a second with `20260723020000_character_skill.sql`, `schema_migrations` was keyed on `(version)` alone, and production was repaired by hand to unblock the queue stuck behind the pair. The repair left the history consistent — version `20260723020000` recorded, key widened to `(version, name)` — and the `add_sheet_csv` DDL never ran. Because the history says it is applied, no future `supabase db push` will ever run it.

It went unnoticed for three weeks because both readers fail where nobody looks: `/sheets/[file]` 500s at Google Sheets' `IMPORTDATA` fetcher, and the mirror only reaches `encodeSheets` after a full ingest — which was itself failing earlier on the bug #878 fixed. The first run to get that far reported `PGRST205`, which reads exactly like the transient reload race and is nothing of the sort.

`20260814000000_repair_sheet_csv.sql` creates it, idempotently (a database built from `schema.sql` already has the table; production doesn't) with a `notify pgrst`.

**I checked whether anything else was lost the same way.** The other half of this collision (`character_skill`) uses `create table if not exists` and its table is in use. The second colliding pair, `20260725000000` `blueprint_search` / `mercenary_den_alliance_sharing`, is intact — probed against production, `blueprint_search` returns real aggregates (10914 blueprints) and the den-sharing functions resolve rather than erroring. `sheet_csv` is the only casualty.

## The schema-cache retry (first commit)

Still worth having, on its own merits rather than as the `sheet_csv` fix. The 2026-08-13 run showed the real race: `sde_metenox_moon_drill`, `sde_corporation_role_groups` and `sde_industry_target_filters` were each minted and each hit `PGRST205`, recovering on the 500ms/1000ms retries **in the same run** — where before #878 each would have cost a night.

The retry moves to `src/jobs/lib.js` as `writeWithSchemaRetry(label, write)` and now covers every PostgREST write in the mirror's blast radius: ingest chunks, the station-name upsert, `sheet_csv`, `esf_data`, and the `sde_mirror_state` completion stamp. It takes a thunk (each attempt needs a fresh request) and returns the result unchanged so callers keep their own error messages. Only `PGRST205` retries.

The comments claiming this fixed `sheet_csv` are corrected in the second commit — a retry cannot conjure a missing table, it only delays the same failure by ~15s. Worth knowing when reading logs: `PGRST205` has two causes, one transient and one permanent.

## Worth a follow-up, not in this PR

Nothing detects a migration that is recorded but unapplied. The ordering guard in `.github/scripts/check-migrations.mjs` is static, and drift detection needs a real database to compare against. Happy to write one if you want it.

## Testing

- `pnpm run lint`, `pnpm test` (276 pass), `pnpm run build`.
- Retry helper exercised directly: recovers after two misses in ~1.5s, gives up after the ladder returning the error, passes a non-cache error (`57014`) straight back without retrying.
- Entry-stream check from #878 re-run against a local zip server with and without `Range`: byte-identical on both paths.
- The migration is not covered by CI — `test:branch` builds a fresh branch database, where the table already exists via `schema.sql`, so it exercises the `if not exists` path and not the production repair.