### PR TITLE
Harden the SDE mirror against transient upsert failures

### DIFF
--- a/src/jobs/lib.js
+++ b/src/jobs/lib.js
@@ -308,7 +308,7 @@ export const fetchAllPages = async (fetchPage) => {
 const SCHEMA_CACHE_MISS = 'PGRST205'
 const RELOAD_BACKOFF_MS = [500, 1000, 2000, 4000, 8000]
 
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+export const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
 // Run a PostgREST write, retrying while it reports a schema-cache miss, and
 // return its final result unchanged so the caller keeps its own error message.

--- a/src/jobs/sdeMirror.js
+++ b/src/jobs/sdeMirror.js
@@ -31,7 +31,8 @@ import { userAgent } from '../esi.js'
 import { recordPeakRss } from '../observability.js'
 import { resolveAllIds } from '../resolveNames.js'
 import { recordHeartbeat, sudoSupabase } from '../supabase.js'
-import { cli, forEachSequential, writeWithSchemaRetry } from './lib.js'
+import { cli, forEachSequential, sleep, writeWithSchemaRetry } from './lib.js'
+import { MIN_BISECT_ROWS, planUpsertRecovery } from './upsertRecovery.js'
 
 const SDE_LATEST_URL = 'https://developers.eveonline.com/static-data/eve-online-static-data-latest-jsonl.zip'
 
@@ -286,11 +287,28 @@ const ensureMirrorTable = async (stem, keyType) => {
 // cache reloads — writeWithSchemaRetry waits that window out. A new table's
 // first chunk is always at the start of its step, so its ~15s ceiling fits the
 // slice budget.
-const upsertChunk = async (table, rows) => {
+//
+// Beyond the schema-cache window, transient failures are handled per
+// planUpsertRecovery (src/jobs/upsertRecovery.js): a statement timeout bisects
+// the chunk (replaying the identical statement times out identically — the
+// workflow's own step retries proved that the hard way), connection/network
+// errors wait and retry, everything else throws. Returns whether a statement
+// timeout was seen, so the caller can shrink its chunk size for the rest of
+// the slice. Keyed upserts keep every retry path idempotent.
+const upsertChunk = async (table, rows, attempt = 0) => {
   const { error } = await writeWithSchemaRetry(table, () =>
     sudoSupabase.from(table).upsert(rows, { onConflict: '_key' })
   )
-  if (error) throw new Error(`sde-mirror: upsert into ${table} failed: ${error.message}`)
+  if (!error) return false
+  const plan = planUpsertRecovery(error, rows.length, attempt)
+  if (plan.action === 'fail') throw new Error(`sde-mirror: upsert into ${table} failed: ${error.message}`)
+  console.warn(`[sde-mirror] ${table}: ${error.code ?? '?'} on ${rows.length} rows — ${plan.action}`)
+  if (plan.action === 'retry') {
+    await sleep(plan.waitMs)
+    return upsertChunk(table, rows, attempt + 1)
+  }
+  await forEachSequential(splitEvery(Math.ceil(rows.length / 2), rows), (half) => upsertChunk(table, half, attempt + 1))
+  return true
 }
 
 // Rows that vanished from the current dump kept their old sde_build stamp;
@@ -328,10 +346,14 @@ export const ingestEntrySlice = async (zipUrl, file, build, startLine = 0, budge
   let carry = Buffer.alloc(0)
   let pauseLine = null
   let skipFile = false
+  // Shrinks (floor MIN_BISECT_ROWS) when a flush hits a statement timeout, so
+  // one fat-row region doesn't force a fresh bisect on every later chunk.
+  let rowCap = CHUNK_ROWS
 
   const flush = async () => {
     if (chunk.length === 0) return
-    await upsertChunk(table, chunk)
+    const timedOut = await upsertChunk(table, chunk)
+    if (timedOut) rowCap = Math.max(MIN_BISECT_ROWS, Math.floor(rowCap / 2))
     upserted += chunk.length
     chunk = []
     chunkBytes = 0
@@ -369,7 +391,7 @@ export const ingestEntrySlice = async (zipUrl, file, build, startLine = 0, budge
 
       chunk.push({ _key: parsed._key, data: parsed, sde_build: build })
       chunkBytes += text.length
-      if (chunk.length >= CHUNK_ROWS || chunkBytes >= CHUNK_BYTES) {
+      if (chunk.length >= rowCap || chunkBytes >= CHUNK_BYTES) {
         await flush()
         if (Date.now() - t0 > budgetMs) pauseLine = thisLine + 1
       }

--- a/src/jobs/upsertRecovery.js
+++ b/src/jobs/upsertRecovery.js
@@ -1,0 +1,42 @@
+// The recovery decision for a failed sde-mirror chunk upsert, split out from
+// the I/O so it's unit-testable (the codebase's pure-seam pattern). PostgREST
+// schema-cache misses (PGRST205) never reach this — writeWithSchemaRetry
+// handles those first — so the inputs here are Postgres/network errors.
+//
+// A statement timeout (57014) is sized-shaped, not luck-shaped: replaying the
+// identical 500-row jsonb statement times out the same way (exactly what the
+// workflow's bounded step retries did to the 2026-08-15 run). So the answer to
+// a timeout is to bisect the chunk while it's still big enough to matter; only
+// once it's down to MIN_BISECT_ROWS does a timeout mean "slow database", where
+// waiting and retrying is all that's left.
+
+export const MIN_BISECT_ROWS = 32
+export const RETRY_BACKOFF_MS = [1000, 2000, 4000]
+// Shared across bisects and retries, so a persistently sick table fails the
+// file loudly instead of grinding through the step budget forever.
+export const MAX_ATTEMPTS = 6
+
+const STATEMENT_TIMEOUT_CODE = '57014'
+// Connection-class SQLSTATEs (08xxx) plus admin shutdown/crash — the server
+// went away mid-statement; the row payload is blameless.
+const CONNECTION_CODE_RE = /^08|^57P0[123]$/
+const NETWORK_MESSAGE_RE = /fetch failed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|socket|network|timeout/i
+
+const isStatementTimeout = (error) =>
+  error?.code === STATEMENT_TIMEOUT_CODE || /statement timeout/i.test(error?.message ?? '')
+
+const isTransient = (error) =>
+  (error?.code != null && CONNECTION_CODE_RE.test(String(error.code))) ||
+  (error?.code == null && NETWORK_MESSAGE_RE.test(error?.message ?? '')) ||
+  /^5\d\d$/.test(String(error?.status ?? ''))
+
+// → { action: 'bisect' } | { action: 'retry', waitMs } | { action: 'fail' }
+export const planUpsertRecovery = (error, rowCount, attempt) => {
+  if (attempt >= MAX_ATTEMPTS) return { action: 'fail' }
+  const waitMs = RETRY_BACKOFF_MS[Math.min(attempt, RETRY_BACKOFF_MS.length - 1)]
+  if (isStatementTimeout(error)) {
+    return rowCount > MIN_BISECT_ROWS ? { action: 'bisect' } : { action: 'retry', waitMs }
+  }
+  if (isTransient(error)) return { action: 'retry', waitMs }
+  return { action: 'fail' }
+}

--- a/src/workflows/sdeIngestSteps.ts
+++ b/src/workflows/sdeIngestSteps.ts
@@ -12,7 +12,7 @@
 // CCP adds later that aren't in this roster still ingest — sdeMirrorWorkflow
 // falls back to the generic `ingestSlice` step for any stem not found here.
 //
-// Roster captured from SDE build 3442663 (78 files).
+// Roster captured from SDE build 3466501 (101 files).
 
 export type SdeFile = {
   entry: string
@@ -33,6 +33,16 @@ const slice: IngestSliceStep = async (zipUrl, file, build, startLine) => {
   return ingestEntrySlice(zipUrl, file, build, startLine)
 }
 
+async function ingest_accounting_entry_types(
+  zipUrl: string,
+  file: SdeFile,
+  build: number,
+  startLine: number
+): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
 async function ingest_agent_types(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
   'use step'
   return slice(zipUrl, file, build, startLine)
@@ -49,6 +59,16 @@ async function ingest_agents_in_space(
 }
 
 async function ingest_ancestries(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_applied_proximity_effects(
+  zipUrl: string,
+  file: SdeFile,
+  build: number,
+  startLine: number
+): Promise<number> {
   'use step'
   return slice(zipUrl, file, build, startLine)
 }
@@ -143,6 +163,26 @@ async function ingest_corporation_activities(
   return slice(zipUrl, file, build, startLine)
 }
 
+async function ingest_corporation_role_groups(
+  zipUrl: string,
+  file: SdeFile,
+  build: number,
+  startLine: number
+): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_corporation_roles(
+  zipUrl: string,
+  file: SdeFile,
+  build: number,
+  startLine: number
+): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
 async function ingest_dbuff_collections(
   zipUrl: string,
   file: SdeFile,
@@ -203,7 +243,32 @@ async function ingest_epic_arcs(zipUrl: string, file: SdeFile, build: number, st
   return slice(zipUrl, file, build, startLine)
 }
 
+async function ingest_expert_systems(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
 async function ingest_factions(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_fighter_abilities(
+  zipUrl: string,
+  file: SdeFile,
+  build: number,
+  startLine: number
+): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_fighter_abilities_by_type(
+  zipUrl: string,
+  file: SdeFile,
+  build: number,
+  startLine: number
+): Promise<number> {
   'use step'
   return slice(zipUrl, file, build, startLine)
 }
@@ -243,7 +308,62 @@ async function ingest_icons(zipUrl: string, file: SdeFile, build: number, startL
   return slice(zipUrl, file, build, startLine)
 }
 
+async function ingest_industry_activities(
+  zipUrl: string,
+  file: SdeFile,
+  build: number,
+  startLine: number
+): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_industry_assembly_lines(
+  zipUrl: string,
+  file: SdeFile,
+  build: number,
+  startLine: number
+): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_industry_installation_types(
+  zipUrl: string,
+  file: SdeFile,
+  build: number,
+  startLine: number
+): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_industry_modifier_sources(
+  zipUrl: string,
+  file: SdeFile,
+  build: number,
+  startLine: number
+): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_industry_target_filters(
+  zipUrl: string,
+  file: SdeFile,
+  build: number,
+  startLine: number
+): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
 async function ingest_landmarks(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_link_with_ship(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
   'use step'
   return slice(zipUrl, file, build, startLine)
 }
@@ -338,6 +458,16 @@ async function ingest_meta_groups(zipUrl: string, file: SdeFile, build: number, 
   return slice(zipUrl, file, build, startLine)
 }
 
+async function ingest_metenox_moon_drill(
+  zipUrl: string,
+  file: SdeFile,
+  build: number,
+  startLine: number
+): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
 async function ingest_military_campaign_objectives(
   zipUrl: string,
   file: SdeFile,
@@ -359,6 +489,16 @@ async function ingest_military_campaigns(
 }
 
 async function ingest_missions(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_notification_types(
+  zipUrl: string,
+  file: SdeFile,
+  build: number,
+  startLine: number
+): Promise<number> {
   'use step'
   return slice(zipUrl, file, build, startLine)
 }
@@ -413,7 +553,22 @@ async function ingest_planet_schematics(
   return slice(zipUrl, file, build, startLine)
 }
 
+async function ingest_proximity_trap(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
 async function ingest_races(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_school_map(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_schools(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
   'use step'
   return slice(zipUrl, file, build, startLine)
 }
@@ -444,6 +599,11 @@ async function ingest_ship_tree_groups(
   build: number,
   startLine: number
 ): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_skill_plans(zipUrl: string, file: SdeFile, build: number, startLine: number): Promise<number> {
   'use step'
   return slice(zipUrl, file, build, startLine)
 }
@@ -533,6 +693,16 @@ async function ingest_skinr_slots(zipUrl: string, file: SdeFile, build: number, 
   return slice(zipUrl, file, build, startLine)
 }
 
+async function ingest_skinr_slots_to_materials(
+  zipUrl: string,
+  file: SdeFile,
+  build: number,
+  startLine: number
+): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
 async function ingest_skinr_tier_thresholds(
   zipUrl: string,
   file: SdeFile,
@@ -569,6 +739,36 @@ async function ingest_station_operations(
 }
 
 async function ingest_station_services(
+  zipUrl: string,
+  file: SdeFile,
+  build: number,
+  startLine: number
+): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_station_standings_restrictions(
+  zipUrl: string,
+  file: SdeFile,
+  build: number,
+  startLine: number
+): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_system_dbuff_emitters(
+  zipUrl: string,
+  file: SdeFile,
+  build: number,
+  startLine: number
+): Promise<number> {
+  'use step'
+  return slice(zipUrl, file, build, startLine)
+}
+
+async function ingest_system_wide_effects(
   zipUrl: string,
   file: SdeFile,
   build: number,
@@ -621,9 +821,11 @@ async function ingest_types(zipUrl: string, file: SdeFile, build: number, startL
 // Stem → its named ingest step. sdeMirrorWorkflow looks a file's stem up here
 // and falls back to the generic `ingestSlice` for anything not listed.
 export const INGEST_STEPS: Record<string, IngestSliceStep> = {
+  accounting_entry_types: ingest_accounting_entry_types,
   agent_types: ingest_agent_types,
   agents_in_space: ingest_agents_in_space,
   ancestries: ingest_ancestries,
+  applied_proximity_effects: ingest_applied_proximity_effects,
   archetypes: ingest_archetypes,
   bloodlines: ingest_bloodlines,
   blueprints: ingest_blueprints,
@@ -636,6 +838,8 @@ export const INGEST_STEPS: Record<string, IngestSliceStep> = {
   contraband_types: ingest_contraband_types,
   control_tower_resources: ingest_control_tower_resources,
   corporation_activities: ingest_corporation_activities,
+  corporation_role_groups: ingest_corporation_role_groups,
+  corporation_roles: ingest_corporation_roles,
   dbuff_collections: ingest_dbuff_collections,
   dogma_attribute_categories: ingest_dogma_attribute_categories,
   dogma_attributes: ingest_dogma_attributes,
@@ -644,13 +848,22 @@ export const INGEST_STEPS: Record<string, IngestSliceStep> = {
   dungeons: ingest_dungeons,
   dynamic_item_attributes: ingest_dynamic_item_attributes,
   epic_arcs: ingest_epic_arcs,
+  expert_systems: ingest_expert_systems,
   factions: ingest_factions,
+  fighter_abilities: ingest_fighter_abilities,
+  fighter_abilities_by_type: ingest_fighter_abilities_by_type,
   freelance_job_schemas: ingest_freelance_job_schemas,
   graphic_material_sets: ingest_graphic_material_sets,
   graphics: ingest_graphics,
   groups: ingest_groups,
   icons: ingest_icons,
+  industry_activities: ingest_industry_activities,
+  industry_assembly_lines: ingest_industry_assembly_lines,
+  industry_installation_types: ingest_industry_installation_types,
+  industry_modifier_sources: ingest_industry_modifier_sources,
+  industry_target_filters: ingest_industry_target_filters,
   landmarks: ingest_landmarks,
+  link_with_ship: ingest_link_with_ship,
   map_asteroid_belts: ingest_map_asteroid_belts,
   map_constellations: ingest_map_constellations,
   map_moons: ingest_map_moons,
@@ -664,19 +877,25 @@ export const INGEST_STEPS: Record<string, IngestSliceStep> = {
   masteries: ingest_masteries,
   mercenary_tactical_operations: ingest_mercenary_tactical_operations,
   meta_groups: ingest_meta_groups,
+  metenox_moon_drill: ingest_metenox_moon_drill,
   military_campaign_objectives: ingest_military_campaign_objectives,
   military_campaigns: ingest_military_campaigns,
   missions: ingest_missions,
+  notification_types: ingest_notification_types,
   npc_characters: ingest_npc_characters,
   npc_corporation_divisions: ingest_npc_corporation_divisions,
   npc_corporations: ingest_npc_corporations,
   npc_stations: ingest_npc_stations,
   planet_resources: ingest_planet_resources,
   planet_schematics: ingest_planet_schematics,
+  proximity_trap: ingest_proximity_trap,
   races: ingest_races,
+  school_map: ingest_school_map,
+  schools: ingest_schools,
   ship_tree_elements: ingest_ship_tree_elements,
   ship_tree_factions: ingest_ship_tree_factions,
   ship_tree_groups: ingest_ship_tree_groups,
+  skill_plans: ingest_skill_plans,
   skin_licenses: ingest_skin_licenses,
   skin_materials: ingest_skin_materials,
   skinr_component_categories: ingest_skinr_component_categories,
@@ -687,11 +906,15 @@ export const INGEST_STEPS: Record<string, IngestSliceStep> = {
   skinr_slot_configurations: ingest_skinr_slot_configurations,
   skinr_slot_names: ingest_skinr_slot_names,
   skinr_slots: ingest_skinr_slots,
+  skinr_slots_to_materials: ingest_skinr_slots_to_materials,
   skinr_tier_thresholds: ingest_skinr_tier_thresholds,
   skins: ingest_skins,
   sovereignty_upgrades: ingest_sovereignty_upgrades,
   station_operations: ingest_station_operations,
   station_services: ingest_station_services,
+  station_standings_restrictions: ingest_station_standings_restrictions,
+  system_dbuff_emitters: ingest_system_dbuff_emitters,
+  system_wide_effects: ingest_system_wide_effects,
   translation_languages: ingest_translation_languages,
   type_bonus: ingest_type_bonus,
   type_dogma: ingest_type_dogma,

--- a/src/workflows/sdeMirror.ts
+++ b/src/workflows/sdeMirror.ts
@@ -189,14 +189,31 @@ export async function sdeMirrorWorkflow() {
 
     // Drain one entry: chase its slice cursor until the entry reports done,
     // through the file's own named step (ingest_<stem>) so the run tree names
-    // each file instead of showing a wall of "ingestSlice".
+    // each file instead of showing a wall of "ingestSlice". A slice returning
+    // the cursor it was given can't happen today (a pause line is always past
+    // startLine), but if a regression ever makes it possible, fail the file
+    // rather than spawning steps forever.
     const drainFile = async (file: SdeFile): Promise<void> => {
       const step = ingestStepFor(file)
       let cursor = 0
       while (cursor !== -1) {
-        cursor = await step(plan.zipUrl, file, plan.build, cursor)
+        const next = await step(plan.zipUrl, file, plan.build, cursor)
+        if (next === cursor) throw new Error(`sde-mirror: ${file.stem} made no progress at line ${cursor}`)
+        cursor = next
       }
     }
+
+    // Per-file fault isolation (the characterAssets catch-collect shape): a
+    // file whose slices exhaust their bounded step retries should cost that
+    // file — and any tail step reading it — not the other 100 files' committed
+    // work. Failures are collected and thrown together after everything else
+    // drains, so the run still reads failed and completed_at is never stamped.
+    const failures: { stem: string; message: string }[] = []
+    const caught = (stem: string, p: Promise<void>): Promise<void> =>
+      p.catch((e) => {
+        console.error(`[sde-mirror] ${stem} failed:`, e)
+        failures.push({ stem, message: e instanceof Error ? e.message : String(e) })
+      })
 
     // Largest compressed entries first, so the longest slice chains (typeDogma)
     // start at t=0 and wall clock tracks the longest chain instead of whatever
@@ -207,13 +224,17 @@ export async function sdeMirrorWorkflow() {
 
     // Build each lane's sequential drain chain synchronously, keeping a per-file
     // completion promise so the tail steps below can start on their actual
-    // inputs rather than on the whole ingest.
+    // inputs rather than on the whole ingest. The drained map holds the
+    // UNCAUGHT per-file promise — a tail step whose input failed must reject,
+    // not run over a half-ingested table — while the lane chains on the caught
+    // continuation so it proceeds past a failed file to its lane-mates.
     const drained = new Map<string, Promise<void>>()
     const laneDone = lanes.map((lane) => {
       let prev: Promise<void> = Promise.resolve()
       for (const file of lane) {
-        prev = prev.then(() => drainFile(file))
-        drained.set(file.stem, prev)
+        const attempt = prev.then(() => drainFile(file))
+        drained.set(file.stem, attempt)
+        prev = caught(file.stem, attempt)
       }
       return prev
     })
@@ -226,12 +247,37 @@ export async function sdeMirrorWorkflow() {
     // only sde_npc_stations, the esf_data re-encode needs only its 7 input
     // tables, and the sheet_csv re-encode needs only sde_types + sde_blueprints.
     // All are forced — a non-skipped run always re-does the full ingest, and the
-    // derived encodes re-write to match.
-    const stations = afterStems(['npc_stations']).then(() => stationNames())
-    const esf = afterStems(ESF_INPUT_STEMS).then(() => encodeEsf(plan.build))
-    const sheets = afterStems(SHEET_INPUT_STEMS).then(() => encodeSheets(plan.build))
+    // derived encodes re-write to match. Each is caught like the files are: a
+    // failed input file rejects its afterStems, so the tail step is skipped and
+    // recorded as its own failure (alongside the file's) instead of running
+    // over a half-ingested table or killing the run.
+    const stations = caught(
+      'station_names',
+      afterStems(['npc_stations']).then(() => stationNames())
+    )
+    const esf = caught(
+      'esf_data',
+      afterStems(ESF_INPUT_STEMS).then(() => encodeEsf(plan.build))
+    )
+    const sheets = caught(
+      'sheet_csv',
+      afterStems(SHEET_INPUT_STEMS).then(() => encodeSheets(plan.build))
+    )
 
     await Promise.all([allDrained, stations, esf, sheets])
+    // A partial ingest must not finalize: no view refresh over half-ingested
+    // tables, no completed_at stamp (so the next night re-ingests). Throwing
+    // lands in the catch below — finalizeFailed closes the heartbeat ok: false
+    // and the rethrow marks the run failed in Observability — while everything
+    // that did land stays committed.
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures.map(({ stem, message }) => new Error(`${stem}: ${message}`)),
+        // The message is what finalizeFailed records and /jobs renders, so
+        // name the casualties rather than just counting them.
+        `sde-mirror: ${failures.length} step(s) failed: ${failures.map(({ stem }) => stem).join(', ')}`
+      )
+    }
     // Last, once every table has landed: refresh the derived views, stamp the
     // build completed with this run's commit, and close the heartbeat planRun()
     // opened.

--- a/test/upsertRecovery.test.ts
+++ b/test/upsertRecovery.test.ts
@@ -1,0 +1,75 @@
+// Unit coverage for the sde-mirror upsert recovery seam. The classification
+// decides whether a nightly ingest self-heals or dies: treating a statement
+// timeout as fatal is what lost the 2026-08-15 run, and treating a constraint
+// violation as retryable would grind a broken file through six attempts before
+// reporting the same error.
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { MAX_ATTEMPTS, MIN_BISECT_ROWS, planUpsertRecovery, RETRY_BACKOFF_MS } from '../src/jobs/upsertRecovery.js'
+
+test('statement timeout on a big chunk bisects', () => {
+  assert.deepEqual(
+    planUpsertRecovery({ code: '57014', message: 'canceling statement due to statement timeout' }, 500, 0),
+    {
+      action: 'bisect',
+    }
+  )
+})
+
+test('statement timeout is recognized by message when the code is absent', () => {
+  // PostgREST sometimes surfaces the Postgres message without its SQLSTATE.
+  assert.deepEqual(planUpsertRecovery({ message: 'canceling statement due to statement timeout' }, 500, 0), {
+    action: 'bisect',
+  })
+})
+
+test('statement timeout at the bisect floor retries instead', () => {
+  const plan = planUpsertRecovery({ code: '57014', message: 'statement timeout' }, MIN_BISECT_ROWS, 1)
+  assert.deepEqual(plan, { action: 'retry', waitMs: RETRY_BACKOFF_MS[1] })
+})
+
+test('connection-class SQLSTATEs retry with backoff', () => {
+  assert.deepEqual(planUpsertRecovery({ code: '08006', message: 'connection failure' }, 500, 0), {
+    action: 'retry',
+    waitMs: RETRY_BACKOFF_MS[0],
+  })
+  assert.deepEqual(planUpsertRecovery({ code: '57P01', message: 'terminating connection' }, 500, 0), {
+    action: 'retry',
+    waitMs: RETRY_BACKOFF_MS[0],
+  })
+})
+
+test('a codeless network error retries', () => {
+  assert.deepEqual(planUpsertRecovery({ message: 'TypeError: fetch failed' }, 500, 2), {
+    action: 'retry',
+    waitMs: RETRY_BACKOFF_MS[2],
+  })
+})
+
+test('a 5xx-shaped error retries', () => {
+  assert.deepEqual(planUpsertRecovery({ status: 503, message: 'Service Unavailable' }, 500, 0), {
+    action: 'retry',
+    waitMs: RETRY_BACKOFF_MS[0],
+  })
+})
+
+test('backoff is capped at the last rung, not extended', () => {
+  const plan = planUpsertRecovery({ message: 'fetch failed' }, 500, MAX_ATTEMPTS - 1)
+  assert.deepEqual(plan, { action: 'retry', waitMs: RETRY_BACKOFF_MS[RETRY_BACKOFF_MS.length - 1] })
+})
+
+test('a constraint violation fails on the first attempt', () => {
+  // Data-shaped errors replay identically; retrying only delays the report.
+  assert.deepEqual(planUpsertRecovery({ code: '23505', message: 'duplicate key value' }, 500, 0), { action: 'fail' })
+})
+
+test('a message-only error that is not network-shaped fails', () => {
+  assert.deepEqual(planUpsertRecovery({ message: 'invalid input syntax for type bigint' }, 500, 0), { action: 'fail' })
+})
+
+test('attempt exhaustion fails even for a retryable error', () => {
+  assert.deepEqual(planUpsertRecovery({ code: '57014', message: 'statement timeout' }, 500, MAX_ATTEMPTS), {
+    action: 'fail',
+  })
+})


### PR DESCRIPTION
## Why

The 2026-08-15 nightly `sde-mirror` run died on a single statement timeout (from Vercel runtime logs):

```
sde-mirror: upsert into sde_missions failed: canceling statement due to statement timeout
```

The workflow's bounded step retries replayed the identical 500-row jsonb statement within seconds — same timeout every attempt — then the top-level `Promise.all` failed the whole run, discarding five other files' in-flight slice chains (`ingest_types`, `ingest_map_planets`, `ingest_type_dogma`, `ingest_map_moons`, `ingest_map_asteroid_belts`) and never stamping `completed_at`, so the next night re-ingested all ~101 files from scratch. And since every new deployment forces a full re-ingest, the risky path runs far more often than "when CCP ships a build".

Two failure modes, two fixes: transient DB errors should self-heal, and a genuinely bad file should cost only that file.

## What

- **New pure seam `src/jobs/upsertRecovery.js`** (tested): `planUpsertRecovery(error, rowCount, attempt)` → `bisect` / `retry` / `fail`. A statement timeout is sized-shaped, not luck-shaped — replaying the identical fat statement times out identically — so it bisects the chunk while it's above 32 rows, and only retries with backoff below that floor. Connection-class SQLSTATEs, codeless network errors, and 5xx retry with backoff `[1s, 2s, 4s]`; data-shaped errors fail on the first attempt; six attempts total. PGRST205 never reaches this seam (`writeWithSchemaRetry` still handles the schema-cache window first).
- **`upsertChunk` follows the plan recursively**, and `ingestEntrySlice` halves its chunk row cap (floor 32) for the rest of a slice after a timeout, so one fat-row region doesn't force a fresh bisect on every later chunk. Retry time counts against the existing 35s slice budget, and keyed upserts keep every retry path idempotent.
- **Per-file fault isolation in `src/workflows/sdeMirror.ts`** (the `characterAssets` catch-collect shape): a file that exhausts its step retries no longer aborts its lane-mates or unrelated tail steps. The `drained` map keeps the *uncaught* per-file promise so a tail step (`stationNames`/`encodeEsf`/`encodeSheets`) whose input file failed is skipped and recorded, never run over a half-ingested table. After everything drains, any failures skip `finalize` (no view refresh over partial tables, no `completed_at`) and throw one `AggregateError` naming the casualties — the heartbeat still closes `ok: false` and /jobs reads failed, but all committed tables and successful tail steps survive.
- **No-progress guard in `drainFile`**: a slice returning the cursor it was given fails that file instead of spawning steps forever (unreachable today; cheap insurance against a future regression).
- **Regenerated `sdeIngestSteps.ts`**: 78 → 101 named steps (build 3466501), so the ~23 files CCP has added since build 3442663 — `missions` included — get their own step names in Workflows observability.

## Verification

- `pnpm test` — 342 pass, including the new `test/upsertRecovery.test.ts` (every classification branch, message-match fallback, bisect floor, backoff cap, attempt exhaustion).
- `pnpm run lint`, `pnpm run build` — clean (the build is what proves the orchestrator edits are workflow-directive-legal).
- No local workflow runner; the next nightly run is the integration test — watch for a `[sde-mirror] sde_missions: 57014 on N rows — bisect` recovery line and a green heartbeat on /jobs.

No migrations or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SY8JMupZuWs16dXN1JvL4N

---
_Generated by [Claude Code](https://claude.ai/code/session_01SY8JMupZuWs16dXN1JvL4N)_