### PR TITLE
Stop universe-structures re-asking about structures nobody can reach

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -3968,8 +3968,19 @@ create table public.universe_structure (
   -- precedence explicit instead of last-write-wins — a name we resolved
   -- ourselves outranks EVE Ref's copy, and EVE Ref never overwrites it.
   source text,
-  resolved_at timestamptz not null default now()
+  resolved_at timestamptz not null default now(),
+  -- When a pass last got a definitive "no" from ESI about this structure — 403
+  -- (no docking access for any of our characters) or 404 (gone). The
+  -- universe-structures job skips these for UNRESOLVED_TTL_DAYS instead of
+  -- re-asking every scoped token nightly, which is what used to push it past
+  -- the function's 800s budget. A pause, not a blacklist: access does get
+  -- granted, and a successful resolve clears this back to null. Never set from
+  -- a 420 or a 5xx — those say nothing about the structure.
+  unresolved_at timestamptz
 );
+create index universe_structure_unresolved_at_idx
+  on public.universe_structure (unresolved_at)
+  where unresolved_at is not null;
 
 alter table public.universe_structure enable row level security;
 -- Readable by any *established* account — a member, not an account still

--- a/src/esi.js
+++ b/src/esi.js
@@ -7,17 +7,35 @@ const ESI_BASE = 'https://esi.evetech.net/latest'
 // is byte-for-byte what the plain Error carried before, since it's what lands in
 // heartbeat.error and the logs.
 export class EsiError extends Error {
-  constructor(label, status, statusText, body) {
+  constructor(label, status, statusText, body, errorLimit = {}) {
     super(`${label}: ${status} ${statusText} body=${body}`)
     this.name = 'EsiError'
     this.status = status
     this.body = body
+    // ESI's error budget, as reported on the failing response itself: how many
+    // errors are left in the current window and how many seconds until it
+    // resets. Carried on the error so a caller issuing many requests can stand
+    // down *before* CCP starts answering 420 (see shouldStandDown in
+    // src/jobs/structureResolution.js). Null when the response omitted them.
+    this.errorLimitRemain = errorLimit.remain ?? null
+    this.errorLimitReset = errorLimit.reset ?? null
   }
+}
+
+// The error budget headers, as numbers. Absent or unparseable reads as null —
+// "unknown", never "zero", so a missing header can't look like an exhausted
+// budget and stop a job that was fine.
+const errorLimitOf = (response) => {
+  const num = (name) => {
+    const value = Number(response.headers.get(name))
+    return Number.isFinite(value) ? value : null
+  }
+  return { remain: num('x-esi-error-limit-remain'), reset: num('x-esi-error-limit-reset') }
 }
 
 const esiError = async (response, path, label) => {
   const text = await response.text().catch(() => '')
-  return new EsiError(label ?? path, response.status, response.statusText, text.slice(0, 500))
+  return new EsiError(label ?? path, response.status, response.statusText, text.slice(0, 500), errorLimitOf(response))
 }
 
 // A 403 that means "this character isn't allowed to ask", not "something broke".

--- a/src/jobs/structureResolution.js
+++ b/src/jobs/structureResolution.js
@@ -1,0 +1,62 @@
+// The decisions the universe-structures resolve pass has to make, separated
+// from the I/O so they can be tested: when a failure means "stop asking about
+// this structure for a while", when the whole pass should stand down, and how
+// long a stand-down lasts. No I/O; tested in test/structureResolution.test.ts.
+//
+// Background. The job pools candidate structure ids from every location column
+// we already extract and tries each against *every* token carrying the
+// read-structures scope, because a structure only needs one character with
+// docking access and that is rarely the character whose assets sit there. With
+// ~860 candidates and ~77 tokens that is up to ~66,000 ESI calls in one pass —
+// and since a failure was never remembered, the same mostly-unresolvable set
+// came back every night. The pass ran until Vercel killed the function at 800
+// seconds, which recorded nothing at all: a timeout leaves no end heartbeat, so
+// /jobs showed the job as never having run while it was in fact running (and
+// dying) daily.
+
+// How long a structure nobody could resolve is left alone. Docking access does
+// get granted, so this is a pause and not a blacklist — but re-asking 77 tokens
+// every 24 hours to be told 403 again is what generated the load.
+export const UNRESOLVED_TTL_DAYS = 7
+
+// ESI's error limit is a bucket of ~100 errors per 60s window, reported on every
+// response as x-esi-error-limit-remain. Blowing through it earns 420s across the
+// whole application, which is why a pass that ignored it poisoned structures
+// that would otherwise have resolved. Stand down with room to spare: other jobs
+// share this budget.
+export const ERROR_LIMIT_FLOOR = 20
+
+// A 403 here is the normal answer for "this character can't dock there", so the
+// bucket drains fast and legitimately. That is the cost of the design, not a
+// malfunction — the negative cache is what keeps it from recurring nightly.
+
+// Should this failure stop us asking about this structure for a while?
+//
+// Only when ESI gave a definitive answer *about the structure*: 403 (no docking
+// access for this character) or 404 (no such structure, or unreanchored).
+// Everything else — 420 rate limiting, 5xx, a network blip — says nothing about
+// the structure and must not be cached, or one bad minute would silence a
+// structure for a week.
+export const isDefinitiveFailure = (error) => error?.status === 403 || error?.status === 404
+
+// Should the pass stop issuing requests? True once ESI is already refusing
+// (420) or the error budget is nearly spent. `errorLimitRemain` is null when no
+// response carried the header, which is not evidence of trouble — reading a
+// missing header as zero would stand the pass down on its first 403 and nothing
+// would ever resolve again.
+//
+// Typed explicitly: inferred from the defaults alone these read as `null`, and
+// every numeric call site becomes a type error.
+/**
+ * @param {{ status?: number | null, errorLimitRemain?: number | null }} [failure]
+ * @returns {boolean}
+ */
+export const shouldStandDown = (failure = {}) => {
+  const { status = null, errorLimitRemain = null } = failure
+  return status === 420 || (errorLimitRemain != null && errorLimitRemain <= ERROR_LIMIT_FLOOR)
+}
+
+// The timestamp before which an unresolved mark has expired and the structure is
+// worth another try. Takes `now` so it is pure.
+export const unresolvedCutoff = (now = Date.now()) =>
+  new Date(now - UNRESOLVED_TTL_DAYS * 24 * 60 * 60 * 1000).toISOString()

--- a/src/jobs/universeStructures.js
+++ b/src/jobs/universeStructures.js
@@ -4,6 +4,7 @@ import { universeStructure } from '../esi.js'
 import { sudoSupabase } from '../supabase.js'
 import { refreshAccessToken } from '../tokenRefresh.js'
 import { cli, forEachSequential } from './lib.js'
+import { isDefinitiveFailure, shouldStandDown, UNRESOLVED_TTL_DAYS, unresolvedCutoff } from './structureResolution.js'
 
 const TAG = 'universe-structures'
 const SCOPE = 'esi-universe.read_structures.v1'
@@ -153,8 +154,24 @@ export const runUniverseStructures = async () => {
     if (Number.isFinite(id) && id >= STRUCTURE_ID_FLOOR) locationIds.add(id)
   }, cloneRows ?? [])
 
-  const candidates = reject((id) => itemIds.has(id) || resolved.has(id), [...locationIds])
-  console.log(`[${TAG}] ${candidates.length} candidate player structure(s) to resolve`)
+  // Structures a recent pass already established nobody can resolve. Re-asking
+  // every token about each of these nightly is what pushed the job past its
+  // function budget, so they're parked for UNRESOLVED_TTL_DAYS — long enough to
+  // stop the churn, short enough that newly granted docking access is picked up
+  // within the week.
+  const { data: parkedRows, error: parkedErr } = await sudoSupabase
+    .from('universe_structure')
+    .select('structure_id')
+    .is('name', null)
+    .gt('unresolved_at', unresolvedCutoff())
+  if (parkedErr) throw parkedErr
+  const parkedIds = new Set(map(pipe(prop('structure_id'), Number), parkedRows ?? []))
+
+  const candidates = reject((id) => itemIds.has(id) || resolved.has(id) || parkedIds.has(id), [...locationIds])
+  console.log(
+    `[${TAG}] ${candidates.length} candidate player structure(s) to resolve ` +
+      `(${parkedIds.size} parked as unresolvable within the last ${UNRESOLVED_TTL_DAYS} day(s))`
+  )
   if (candidates.length === 0) return
 
   // Refresh each token's access token at most once and remember the result, so
@@ -174,11 +191,17 @@ export const runUniverseStructures = async () => {
     return access
   }
 
+  // Set once ESI's error budget runs low (or it starts answering 420). Every
+  // remaining candidate is then left for the next run rather than spending the
+  // rest of the function's lifetime collecting 420s — which is precisely how
+  // this job used to die at the 800s timeout, recording nothing.
+  let standDown = null
+
   // Try resolving `structureID` against tokens in order, stopping at the first
   // one that succeeds. `lastError` carries the most recent failure forward so a
   // structure nobody can resolve still reports why.
   const resolveAgainstTokens = async (structureID, remainingTokens, lastError) => {
-    if (remainingTokens.length === 0) return { info: null, lastError }
+    if (standDown || remainingTokens.length === 0) return { info: null, lastError }
     const [tokenRow, ...rest] = remainingTokens
     const access = await getAccess(tokenRow)
     if (!access) return resolveAgainstTokens(structureID, rest, lastError)
@@ -186,6 +209,13 @@ export const runUniverseStructures = async () => {
       const info = await universeStructure(access, structureID)
       return { info, lastError }
     } catch (e) {
+      // Stop the whole pass, not just this structure: the error budget is
+      // shared across every job, and pushing past it turns other characters'
+      // legitimate lookups into 420s too.
+      if (shouldStandDown(e)) {
+        standDown = e
+        return { info: null, lastError: e }
+      }
       // Usually 403 = this character can't dock here; another linked character
       // might, so try the next token before giving up on this structure.
       return resolveAgainstTokens(structureID, rest, e)
@@ -193,11 +223,30 @@ export const runUniverseStructures = async () => {
   }
 
   let upserted = 0
+  let parked = 0
+  let skipped = 0
   await forEachSequential(candidates, async (structureID) => {
+    if (standDown) {
+      skipped += 1
+      return
+    }
     const { info, lastError } = await resolveAgainstTokens(structureID, tokens, undefined)
     if (!info) {
-      // No linked character can resolve it (e.g. nobody has docking access). Don't
-      // cache — a later pass may succeed if access is granted.
+      // Nobody could resolve it. If ESI answered definitively about the
+      // structure (403 no docking access / 404 gone), park it for
+      // UNRESOLVED_TTL_DAYS so tomorrow's pass doesn't spend another ~77 calls
+      // being told the same thing. A stand-down or any other failure says
+      // nothing about the structure, so it stays a candidate.
+      if (isDefinitiveFailure(lastError)) {
+        const { error: parkErr } = await sudoSupabase
+          .from('universe_structure')
+          .upsert(
+            { structure_id: structureID, unresolved_at: new Date().toISOString() },
+            { onConflict: 'structure_id' }
+          )
+        if (parkErr) console.warn(`[${TAG}] structure ${structureID} park failed: ${parkErr.message}`)
+        else parked += 1
+      }
       console.warn(
         `[${TAG}] structure ${structureID} unresolved by any token: ${lastError?.message ?? 'no scoped token'}`
       )
@@ -215,6 +264,9 @@ export const runUniverseStructures = async () => {
         // is the only source that can name a *private* structure.
         source: 'esi-token',
         resolved_at: new Date().toISOString(),
+        // Access was granted (or restored): clear any park so the row reads as
+        // resolved rather than resolved-but-parked.
+        unresolved_at: null,
       },
       { onConflict: 'structure_id' }
     )
@@ -225,7 +277,19 @@ export const runUniverseStructures = async () => {
     resolved.add(structureID)
     upserted += 1
   })
-  console.log(`[${TAG}] resolved ${upserted} player structure name(s)`)
+  console.log(
+    `[${TAG}] resolved ${upserted} player structure name(s), parked ${parked} for ${UNRESOLVED_TTL_DAYS} day(s)`
+  )
+  if (standDown) {
+    // Not a failure: a partial pass is the designed behaviour under a shared
+    // error budget, and the parked ids mean the next run starts further along.
+    // Logged loudly because a run that stands down every night means the
+    // candidate set is growing faster than it can be worked through.
+    console.warn(
+      `[${TAG}] stood down on ESI's error budget with ${skipped} candidate(s) unattempted ` +
+        `(${standDown.message}); they stay candidates for the next run`
+    )
+  }
 }
 
 cli(import.meta.url, TAG, runUniverseStructures)

--- a/supabase/migrations/20260814130000_universe_structure_unresolved_at.sql
+++ b/supabase/migrations/20260814130000_universe_structure_unresolved_at.sql
@@ -1,0 +1,34 @@
+-- Remember that nobody could resolve a structure, so the universe-structures
+-- job stops re-asking every token about it every night.
+--
+-- The job pools candidate structure ids from every location column we extract
+-- and tries each against every token carrying esi-universe.read_structures.v1,
+-- because a structure needs only one character with docking access and that is
+-- rarely the character whose assets sit there. With ~860 candidates and ~77
+-- tokens that is up to ~66,000 ESI calls per pass, and a failure was never
+-- recorded — so the same mostly-unresolvable set came back the next night, and
+-- the next. In practice the pass blew ESI's error budget (420s), then ran until
+-- Vercel killed the function at 800 seconds. A timeout writes no end heartbeat,
+-- so latest_heartbeats() never saw the run at all and /jobs reported the job as
+-- stale while it was in fact running, and dying, daily.
+--
+-- unresolved_at is the timestamp of the last pass that got a definitive "no"
+-- from ESI about this structure — 403 (this character cannot dock) or 404 (no
+-- such structure). Only those two: a 420 or a 5xx says nothing about the
+-- structure, and caching one would silence a resolvable structure for a week.
+--
+-- Deliberately a pause, not a blacklist. Docking access does get granted, so the
+-- job ignores marks older than its TTL (7 days, UNRESOLVED_TTL_DAYS in
+-- src/jobs/structureResolution.js) and a successful resolve clears the column.
+--
+-- Nullable with no default: null means "never established as unresolvable",
+-- which is the correct reading of every existing row, including the ids the
+-- structure-directory job seeds from ESI's public list with no name yet.
+alter table public.universe_structure
+  add column if not exists unresolved_at timestamptz;
+
+-- The candidate query asks for nameless rows parked within the TTL. Partial, so
+-- it indexes only the parked rows rather than every structure we have ever seen.
+create index if not exists universe_structure_unresolved_at_idx
+  on public.universe_structure (unresolved_at)
+  where unresolved_at is not null;

--- a/test/structureResolution.test.ts
+++ b/test/structureResolution.test.ts
@@ -1,0 +1,78 @@
+// The universe-structures resolve pass used to run until Vercel killed it at
+// 800 seconds — ~860 candidates × ~77 tokens of ESI calls, nightly, with
+// failures never remembered. A timeout records no end heartbeat, so /jobs
+// showed the job as stale rather than as failing.
+//
+// Two decisions keep it inside its budget now, and both are the kind that fail
+// quietly in the wrong direction: cache too eagerly and a resolvable structure
+// goes unnamed for a week; stand down too late and the whole application eats
+// 420s. Pinned here, offline.
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  ERROR_LIMIT_FLOOR,
+  isDefinitiveFailure,
+  shouldStandDown,
+  UNRESOLVED_TTL_DAYS,
+  unresolvedCutoff,
+} from '../src/jobs/structureResolution.js'
+
+test('only a definitive answer about the structure parks it', () => {
+  // 403 = no docking access for this character, 404 = no such structure. Both
+  // are facts about the structure and worth remembering.
+  assert.equal(isDefinitiveFailure({ status: 403 }), true)
+  assert.equal(isDefinitiveFailure({ status: 404 }), true)
+})
+
+test('a transient failure never parks a structure', () => {
+  // The dangerous direction: parking on any of these would silence a structure
+  // that nobody had actually been refused, for a week, because of one bad
+  // minute.
+  assert.equal(isDefinitiveFailure({ status: 420 }), false)
+  assert.equal(isDefinitiveFailure({ status: 500 }), false)
+  assert.equal(isDefinitiveFailure({ status: 503 }), false)
+  assert.equal(isDefinitiveFailure({ status: 401 }), false)
+  // No response at all (a network error, or no scoped token ever tried).
+  assert.equal(isDefinitiveFailure(undefined), false)
+  assert.equal(isDefinitiveFailure(null), false)
+  assert.equal(isDefinitiveFailure(new Error('socket hang up')), false)
+})
+
+test('an outright 420 stands the pass down', () => {
+  assert.equal(shouldStandDown({ status: 420 }), true)
+})
+
+test('a nearly-spent error budget stands the pass down before the 420s', () => {
+  assert.equal(shouldStandDown({ status: 403, errorLimitRemain: ERROR_LIMIT_FLOOR }), true)
+  assert.equal(shouldStandDown({ status: 403, errorLimitRemain: ERROR_LIMIT_FLOOR - 1 }), true)
+  assert.equal(shouldStandDown({ status: 403, errorLimitRemain: 0 }), true)
+})
+
+test('a healthy error budget keeps the pass going', () => {
+  assert.equal(shouldStandDown({ status: 403, errorLimitRemain: ERROR_LIMIT_FLOOR + 1 }), false)
+  assert.equal(shouldStandDown({ status: 403, errorLimitRemain: 99 }), false)
+})
+
+test('a missing error-limit header reads as unknown, not as exhausted', () => {
+  // ESI omits the header on some responses. Treating absent as zero would stand
+  // the pass down on its first 403 and it would never resolve anything again.
+  assert.equal(shouldStandDown({ status: 403, errorLimitRemain: null }), false)
+  assert.equal(shouldStandDown({ status: 403 }), false)
+  assert.equal(shouldStandDown({}), false)
+  assert.equal(shouldStandDown(), false)
+})
+
+test('the park expires after the TTL', () => {
+  const now = Date.parse('2026-08-14T12:00:00.000Z')
+  assert.equal(unresolvedCutoff(now), '2026-08-07T12:00:00.000Z')
+
+  // A mark older than the cutoff is no longer excluded, so access granted in
+  // the meantime is picked up within the week.
+  const day = 24 * 60 * 60 * 1000
+  const parkedAt = new Date(now - (UNRESOLVED_TTL_DAYS + 1) * day).toISOString()
+  assert.ok(parkedAt < unresolvedCutoff(now), 'a mark past the TTL sorts before the cutoff')
+
+  const fresh = new Date(now - day).toISOString()
+  assert.ok(fresh > unresolvedCutoff(now), 'a mark inside the TTL sorts after the cutoff')
+})


### PR DESCRIPTION
`universe-structures` looks stale on `/jobs`. It isn't — it runs every day at 09:57 UTC and dies every day.

```
09:57:35  [cron/universe-structures] started workflow run=…
09:57:35  [heartbeat] recorded: universe-structures start
          856 candidate player structure(s) to resolve
          … 403 Forbidden … 420 Rate limit exceeded … (hundreds)
          Vercel Runtime Timeout Error: Task timed out after 800 seconds
```

Same on 13 Aug (868 candidates) and 14 Aug (856). A timeout leaves no end heartbeat, and `latest_heartbeats()` only counts completed runs, so the page shows the last successful run's age. Worth noting the heartbeat-on-failure work in #878 **cannot** catch this: the function is killed outright, so no `catch` ever runs. Timeouts are invisible to `/jobs` by construction.

## Why it can't finish

Each candidate is tried against *every* token carrying `esi-universe.read_structures.v1` — correct in principle, since a structure needs only one character with docking access and that's rarely the character whose assets sit there. But at ~860 candidates × ~77 tokens that's up to **~66,000 ESI calls** in one pass, and a structure nobody can dock at costs the full 77 before it's given up on.

And nothing was remembered. The old comment said so outright:

> `// No linked character can resolve it (e.g. nobody has docking access). Don't`
> `// cache — a later pass may succeed if access is granted.`

So the same mostly-unresolvable set returned every night, drained ESI's shared error budget, and the resulting `420`s then poisoned structures that *would* have resolved.

## What changed

**1. Park what ESI answers definitively about.** New `universe_structure.unresolved_at` records a `403` (nobody can dock) or `404` (gone); those ids are skipped for 7 days.

A pause, not a blacklist — access does get granted, so the mark expires and a successful resolve clears it back to null. Crucially **only** 403/404 park: a 420 or 5xx says nothing about the structure, and caching one would silence a resolvable structure for a week. That asymmetry is the easiest thing to get wrong here, so it's pinned in tests.

**2. Stand down on the error budget instead of riding it.** `EsiError` now carries `x-esi-error-limit-remain` / `-reset` from the failing response, so the pass stops when the budget is nearly spent (floor of 20) rather than after CCP starts refusing. Remaining candidates are left for the next run — which now starts further along, because of the parking above. The budget is shared across every job, so pushing past it costs the other extracts too.

Together these converge: each run parks some portion of the unresolvable set, so the candidate list shrinks night over night instead of resetting.

## Notes

- A partial pass ends **successfully**, with a loud `warn` naming how many candidates went unattempted. A run that stands down every night means the candidate set is growing faster than it's worked through — worth seeing, but not a failure.
- The migration is additive: nullable column, no default, plus a partial index over parked rows only. Existing rows read as "never established as unresolvable", which is correct, including the nameless ids the structure-directory job seeds from ESI's public list.

## Testing

- `pnpm test` — 315 pass, including 7 new cases in `test/structureResolution.test.ts` covering both quiet-failure directions: parking on a transient error, and reading a missing error-limit header as an exhausted budget (which would stand the pass down on its first 403 and resolve nothing ever again).
- `pnpm run lint` and `pnpm run build` clean.
- Not verifiable offline: the live behaviour against ESI's real error budget. The proof will be tomorrow's 09:57 UTC run completing and `/jobs` showing a fresh timestamp — I'll check it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lxb1QfWbjdDKonAdtkaQbV)_