### PR TITLE
Version the favicon URLs so Safari drops the stale mark

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,26 +5,34 @@ import './globals.css'
 import Header from './layout/header'
 import Footer from './layout/footer'
 
+// Safari keeps a favicon store keyed on the icon URL and consults it before
+// any HTTP cache — Cache-Control and ETag never get a say — so a tab that
+// once saw an old mark keeps drawing it forever while the bytes at the same
+// path change underneath. Versioning the URLs is the only way to force a
+// refetch. **Bump this whenever the icon artwork changes.**
+const ICON_VERSION = '2'
+const icon = (path: string) => `${path}?v=${ICON_VERSION}`
+
 export const metadata: Metadata = {
   title: 'Edencom Link',
   // Stop mobile browsers from turning long numeric IDs into "tap to dial" links.
   formatDetection: { telephone: false },
   icons: {
     icon: [
-      { url: '/favicon.ico', sizes: '16x16 32x32 48x48' },
-      { url: '/favicon.svg', type: 'image/svg+xml' },
+      { url: icon('/favicon.ico'), sizes: '16x16 32x32 48x48' },
+      { url: icon('/favicon.svg'), type: 'image/svg+xml' },
     ],
-    apple: '/apple-touch-icon.png',
+    apple: icon('/apple-touch-icon.png'),
     other: [
       {
         type: 'image/png',
         sizes: '16x16',
-        url: '/favicon-16x16.png',
+        url: icon('/favicon-16x16.png'),
       },
       {
         type: 'image/png',
         sizes: '32x32',
-        url: '/favicon-32x32.png',
+        url: icon('/favicon-32x32.png'),
       },
       // Scrapers that want a larger tile — Google's s2 favicon service,
       // which is what Claude renders next to the MCP connector — pick the
@@ -33,12 +41,12 @@ export const metadata: Metadata = {
       {
         type: 'image/png',
         sizes: '48x48',
-        url: '/favicon-48x48.png',
+        url: icon('/favicon-48x48.png'),
       },
       {
         type: 'image/png',
         sizes: '192x192',
-        url: '/android-chrome-192x192.png',
+        url: icon('/android-chrome-192x192.png'),
       },
     ],
   },


### PR DESCRIPTION
Safari tabs still draw the old blue-check favicon instead of the CONCORD star.

## Diagnosis

Nothing is wrong with what we ship. Production serves the correct icon, byte-identical to the repo:

```
$ curl -s https://edencom.link/favicon.ico | md5sum
6d9c5efb256176b33940a2c15655a9d6  -
$ md5sum public/favicon.ico
6d9c5efb256176b33940a2c15655a9d6  public/favicon.ico
```

The response even carries `cache-control: public, max-age=0, must-revalidate`. That doesn't help: Safari keeps a separate favicon store (`~/Library/Safari/Favicon Cache`) keyed on the icon **URL**, and consults it before the HTTP cache. `Cache-Control` and `ETag` never get a say. As long as the mark lives at a URL Safari has seen before, it keeps drawing whatever it cached the first time — indefinitely, across the artwork changes in #893 and everything before it.

## Change

Hang a `?v=` token off every linked icon URL in the root layout's `metadata.icons`. A new URL is a new cache entry, so Safari fetches fresh. `ICON_VERSION` is a single constant with a comment saying to bump it whenever the artwork changes, so the next redesign doesn't rediscover this.

The files themselves stay at their existing unversioned paths, so Safari's bare-`/favicon.ico` root probe and anything hard-coding those paths still resolve.

## Verification

- `pnpm run lint` and `pnpm run build` pass.
- Rendered head goes from `<link rel="icon" href="/favicon.ico" sizes="16x16 32x32 48x48"/>` to the same links with `?v=2`, across all seven icon entries.

Existing Safari tabs pick this up once the deploy lands; no user-side cache clearing needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GrvigYerD85Yw1bCw3hwsU)_