### PR TITLE
feat(graphql): add a restock root field for supply-buffer lenses

### DIFF
--- a/docs/sharing-layer/04-graphql-shared.md
+++ b/docs/sharing-layer/04-graphql-shared.md
@@ -46,6 +46,24 @@ requires a session; use a Lens"), and phase 7's Lens is the designed answer
 for external tools consuming shared data (the creator's context does the
 authorizing instead).
 
+## Later addition: `restock`
+
+`restock` (see `08-restock-lens.md`) is the schema's first **aggregate** root
+field — it sums asset stacks per item type against per-type targets, rather
+than returning rows one-to-one. Three things about it are worth knowing here,
+because they're where it departs from every other field:
+
+- **`RestockLine` carries no owner block.** A summed line may span two of your
+  characters and a corp hangar, so there is no single owner to name; the
+  `owner:` filter is how you ask per owner instead. It's therefore absent from
+  `ROW_TYPES` in `test/graphqlSchema.test.ts`.
+- **Targets come from the caller, not the schema.** They ride in a lens's
+  frozen `variables`, which is what makes a restock lens a shareable shopping
+  list: viewers can't supply variables, so the buffer levels stay the
+  creator's.
+- **It's token-mode safe**, and deliberately takes no `includeShared` — shared
+  rows would double-count into someone else's total.
+
 ## Deliverables
 
 - `schema.graphql.ts` + `resolvers.ts` changes; `test/graphqlSchema.test.ts`

--- a/docs/sharing-layer/08-restock-lens.md
+++ b/docs/sharing-layer/08-restock-lens.md
@@ -1,5 +1,15 @@
 # Restock lens: `restock` GraphQL root field
 
+**Status: ✅ done** — `restock` ships in `schema.graphql.ts`/`resolvers.ts`
+over the pure seam `restock.ts`, with `test/graphqlRestock.test.ts` and the
+`test/graphqlSchema.test.ts` drift guard covering it.
+
+One amendment to the design below: the line carries **both** computed columns,
+not just `toBuy`. `delta` is signed (`onHand - target`, negative when short) so
+overstock reads as readily as shortfall; `toBuy` is the clamped shopping
+number. They only disagree above target, which is exactly where a lens author
+wants the choice.
+
 ## Context
 
 Goal: a **shareable lens** that tells its audience "here's what I want to buy" — for each item
@@ -28,8 +38,8 @@ Decisions:
   for: empty targets, non-positive/non-integer quantity, unmatched name, ambiguous name (list
   candidates), duplicate resolved typeId across targets.
 - `restockLines(targets, stacks, onlyBelowTarget)` — ramda fold summing `quantity ?? 1` per
-  `type_id`, producing `{typeId, target, onHand, toBuy: max(0, target - onHand)}` in target
-  input order; `onlyBelowTarget` drops covered lines (default true).
+  `type_id`, producing `{typeId, target, onHand, delta: onHand - target, toBuy: max(0, target -
+  onHand)}` in target input order; `onlyBelowTarget` drops covered lines (default true).
 
 ### 2. SDL — `src/app/api/graphql/schema.graphql.ts`
 
@@ -55,6 +65,9 @@ type RestockLine {
   groupName: String
   target: String!
   onHand: String!
+  "onHand - target; negative when short."
+  delta: String!
+  "max(0, target - onHand) — what to buy."
   toBuy: String!
   type: ItemType!
 }
@@ -122,6 +135,7 @@ New `Query.restock`, reusing existing helpers (`ownerScopesFor`, `locationIdsFor
        groupName
        target
        onHand
+       delta
        toBuy
      }
    }

--- a/src/app/api/graphql/resolvers.ts
+++ b/src/app/api/graphql/resolvers.ts
@@ -31,6 +31,7 @@ import {
   splitRefEntries,
 } from './filters'
 import { searchLocationCandidates } from './locationSearch'
+import { resolveTargets, restockLines, type Stack } from './restock'
 import type { OwnerScopes } from './filters'
 import type { GraphqlContext } from './context'
 
@@ -503,6 +504,92 @@ export const resolvers = {
           }
         }),
       }
+    },
+
+    restock: async (
+      _parent: unknown,
+      args: {
+        targets: ReadonlyArray<{ type: string; quantity: number }>
+        location?: string | null
+        locations?: readonly string[] | null
+        owner?: string | null
+        owners?: readonly string[] | null
+        onlyBelowTarget?: boolean | null
+      },
+      ctx: GraphqlContext
+    ) => {
+      // Target names resolve the way an exact `types:` list does — through the
+      // ranked SDE search, counting only whole-name hits (see typeIdsFor).
+      const names = uniq(args.targets.map((t) => (t.type ?? '').trim()).filter((t) => t !== '' && !/^\d+$/.test(t)))
+      const found = await Promise.all(names.map(async (name) => [name, await searchSdeTypesAll(name)] as const))
+      const byName = new Map(
+        found.map(([name, matches]) => [name, matches.map((m) => ({ id: String(m.typeID), name: m.name }))])
+      )
+      const resolved = resolveTargets(args.targets, (name) => byName.get(name) ?? [])
+      if (!resolved.ok) return badRequest(resolved.message)
+      const targetTypeIds = resolved.targets.map((t) => t.typeId)
+
+      // One SDE batch covers three needs: the line names, the ItemType edge,
+      // and existence-checking the targets given as bare ids — an id the SDE
+      // doesn't know is an error, not a phantom line reading zero on hand.
+      const types = await typesFor(targetTypeIds)
+      const unknown = targetTypeIds.filter((id) => types[id] === undefined)
+      if (unknown.length > 0) {
+        return badRequest(`No item type matched ${unknown.map((id) => `"${id}"`).join(', ')}.`)
+      }
+
+      const scopes = await ownerScopesFor(ctx, args)
+      const locationIds = await locationIdsFor(ctx, args)
+
+      // A TARGETED read: only the target types, only the two columns the sum
+      // needs. Filtering by type keeps this far below the cap that paging the
+      // whole hangar would hit — and a truncated read here wouldn't look
+      // truncated, it would look like a smaller stockpile.
+      const filtered = (query: any, ownerColumn: string, ownerIds: string[]): any => {
+        let q = query.in(ownerColumn, ownerIds).in('type_id', targetTypeIds)
+        if (locationIds !== null) q = q.in('location_id', locationIds)
+        return q
+      }
+
+      const read = async (table: string, ownerColumn: string, ownerIds: string[]): Promise<Stack[]> => {
+        if (ownerIds.length === 0) return []
+        const { count, error } = await filtered(
+          ctx.supabase.from(table).select('item_id', { count: 'exact', head: true }),
+          ownerColumn,
+          ownerIds
+        )
+        if (error) return queryFailed()
+        // Refuse rather than sum a truncated read: a wrong total here is a
+        // wrong number to buy, and nothing downstream could tell.
+        if ((count ?? 0) > ASSET_CAP) {
+          return badRequest(
+            `Too many stacks to sum reliably (${count} in ${table}) — narrow the owner or location filter.`
+          )
+        }
+        return fetchCapped<Stack>(
+          (from, to) =>
+            filtered(ctx.supabase.from(table).select('type_id, quantity'), ownerColumn, ownerIds)
+              .order('item_id')
+              .range(from, to),
+          ASSET_CAP
+        )
+      }
+
+      const [own, corp] = await Promise.all([
+        read('character_asset', 'registration_id', scopes.registrationIds),
+        read('corp_asset', 'corporation_id', scopes.corporationIds),
+      ])
+
+      return restockLines(resolved.targets, [...own, ...corp], args.onlyBelowTarget !== false).map((line) => ({
+        typeId: String(line.typeId),
+        typeName: typeNameOf(types, line.typeId),
+        groupName: types[line.typeId]?.groupName ?? null,
+        target: String(line.target),
+        onHand: String(line.onHand),
+        delta: String(line.delta),
+        toBuy: String(line.toBuy),
+        type: itemTypeOf(types, line.typeId),
+      }))
     },
 
     sharedWithMe: async (_parent: unknown, _args: unknown, ctx: GraphqlContext) => {

--- a/src/app/api/graphql/restock.ts
+++ b/src/app/api/graphql/restock.ts
@@ -1,0 +1,136 @@
+// Pure target resolution and shortfall arithmetic for the `restock` root field
+// (docs/sharing-layer/08-restock-lens.md). No I/O imports, so
+// test/graphqlRestock.test.ts can exercise it under the node test runner — the
+// same split filters.ts makes for the argument shaping.
+//
+// A restock line answers "how much should I buy": you name item types and the
+// quantity you want ON HAND, and each line reports what you actually hold plus
+// two computed columns. Both are there deliberately — `delta` is signed, so it
+// shows overstock as readily as shortfall, while `toBuy` is the shopping
+// number and never goes negative.
+//
+// REFUSALS BEAT SILENTLY WRONG SUMS, the same stance filters.ts takes on an
+// unmatched filter entry. A target naming nothing, or naming two types at
+// once, is an error rather than a line summed over the wrong denominator; so
+// is naming one type twice, since the two targets would disagree about a
+// single sum.
+import { countBy, reduce, uniq } from 'ramda'
+
+import type { NamedRef } from './filters.ts'
+
+// Re-exported because it IS this module's input contract: the candidate shape
+// the resolver hands `resolveTargets` after the ranked SDE search.
+export type { NamedRef }
+
+// What a caller asks for: an item type (id or whole name) and the quantity
+// they want on hand. Quantity is a GraphQL Int, hence a 32-bit ceiling — the
+// SUMS can exceed that, which is why the output columns are strings.
+export type RawTarget = { type: string; quantity: number }
+
+// The same, once the name has become an SDE type id.
+export type ResolvedTarget = { typeId: number; quantity: number }
+
+export type TargetResolution = { ok: true; targets: ResolvedTarget[] } | { ok: false; message: string }
+
+const refuse = (message: string): TargetResolution => ({ ok: false, message })
+
+type TargetOutcome = { ok: true; target: ResolvedTarget } | { ok: false; message: string }
+
+// A bare positive integer is a type id, anything else a name — the same split
+// the exact-list filters make (filters.ts splitRefEntries).
+const isId = (entry: string): boolean => /^\d+$/.test(entry)
+
+const resolveOne = (raw: RawTarget, candidatesFor: (name: string) => readonly NamedRef[]): TargetOutcome => {
+  const entry = (raw.type ?? '').trim()
+  if (entry === '') return { ok: false, message: 'A target needs an item type.' }
+  if (!Number.isInteger(raw.quantity) || raw.quantity <= 0) {
+    return {
+      ok: false,
+      message: `The target for "${entry}" must be a whole number above zero, not ${raw.quantity}.`,
+    }
+  }
+  if (isId(entry)) return { ok: true, target: { typeId: Number(entry), quantity: raw.quantity } }
+
+  const wanted = entry.toLowerCase()
+  const ids = uniq(
+    candidatesFor(entry)
+      .filter((c) => c.name.toLowerCase() === wanted)
+      .map((c) => c.id)
+  )
+  if (ids.length === 0) return { ok: false, message: `No item type matched "${entry}".` }
+  // Where the `types:` filter happily keeps every match, a target needs ONE
+  // denominator: two types sharing a name can't share a buffer level.
+  if (ids.length > 1) {
+    return {
+      ok: false,
+      message: `"${entry}" matched ${ids.length} item types (${ids.join(', ')}) — name the one you mean by id.`,
+    }
+  }
+  return { ok: true, target: { typeId: Number(ids[0]), quantity: raw.quantity } }
+}
+
+export const resolveTargets = (
+  raw: readonly RawTarget[],
+  candidatesFor: (name: string) => readonly NamedRef[]
+): TargetResolution => {
+  if (raw.length === 0) return refuse('A restock list needs at least one target.')
+
+  const outcomes = raw.map((target) => resolveOne(target, candidatesFor))
+  const failed = outcomes.find((o): o is Extract<TargetOutcome, { ok: false }> => !o.ok)
+  if (failed !== undefined) return refuse(failed.message)
+
+  const targets = outcomes.flatMap((o) => (o.ok ? [o.target] : []))
+  const counts = countBy((t: ResolvedTarget) => String(t.typeId), targets)
+  const duplicated = Object.keys(counts).filter((typeId) => counts[typeId] > 1)
+  if (duplicated.length > 0) {
+    return refuse(
+      `Each item type takes one target, but ${duplicated.map((id) => `type ${id}`).join(', ')} appears more than once.`
+    )
+  }
+  return { ok: true, targets }
+}
+
+// An asset stack, narrowed to the two columns the sum needs.
+export type Stack = { type_id: number | string; quantity: number | null }
+
+export type RestockLine = {
+  typeId: number
+  target: number
+  onHand: number
+  // onHand - target: negative when short, positive when overstocked.
+  delta: number
+  // max(0, target - onHand) — the shopping number.
+  toBuy: number
+}
+
+export const restockLines = (
+  targets: readonly ResolvedTarget[],
+  stacks: readonly Stack[],
+  onlyBelowTarget: boolean
+): RestockLine[] => {
+  // A stack with no quantity counts as one unit — the same `quantity ?? 1` the
+  // asset resolver applies, since ESI omits it for singletons (a ship, a
+  // fitted module). The Map accumulator is mutated rather than re-spread per
+  // stack: the accepted exception, since spreading would make this O(n²).
+  const onHandByType = reduce(
+    (acc: Map<number, number>, stack: Stack) => {
+      const typeId = Number(stack.type_id)
+      return acc.set(typeId, (acc.get(typeId) ?? 0) + (stack.quantity ?? 1))
+    },
+    new Map<number, number>(),
+    stacks
+  )
+
+  // Target order is the caller's order — a shopping list is authored in one.
+  const lines = targets.map((t): RestockLine => {
+    const onHand = onHandByType.get(t.typeId) ?? 0
+    return {
+      typeId: t.typeId,
+      target: t.quantity,
+      onHand,
+      delta: onHand - t.quantity,
+      toBuy: Math.max(0, t.quantity - onHand),
+    }
+  })
+  return onlyBelowTarget ? lines.filter((l) => l.toBuy > 0) : lines
+}

--- a/src/app/api/graphql/schema.graphql.ts
+++ b/src/app/api/graphql/schema.graphql.ts
@@ -71,6 +71,26 @@ export const typeDefs = /* GraphQL */ `
       includeShared: Boolean = false
     ): AssetPage!
 
+    """
+    A restock (shopping) list. You give TARGETS — an item type and the quantity
+    you want on hand — and each line sums your current stacks of that type
+    (across your characters AND their corporations, like assets) and reports
+    what you're missing. location/locations and owner/owners narrow which
+    hangars count as "on hand", exactly as they do on assets; the types come
+    from the targets, so there is no type filter here.
+
+    By default only lines below target come back; onlyBelowTarget: false keeps
+    every target, including the covered ones.
+    """
+    restock(
+      targets: [RestockTarget!]!
+      location: String
+      locations: [String!]
+      owner: String
+      owners: [String!]
+      onlyBelowTarget: Boolean = true
+    ): [RestockLine!]!
+
     "Asset shares other users have aimed at you (corporation/alliance/public). Session auth only."
     sharedWithMe: [ShareGrant!]!
 
@@ -268,6 +288,44 @@ export const typeDefs = /* GraphQL */ `
     "Rows matching the filters, before the limit."
     totalCount: Int!
     truncated: Boolean!
+  }
+
+  """
+  One entry of a restock list: an item type and how many of it you want on
+  hand. Like an entry of a \`types:\` list, \`type\` is an SDE typeId or a WHOLE
+  item name (case-insensitive) — a name matching nothing, or matching two
+  types at once, is an error rather than a line summed over the wrong
+  denominator. Naming the same type twice is an error for the same reason.
+  """
+  input RestockTarget {
+    type: String!
+    "How many you want on hand. A whole number above zero, up to 2147483647 — GraphQL Int is 32-bit."
+    quantity: Int!
+  }
+
+  """
+  One line of a restock list. This is the schema's one AGGREGATE row — it sums
+  stacks — so unlike every other row type it carries no owner block: "on hand"
+  may span two of your characters and a corp hangar at once, and there'd be no
+  single owner to name. Narrow with \`owner:\` to ask per owner instead.
+
+  Leaf-only apart from the \`type\` edge, so a line still flattens to one CSV
+  line like every other row.
+  """
+  type RestockLine {
+    typeId: String!
+    typeName: String
+    "e.g. \\"Mineral\\", \\"Fuel Block\\" — handy for grouping a shopping list."
+    groupName: String
+    "The quantity you asked for, as given in targets."
+    target: String!
+    "Sum of your matching stacks of this type, under the filters given."
+    onHand: String!
+    "onHand - target: NEGATIVE when you're short, positive when overstocked."
+    delta: String!
+    "max(0, target - onHand) — the number to buy, never negative."
+    toBuy: String!
+    type: ItemType!
   }
 
   type Blueprint {

--- a/src/app/api/mcp/lensTools.ts
+++ b/src/app/api/mcp/lensTools.ts
@@ -67,26 +67,43 @@ const FLAG_REFUSAL =
 // result into a data dump — the lens's own page and CSV are where the rows live.
 const PREVIEW_ROWS = 5
 
-// Worked examples beat prose for query shape, and these two cover the joints a
-// model actually gets wrong: filtering to a container (locationId is the item
-// id of the container, which search_assets / browse_assets resolve) and
-// filtering to a set of types (typeIds are SDE type ids, as strings).
+// Worked examples beat prose for query shape, and these cover the joints a
+// model actually gets wrong: filtering to a container (the plural `locations:`
+// takes the item id of the container, which search_assets / browse_assets
+// resolve), filtering to a set of types (`types:` takes SDE type ids or whole
+// names), and the restock list, whose targets live in the variables.
+//
+// Every filter is a SINGULAR/PLURAL pair — `location:` searches names,
+// `locations:` is an exact list — so an example using one of the pre-pairing
+// spellings (locationId:, typeIds:) no longer validates against the schema.
 const EXAMPLES = [
   {
     intent: 'Everything sitting in one container or ship, by its item id.',
     query:
-      'query { assets(locationId: "1046809423988", limit: 500) { totalCount truncated rows { itemId typeId typeName quantity locationFlag ownerName } } }',
+      'query { assets(locations: ["1046809423988"], limit: 500) { totalCount truncated rows { itemId typeId typeName quantity locationFlag ownerName } } }',
   },
   {
     intent: 'Only certain item types, wherever they are — e.g. the inputs to a fuel block.',
     query:
-      'query { assets(typeIds: ["16273", "17887", "16275", "9832", "44"], limit: 500) { totalCount rows { typeId typeName quantity locationName ownerName } } }',
+      'query { assets(types: ["16273", "17887", "16275", "9832", "44"], limit: 500) { totalCount rows { typeId typeName quantity locationName ownerName } } }',
   },
   {
     intent: 'Both at once: those types, but only inside that container. Variables keep the ids out of the query text.',
     query:
-      'query Stock($container: String!, $types: [String!]) { assets(locationId: $container, typeIds: $types, limit: 500) { totalCount rows { typeId typeName quantity } } }',
-    variables: { container: '1046809423988', types: ['16273', '17887'] },
+      'query Stock($container: [String!], $types: [String!]) { assets(locations: $container, types: $types, limit: 500) { totalCount rows { typeId typeName quantity } } }',
+    variables: { container: ['1046809423988'], types: ['16273', '17887'] },
+  },
+  {
+    intent:
+      "A restock list: how much to buy of each item to get back up to a supply buffer. The targets ARE the lens — a viewer cannot change them, so the buffer levels stay the creator's.",
+    query:
+      'query Restock($targets: [RestockTarget!]!) { restock(targets: $targets, location: "1DQ1-A") { typeName groupName target onHand delta toBuy } }',
+    variables: {
+      targets: [
+        { type: 'Nitrogen Fuel Block', quantity: 10000 },
+        { type: 'Tritanium', quantity: 1000000 },
+      ],
+    },
   },
 ]
 

--- a/test/graphqlRestock.test.ts
+++ b/test/graphqlRestock.test.ts
@@ -1,0 +1,183 @@
+// Unit coverage for the restock field's pure seam
+// (src/app/api/graphql/restock.ts). Two things matter here and neither is
+// visible from the resolver: the ARITHMETIC (a sum spread over several stacks
+// and both owner sides, and the two computed columns disagreeing in sign by
+// design), and the REFUSALS — a target that resolved to the wrong denominator
+// would produce a confidently wrong shopping number, so every ambiguous
+// spelling has to fail loudly instead.
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { resolveTargets, restockLines, type NamedRef } from '../src/app/api/graphql/restock.ts'
+
+// Stand-in for the ranked SDE search the resolver feeds in.
+const CANDIDATES: Record<string, NamedRef[]> = {
+  Tritanium: [{ id: '34', name: 'Tritanium' }],
+  'Nitrogen Fuel Block': [{ id: '4051', name: 'Nitrogen Fuel Block' }],
+  // A partial-match neighbour: the ranked search returns it, whole-name
+  // matching must drop it.
+  Nitrogen: [
+    { id: '4051', name: 'Nitrogen Fuel Block' },
+    { id: '17887', name: 'Oxygen Isotopes' },
+  ],
+  // Two DIFFERENT types genuinely sharing a name.
+  Twins: [
+    { id: '100', name: 'Twins' },
+    { id: '200', name: 'Twins' },
+  ],
+  // The same type arriving twice from the search — one denominator, so fine.
+  Echo: [
+    { id: '300', name: 'Echo' },
+    { id: '300', name: 'Echo' },
+  ],
+}
+
+// The real search is case-insensitive, so the stub's own lookup has to be —
+// otherwise it would fail a case the resolver handles.
+const candidatesFor = (name: string): readonly NamedRef[] =>
+  Object.entries(CANDIDATES).find(([term]) => term.toLowerCase() === name.toLowerCase())?.[1] ?? []
+
+const resolved = (raw: Parameters<typeof resolveTargets>[0]) => {
+  const result = resolveTargets(raw, candidatesFor)
+  assert.ok(result.ok, `expected targets to resolve: ${result.ok ? '' : result.message}`)
+  return result.targets
+}
+
+test('a whole name resolves to its type id, and a bare integer is already one', () => {
+  assert.deepEqual(
+    resolved([
+      { type: 'Tritanium', quantity: 1000 },
+      { type: '4051', quantity: 50 },
+    ]),
+    [
+      { typeId: 34, quantity: 1000 },
+      { typeId: 4051, quantity: 50 },
+    ]
+  )
+})
+
+test('name matching is case-insensitive but WHOLE — a partial hit is not a target', () => {
+  assert.deepEqual(resolved([{ type: 'tritanium', quantity: 5 }]), [{ typeId: 34, quantity: 5 }])
+  // "Nitrogen" ranks Nitrogen Fuel Block first, but names neither type whole.
+  const partial = resolveTargets([{ type: 'Nitrogen', quantity: 5 }], candidatesFor)
+  assert.equal(partial.ok, false)
+  assert.match(partial.ok ? '' : partial.message, /No item type matched "Nitrogen"/)
+})
+
+test('the same type arriving twice from the search is one denominator, not an ambiguity', () => {
+  assert.deepEqual(resolved([{ type: 'Echo', quantity: 7 }]), [{ typeId: 300, quantity: 7 }])
+})
+
+test('a name matching two different types is refused rather than summed over either', () => {
+  const result = resolveTargets([{ type: 'Twins', quantity: 7 }], candidatesFor)
+  assert.equal(result.ok, false)
+  assert.match(result.ok ? '' : result.message, /matched 2 item types \(100, 200\)/)
+})
+
+test('an empty list, a blank type and a non-positive or fractional quantity are all refused', () => {
+  for (const [raw, pattern] of [
+    [[], /at least one target/],
+    [[{ type: '   ', quantity: 5 }], /needs an item type/],
+    [[{ type: 'Tritanium', quantity: 0 }], /whole number above zero/],
+    [[{ type: 'Tritanium', quantity: -5 }], /whole number above zero/],
+    [[{ type: 'Tritanium', quantity: 2.5 }], /whole number above zero/],
+  ] as const) {
+    const result = resolveTargets(raw, candidatesFor)
+    assert.equal(result.ok, false, `expected a refusal for ${JSON.stringify(raw)}`)
+    assert.match(result.ok ? '' : result.message, pattern)
+  }
+})
+
+// Spelling one type two ways is the subtle one: both entries resolve, so only
+// the post-resolution check catches that the two targets contradict each other.
+test('naming one type twice is refused, even spelled once by name and once by id', () => {
+  const result = resolveTargets(
+    [
+      { type: 'Tritanium', quantity: 1000 },
+      { type: '34', quantity: 2000 },
+    ],
+    candidatesFor
+  )
+  assert.equal(result.ok, false)
+  assert.match(result.ok ? '' : result.message, /type 34 appears more than once/)
+})
+
+const TARGETS = [
+  { typeId: 34, quantity: 1000 },
+  { typeId: 4051, quantity: 100 },
+]
+
+test('stacks of one type sum across rows, whichever owner side they came from', () => {
+  const [line] = restockLines(
+    [{ typeId: 34, quantity: 1000 }],
+    [
+      // two character stacks and a corp hangar stack, all the same type
+      { type_id: 34, quantity: 200 },
+      { type_id: 34, quantity: 300 },
+      { type_id: '34', quantity: 100 },
+    ],
+    false
+  )
+  assert.equal(line.onHand, 600)
+  assert.equal(line.toBuy, 400)
+  assert.equal(line.delta, -400)
+})
+
+test('a stack with no quantity counts as one unit, like a ship or a fitted module', () => {
+  const [line] = restockLines([{ typeId: 34, quantity: 10 }], [{ type_id: 34, quantity: null }], false)
+  assert.equal(line.onHand, 1)
+  assert.equal(line.toBuy, 9)
+})
+
+test('a type with no stacks at all reads as zero on hand, not as a missing line', () => {
+  const [line] = restockLines([{ typeId: 34, quantity: 1000 }], [], false)
+  assert.deepEqual(line, { typeId: 34, target: 1000, onHand: 0, delta: -1000, toBuy: 1000 })
+})
+
+// The two columns exist precisely because they disagree above target: delta
+// keeps the surplus, toBuy clamps it away.
+test('delta stays signed while toBuy clamps at zero', () => {
+  const [over] = restockLines([{ typeId: 34, quantity: 100 }], [{ type_id: 34, quantity: 250 }], false)
+  assert.equal(over.delta, 150)
+  assert.equal(over.toBuy, 0)
+
+  const [exact] = restockLines([{ typeId: 34, quantity: 100 }], [{ type_id: 34, quantity: 100 }], false)
+  assert.equal(exact.delta, 0)
+  assert.equal(exact.toBuy, 0)
+})
+
+test('onlyBelowTarget drops the covered lines, and false keeps every target', () => {
+  const stacks = [
+    { type_id: 34, quantity: 5000 },
+    { type_id: 4051, quantity: 40 },
+  ]
+  assert.deepEqual(
+    restockLines(TARGETS, stacks, true).map((l) => l.typeId),
+    [4051]
+  )
+  assert.deepEqual(
+    restockLines(TARGETS, stacks, false).map((l) => l.typeId),
+    [34, 4051]
+  )
+})
+
+test('lines come back in the order the targets were given', () => {
+  const reversed = [...TARGETS].reverse()
+  assert.deepEqual(
+    restockLines(reversed, [], false).map((l) => l.typeId),
+    [4051, 34]
+  )
+})
+
+test('a stack of an untargeted type never leaks into a line', () => {
+  const lines = restockLines(
+    [{ typeId: 34, quantity: 10 }],
+    [
+      { type_id: 34, quantity: 4 },
+      { type_id: 9999, quantity: 100000 },
+    ],
+    false
+  )
+  assert.equal(lines.length, 1)
+  assert.equal(lines[0].onHand, 4)
+})

--- a/test/graphqlSchema.test.ts
+++ b/test/graphqlSchema.test.ts
@@ -9,6 +9,7 @@ import test from 'node:test'
 import {
   buildSchema,
   getNamedType,
+  isInputObjectType,
   isObjectType,
   type GraphQLNamedType,
   type GraphQLObjectType,
@@ -24,7 +25,10 @@ const ENTITY_TYPES = ['Character', 'Corporation', 'ItemType', 'Location']
 // corporation edge, with ownerType saying which side a row came from.
 const CORP_OWNABLE = ['Asset', 'Blueprint', 'IndustryJob']
 
-// Every type whose values are rows of a result set.
+// Every type whose values are rows of a result set — except RestockLine, which
+// is deliberately absent: it's the schema's one AGGREGATE row, summing stacks
+// that may span two characters and a corp hangar, so it carries no owner block
+// for the uniformity test below to check. See the restock tests at the bottom.
 const ROW_TYPES = [
   'Asset',
   'Blueprint',
@@ -48,7 +52,7 @@ const objectType = (schema: GraphQLSchema, name: string): GraphQLObjectType => {
 test('the owner filter is on every list, including the character-only ones', () => {
   const schema = buildSchema(typeDefs)
   const fields = (schema.getQueryType() as GraphQLObjectType).getFields()
-  for (const name of ['assets', 'blueprints', 'industryJobs', 'marketOrders', 'walletTransactions']) {
+  for (const name of ['assets', 'blueprints', 'industryJobs', 'marketOrders', 'restock', 'walletTransactions']) {
     const args = new Map(fields[name].args.map((a) => [a.name, String(a.type)]))
     assert.equal(args.get('owner'), 'String', `${name}.owner`)
     assert.equal(args.get('owners'), '[String!]', `${name}.owners`)
@@ -65,6 +69,7 @@ test('the SDL parses and exposes the expected query fields', () => {
     'corporations',
     'industryJobs',
     'marketOrders',
+    'restock',
     'sharedWithMe',
     'walletBalances',
     'walletTransactions',
@@ -171,6 +176,48 @@ test('Character exposes the EVE character id distinctly from the registration id
   assert.ok(character.id.description?.includes('registration id'))
 })
 
+// restock is the first field to take a structured input and the first to
+// return an aggregate. Both are easy to erode: an extra object field on
+// RestockLine would break CSV flattening, and a widened target input would let
+// a lens ask for a sum nobody can reproduce.
+test('restock takes a required list of RestockTargets and defaults to below-target only', () => {
+  const schema = buildSchema(typeDefs)
+  const field = (schema.getQueryType() as GraphQLObjectType).getFields().restock
+  assert.equal(String(field.type), '[RestockLine!]!')
+
+  const args = new Map(field.args.map((a) => [a.name, a]))
+  assert.equal(String(args.get('targets')?.type), '[RestockTarget!]!')
+  // Read the default off the SDL ast, like the includeShared test above.
+  const defaultNode = args.get('onlyBelowTarget')?.astNode?.defaultValue
+  assert.ok(defaultNode?.kind === 'BooleanValue' && defaultNode.value === true)
+
+  const target = schema.getType('RestockTarget')
+  assert.ok(target && isInputObjectType(target), 'RestockTarget is an input type')
+  const fields = target.getFields()
+  assert.equal(String(fields.type.type), 'String!')
+  // The wanted quantity is an Int (a caller types it); the SUMS are strings,
+  // since on-hand of a mineral overflows 32 bits long before the target does.
+  assert.equal(String(fields.quantity.type), 'Int!')
+})
+
+test('a restock line is an aggregate: no owner block, and its sums are strings', () => {
+  const schema = buildSchema(typeDefs)
+  const fields = objectType(schema, 'RestockLine').getFields()
+  for (const column of ['target', 'onHand', 'delta', 'toBuy']) {
+    assert.equal(String(fields[column]?.type), 'String!', `RestockLine.${column}`)
+  }
+  // A summed line spans owners, so naming one would be a lie.
+  for (const absent of ['ownerType', 'ownerId', 'ownerName', 'character', 'corporation']) {
+    assert.equal(fields[absent], undefined, `RestockLine.${absent}`)
+  }
+  // The CSV invariant: one object edge, pointing at a leaf-only entity type.
+  const edges = Object.values(fields).filter((f) => isObjectType(getNamedType(f.type)))
+  assert.deepEqual(
+    edges.map((f) => `${f.name}: ${getNamedType(f.type).name}`),
+    ['type: ItemType']
+  )
+})
+
 test('every filter dimension is a singular/plural pair, and the old names are gone', () => {
   const schema = buildSchema(typeDefs)
   const fields = (schema.getQueryType() as GraphQLObjectType).getFields()
@@ -182,6 +229,9 @@ test('every filter dimension is a singular/plural pair, and the old names are go
     blueprints: ['type', 'owner'],
     industryJobs: ['owner'],
     marketOrders: ['owner'],
+    // No type pair on restock — its targets carry the types, and a second way
+    // to name them would be a filter that silently disagreed with the list.
+    restock: ['location', 'owner'],
     walletTransactions: ['type', 'owner'],
   }
   for (const [field, dims] of Object.entries(dimensions)) {


### PR DESCRIPTION
Implements the design from #883.

## Why

A lens answering *"how much should I buy when my stock runs low"* was inexpressible. The SDL had no aggregation (assets come back as raw stacks, one row per `item_id`), no arithmetic, and no quantity thresholds — `Asset.quantity` is output-only and nothing filters on it. Since the schema is hand-authored and `validateLensQuery` only enforces one-operation / one-top-level-field / no-session-only, a new root field becomes lens-able with **zero** changes to the lens layer.

## What

`restock(targets: [RestockTarget!]!, location/locations, owner/owners, onlyBelowTarget)` → `[RestockLine!]!`

```graphql
query Restock($targets: [RestockTarget!]!) {
  restock(targets: $targets, location: "1DQ1-A") { typeName groupName target onHand delta toBuy }
}
```
```json
{ "targets": [{ "type": "Nitrogen Fuel Block", "quantity": 10000 }, { "type": "34", "quantity": 1000000 }] }
```

Targets ride in a lens's **frozen `variables`** — no new table, no migration — which is what makes a restock lens the shopping list itself: viewers can't supply variables, so the buffer levels stay the creator's.

Both computed columns are emitted: `delta` is signed (`onHand - target`, negative when short, so overstock reads too) and `toBuy` is clamped (`max(0, target - onHand)`). They only disagree above target, which is exactly where the lens author wants the choice.

## Design notes worth a reviewer's eye

- **`RestockLine` carries no owner block.** It's the schema's first aggregate row — a line may sum stacks from two of your characters *and* a corp hangar, so there's no single owner to name and a fabricated one would break the `ownerName` contract. It's therefore deliberately absent from `ROW_TYPES` in the drift guard, with a comment saying why. `owner:` is how you ask per owner instead.
- **The read is targeted, not the `assets` machinery.** It selects only `type_id, quantity` filtered `.in('type_id', targetTypeIds)`, which keeps it far below the cap that paging a whole hangar would hit. Past `ASSET_CAP` it **refuses** rather than summing a truncated read — a short sum here isn't a short list, it's a wrong number to buy, and nothing downstream could tell.
- **Ambiguity is refused, not guessed.** A target name matching nothing or matching two types, and the same type named twice (even spelled once by name and once by id), all fail loudly — a target needs exactly one denominator.
- **No `includeShared`**: shared rows would double-count into someone else's total, and its absence keeps the field lens-safe.
- The leak guard (`.in(ownerColumn, ownerIds)`) is preserved on both sources — load-bearing here, since lenses run in token mode on the service client.

## Drive-by fix

All three `lens_schema` examples still used the pre-pairing `locationId:`/`typeIds:` argument names, which the schema dropped. I confirmed they fail validation today (`Unknown argument "locationId" on field "Query.assets"`), so `create_lens` would have refused any model that copied them. Rewritten to `location:`/`types:`, and all four examples now pass `validateLensQuery`.

## Verification

`pnpm run lint`, `pnpm test` (308 pass, 13 new in `test/graphqlRestock.test.ts` plus 2 new drift-guard tests), `pnpm run build` — all green.

Not yet exercised against real data: the resolver needs the `graphql` flag and a live hangar, so the sums want a spot-check against `/asset` before this is relied on.

---
_Generated by [Claude Code](https://claude.ai/code/session_019N8KP7w6uTSGxg535rwkji)_