### PR TITLE
Give the branch's SMTP admin address a valid, undeliverable value

### DIFF
--- a/test/branchEmail.test.ts
+++ b/test/branchEmail.test.ts
@@ -22,8 +22,20 @@ test('the branch config skips signup confirmation mail', () => {
 test('the branch config clears every inherited SMTP credential', () => {
   // Empty strings, not nulls: the Management API reads null as "unchanged",
   // which would leave production's sender in place on the branch.
-  const smtp = ['smtp_host', 'smtp_port', 'smtp_user', 'smtp_pass', 'smtp_admin_email', 'smtp_sender_name'] as const
+  const smtp = ['smtp_host', 'smtp_port', 'smtp_user', 'smtp_pass', 'smtp_sender_name'] as const
   smtp.forEach((field) => assert.equal(EMAIL_DISABLED_CONFIG[field], '', `${field} must be cleared, not left null`))
+})
+
+test('the admin address is valid but undeliverable', () => {
+  // smtp_admin_email is the one field the Management API validates as an email
+  // address, so clearing it the way the others are cleared 400s the entire
+  // PATCH and leaves mail ON. It has to be a well-formed address, and the only
+  // safe well-formed address is one that can never reach a real inbox: .test is
+  // reserved by RFC 2606. Anything routable here — @edencom.link above all —
+  // puts a real domain back in the loop, which is the bug this file exists for.
+  const admin = EMAIL_DISABLED_CONFIG.smtp_admin_email
+  assert.notEqual(admin, '', 'an empty admin address is rejected by the Management API')
+  assert.match(admin, /^[^@\s]+@[^@\s]+\.test$/, 'the admin address must be well-formed and in the reserved .test TLD')
 })
 
 test('a silenced branch passes the check', () => {

--- a/test/lib/supabaseBranch.ts
+++ b/test/lib/supabaseBranch.ts
@@ -138,7 +138,17 @@ export const EMAIL_DISABLED_CONFIG = {
   smtp_port: '',
   smtp_user: '',
   smtp_pass: '',
-  smtp_admin_email: '',
+  // …except this one, which the API validates as an email address and rejects
+  // empty, failing the whole PATCH:
+  //
+  //   PATCH /v1/projects/<ref>/config/auth failed: 400
+  //   {"message":"smtp_admin_email: Invalid email address"}
+  //
+  // and a rejected PATCH means no locks applied at all. So hand it something
+  // syntactically valid and permanently undeliverable instead: .test is
+  // reserved by RFC 2606 and resolves nowhere. Harmless either way — with
+  // smtp_host cleared there is no server left for a sender to send through.
+  smtp_admin_email: 'noreply@edencom.test',
   smtp_sender_name: '',
 } as const
 


### PR DESCRIPTION
Unblocks the `branch` check, which has failed on every migration-touching PR since the email lock landed — including #885, which had to be merged past it.

## The failure

`disableBranchEmail` clears all six inherited SMTP fields with empty strings, but the Management API validates one of them as an email address:

```
PATCH /v1/projects/<ref>/config/auth failed: 400
{"message":"smtp_admin_email: Invalid email address"}
    at disableBranchEmail (test/lib/supabaseBranch.ts:169:3)
    at async createTestBranch (test/lib/supabaseBranch.ts:335:5)
```

A rejected PATCH applies nothing, so `createTestBranch` threw before any test ran and all three subtests were cancelled.

The severity is worth stating plainly: the visible symptom is a red check, but the dangerous version of this bug is a PATCH that gets *partially* accepted — the helper's whole reason for existing is that mail must be off before a branch is touched, and an all-or-nothing rejection of the payload is the failure mode where mail stays on.

## The fix

`smtp_admin_email` gets a well-formed address that can never reach an inbox: `noreply@edencom.test`. `.test` is reserved by RFC 2606 and resolves nowhere. With `smtp_host` cleared there is no server for a sender to send through, so the value is inert regardless — it just has to parse.

The other five fields keep their empty strings, and the `mailIsDisabled` predicate is unchanged (it gates on `mailer_autoconfirm` and `smtp_host`).

## The pin moves with it

`test/branchEmail.test.ts` asserted all six fields were `''`. It now checks the five clearable ones, plus a separate assertion that the admin address is well-formed **and** inside `.test` — deliberately stricter than "non-empty", so a future edit can't quietly point it at a routable domain. Pointing it at `@edencom.link` would pass a non-empty check and reintroduce exactly the bounce problem this file was written to stop.

## Testing

- `pnpm test` — 292 pass, including the reworked pins.
- `pnpm run lint` clean.
- The real proof is this PR's own `branch` check: it touches `test/lib/` and `test/branchEmail.test.ts`, both in the job's path filter, so `test:branch` runs against a live ephemeral branch. Green here means the PATCH is accepted and mail is verifiably off.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lxb1QfWbjdDKonAdtkaQbV)_