### PR TITLE
Lenses supersede the Sheets CSV routes, request timing, and a standardized BRIN plan

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ honest when a project ships or a new doc lands.
 | [fittings.md](fittings.md) | Read-only saved-fitting extract + `/fitting` page + MCP `list_fittings` | Shipped as #742–#745. ESI has no corp/alliance fittings endpoint — the doc explains why |
 | [gice-auth.md](gice-auth.md) | GICE (Goonfleet OIDC) as an auth method, hand-rolled auth-code client | Live; doubles as the reference for how the flow works |
 | [sde-db-cutover/](sde-db-cutover/) | Stop downloading the SDE at build time; read the nightly-mirrored `sde_*` tables at runtime | Docs 00–04 all done, including the esf-data move into the `sde-mirror` workflow tail |
-| [sharing-layer/](sharing-layer/) | Unified recursive asset shares + folding fitting/den shares into one audience model + Lenses | Docs 01–07 all done; the `/lens` editor sits behind the `lens` dark-launch flag |
+| [sharing-layer/](sharing-layer/) | Unified recursive asset shares + folding fitting/den shares into one audience model + Lenses | Docs 01–08 all done; 09 (lenses supersede the api_token Sheets CSV routes: drop-in templates, export caps, deprecation) in progress. The `/lens` editor sits behind the `lens` dark-launch flag |
 | [sheet-csv/](sheet-csv/) | Nightly industry CSVs from the SDE mirror, served at `/sheets/[file]` for `=IMPORTDATA()` | Runs as a tail step of the `sde-mirror` workflow |
 
 ## In progress
@@ -36,7 +36,7 @@ honest when a project ships or a new doc lands.
 | Project | What it will be | Notes |
 |---|---|---|
 | [asset-proximity/](asset-proximity/) | Sort `/asset` by stargate jumps from the main character's location | Feasibility validated (the SDE stargate graph is mirrored); no code yet |
-| [brin-indexes/](brin-indexes/) | Survey whether the append-ordered growth tables should follow `market_price_over_time` onto BRIN indexes | Prompted by the market-prices sizing work, where BRIN cut a 60 MB btree to 40 kB for ~2.5 ms. Phase 1 is measurement and may legitimately conclude nothing else is big enough to bother |
+| [brin-indexes/](brin-indexes/) | Standardize the SCD-2 `*_over_time` tables on a BRIN `(valid_from)` time-travel index, measured on live endpoint timings | Adopted (supersedes the measure-and-maybe-stop survey). The `request.timing` instrumentation is live; index migrations roll out one table per PR, gains read off the `served=historical` series plus EXPLAIN at production row counts |
 | [custom-fit-ui.md](custom-fit-ui.md) | Replace `@eveshipfit/react` rendering with our own components, keeping the dogma-engine math | Stage 0 (proof-out) done — decoder, engine glue, flag mapping and skills all verified; stages 1–5 not started |
 | [fitting-paging.md](fitting-paging.md) | Treat the game's 500-fit cap as a resident set and this site as the backing store (page fits in/out via ESI) | Plan only; builds on the shipped fittings feature |
 | [open-registration.md](open-registration.md) | Drop the invite-code gate: anonymous users on first visit, invites become referral attribution, identities (email / EVE SSO / Discord / GICE) affix in any order | Plan merged 2026-08-12 (#860); implementation not started. Its stage 5 delivers discord-bot stage 06 |

--- a/docs/brin-indexes/README.md
+++ b/docs/brin-indexes/README.md
@@ -1,106 +1,201 @@
-# BRIN indexes for the append-ordered tables: survey and plan
+# BRIN as the standard time-travel index for the SCD-2 tables
 
-> **Status: proposed, nothing done.** `market_price_over_time` is the only
-> table in the schema using BRIN today (added with the market-prices capture —
-> [docs/market-prices/README.md](../market-prices/README.md) "Storage"). This
-> doc asks whether the same trick applies to the other growth tables, and
-> deliberately does **not** answer it: the first phase is measurement, because
-> the answer depends on production row counts nobody has looked at.
+> **Status: adopted, rollout pending.** This doc supersedes the earlier
+> "survey and plan" version, whose posture was "measure, and possibly stop."
+> The posture is now **standardize, measured**: every `*_over_time` table gets
+> a BRIN on `valid_from`, one migration PR at a time, with the gains (and any
+> regressions) read off live endpoint timings — the `request.timing` metric
+> (`src/observability.js`) that instruments the CSV/lens/GraphQL surfaces —
+> plus `EXPLAIN` evidence at production row counts. What changed since the
+> survey: the SCD tables now have a uniform, user-facing time-travel access
+> path worth serving well, and the instrumentation to watch it exists.
 
-## The finding that prompted this
+## The finding that anchors this
 
 While sizing `market_price_over_time`, swapping its as-of index from btree to
 BRIN measured, at 2M rows:
 
-| | btree `(market, valid_from desc)` | BRIN `(valid_from)` |
-|---|---|---|
-| Size | 60 MB | **40 kB** |
-| Deep-history query (0.6% of rows) | 2.6 ms | 5.1 ms |
-| Mid-history query (74% of rows) | 166 ms (index unused) | 181 ms |
+|                                   | btree `(market, valid_from desc)` | BRIN `(valid_from)` |
+| --------------------------------- | --------------------------------- | ------------------- |
+| Size                              | 60 MB                             | **40 kB**           |
+| Deep-history query (0.6% of rows) | 2.6 ms                            | 5.1 ms              |
+| Mid-history query (74% of rows)   | 166 ms (index unused)             | 181 ms              |
 
-A **1500× smaller index for ~2.5 ms**. And it survives churn: after 60 simulated
-hourly cycles running the job's real touch/close/insert statements,
-`valid_from`'s correlation with physical order was still **0.9996**, so the
-`is_current` flips that move tuples do not scatter the index.
+A **1500× smaller index for ~2.5 ms**. And it survives churn: after 60
+simulated hourly cycles running the job's real touch/close/insert statements,
+`valid_from`'s correlation with physical order was still **0.9996** — the
+`is_current` flips that move tuples do not scatter the index. Full method in
+[docs/market-prices/README.md](../market-prices/README.md) "Storage".
 
-## Why it worked there, which is the whole question
+## Why this generalizes to every SCD-2 table
 
-BRIN stores one min/max summary per *range of blocks* instead of one entry per
-row. That is only useful when the table's **physical order correlates with the
-indexed column**, and only for **range** predicates. `market_price_over_time`
-satisfies both by construction: every run appends its changed rows at the end of
-the heap, so `valid_from` climbs with block number, and time travel asks
-`valid_from <= X`.
+The tables share one write pattern and one read pattern, by construction:
 
-Two things it is *not*:
+- **Writes append.** Every reconcile bumps `valid_until` on unchanged rows in
+  place, closes vanished rows in place, and *appends* new versions — so
+  `valid_from` climbs with block number on every `*_over_time` table, exactly
+  the correlation BRIN needs.
+- **Time travel is a range predicate the btrees can't serve.** Every snapshot
+  function (`character_asset_snapshot_at`, `character_orders`,
+  `character_industry_jobs`, `corp_industry_jobs`, `market_price_snapshot`)
+  asks the same shape:
 
-- **Not a general btree replacement.** An equality lookup on a high-cardinality
-  column (`item_id`, `job_id`, `order_id`) has no correlation to exploit and
-  gets a lossy scan of many blocks instead of a direct probe. Those indexes must
-  stay btree.
-- **Not free on a leading equality column.** `(registration_id, date desc)` is
-  efficient because the btree seeks straight to one owner's rows. A BRIN on
-  `date` alone loses that seek and filters every candidate block on recheck.
-  Whether that is a win depends entirely on how many rows the owner filter
-  removes — i.e. on how many registrations exist, which is a production fact.
+  ```sql
+  where <owner> = any(...)
+    and valid_from <= as_of
+    and (is_current or valid_until >= as_of)
+  ```
 
-## Survey: every index on a table that grows without bound
+  The `or` defeats a btree on `(entity_id, valid_until desc)`; the
+  `valid_from <= as_of` half is a textbook BRIN range scan. Today **no
+  `*_over_time` table except `market_price_over_time` has any index on
+  `valid_from` at all** — the time-travel branch seq-scans.
 
-Grouped by whether BRIN could plausibly apply. **No sizes here on purpose** —
-see Phase 1.
+## The standard
 
-### Group A — plausible candidates: append-ordered, range-queried
+Every `*_over_time` table carries:
 
-| Table | Index today | Correlated column | Note |
-|---|---|---|---|
-| `heartbeat` | `heartbeat_ran_at_idx (ran_at desc)` | `ran_at` | Purely append-only, never updated. The cleanest candidate in the schema. |
-| `heartbeat` | `heartbeat_job_ended_at_idx (job, ended_at desc)` | `ended_at` | Leading equality on `job` (low cardinality — one value per extract job), so a BRIN on `ended_at` plus a recheck on `job` may beat it. Backs `latest_heartbeats()`. |
-| `industry_system_index` | `(system_id, activity, recorded_at desc)` | `recorded_at` | Explicitly append-only ("so the indices' drift over time can be charted"). Point lookups by system+activity are the current shape though — see Phase 2. |
-| `character_mercenary_den_status` | `character_mercenary_den_status_den_idx` | `observed_at` | Append-only observations. |
-| `character_wallet` | `(registration_id, recorded_at desc)` | `recorded_at` | Balance history, append-only. |
-| `character_wallet_transaction` | `(registration_id, date desc)` | `date` | ESI returns transactions newest-first and they are inserted as fetched, so `date` correlates well but not perfectly. |
-| `corp_wallet_journal` | `(corporation_id, date desc)` | `date` | Same shape. Already range-paged by `/structure/revenue`, which is the one query here known to page past PostgREST's row cap. |
-| `corp_wallet_transaction` | `(registration_id, date desc)` | `date` | Same shape. |
+```sql
+-- Time travel: valid_from climbs with physical order (the reconcile appends),
+-- so a BRIN serves `valid_from <= as_of` at ~kB size. Measured precedent and
+-- churn-survival numbers: docs/brin-indexes/README.md.
+create index <table>_asof_idx on public.<table>
+  using brin (valid_from) with (pages_per_range = 32);
+```
 
-### Group B — the SCD-2 histories: possible, but each needs its own answer
-
-Every `*_over_time` table carries three index shapes:
-
-1. `(<owner>_id)` — a bare btree over a **very low cardinality** column (one
-   value per registration or corporation). 18 of these exist. On a large table
-   this is the classic BRIN candidate *if* rows for one owner land contiguously
-   — which they do, because the per-character fan-out runs one character per
-   step, so a run appends that character's rows in a block. Worth measuring.
-2. `(<entity>_id, valid_until desc)` — high-cardinality equality on the leading
-   column. **Leave as btree.**
-3. `... where is_current` partial uniques — these only index the *current*
-   rows, so they are already small and are the identity constraint besides.
-   **Leave alone.**
-
-Tables in this group: `character_asset_over_time`, `character_blueprint_over_time`,
+All 13 tables — the 12 without one today plus `market_price_over_time`, the
+precedent: `character_asset_over_time`, `character_blueprint_over_time`,
 `character_order_over_time`, `character_industry_job_over_time`,
 `character_clone_over_time`, `character_skill_over_time`,
 `character_ship_over_time`, `character_fitting_over_time`,
-`character_mercenary_den_over_time`, and the `corp_*` mirrors
-(`corp_asset_over_time`, `corp_blueprint_over_time`, `corp_industry_job_over_time`).
+`character_mercenary_den_over_time`, `corp_asset_over_time`,
+`corp_blueprint_over_time`, `corp_industry_job_over_time`.
 
-### Group C — explicitly out of scope
+**Small tables get one too.** The earlier plan gated on "> ~1 GB", reasoning
+that small tables don't matter. Inverted: a BRIN on a 50k-row table costs
+kilobytes and near-zero write overhead, and standardizing means every table is
+already correct when it grows and every time-travel query plans the same way —
+uniformity is cheaper than a per-table debate nobody re-opens at the right
+moment. (Tables with no snapshot function yet — clone/skill/ship/fitting/
+mercenary-den — are included for the same reason: the index is the cheap half;
+the RPC, when someone wants one, is the expensive half.)
 
-`universe_name`, `universe_structure`, `esi_etag`, `sde_*`, `sheet_csv`,
-`esf_data`: bounded by the size of New Eden or by one row per key, not by time.
-Contract tables (`character_contract`, `corp_contract`) upsert in place and are
-bounded by contracts seen. `registration`, `token`, `user_settings` and friends
-are bounded by account count.
+### What stays, what might go
 
-## Phases
+- **Keep** the `(<entity>_id, valid_until desc)` btrees: high-cardinality
+  equality probes (`asset_share_covers`'s per-node lateral lookup, the
+  `distinct on (item_id)` walkers) have no correlation to exploit — BRIN is
+  wrong for them.
+- **Keep** the `where is_current` partial uniques: they are the identity
+  constraint, the reconcile's conflict target, and the live-path index.
+- **Owner btrees (`(registration_id)` / `(corporation_id)`) are drop
+  candidates, not conversion candidates.** Very low cardinality; RLS and the
+  snapshot functions filter on them, but usually alongside predicates the
+  other indexes serve. Decide per table from `pg_stat_user_indexes.idx_scan`
+  over a real window (the third Phase-1 query below); each drop is its **own
+  PR, never bundled with a BRIN add** — a plan regression must be
+  attributable to exactly one change. The market-prices work already found one
+  60 MB btree the planner never chose; expect more.
 
-### Phase 1 — measure, and possibly stop
+### Migration mechanics
 
-Nothing below is worth doing on a table with 50k rows. **This phase may
-legitimately conclude that `market_price_over_time` was the only table big
-enough to care about**, and that is a fine outcome to write down and close.
+- Plain `create index` in a normal migration. The Supabase CLI applies
+  migrations transactionally, so `concurrently` is unavailable — and
+  unnecessary: a BRIN build is one sequential heap pass, and the writers it
+  would briefly block are the 6-hourly extract jobs. Merge away from the
+  busiest cron minutes (`vercel.json`) for the large tables.
+- Every migration edits `schema.sql` too (source of truth), never renames an
+  existing migration, and **records the measured numbers in its comment** the
+  way `20260816040000_market_price.sql` does — a future reader must be able to
+  tell whether the choice was reasoned or copied.
+- Naming: `<table>_asof_idx`, matching the precedent.
 
-Against production (read-only):
+## Measurement protocol (per table PR)
+
+The point of standardizing *measured* is that every claim below is checkable
+in Vercel Observability, not a rerun of someone's laptop benchmark.
+
+### 1. Baseline window
+
+≥7 days of `request.timing` (metric emitted by `src/observability.js`,
+ingested from function logs) before the migration merges, grouped by
+`route` + `field`, split on `served`:
+
+- `served='historical'` — requests that exercised the time-travel predicate
+  (an explicit `at=`). Record p50/p95 `duration_ms` and typical `rows`.
+- `served='live'` — the current-rows path (lens CSV, GraphQL, legacy without
+  `at=`). This is the regression guard: the BRIN must not change these plans.
+
+Organic historical traffic may be thin — lenses are deliberately current-only
+(docs/sharing-layer/09-sheets-parity.md), so `at=` arrives only through the
+legacy CSV routes and `/sheets/market/[market]`. So each PR also runs a
+**synthetic probe**: a scripted loop hitting the table's `at=` endpoint at
+fixed offsets (1 day / 30 days / 90 days back) a few dozen times, from the
+same region, before and after — enough samples for a stable p50 either side.
+The probe's requests land in the same metric with `served='historical'`;
+nothing special to build.
+
+### 2. Plan-level evidence
+
+`EXPLAIN (ANALYZE, BUFFERS)` of the serving RPC's query at **production row
+counts**, before and after, plus `pg_relation_size` of every index touched.
+Use a production read-only session or a restored copy — a Supabase preview
+branch clones schema, not data, and an empty table's plan proves nothing.
+
+### 3. Apply, compare, accept
+
+Merge the migration, run an equal-length comparison window (and re-run the
+synthetic probe). Acceptance:
+
+- `served='live'` p50/p95 not regressed for the routes reading this table;
+- `served='historical'` improved or neutral (the market-price precedent says
+  "a few ms slower deep-history is fine" — the win is the index size, which
+  gets recorded);
+- index sizes recorded in the migration comment closed out with the real
+  numbers.
+
+A regression reverts the one migration — which is why each table ships alone.
+
+### 4. Health, ongoing
+
+- **BRIN degrades silently**: correlation drops, queries slow, nothing
+  errors. Re-run the correlation query below periodically (fold it into
+  whatever check next touches this area) and re-check after any change to a
+  reconcile's write order.
+- **Summarisation lags inserts**: new heap blocks aren't summarised until
+  autovacuum runs or `brin_summarize_new_values()` is called, so the newest
+  rows fall back to a scan. Harmless for history queries, which is all this
+  index serves. `autosummarize=on` is the recorded open question — the
+  market-price index doesn't set it; revisit if p95 on fresh-history probes
+  looks worse than stale-history ones.
+
+## Table → probe map
+
+Which timing series measures which table. `field` is the metric's dimension.
+
+| Table                               | Historical probe                                        | `field`                      |
+| ----------------------------------- | ------------------------------------------------------- | ---------------------------- |
+| `character_asset_over_time`         | `/api/character/assets?at=`                             | `character_asset_snapshot_at`|
+| `character_order_over_time`         | `/api/character/orders?at=`                             | `character_orders`           |
+| `character_industry_job_over_time`  | `/api/character/jobs?at=`                               | `character_industry_jobs`    |
+| `corp_industry_job_over_time`       | `/api/corp/jobs?at=`                                    | `corp_industry_jobs`         |
+| `market_price_over_time`            | `/sheets/market/[market]?at=` (the control — BRIN'd already) | `market_price_snapshot` |
+| `character_blueprint_over_time`, `corp_asset_over_time`, `corp_blueprint_over_time` | none — their RPCs are live-only | EXPLAIN-only evidence, stated honestly in the PR |
+| `character_clone/skill/ship/fitting/mercenary_den_over_time` | none — no snapshot RPC exists | EXPLAIN-only evidence |
+
+The live-path guard for every table is the same tables' `served='live'`
+series: `lens_csv`/`graphql` (`assets`, `blueprints`, `industryJobs`,
+`marketOrders`) and the legacy routes without `at=`.
+
+The MCP `list_market_orders`/`list_industry_jobs` tools take `as_of` and call
+the same RPCs — they benefit identically but aren't instrumented; the CSV
+routes are the measured proxy.
+
+## Pre-flight queries (kept from the survey)
+
+Still the right first move before each PR — sizing, correlation, and the
+index-usage read that decides owner-btree drops. Against production,
+read-only:
 
 ```sql
 -- Which tables are actually large, and how much of each is index?
@@ -114,17 +209,17 @@ where n.nspname = 'public' and c.relkind = 'r'
 order by pg_total_relation_size(c.oid) desc
 limit 25;
 
--- Is the candidate column actually correlated with physical order?
--- Below ~0.9 and BRIN is not worth trying.
+-- Is valid_from actually correlated with physical order? Below ~0.9,
+-- investigate the table's reconcile before indexing it — that would mean the
+-- append assumption broke somewhere.
 select tablename, attname, correlation, n_distinct
 from pg_stats
 where schemaname = 'public'
-  and attname in ('ran_at','ended_at','recorded_at','date','observed_at',
-                  'valid_from','registration_id','corporation_id')
+  and attname in ('valid_from','valid_until','registration_id','corporation_id')
 order by tablename, attname;
 
--- Which indexes is nobody using? A never-scanned index is a pure write tax,
--- and dropping it beats converting it.
+-- Which indexes is nobody using? A never-scanned owner btree on a big table
+-- is a drop candidate (its own PR).
 select relname, indexrelname, idx_scan,
        pg_size_pretty(pg_relation_size(indexrelid)) as size
 from pg_stat_user_indexes
@@ -133,62 +228,51 @@ order by pg_relation_size(indexrelid) desc
 limit 30;
 ```
 
-The third query matters as much as the other two. The market-prices work found a
-60 MB btree the planner **never chose** — for that index the right change was not
-"convert to BRIN" but "this should not exist". Expect more of those.
+## Sequencing
 
-Gate to Phase 2: a table is a candidate only if it is **> ~1 GB**, its column
-correlation is **> 0.9**, and the index in question is **either large and
-unused, or large and serving range scans**.
+1. ~~Instrument the serving endpoints~~ — done: `request.timing` covers the
+   seven CSV routes, `/sheets/market/[market]`, the lens viewer/CSV, and
+   `/api/graphql`, with the `served` live/historical split.
+2. **PR: small-table batch.** One migration adding the BRIN to the tables the
+   sizing query shows as small (expected: clone, skill, ship, fitting,
+   mercenary-den, and possibly blueprints). EXPLAIN evidence only; batching is
+   safe exactly because these can't regress anything measurable.
+3. **One PR per large table**, in descending size order (expected: assets,
+   then orders/industry jobs — confirm with the sizing query), each running
+   the full protocol above.
+4. **Owner-btree drops**, per `idx_scan` evidence, one PR each, after the
+   BRIN adds have settled.
+5. **Fillfactor experiment** (below), last and independent.
 
-### Phase 2 — one table, end to end, as the template
+## The adjacent project: churn, not indexes
 
-Take the single best candidate from Phase 1 (`heartbeat` is the likely winner:
-purely append-only, never updated, and `latest_heartbeats()` is a known query).
-For it:
+Kept from the survey because the numbers were striking: the market-prices
+simulation measured 267k live rows occupying 143 MB — dead tuples from the
+hourly `valid_until` touch, not row width. **Every SCD-2 table does that same
+touch every 6 hours.** If the sizing query shows heap ≫ live-row estimate on
+the big tables, the higher-value fix is a measured `fillfactor` experiment on
+one mid-size table:
 
-1. Write down the queries that touch the index, from the calling code, not from
-   imagination.
-2. Restore a production-shaped copy locally and measure `EXPLAIN (ANALYZE,
-   BUFFERS)` for each, before and after, at real row counts. The market-prices
-   method — build both variants side by side in one database and compare
-   `pg_total_relation_size` plus plans — is in
-   [docs/market-prices/README.md](../market-prices/README.md).
-3. Only then write the migration. `create index concurrently` for anything on a
-   live table; the migration runner applies on push to `main`, so a long index
-   build blocks deploys.
-4. Record the measured numbers in the migration comment, the way the
-   market-price migration does. A future reader must be able to tell whether the
-   choice was reasoned or copied.
+- `alter table <t> set (fillfactor = 90)` affects only future pages;
+  reclaiming existing bloat needs `vacuum full`/`pg_repack`, which is out of
+  scope here.
+- Track `pg_stat_user_tables.n_dead_tup` and heap size over two weeks against
+  an untouched sibling table.
+- HOT updates are the mechanism to verify: with free space per page, the
+  `valid_until` touch can stay on-page instead of appending a dead tuple —
+  which *also* protects the BRIN correlation, since fewer relocations means
+  the append order stays clean.
 
-### Phase 3 — roll out to whatever else Phase 1 justified
+Separate follow-up; does not block the index rollout.
 
-One PR per table. Do not batch: each conversion changes query plans, and a
-regression is much easier to attribute when it arrives alone.
+## Risks and non-goals (unchanged in spirit)
 
-### Phase 4 — the adjacent finding, if it survives Phase 1
-
-The market-prices churn simulation measured 267k live rows occupying 143 MB —
-the excess being dead tuples from the hourly `valid_until` touch, not row width.
-**Every SCD-2 table here does that same touch on every run.** If Phase 1 shows
-the big tables are mostly bloat rather than data, the higher-value project is
-not indexes at all; it is revisiting the touch, or `fillfactor`, or autovacuum
-settings (no table in `schema.sql` sets a `fillfactor` today). Worth a doc of its
-own if the numbers point that way.
-
-## Risks and non-goals
-
-- **BRIN degrades silently.** It has no health metric a dashboard would show:
-  correlation drops, queries get slower, nothing errors. Any table converted
-  should have its `pg_stats.correlation` re-checked periodically — worth folding
-  into whatever Phase 1 tooling gets written.
-- **Summarisation lags inserts.** New heap blocks are not summarised until
-  autovacuum runs or `brin_summarize_new_values()` is called, so freshly
-  inserted rows fall back to a scan. Harmless for history queries, bad for
-  anything reading the newest rows through the BRIN.
-- **Not a substitute for retention.** BRIN shrinks the *index*. If a table is
-  large because it keeps everything forever, the honest fix is a retention
-  policy; BRIN just makes the table cheaper to keep.
-- **Non-goal: converting anything on read-path latency grounds.** Every
-  conversion here trades a little query time for a lot of space. If a table is
-  small enough that its indexes do not matter, leave it alone.
+- **Not a btree replacement** for high-cardinality equality (`item_id`,
+  `job_id`, `order_id` probes stay btree).
+- **Not a substitute for retention.** BRIN shrinks the index; a table large
+  because it keeps everything forever still wants a retention policy —
+  cheaper to keep is not the same as worth keeping.
+- **Non-goal: latency wins.** The measured precedent trades a few ms on
+  deep-history reads for three orders of magnitude of index size. The
+  acceptance bar is "no live-path regression, historical neutral-or-better",
+  not "faster".

--- a/docs/sharing-layer/09-sheets-parity.md
+++ b/docs/sharing-layer/09-sheets-parity.md
@@ -1,0 +1,106 @@
+# Sheets parity: lenses supersede the api_token CSV routes
+
+**Status: in progress** — this phase's code ships alongside the lens creator
+UI (templates, fork, IMPORTDATA surfacing) and the `request.timing`
+instrumentation the BRIN index project reads (`docs/brin-indexes/README.md`).
+
+## Context
+
+Seven bespoke CSV endpoints serve Google Sheets `=IMPORTDATA()`, authenticated
+by the per-user `api_token` in the query string:
+
+| Route | Postgres function | `at=` time travel |
+| --- | --- | --- |
+| `/api/character/assets` | `character_asset_snapshot_at` | yes |
+| `/api/character/blueprints` | `character_blueprints` | no |
+| `/api/character/jobs` | `character_industry_jobs` | yes |
+| `/api/character/orders` | `character_orders` | yes |
+| `/api/corp/assets` | `corp_assets` | no |
+| `/api/corp/blueprints` | `corp_blueprints` | no |
+| `/api/corp/jobs` | `corp_industry_jobs` | yes |
+
+The lens CSV surface (`/lens/[id]/csv?share=…`, `docs/sharing-layer/07-lens.md`)
+was always positioned to supersede them: a lens is a stored GraphQL query, so
+one general surface replaces seven bespoke ones, and sharing rides the unified
+audience model instead of a bearer token that unlocks *everything* the account
+owns. This phase closes the parity gaps and starts the deprecation.
+
+## Decisions
+
+- **No time travel in lenses.** The GraphQL schema stays current-data-only —
+  the `_over_time` SCD histories are deliberately not exposed (see
+  `04-graphql-shared.md`). `at=` stays a legacy-route capability, documented as
+  the one thing lenses do not replace. This is also load-bearing for
+  measurement: the legacy `at=` requests are the `served: 'historical'` series
+  the BRIN before/after comparison pivots on, so those routes cannot be removed
+  until that project's measurement windows close.
+- **Column-name parity is template authoring, not resolver code.** `toCsv`
+  derives CSV headers from response keys, and GraphQL aliases control those
+  keys — so a lens template selecting `item_id: itemId` produces a
+  byte-identical header row to the legacy route, and an existing sheet tab
+  re-points cleanly. The drop-in templates in `src/app/lens/templates.ts` pin
+  this, tested against the routes' own column lists.
+- **`output_count` is not carried over.** In the jobs RPCs it is an SQL join
+  against `sde_blueprint_product` (`runs * product_quantity`), and on the
+  legacy routes it is opt-in only (excluded from the default columns). The six
+  plain columns the GraphQL `IndustryJob` type lacked (`blueprintId`,
+  `blueprintLocationId`, `outputLocationId`, `facilityId`, `pauseDate`,
+  `completedCharacterId`) are added instead; a sheet that needs `output_count`
+  keeps the legacy route until removal, or derives it from
+  `blueprint_for_product`.
+- **Exports are uncapped up to `EXPORT_CAP`, and refuse beyond it.** The
+  interactive GraphQL caps (`ASSET_CAP` 5000 / `LIST_CAP` 1000) exist so an
+  ad-hoc query stays bounded; a Sheets tab can't page, so a capped CSV would be
+  *silently* short — the one failure mode worse than failing. The lens CSV
+  route runs its query with the caps raised to `EXPORT_CAP` (50 000, sized to
+  what the uncapped legacy routes already serve inside the same 60 s budget)
+  via `contextForUser(userId, { exporting: true })`, and answers 400 rather
+  than emitting a shortened CSV when even that bound bites. An author's own
+  smaller `limit:` argument is deliberate and passes untouched.
+
+## Changes
+
+1. **IndustryJob columns** — `schema.graphql.ts` + `resolvers.ts` add the six
+   fields above (all `String` per the ids-overflow-Int house rule; the
+   resolvers already `select('*')`, so the columns were on the wire).
+   Drift-guarded in `test/graphqlSchema.test.ts`.
+2. **Export caps** — `EXPORT_CAP` in `filters.ts`; `GraphqlContext.caps`
+   (defaults `ASSET_CAP`/`LIST_CAP`) threaded through every resolver cap site;
+   `runLens(lens, { exporting })` → `contextForUser(userId, { exporting })`;
+   the CSV route refuses at the bound.
+3. **Drop-in templates** — one `LensTemplate` per legacy route in
+   `src/app/lens/templates.ts`, aliasing every default column to its
+   snake_case legacy name, tested for exact header equality in
+   `test/lensTemplates.test.ts`.
+4. **Deprecation** — `/account/settings` presents lenses as the primary Sheets
+   integration for `lens`-flagged accounts and moves the legacy formulas under
+   a Deprecated heading; the seven routes answer a `Deprecation: true` header.
+
+## What deprecation means here
+
+- The routes stay live and instrumented. They are the `served: 'historical'`
+  measurement instrument for `docs/brin-indexes/README.md`; removal is not
+  scheduled before that project's per-table measurement windows have closed,
+  and `at=` users have no lens replacement to move to.
+- Steering *all* users to lenses requires lifting the `lens` dark-launch flag
+  (`src/flags.ts`) — a product call taken separately, not by this phase.
+- When removal is eventually scheduled, it is its own phase with its own
+  notice period; nothing in this phase breaks an existing `=IMPORTDATA()`
+  formula.
+
+## Tests
+
+- `test/graphqlSchema.test.ts` — the six IndustryJob columns.
+- `test/lensTemplates.test.ts` — every template validates against the schema;
+  the drop-in templates' aliases equal the legacy routes' default column lists
+  exactly.
+- `test/lensValidate.test.ts` — `topLevelFieldOf` (the timing metric's `field`
+  dimension).
+
+## Verification
+
+- Save a drop-in template as a lens, link-share it, and diff
+  `/lens/<id>/csv?share=…` against the matching legacy route's output: header
+  byte-identical, rows equal modulo ordering.
+- A lens whose result reaches `EXPORT_CAP` answers 400, not a shortened CSV.
+- `request.timing` lines appear for both surfaces in Vercel Observability.

--- a/src/app/account/settings/apiToken.tsx
+++ b/src/app/account/settings/apiToken.tsx
@@ -5,7 +5,12 @@ import { useEffect, useState } from 'react'
 import { generateApiToken } from './actions'
 import Dot from './dot'
 
-const ApiToken = ({ initialToken }: { initialToken: string | null }) => {
+// `lensEnabled`: the account carries the `lens` dark-launch flag, so lenses
+// are presented as the primary Sheets integration and the token URLs move
+// under a Deprecated heading (docs/sharing-layer/09-sheets-parity.md). For
+// unflagged accounts the token URLs stay the only offer — deprecating a thing
+// someone has no replacement for would just be rude.
+const ApiToken = ({ initialToken, lensEnabled }: { initialToken: string | null; lensEnabled: boolean }) => {
   const [token, setToken] = useState(initialToken)
   const [origin, setOrigin] = useState('')
   const [response, setResponse] = useState('')
@@ -37,9 +42,27 @@ const ApiToken = ({ initialToken }: { initialToken: string | null }) => {
   return (
     <>
       <h2>API Access (Google Sheets)</h2>
-      <p>
-        Pull your data into a spreadsheet with <code>=IMPORTDATA(url)</code> (the first row is the column headers):
-      </p>
+      {lensEnabled && (
+        <p>
+          The current way to feed a spreadsheet is a <a href="/lens">lens</a>: pick a &quot;Sheets drop-in&quot;
+          template (same columns as the URLs below), share it as a link, and paste the <code>=IMPORTDATA(…)</code>{' '}
+          formula it shows you. A lens link exposes only that one query — unlike the API token below, which unlocks
+          everything at once.
+        </p>
+      )}
+      {lensEnabled ? (
+        <h3>Deprecated: token URLs</h3>
+      ) : (
+        <p>
+          Pull your data into a spreadsheet with <code>=IMPORTDATA(url)</code> (the first row is the column headers):
+        </p>
+      )}
+      {lensEnabled && (
+        <p>
+          These keep working, but new sheets should use lenses. The one thing staying here for now is <code>at=</code>{' '}
+          history — lenses read current data only.
+        </p>
+      )}
       {assetsUrl && blueprintsUrl && industryUrl && ordersUrl && corpAssetsUrl && corpBlueprintsUrl && corpJobsUrl && (
         <ul>
           <li>

--- a/src/app/account/settings/page.tsx
+++ b/src/app/account/settings/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
+import { LENS_FLAG, hasFlag } from '@/flags'
 import { createClient } from '@/utils/supabase/server'
 
 import { establishedUser } from '../lib/establishedUser'
@@ -80,7 +81,7 @@ const SettingsPage = async ({ searchParams }: { searchParams: Promise<{ gice?: s
 
       <Discord appId={process.env.DISCORD_APP_ID ?? null} channels={discordChannels ?? []} />
 
-      <ApiToken initialToken={settings?.api_token ?? null} />
+      <ApiToken initialToken={settings?.api_token ?? null} lensEnabled={await hasFlag(user.id, LENS_FLAG)} />
 
       {chancellor && (
         <>

--- a/src/app/api/character/assets/route.ts
+++ b/src/app/api/character/assets/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { RequestTiming, withRequestTiming } from '@/app/api/requestTiming'
 import { resolvePlayer } from '@/utils/apiToken'
 import { AT_PARAM_ERROR, parseAtParam } from '@/utils/atParam'
 import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
@@ -28,12 +29,13 @@ export const dynamic = 'force-dynamic'
 // Headroom over Vercel's default function timeout for a large inventory.
 export const maxDuration = 60
 
-export const GET = async (request: NextRequest): Promise<NextResponse> => {
+const handler = async (request: NextRequest, _context: unknown, timing: RequestTiming): Promise<NextResponse> => {
   const { searchParams } = new URL(request.url)
 
   // `at` is the moment to reconstruct the inventory at; default to now (the live
   // inventory). character_asset_over_time keeps full SCD-2 history, so any past
   // time works.
+  if (searchParams.get('at') !== null) timing.served = 'historical'
   const at = parseAtParam(searchParams.get('at'))
   if (!at.ok) {
     return NextResponse.json({ error: AT_PARAM_ERROR }, { status: 400 })
@@ -62,7 +64,13 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
 
+  timing.rows = (rows ?? []).length
   return new NextResponse(toCsv(selectColumns(rows ?? [], columnsResult.columns)), {
     headers: { 'Content-Type': 'text/csv; charset=utf-8' },
   })
 }
+
+export const GET = withRequestTiming(
+  { route: '/api/character/assets', surface: 'legacy_csv', field: 'character_asset_snapshot_at' },
+  handler
+)

--- a/src/app/api/character/assets/route.ts
+++ b/src/app/api/character/assets/route.ts
@@ -62,6 +62,6 @@ const handler = async (request: NextRequest, _context: unknown, timing: RequestT
 }
 
 export const GET = withRequestTiming(
-  { route: '/api/character/assets', surface: 'legacy_csv', field: 'character_asset_snapshot_at' },
+  { route: '/api/character/assets', surface: 'legacy_csv', field: 'character_asset_snapshot_at', deprecated: true },
   handler
 )

--- a/src/app/api/character/assets/route.ts
+++ b/src/app/api/character/assets/route.ts
@@ -1,24 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { CHARACTER_ASSET_COLUMNS } from '@/app/api/csvColumns'
 import { RequestTiming, withRequestTiming } from '@/app/api/requestTiming'
 import { resolvePlayer } from '@/utils/apiToken'
 import { AT_PARAM_ERROR, parseAtParam } from '@/utils/atParam'
 import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
 import { toCsv } from '@/utils/csv'
 
-// Default column set/order, matching character_asset_snapshot_at()'s
-// json_build_object in schema.sql. ?columns= can reorder/subset these.
-const ALLOWED_COLUMNS = [
-  'is_blueprint_copy',
-  'is_singleton',
-  'item_id',
-  'location_flag',
-  'location_id',
-  'location_type',
-  'quantity',
-  'type_id',
-  'character_name',
-] as const
+// Default column set/order (src/app/api/csvColumns.ts, shared with the lens
+// drop-in templates). ?columns= can reorder/subset these.
+const ALLOWED_COLUMNS = CHARACTER_ASSET_COLUMNS
 
 // Public CSV endpoint for Google Sheets =IMPORTDATA(): the player's raw asset
 // rows (one per item stack) with the owning character's name, as of an optional

--- a/src/app/api/character/blueprints/route.ts
+++ b/src/app/api/character/blueprints/route.ts
@@ -48,6 +48,6 @@ const handler = async (request: NextRequest, _context: unknown, timing: RequestT
 }
 
 export const GET = withRequestTiming(
-  { route: '/api/character/blueprints', surface: 'legacy_csv', field: 'character_blueprints' },
+  { route: '/api/character/blueprints', surface: 'legacy_csv', field: 'character_blueprints', deprecated: true },
   handler
 )

--- a/src/app/api/character/blueprints/route.ts
+++ b/src/app/api/character/blueprints/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { RequestTiming, withRequestTiming } from '@/app/api/requestTiming'
 import { resolvePlayer } from '@/utils/apiToken'
 import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
 import { toCsv } from '@/utils/csv'
@@ -26,7 +27,7 @@ const ALLOWED_COLUMNS = [
 export const dynamic = 'force-dynamic'
 export const maxDuration = 60
 
-export const GET = async (request: NextRequest): Promise<NextResponse> => {
+const handler = async (request: NextRequest, _context: unknown, timing: RequestTiming): Promise<NextResponse> => {
   const { searchParams } = new URL(request.url)
 
   const columnsResult = parseColumnsParam(searchParams.get('columns'), ALLOWED_COLUMNS)
@@ -49,7 +50,13 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
 
+  timing.rows = (rows ?? []).length
   return new NextResponse(toCsv(selectColumns(rows ?? [], columnsResult.columns)), {
     headers: { 'Content-Type': 'text/csv; charset=utf-8' },
   })
 }
+
+export const GET = withRequestTiming(
+  { route: '/api/character/blueprints', surface: 'legacy_csv', field: 'character_blueprints' },
+  handler
+)

--- a/src/app/api/character/blueprints/route.ts
+++ b/src/app/api/character/blueprints/route.ts
@@ -1,23 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { CHARACTER_BLUEPRINT_COLUMNS } from '@/app/api/csvColumns'
 import { RequestTiming, withRequestTiming } from '@/app/api/requestTiming'
 import { resolvePlayer } from '@/utils/apiToken'
 import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
 import { toCsv } from '@/utils/csv'
 
-// Default column set/order, matching character_blueprints()'s json_build_object
-// in schema.sql. ?columns= can reorder/subset these.
-const ALLOWED_COLUMNS = [
-  'item_id',
-  'location_flag',
-  'location_id',
-  'material_efficiency',
-  'quantity',
-  'runs',
-  'time_efficiency',
-  'type_id',
-  'character_name',
-] as const
+// Default column set/order (src/app/api/csvColumns.ts, shared with the lens
+// drop-in templates). ?columns= can reorder/subset these.
+const ALLOWED_COLUMNS = CHARACTER_BLUEPRINT_COLUMNS
 
 // Public CSV endpoint for Google Sheets =IMPORTDATA(): the player's current
 // blueprint rows (one per blueprint stack) across all of their characters,

--- a/src/app/api/character/jobs/route.ts
+++ b/src/app/api/character/jobs/route.ts
@@ -1,40 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { CHARACTER_JOB_COLUMNS } from '@/app/api/csvColumns'
 import { RequestTiming, withRequestTiming } from '@/app/api/requestTiming'
 import { resolvePlayer } from '@/utils/apiToken'
 import { AT_PARAM_ERROR, parseAtParam } from '@/utils/atParam'
 import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
 import { toCsv } from '@/utils/csv'
 
-// Column set/order returned when ?columns= is omitted, matching
-// character_industry_jobs()'s json_build_object in schema.sql.
-const DEFAULT_COLUMNS = [
-  'activity_id',
-  'blueprint_id',
-  'blueprint_location_id',
-  'blueprint_type_id',
-  'completed_character_id',
-  'completed_date',
-  'cost',
-  'duration',
-  'end_date',
-  'facility_id',
-  'installer_id',
-  'job_id',
-  'licensed_runs',
-  'output_location_id',
-  'pause_date',
-  'probability',
-  'product_type_id',
-  'runs',
-  'start_date',
-  'station_id',
-  'status',
-  'successful_runs',
-  'character_name',
-  'blueprint_type_name',
-  'product_type_name',
-] as const
+// Column set/order returned when ?columns= is omitted (src/app/api/
+// csvColumns.ts, shared with the lens drop-in templates).
+const DEFAULT_COLUMNS = CHARACTER_JOB_COLUMNS
 
 // Every column ?columns= may select, in any order/subset: DEFAULT_COLUMNS plus
 // fields that exist in the json_build_object but are opt-in only (excluded

--- a/src/app/api/character/jobs/route.ts
+++ b/src/app/api/character/jobs/route.ts
@@ -71,6 +71,6 @@ const handler = async (request: NextRequest, _context: unknown, timing: RequestT
 }
 
 export const GET = withRequestTiming(
-  { route: '/api/character/jobs', surface: 'legacy_csv', field: 'character_industry_jobs' },
+  { route: '/api/character/jobs', surface: 'legacy_csv', field: 'character_industry_jobs', deprecated: true },
   handler
 )

--- a/src/app/api/character/jobs/route.ts
+++ b/src/app/api/character/jobs/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { RequestTiming, withRequestTiming } from '@/app/api/requestTiming'
 import { resolvePlayer } from '@/utils/apiToken'
 import { AT_PARAM_ERROR, parseAtParam } from '@/utils/atParam'
 import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
@@ -50,11 +51,12 @@ export const dynamic = 'force-dynamic'
 // Headroom over Vercel's default function timeout.
 export const maxDuration = 60
 
-export const GET = async (request: NextRequest): Promise<NextResponse> => {
+const handler = async (request: NextRequest, _context: unknown, timing: RequestTiming): Promise<NextResponse> => {
   const { searchParams } = new URL(request.url)
 
   // `at` time-travels the SCD-2 history (character_industry_job_over_time) to the
   // job versions valid at that moment; default now is the live set.
+  if (searchParams.get('at') !== null) timing.served = 'historical'
   const at = parseAtParam(searchParams.get('at'))
   if (!at.ok) {
     return NextResponse.json({ error: AT_PARAM_ERROR }, { status: 400 })
@@ -87,7 +89,13 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
 
+  timing.rows = (rows ?? []).length
   return new NextResponse(toCsv(selectColumns(rows ?? [], columnsResult.columns ?? DEFAULT_COLUMNS)), {
     headers: { 'Content-Type': 'text/csv; charset=utf-8' },
   })
 }
+
+export const GET = withRequestTiming(
+  { route: '/api/character/jobs', surface: 'legacy_csv', field: 'character_industry_jobs' },
+  handler
+)

--- a/src/app/api/character/orders/route.ts
+++ b/src/app/api/character/orders/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { RequestTiming, withRequestTiming } from '@/app/api/requestTiming'
 import { resolvePlayer } from '@/utils/apiToken'
 import { AT_PARAM_ERROR, parseAtParam } from '@/utils/atParam'
 import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
@@ -34,11 +35,12 @@ export const dynamic = 'force-dynamic'
 // Headroom over Vercel's default function timeout.
 export const maxDuration = 60
 
-export const GET = async (request: NextRequest): Promise<NextResponse> => {
+const handler = async (request: NextRequest, _context: unknown, timing: RequestTiming): Promise<NextResponse> => {
   const { searchParams } = new URL(request.url)
 
   // `at` reconstructs which orders were open at that moment from the SCD-2
   // history (character_order_over_time); default now is the live open set.
+  if (searchParams.get('at') !== null) timing.served = 'historical'
   const at = parseAtParam(searchParams.get('at'))
   if (!at.ok) {
     return NextResponse.json({ error: AT_PARAM_ERROR }, { status: 400 })
@@ -64,7 +66,13 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
 
+  timing.rows = (rows ?? []).length
   return new NextResponse(toCsv(selectColumns(rows ?? [], columnsResult.columns)), {
     headers: { 'Content-Type': 'text/csv; charset=utf-8' },
   })
 }
+
+export const GET = withRequestTiming(
+  { route: '/api/character/orders', surface: 'legacy_csv', field: 'character_orders' },
+  handler
+)

--- a/src/app/api/character/orders/route.ts
+++ b/src/app/api/character/orders/route.ts
@@ -1,30 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { CHARACTER_ORDER_COLUMNS } from '@/app/api/csvColumns'
 import { RequestTiming, withRequestTiming } from '@/app/api/requestTiming'
 import { resolvePlayer } from '@/utils/apiToken'
 import { AT_PARAM_ERROR, parseAtParam } from '@/utils/atParam'
 import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
 import { toCsv } from '@/utils/csv'
 
-// Default column set/order, matching character_orders()'s json_build_object
-// in schema.sql. ?columns= can reorder/subset these.
-const ALLOWED_COLUMNS = [
-  'duration',
-  'escrow',
-  'is_buy_order',
-  'is_corporation',
-  'issued',
-  'location_id',
-  'min_volume',
-  'order_id',
-  'price',
-  'range',
-  'region_id',
-  'type_id',
-  'volume_remain',
-  'volume_total',
-  'character_name',
-] as const
+// Default column set/order (src/app/api/csvColumns.ts, shared with the lens
+// drop-in templates). ?columns= can reorder/subset these.
+const ALLOWED_COLUMNS = CHARACTER_ORDER_COLUMNS
 
 // Public CSV endpoint for Google Sheets =IMPORTDATA(): the player's open market
 // orders across all of their characters, with the owning character's name, as of

--- a/src/app/api/character/orders/route.ts
+++ b/src/app/api/character/orders/route.ts
@@ -58,6 +58,6 @@ const handler = async (request: NextRequest, _context: unknown, timing: RequestT
 }
 
 export const GET = withRequestTiming(
-  { route: '/api/character/orders', surface: 'legacy_csv', field: 'character_orders' },
+  { route: '/api/character/orders', surface: 'legacy_csv', field: 'character_orders', deprecated: true },
   handler
 )

--- a/src/app/api/corp/assets/route.ts
+++ b/src/app/api/corp/assets/route.ts
@@ -1,23 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { CORP_ASSET_COLUMNS } from '@/app/api/csvColumns'
 import { RequestTiming, withRequestTiming } from '@/app/api/requestTiming'
 import { resolvePlayer } from '@/utils/apiToken'
 import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
 import { toCsv } from '@/utils/csv'
 
-// Default column set/order, matching corp_assets()'s json_build_object in
-// schema.sql. ?columns= can reorder/subset these.
-const ALLOWED_COLUMNS = [
-  'item_id',
-  'corporation_id',
-  'type_id',
-  'location_id',
-  'location_flag',
-  'location_type',
-  'quantity',
-  'is_singleton',
-  'is_blueprint_copy',
-] as const
+// Default column set/order (src/app/api/csvColumns.ts, shared with the lens
+// drop-in templates). ?columns= can reorder/subset these.
+const ALLOWED_COLUMNS = CORP_ASSET_COLUMNS
 
 // Public CSV endpoint for Google Sheets =IMPORTDATA(): the current live asset
 // rows (one per item stack) for the corporation(s) the caller's characters

--- a/src/app/api/corp/assets/route.ts
+++ b/src/app/api/corp/assets/route.ts
@@ -48,6 +48,6 @@ const handler = async (request: NextRequest, _context: unknown, timing: RequestT
 }
 
 export const GET = withRequestTiming(
-  { route: '/api/corp/assets', surface: 'legacy_csv', field: 'corp_assets' },
+  { route: '/api/corp/assets', surface: 'legacy_csv', field: 'corp_assets', deprecated: true },
   handler
 )

--- a/src/app/api/corp/assets/route.ts
+++ b/src/app/api/corp/assets/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { RequestTiming, withRequestTiming } from '@/app/api/requestTiming'
 import { resolvePlayer } from '@/utils/apiToken'
 import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
 import { toCsv } from '@/utils/csv'
@@ -27,7 +28,7 @@ export const dynamic = 'force-dynamic'
 // Headroom over Vercel's default function timeout for a large inventory.
 export const maxDuration = 60
 
-export const GET = async (request: NextRequest): Promise<NextResponse> => {
+const handler = async (request: NextRequest, _context: unknown, timing: RequestTiming): Promise<NextResponse> => {
   const { searchParams } = new URL(request.url)
 
   const columnsResult = parseColumnsParam(searchParams.get('columns'), ALLOWED_COLUMNS)
@@ -49,7 +50,13 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
 
+  timing.rows = (rows ?? []).length
   return new NextResponse(toCsv(selectColumns(rows ?? [], columnsResult.columns)), {
     headers: { 'Content-Type': 'text/csv; charset=utf-8' },
   })
 }
+
+export const GET = withRequestTiming(
+  { route: '/api/corp/assets', surface: 'legacy_csv', field: 'corp_assets' },
+  handler
+)

--- a/src/app/api/corp/blueprints/route.ts
+++ b/src/app/api/corp/blueprints/route.ts
@@ -48,6 +48,6 @@ const handler = async (request: NextRequest, _context: unknown, timing: RequestT
 }
 
 export const GET = withRequestTiming(
-  { route: '/api/corp/blueprints', surface: 'legacy_csv', field: 'corp_blueprints' },
+  { route: '/api/corp/blueprints', surface: 'legacy_csv', field: 'corp_blueprints', deprecated: true },
   handler
 )

--- a/src/app/api/corp/blueprints/route.ts
+++ b/src/app/api/corp/blueprints/route.ts
@@ -1,23 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { CORP_BLUEPRINT_COLUMNS } from '@/app/api/csvColumns'
 import { RequestTiming, withRequestTiming } from '@/app/api/requestTiming'
 import { resolvePlayer } from '@/utils/apiToken'
 import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
 import { toCsv } from '@/utils/csv'
 
-// Default column set/order, matching corp_blueprints()'s json_build_object in
-// schema.sql. ?columns= can reorder/subset these.
-const ALLOWED_COLUMNS = [
-  'item_id',
-  'corporation_id',
-  'location_flag',
-  'location_id',
-  'material_efficiency',
-  'quantity',
-  'runs',
-  'time_efficiency',
-  'type_id',
-] as const
+// Default column set/order (src/app/api/csvColumns.ts, shared with the lens
+// drop-in templates). ?columns= can reorder/subset these.
+const ALLOWED_COLUMNS = CORP_BLUEPRINT_COLUMNS
 
 // Public CSV endpoint for Google Sheets =IMPORTDATA(): the current live
 // blueprint rows (one per blueprint stack) for the corporation(s) the

--- a/src/app/api/corp/blueprints/route.ts
+++ b/src/app/api/corp/blueprints/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { RequestTiming, withRequestTiming } from '@/app/api/requestTiming'
 import { resolvePlayer } from '@/utils/apiToken'
 import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
 import { toCsv } from '@/utils/csv'
@@ -26,7 +27,7 @@ const ALLOWED_COLUMNS = [
 export const dynamic = 'force-dynamic'
 export const maxDuration = 60
 
-export const GET = async (request: NextRequest): Promise<NextResponse> => {
+const handler = async (request: NextRequest, _context: unknown, timing: RequestTiming): Promise<NextResponse> => {
   const { searchParams } = new URL(request.url)
 
   const columnsResult = parseColumnsParam(searchParams.get('columns'), ALLOWED_COLUMNS)
@@ -49,7 +50,13 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
 
+  timing.rows = (rows ?? []).length
   return new NextResponse(toCsv(selectColumns(rows ?? [], columnsResult.columns)), {
     headers: { 'Content-Type': 'text/csv; charset=utf-8' },
   })
 }
+
+export const GET = withRequestTiming(
+  { route: '/api/corp/blueprints', surface: 'legacy_csv', field: 'corp_blueprints' },
+  handler
+)

--- a/src/app/api/corp/jobs/route.ts
+++ b/src/app/api/corp/jobs/route.ts
@@ -71,6 +71,6 @@ const handler = async (request: NextRequest, _context: unknown, timing: RequestT
 }
 
 export const GET = withRequestTiming(
-  { route: '/api/corp/jobs', surface: 'legacy_csv', field: 'corp_industry_jobs' },
+  { route: '/api/corp/jobs', surface: 'legacy_csv', field: 'corp_industry_jobs', deprecated: true },
   handler
 )

--- a/src/app/api/corp/jobs/route.ts
+++ b/src/app/api/corp/jobs/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { RequestTiming, withRequestTiming } from '@/app/api/requestTiming'
 import { resolvePlayer } from '@/utils/apiToken'
 import { AT_PARAM_ERROR, parseAtParam } from '@/utils/atParam'
 import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
@@ -50,11 +51,12 @@ export const dynamic = 'force-dynamic'
 // Headroom over Vercel's default function timeout.
 export const maxDuration = 60
 
-export const GET = async (request: NextRequest): Promise<NextResponse> => {
+const handler = async (request: NextRequest, _context: unknown, timing: RequestTiming): Promise<NextResponse> => {
   const { searchParams } = new URL(request.url)
 
   // `at` time-travels the SCD-2 history (corp_industry_job_over_time) to the job
   // versions valid at that moment; default now is the live set.
+  if (searchParams.get('at') !== null) timing.served = 'historical'
   const at = parseAtParam(searchParams.get('at'))
   if (!at.ok) {
     return NextResponse.json({ error: AT_PARAM_ERROR }, { status: 400 })
@@ -87,7 +89,13 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
 
+  timing.rows = (rows ?? []).length
   return new NextResponse(toCsv(selectColumns(rows ?? [], columnsResult.columns ?? DEFAULT_COLUMNS)), {
     headers: { 'Content-Type': 'text/csv; charset=utf-8' },
   })
 }
+
+export const GET = withRequestTiming(
+  { route: '/api/corp/jobs', surface: 'legacy_csv', field: 'corp_industry_jobs' },
+  handler
+)

--- a/src/app/api/corp/jobs/route.ts
+++ b/src/app/api/corp/jobs/route.ts
@@ -1,40 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { CORP_JOB_COLUMNS } from '@/app/api/csvColumns'
 import { RequestTiming, withRequestTiming } from '@/app/api/requestTiming'
 import { resolvePlayer } from '@/utils/apiToken'
 import { AT_PARAM_ERROR, parseAtParam } from '@/utils/atParam'
 import { parseColumnsParam, selectColumns } from '@/utils/columnsParam'
 import { toCsv } from '@/utils/csv'
 
-// Column set/order returned when ?columns= is omitted, matching
-// corp_industry_jobs()'s json_build_object in schema.sql.
-const DEFAULT_COLUMNS = [
-  'activity_id',
-  'blueprint_id',
-  'blueprint_location_id',
-  'blueprint_type_id',
-  'completed_character_id',
-  'completed_date',
-  'corporation_id',
-  'cost',
-  'duration',
-  'end_date',
-  'facility_id',
-  'installer_id',
-  'job_id',
-  'licensed_runs',
-  'output_location_id',
-  'pause_date',
-  'probability',
-  'product_type_id',
-  'runs',
-  'start_date',
-  'station_id',
-  'status',
-  'successful_runs',
-  'blueprint_type_name',
-  'product_type_name',
-] as const
+// Column set/order returned when ?columns= is omitted (src/app/api/
+// csvColumns.ts, shared with the lens drop-in templates).
+const DEFAULT_COLUMNS = CORP_JOB_COLUMNS
 
 // Every column ?columns= may select, in any order/subset: DEFAULT_COLUMNS plus
 // fields that exist in the json_build_object but are opt-in only (excluded

--- a/src/app/api/csvColumns.ts
+++ b/src/app/api/csvColumns.ts
@@ -1,0 +1,128 @@
+// The column sets the api_token CSV routes serve, factored out of the route
+// files so the lens drop-in templates (src/app/lens/templates.ts) can be
+// tested for exact header parity against them (test/lensTemplates.test.ts) —
+// route files may only export Next's route fields, so the arrays live here.
+// Each matches its Postgres function's json_build_object in schema.sql; order
+// is the CSV column order.
+
+export const CHARACTER_ASSET_COLUMNS = [
+  'is_blueprint_copy',
+  'is_singleton',
+  'item_id',
+  'location_flag',
+  'location_id',
+  'location_type',
+  'quantity',
+  'type_id',
+  'character_name',
+] as const
+
+export const CHARACTER_BLUEPRINT_COLUMNS = [
+  'item_id',
+  'location_flag',
+  'location_id',
+  'material_efficiency',
+  'quantity',
+  'runs',
+  'time_efficiency',
+  'type_id',
+  'character_name',
+] as const
+
+export const CHARACTER_ORDER_COLUMNS = [
+  'duration',
+  'escrow',
+  'is_buy_order',
+  'is_corporation',
+  'issued',
+  'location_id',
+  'min_volume',
+  'order_id',
+  'price',
+  'range',
+  'region_id',
+  'type_id',
+  'volume_remain',
+  'volume_total',
+  'character_name',
+] as const
+
+export const CHARACTER_JOB_COLUMNS = [
+  'activity_id',
+  'blueprint_id',
+  'blueprint_location_id',
+  'blueprint_type_id',
+  'completed_character_id',
+  'completed_date',
+  'cost',
+  'duration',
+  'end_date',
+  'facility_id',
+  'installer_id',
+  'job_id',
+  'licensed_runs',
+  'output_location_id',
+  'pause_date',
+  'probability',
+  'product_type_id',
+  'runs',
+  'start_date',
+  'station_id',
+  'status',
+  'successful_runs',
+  'character_name',
+  'blueprint_type_name',
+  'product_type_name',
+] as const
+
+export const CORP_ASSET_COLUMNS = [
+  'item_id',
+  'corporation_id',
+  'type_id',
+  'location_id',
+  'location_flag',
+  'location_type',
+  'quantity',
+  'is_singleton',
+  'is_blueprint_copy',
+] as const
+
+export const CORP_BLUEPRINT_COLUMNS = [
+  'item_id',
+  'corporation_id',
+  'location_flag',
+  'location_id',
+  'material_efficiency',
+  'quantity',
+  'runs',
+  'time_efficiency',
+  'type_id',
+] as const
+
+export const CORP_JOB_COLUMNS = [
+  'activity_id',
+  'blueprint_id',
+  'blueprint_location_id',
+  'blueprint_type_id',
+  'completed_character_id',
+  'completed_date',
+  'corporation_id',
+  'cost',
+  'duration',
+  'end_date',
+  'facility_id',
+  'installer_id',
+  'job_id',
+  'licensed_runs',
+  'output_location_id',
+  'pause_date',
+  'probability',
+  'product_type_id',
+  'runs',
+  'start_date',
+  'station_id',
+  'status',
+  'successful_runs',
+  'blueprint_type_name',
+  'product_type_name',
+] as const

--- a/src/app/api/graphql/context.ts
+++ b/src/app/api/graphql/context.ts
@@ -5,6 +5,7 @@ import { GRAPHQL_FLAG, hasFlag } from '@/flags'
 import { resolvePlayer } from '@/utils/apiToken'
 import { createClient } from '@/utils/supabase/server'
 import { createServiceClient } from '@/utils/supabase/service'
+import { ASSET_CAP, EXPORT_CAP, LIST_CAP } from './filters'
 
 // The per-request context every resolver receives. Two auth modes share it:
 //
@@ -56,6 +57,11 @@ export type GraphqlContext = {
   // registrationIds. Ids are strings for the same reason every id in the schema
   // is: EVE ids overflow 32-bit Int.
   corporationIds: string[]
+  // Per-list row bounds the resolvers cap with. The HTTP surfaces get the
+  // defaults (ASSET_CAP/LIST_CAP); the lens CSV export raises both to
+  // EXPORT_CAP, since a Sheets tab can't page and a silently shortened CSV is
+  // worse than a refusal (docs/sharing-layer/09-sheets-parity.md).
+  caps: { asset: number; list: number }
   // Lazily load the caller's corporation identities (name, alliance) — only the
   // Corporation edge reads them, and there are a handful at most, so one memo
   // per request covers every result set.
@@ -193,7 +199,8 @@ const loadCorporationIdentities = async (
 const contextFor = async (
   supabase: SupabaseClient,
   mode: GraphqlContext['mode'],
-  userId: string
+  userId: string,
+  caps: GraphqlContext['caps'] = { asset: ASSET_CAP, list: LIST_CAP }
 ): Promise<GraphqlContext> => {
   const { data: registrations, error } = await supabase
     .from('registration')
@@ -225,6 +232,7 @@ const contextFor = async (
       rows.flatMap((r): Array<[string, string]> => (r.character_id == null ? [] : [[r.id, String(r.character_id)]]))
     ),
     corporationIds,
+    caps,
     corporationIdentities: () => {
       corporationIdentities ??= loadCorporationIdentities(supabase, corporationIds)
       return corporationIdentities
@@ -246,8 +254,12 @@ const contextFor = async (
 // surfaces (includeShared/sharedWithMe) reject exactly as they do for Bearer
 // callers, and the resolvers' leak-guard .in('registration_id', …) is the
 // barrier. Callers must have authorized the viewer BEFORE building this.
-export const contextForUser = (userId: string): Promise<GraphqlContext> =>
-  contextFor(createServiceClient(), 'token', userId)
+// `exporting` is the lens CSV surface's cap raise — see GraphqlContext.caps.
+export const contextForUser = (
+  userId: string,
+  { exporting = false }: { exporting?: boolean } = {}
+): Promise<GraphqlContext> =>
+  contextFor(createServiceClient(), 'token', userId, exporting ? { asset: EXPORT_CAP, list: EXPORT_CAP } : undefined)
 
 export const buildContext = async (request: Request): Promise<GraphqlContext> => {
   const authorization = request.headers.get('authorization') ?? ''

--- a/src/app/api/graphql/filters.ts
+++ b/src/app/api/graphql/filters.ts
@@ -8,6 +8,12 @@
 // filters, not paging, are how callers narrow further.
 export const ASSET_CAP = 5000
 export const LIST_CAP = 1000
+// The lens CSV surface serves whole result sets — a Sheets =IMPORTDATA() tab
+// can't page or narrow — so its context raises both caps to this bound
+// (docs/sharing-layer/09-sheets-parity.md). Sized to what the uncapped legacy
+// CSV routes already serve inside the same 60s budget; a result that still
+// hits it is refused by the route rather than silently shortened.
+export const EXPORT_CAP = 50000
 
 // Clamp a caller-supplied limit into [1, cap]; absent means the cap itself.
 export const clampLimit = (limit: number | null | undefined, cap: number): number => {

--- a/src/app/api/graphql/resolvers.ts
+++ b/src/app/api/graphql/resolvers.ts
@@ -20,16 +20,7 @@ import { uniq } from 'ramda'
 import { guessLocationRef, resolveTypeFilter } from '@/app/api/mcp/lib'
 import { resolveLocations, type LocationRef, type ResolvedLocations } from '@/app/resolveLocations'
 import { getSdeTypes, searchSdeTypesAll, type SdeType } from '@/sdeTypes'
-import {
-  ASSET_CAP,
-  LIST_CAP,
-  clampLimit,
-  matchExactNames,
-  matchOwnerFilter,
-  parseRefFilter,
-  parseSince,
-  splitRefEntries,
-} from './filters'
+import { clampLimit, matchExactNames, matchOwnerFilter, parseRefFilter, parseSince, splitRefEntries } from './filters'
 import { searchLocationCandidates } from './locationSearch'
 import { resolveTargets, restockLines, type Stack } from './restock'
 import type { OwnerScopes } from './filters'
@@ -417,7 +408,7 @@ export const resolvers = {
       const scopedIds = [...scopes.registrationIds, ...sharedIds]
       const typeIds = await typeIdsFor(args)
       const locationIds = await locationIdsFor(ctx, args)
-      const cap = clampLimit(args.limit, ASSET_CAP)
+      const cap = clampLimit(args.limit, ctx.caps.asset)
 
       // The same filter set applies to the head-only count and the row pages,
       // on both sides — only the owner column differs. The builder is untyped
@@ -561,7 +552,7 @@ export const resolvers = {
         if (error) return queryFailed()
         // Refuse rather than sum a truncated read: a wrong total here is a
         // wrong number to buy, and nothing downstream could tell.
-        if ((count ?? 0) > ASSET_CAP) {
+        if ((count ?? 0) > ctx.caps.asset) {
           return badRequest(
             `Too many stacks to sum reliably (${count} in ${table}) — narrow the owner or location filter.`
           )
@@ -571,7 +562,7 @@ export const resolvers = {
             filtered(ctx.supabase.from(table).select('type_id, quantity'), ownerColumn, ownerIds)
               .order('item_id')
               .range(from, to),
-          ASSET_CAP
+          ctx.caps.asset
         )
       }
 
@@ -658,7 +649,7 @@ export const resolvers = {
     ) => {
       const scopes = await ownerScopesFor(ctx, args)
       const typeIds = await typeIdsFor(args)
-      const cap = clampLimit(args.limit, LIST_CAP)
+      const cap = clampLimit(args.limit, ctx.caps.list)
 
       type BlueprintRow = {
         item_id: number
@@ -776,7 +767,7 @@ export const resolvers = {
             .in('registration_id', ownerIds)
             .order('issued', { ascending: false })
             .range(from, to),
-        LIST_CAP
+        ctx.caps.list
       )
 
       const [types, locations] = await Promise.all([
@@ -830,7 +821,10 @@ export const resolvers = {
         corporation_id?: number | string
         installer_id?: number | string
         activity_id: number
+        blueprint_id: number
         blueprint_type_id: number
+        blueprint_location_id: number
+        output_location_id: number
         product_type_id: number | null
         runs: number
         licensed_runs: number | null
@@ -841,7 +835,9 @@ export const resolvers = {
         duration: number
         start_date: string
         end_date: string
+        pause_date: string | null
         completed_date: string | null
+        completed_character_id: number | null
         station_id: number | null
         facility_id: number
       }
@@ -856,7 +852,7 @@ export const resolvers = {
             .order('start_date', { ascending: false })
             .range(from, to)
           return args.includeDelivered ? q : q.neq('status', 'delivered')
-        }, LIST_CAP)
+        }, ctx.caps.list)
       }
 
       const [own, corp] = await Promise.all([
@@ -873,7 +869,7 @@ export const resolvers = {
         })),
       ]
         .sort((a, b) => b.row.start_date.localeCompare(a.row.start_date))
-        .slice(0, LIST_CAP)
+        .slice(0, ctx.caps.list)
 
       const jobLocationRef = (r: JobRow): LocationRef | null => guessLocationRef(r.station_id ?? r.facility_id)
 
@@ -908,8 +904,14 @@ export const resolvers = {
           duration: r.duration,
           startDate: r.start_date,
           endDate: r.end_date,
+          pauseDate: r.pause_date,
           completedDate: r.completed_date,
+          completedCharacterId: str(r.completed_character_id),
           stationId: str(r.station_id),
+          blueprintId: String(r.blueprint_id),
+          blueprintLocationId: String(r.blueprint_location_id),
+          outputLocationId: String(r.output_location_id),
+          facilityId: String(r.facility_id),
           locationName: ref ? locations.nameFor(ref) : null,
           // Corp jobs name the character who installed them; character jobs
           // are always installed by their owner, so ESI doesn't repeat it.
@@ -966,7 +968,7 @@ export const resolvers = {
       const typeIds = await typeIdsFor(args)
       const since = parseSince(args.since)
       if (!since.ok) return badRequest(since.message)
-      const cap = clampLimit(args.limit, LIST_CAP)
+      const cap = clampLimit(args.limit, ctx.caps.list)
 
       type TransactionRow = {
         transaction_id: number

--- a/src/app/api/graphql/resolvers.ts
+++ b/src/app/api/graphql/resolvers.ts
@@ -750,6 +750,7 @@ export const resolvers = {
         location_id: number
         range: string
         is_buy: boolean
+        is_corporation: boolean
         price: number
         volume_total: number
         volume_remain: number
@@ -790,6 +791,7 @@ export const resolvers = {
           type: itemTypeOf(types, r.type_id),
           location: locationOf(locations, ref),
           isBuy: r.is_buy,
+          isCorporation: r.is_corporation,
           price: Number(r.price),
           volumeTotal: String(r.volume_total),
           volumeRemain: String(r.volume_remain),

--- a/src/app/api/graphql/route.ts
+++ b/src/app/api/graphql/route.ts
@@ -5,6 +5,7 @@ import { GRAPHQL_FLAG, hasFlag } from '@/flags'
 import { createClient } from '@/utils/supabase/server'
 import { buildContext } from './context'
 import { schema } from './schema'
+import { timingPlugin } from './timingPlugin'
 
 // The dark-launched GraphQL endpoint (see /graphql for the in-browser editor).
 // Auth is either the Supabase session cookie (same-origin, the editor page) or
@@ -44,6 +45,8 @@ const { handleRequest } = createYoga({
     ),
   landingPage: false,
   batching: false,
+  // One request.timing metric per executed operation (src/observability.js).
+  plugins: [timingPlugin],
   // Wildcard origin with credentials OFF is the safe pairing: external UIs
   // authenticate with the Bearer token, and the session cookie only ever rides
   // same-origin requests (which need no CORS at all).

--- a/src/app/api/graphql/schema.graphql.ts
+++ b/src/app/api/graphql/schema.graphql.ts
@@ -442,6 +442,18 @@ export const typeDefs = /* GraphQL */ `
 
     "The EVE character who installed a CORP job; null on a character's own job, which ESI doesn't stamp."
     installerId: String
+    "The blueprint ITEM the job consumes — the physical copy or original, not its type."
+    blueprintId: String!
+    "Where the blueprint item sat when the job was installed."
+    blueprintLocationId: String!
+    "Where the job's output will be delivered."
+    outputLocationId: String!
+    "ESI's raw facility id — stationId when the job runs in an NPC station, else the structure id (see also location)."
+    facilityId: String!
+    "When the job was paused (its facility reinforced); null while it runs."
+    pauseDate: String
+    "The EVE character who delivered the job; null until someone does."
+    completedCharacterId: String
     blueprintType: ItemType!
     "Null for research and copy jobs, which produce no new item type."
     productType: ItemType

--- a/src/app/api/graphql/schema.graphql.ts
+++ b/src/app/api/graphql/schema.graphql.ts
@@ -378,6 +378,8 @@ export const typeDefs = /* GraphQL */ `
     locationName: String
     regionId: String!
     isBuy: Boolean!
+    "Placed on behalf of the character's corporation (ESI's flag; the order still rides the character's extract)."
+    isCorporation: Boolean!
     price: Float!
     volumeTotal: String!
     volumeRemain: String!

--- a/src/app/api/graphql/timingPlugin.ts
+++ b/src/app/api/graphql/timingPlugin.ts
@@ -1,0 +1,45 @@
+import { Kind, type DocumentNode, type FieldNode, type OperationDefinitionNode } from 'graphql'
+import type { Plugin } from 'graphql-yoga'
+
+import { recordRequest } from '@/observability'
+
+// The request.timing emitter for /api/graphql (src/observability.js): one
+// metric line per executed operation, timed over the execution phase — the
+// resolver/DB-bound span the BRIN measurement reads. Context building and
+// auth failures never reach onExecute, so a rejected bearer emits nothing;
+// that keeps the series to queries that actually touched data.
+
+// Ad-hoc GraphQL callers may select several root fields (lenses are held to
+// one). Joined sorted so "assets+characters" is one series however the query
+// ordered them; the schema bounds the vocabulary, so cardinality stays flat.
+const rootFieldsOf = (document: DocumentNode): string | null => {
+  const operation = document.definitions.find((d): d is OperationDefinitionNode => d.kind === Kind.OPERATION_DEFINITION)
+  const names = (operation?.selectionSet.selections ?? [])
+    .filter((s): s is FieldNode => s.kind === Kind.FIELD)
+    .map((s) => s.name.value)
+  return names.length > 0 ? [...new Set(names)].sort().join('+') : null
+}
+
+export const timingPlugin: Plugin = {
+  onExecute: ({ args }) => {
+    const startedAt = Date.now()
+    const field = rootFieldsOf(args.document)
+    return {
+      onExecuteDone: ({ result }) => {
+        // Incremental delivery (@defer/@stream) answers an AsyncIterable; not
+        // enabled on this endpoint, so skip rather than misreport a partial.
+        if (Symbol.asyncIterator in result) return
+        recordRequest({
+          route: '/api/graphql',
+          surface: 'graphql',
+          field,
+          // The schema serves current data only — history stays on the legacy
+          // at= CSV routes (docs/sharing-layer/09-sheets-parity.md).
+          served: 'live',
+          outcome: (result.errors ?? []).length > 0 ? 'query_failed' : 'ok',
+          durationMs: Date.now() - startedAt,
+        })
+      },
+    }
+  },
+}

--- a/src/app/api/mcp/lensTools.ts
+++ b/src/app/api/mcp/lensTools.ts
@@ -31,6 +31,7 @@ import { lensEdits, resolveLensRef } from '@/app/lens/lensRef'
 import { runLens } from '@/app/lens/run'
 import { applyLensShare, fetchOwnAudiences } from '@/app/lens/share'
 import { shortLensId } from '@/app/lens/shortId'
+import { LENS_TEMPLATES } from '@/app/lens/templates'
 import { parseLensVariables, SESSION_ONLY_ARGUMENTS, SESSION_ONLY_FIELDS, validateLensQuery } from '@/app/lens/validate'
 import { LENS_FLAG, hasFlag } from '@/flags'
 import { signShare, tokenSalt } from '@/shareToken'
@@ -67,45 +68,16 @@ const FLAG_REFUSAL =
 // result into a data dump — the lens's own page and CSV are where the rows live.
 const PREVIEW_ROWS = 5
 
-// Worked examples beat prose for query shape, and these cover the joints a
-// model actually gets wrong: filtering to a container (the plural `locations:`
-// takes the item id of the container, which search_assets / browse_assets
-// resolve), filtering to a set of types (`types:` takes SDE type ids or whole
-// names), and the restock list, whose targets live in the variables.
-//
-// Every filter is a SINGULAR/PLURAL pair — `location:` searches names,
-// `locations:` is an exact list — so an example using one of the pre-pairing
-// spellings (locationId:, typeIds:) no longer validates against the schema.
-const EXAMPLES = [
-  {
-    intent: 'Everything sitting in one container or ship, by its item id.',
-    query:
-      'query { assets(locations: ["1046809423988"], limit: 500) { totalCount truncated rows { itemId typeId typeName quantity locationFlag ownerName } } }',
-  },
-  {
-    intent: 'Only certain item types, wherever they are — e.g. the inputs to a fuel block.',
-    query:
-      'query { assets(types: ["16273", "17887", "16275", "9832", "44"], limit: 500) { totalCount rows { typeId typeName quantity locationName ownerName } } }',
-  },
-  {
-    intent: 'Both at once: those types, but only inside that container. Variables keep the ids out of the query text.',
-    query:
-      'query Stock($container: [String!], $types: [String!]) { assets(locations: $container, types: $types, limit: 500) { totalCount rows { typeId typeName quantity } } }',
-    variables: { container: ['1046809423988'], types: ['16273', '17887'] },
-  },
-  {
-    intent:
-      "A restock list: how much to buy of each item to get back up to a supply buffer. The targets ARE the lens — a viewer cannot change them, so the buffer levels stay the creator's.",
-    query:
-      'query Restock($targets: [RestockTarget!]!) { restock(targets: $targets, location: "1DQ1-A") { typeName groupName target onHand delta toBuy } }',
-    variables: {
-      targets: [
-        { type: 'Nitrogen Fuel Block', quantity: 10000 },
-        { type: 'Tritanium', quantity: 1000000 },
-      ],
-    },
-  },
-]
+// Worked examples beat prose for query shape. Derived from the shared template
+// list (src/app/lens/templates.ts) — the same prewritten queries the /lens
+// picker and /graphql example buttons offer, so a model and a browser user are
+// taught from one text, and test/lensTemplates.test.ts keeps every example
+// valid against the schema.
+const EXAMPLES = LENS_TEMPLATES.map((t) => ({
+  intent: t.description,
+  query: t.query,
+  ...(t.variables ? { variables: t.variables } : {}),
+}))
 
 // The lens's own URLs. Absolute when the deployment knows its origin, paths
 // otherwise (see src/utils/siteUrl.ts). `pathId` is the shortest id that

--- a/src/app/api/requestTiming.ts
+++ b/src/app/api/requestTiming.ts
@@ -28,6 +28,10 @@ type TimingMeta = {
   // The Postgres function the route calls (CSV routes) or the GraphQL root
   // field (lens/graphql surfaces).
   field: string | null
+  // Stamps a `Deprecation: true` response header: the api_token CSV routes are
+  // superseded by lenses (docs/sharing-layer/09-sheets-parity.md) but stay
+  // live — they are the BRIN measurement instrument and the only at= surface.
+  deprecated?: boolean
 }
 
 const outcomeOf = (status: number): string => {
@@ -45,8 +49,11 @@ export const withRequestTiming =
     const timing: RequestTiming = { rows: null, served: 'live' }
     try {
       const response = await handler(request, context, timing)
+      if (meta.deprecated) response.headers.set('Deprecation', 'true')
       recordRequest({
-        ...meta,
+        route: meta.route,
+        surface: meta.surface,
+        field: meta.field,
         served: timing.served,
         outcome: outcomeOf(response.status),
         status: response.status,
@@ -56,7 +63,9 @@ export const withRequestTiming =
       return response
     } catch (error) {
       recordRequest({
-        ...meta,
+        route: meta.route,
+        surface: meta.surface,
+        field: meta.field,
         served: timing.served,
         outcome: 'query_failed',
         status: 500,

--- a/src/app/api/requestTiming.ts
+++ b/src/app/api/requestTiming.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { recordRequest } from '@/observability'
+
+// Wraps a route handler so every return path emits one `request.timing` metric
+// (src/observability.js) — the measurement seam the BRIN index project reads
+// (docs/brin-indexes/README.md). The wrapper owns the clock and the
+// status→outcome mapping; the handler reports what only it knows (row count,
+// live vs historical) through the mutable `timing` it receives, so a route
+// stays a one-line change: wrap the handler, set `timing.rows`/`timing.served`
+// where they become known.
+
+export type RequestTiming = {
+  // Rows in the response; stays null on requests that never produce any.
+  rows: number | null
+  // 'historical' when the caller asked for a past moment (an explicit at=),
+  // exercising the SCD-2 time-travel predicate instead of the live rows.
+  served: 'live' | 'historical'
+}
+
+export type TimedSurface = 'legacy_csv' | 'lens_csv' | 'lens_view' | 'graphql' | 'public_csv'
+
+type TimingMeta = {
+  // The static route template — never an interpolated id, so the metric's
+  // cardinality stays flat.
+  route: string
+  surface: TimedSurface
+  // The Postgres function the route calls (CSV routes) or the GraphQL root
+  // field (lens/graphql surfaces).
+  field: string | null
+}
+
+const outcomeOf = (status: number): string => {
+  if (status < 400) return 'ok'
+  if (status === 400) return 'bad_request'
+  if (status === 401) return 'unauthorized'
+  if (status === 404) return 'not_found'
+  return 'query_failed'
+}
+
+export const withRequestTiming =
+  <C>(meta: TimingMeta, handler: (request: NextRequest, context: C, timing: RequestTiming) => Promise<NextResponse>) =>
+  async (request: NextRequest, context: C): Promise<NextResponse> => {
+    const startedAt = Date.now()
+    const timing: RequestTiming = { rows: null, served: 'live' }
+    try {
+      const response = await handler(request, context, timing)
+      recordRequest({
+        ...meta,
+        served: timing.served,
+        outcome: outcomeOf(response.status),
+        status: response.status,
+        rows: timing.rows,
+        durationMs: Date.now() - startedAt,
+      })
+      return response
+    } catch (error) {
+      recordRequest({
+        ...meta,
+        served: timing.served,
+        outcome: 'query_failed',
+        status: 500,
+        rows: null,
+        durationMs: Date.now() - startedAt,
+      })
+      throw error
+    }
+  }

--- a/src/app/graphql/queryEditor.tsx
+++ b/src/app/graphql/queryEditor.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 
 import { csvRows } from '@/app/lens/flatten'
+import { LENS_TEMPLATES } from '@/app/lens/templates'
 import { toCsv } from '@/utils/csv'
 import styles from './graphql.module.css'
 
@@ -11,98 +12,12 @@ import styles from './graphql.module.css'
 // Posts same-origin, so the Supabase session cookie authenticates it.
 //
 // GET /api/graphql serves GraphiQL, which is where the schema-aware
-// autocomplete and the docs explorer live. This page keeps the examples, and
-// the CSV download GraphiQL can't offer — sharing the Lens flattening
-// (src/app/lens/flatten.ts), since a lens is a stored query of this same shape.
+// autocomplete and the docs explorer live. This page keeps the examples —
+// the shared lens template list (src/app/lens/templates.ts), since a lens IS
+// a stored query of this same shape — and the CSV download GraphiQL can't
+// offer, via the same Lens flattening (src/app/lens/flatten.ts).
 
-const EXAMPLES: Array<{ label: string; query: string }> = [
-  {
-    label: 'Wallet balances',
-    query: `{
-  walletBalances {
-    ownerName
-    balance
-    recordedAt
-  }
-}`,
-  },
-  {
-    label: 'Stockpile by item',
-    query: `query Stockpile($item: String!) {
-  assets(type: $item) {
-    totalCount
-    truncated
-    rows {
-      typeName
-      quantity
-      locationName
-      ownerName
-    }
-  }
-}`,
-  },
-  {
-    // The edges in anger: group/category and the location's solar system are
-    // reachable only through `type`/`location`, and each nests exactly one
-    // level, so Download CSV still gives one line per row (type.groupName,
-    // location.systemName, …). Open the docs explorer at /api/graphql to see
-    // what else hangs off them.
-    label: 'Stockpile by group (nested)',
-    query: `{
-  assets(type: "Tritanium") {
-    rows {
-      quantity
-      type {
-        name
-        groupName
-        categoryName
-        volume
-      }
-      location {
-        name
-        systemName
-      }
-      character {
-        name
-        corporationName
-      }
-    }
-  }
-}`,
-  },
-  {
-    label: 'Open orders',
-    query: `{
-  marketOrders {
-    typeName
-    isBuy
-    price
-    volumeRemain
-    locationName
-    ownerName
-  }
-}`,
-  },
-  {
-    label: 'Industry jobs',
-    query: `{
-  industryJobs {
-    blueprintTypeName
-    productTypeName
-    activityId
-    runs
-    status
-    endDate
-    locationName
-    ownerName
-  }
-}`,
-  },
-]
-
-const EXAMPLE_VARIABLES: Record<string, string> = {
-  'Stockpile by item': `{ "item": "Tritanium" }`,
-}
+const EXAMPLES = LENS_TEMPLATES
 
 export const QueryEditor = () => {
   const [query, setQuery] = useState(EXAMPLES[0].query)
@@ -160,7 +75,7 @@ export const QueryEditor = () => {
     const example = EXAMPLES.find((e) => e.label === label)
     if (!example) return
     setQuery(example.query)
-    setVariables(EXAMPLE_VARIABLES[label] ?? '')
+    setVariables(example.variables ? JSON.stringify(example.variables, null, 2) : '')
   }
 
   return (

--- a/src/app/lens/[id]/csv/route.ts
+++ b/src/app/lens/[id]/csv/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { EXPORT_CAP } from '@/app/api/graphql/filters'
 import { recordRequest } from '@/observability'
 import { toCsv } from '@/utils/csv'
 import { resolveLens } from '../../access'
@@ -38,7 +39,10 @@ export const GET = async (
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }
 
-  const result = await runLens(resolved.lens, { surface: 'lens_csv', route: '/lens/[id]/csv' })
+  const result = await runLens(resolved.lens, {
+    timing: { surface: 'lens_csv', route: '/lens/[id]/csv' },
+    exporting: true,
+  })
   if (result.errors.length > 0 && result.data == null) {
     return NextResponse.json({ error: result.errors.join(' — ') }, { status: 500 })
   }
@@ -46,7 +50,20 @@ export const GET = async (
   // csvRows, not lensRows: a lens selecting a nullable edge (location on an
   // asset ESI gave no location_id for) returns ragged rows, and toCsv reads its
   // header off the first one.
-  return new NextResponse(toCsv(csvRows(result.data)), {
+  const rows = csvRows(result.data)
+
+  // `exporting` raised the per-list caps to EXPORT_CAP; a result that still
+  // reaches it was almost certainly cut there, and a silently shortened CSV is
+  // worse than a refusal the sheet can see (an author's own smaller `limit:` is
+  // deliberate and passes untouched).
+  if (rows.length >= EXPORT_CAP) {
+    return NextResponse.json(
+      { error: `The result hit the ${EXPORT_CAP}-row export bound — narrow the lens's filters.` },
+      { status: 400 }
+    )
+  }
+
+  return new NextResponse(toCsv(rows), {
     headers: { 'content-type': 'text/csv; charset=utf-8' },
   })
 }

--- a/src/app/lens/[id]/csv/route.ts
+++ b/src/app/lens/[id]/csv/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { recordRequest } from '@/observability'
 import { toCsv } from '@/utils/csv'
 import { resolveLens } from '../../access'
 import { csvRows } from '../../flatten'
@@ -22,12 +23,22 @@ export const GET = async (
   const { searchParams } = new URL(request.url)
   const share = searchParams.get('share')?.trim() || undefined
 
+  const startedAt = Date.now()
   const resolved = await resolveLens(id, share)
   if (!resolved) {
+    // The ok/query_failed runs report from inside runLens (where the lens's
+    // root field is known); a lens that never resolved has no field to name.
+    recordRequest({
+      route: '/lens/[id]/csv',
+      surface: 'lens_csv',
+      outcome: 'not_found',
+      status: 404,
+      durationMs: Date.now() - startedAt,
+    })
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }
 
-  const result = await runLens(resolved.lens)
+  const result = await runLens(resolved.lens, { surface: 'lens_csv', route: '/lens/[id]/csv' })
   if (result.errors.length > 0 && result.data == null) {
     return NextResponse.json({ error: result.errors.join(' — ') }, { status: 500 })
   }

--- a/src/app/lens/[id]/page.tsx
+++ b/src/app/lens/[id]/page.tsx
@@ -30,7 +30,7 @@ const LensViewerPage = async ({
   if (!resolved) notFound()
   const { lens, viewerIsOwner } = resolved
 
-  const result = await runLens(lens, { surface: 'lens_view', route: '/lens/[id]' })
+  const result = await runLens(lens, { timing: { surface: 'lens_view', route: '/lens/[id]' } })
   const rows = lensRows(result.data)
   const headers = rows.length > 0 ? Object.keys(rows[0]) : []
   // Hand the CSV link the short token, whichever generation arrived here.

--- a/src/app/lens/[id]/page.tsx
+++ b/src/app/lens/[id]/page.tsx
@@ -1,10 +1,13 @@
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 
+import { LENS_FLAG, hasFlag } from '@/flags'
 import { parseShareParam } from '@/shareToken'
+import { createClient } from '@/utils/supabase/server'
 import { ShareUrlCleanup } from '../../shareUrlCleanup'
 import { resolveLens } from '../access'
-import { lensRows } from '../flatten'
+import { CopyLensButton } from '../copyButton'
+import { LensTable } from '../lensTable'
 import { runLens } from '../run'
 import styles from '../lens.module.css'
 
@@ -31,11 +34,14 @@ const LensViewerPage = async ({
   const { lens, viewerIsOwner } = resolved
 
   const result = await runLens(lens, { timing: { surface: 'lens_view', route: '/lens/[id]' } })
-  const rows = lensRows(result.data)
-  const headers = rows.length > 0 ? Object.keys(rows[0]) : []
   // Hand the CSV link the short token, whichever generation arrived here.
   const cleanShare = share ? parseShareParam(share).signature : undefined
   const csvHref = `/lens/${lens.id}/csv${cleanShare ? `?share=${encodeURIComponent(cleanShare)}` : ''}`
+
+  // "Save a copy" forks the query (not the data) into the viewer's own lens
+  // list — that's what a lens shared with you being a "prewritten query" means.
+  const { data: auth } = await (await createClient()).auth.getUser()
+  const canCopy = !viewerIsOwner && auth?.user != null && (await hasFlag(auth.user.id, LENS_FLAG))
 
   return (
     <>
@@ -45,35 +51,13 @@ const LensViewerPage = async ({
         <div className={styles.buttons}>
           <a href={csvHref}>CSV</a>
           {viewerIsOwner && <Link href="/lens">Edit</Link>}
+          {canCopy && <CopyLensButton lensId={lens.id} share={cleanShare} />}
         </div>
       </div>
 
       {result.errors.length > 0 && <p className={styles.error}>{result.errors.join(' — ')}</p>}
 
-      {rows.length === 0 ? (
-        <p className={styles.note}>No rows.</p>
-      ) : (
-        <div className={styles.tableWrap}>
-          <table className={styles.table}>
-            <thead>
-              <tr>
-                {headers.map((h) => (
-                  <th key={h}>{h}</th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((row, i) => (
-                <tr key={i}>
-                  {headers.map((h) => (
-                    <td key={h}>{row[h] == null ? '' : String(row[h])}</td>
-                  ))}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <LensTable data={result.data} />
 
       <details>
         <summary className={styles.note}>Raw result</summary>

--- a/src/app/lens/[id]/page.tsx
+++ b/src/app/lens/[id]/page.tsx
@@ -30,7 +30,7 @@ const LensViewerPage = async ({
   if (!resolved) notFound()
   const { lens, viewerIsOwner } = resolved
 
-  const result = await runLens(lens)
+  const result = await runLens(lens, { surface: 'lens_view', route: '/lens/[id]' })
   const rows = lensRows(result.data)
   const headers = rows.length > 0 ? Object.keys(rows[0]) : []
   // Hand the CSV link the short token, whichever generation arrived here.

--- a/src/app/lens/actions.ts
+++ b/src/app/lens/actions.ts
@@ -8,6 +8,7 @@ import { schema } from '@/app/api/graphql/schema'
 import type { SaveShareInput, SaveShareResult } from '@/app/asset/shareActions'
 import { LENS_FLAG, hasFlag } from '@/flags'
 import { createClient } from '@/utils/supabase/server'
+import { resolveLens } from './access'
 import { applyLensShare, fetchOwnAudiences } from './share'
 import { parseLensVariables, validateLensQuery } from './validate'
 
@@ -69,11 +70,12 @@ export const deleteLens = async (lensId: string): Promise<{ error?: string }> =>
 // Run-as-me preview for the editor: validates, then executes under the
 // CALLER's own context — the same result the audience will see, since the
 // caller is the creator. Doesn't require the graphql flag: the lens flag is
-// the editor's gate.
+// the editor's gate. Structured rather than pre-stringified so the editor can
+// render the same table the viewer page does (lensTable.tsx).
 export const previewLens = async (input: {
   query: string
   variables: string
-}): Promise<{ error?: string; result?: string }> => {
+}): Promise<{ error?: string; data?: unknown; errors?: string[] }> => {
   const supabase = await createClient()
   const userId = await flaggedUser(supabase)
   if (!userId) return { error: 'Not available' }
@@ -85,9 +87,38 @@ export const previewLens = async (input: {
 
   const contextValue = await contextForUser(userId)
   const result = await graphql({ schema, source: input.query, variableValues: variables.variables, contextValue })
-  return {
-    result: JSON.stringify({ data: result.data ?? null, errors: result.errors?.map((e) => e.message) }, null, 2),
-  }
+  return { data: result.data ?? null, errors: (result.errors ?? []).map((e) => e.message) }
+}
+
+// Fork a lens someone shared with you into your own list: same query and
+// variables, your name on the row, unshared until you share it. Authorization
+// is exactly the viewer's (resolveLens's RLS or signed-link door) — if you can
+// see a lens run, you can keep its QUERY, which was always visible on its
+// page. The insert carries no audience: a copy never inherits the original's
+// sharing.
+export const copyLens = async (lensId: string, share?: string): Promise<{ error?: string; id?: string }> => {
+  const supabase = await createClient()
+  const userId = await flaggedUser(supabase)
+  if (!userId) return { error: 'Not available' }
+
+  const resolved = await resolveLens(lensId, share)
+  if (!resolved) return { error: 'Not found' }
+
+  // RLS's with check pins the insert to the caller.
+  const { data: saved, error } = await supabase
+    .from('lens')
+    .insert({
+      user_id: userId,
+      name: `Copy of ${resolved.lens.name}`,
+      query: resolved.lens.query,
+      variables: resolved.lens.variables ?? {},
+    })
+    .select('id')
+    .maybeSingle()
+  if (error || !saved) return { error: error?.message ?? 'Copy failed' }
+
+  revalidatePath('/lens')
+  return { id: saved.id as string }
 }
 
 // The audience side, driven by the shared ShareDialog. The lens row IS the

--- a/src/app/lens/copyButton.tsx
+++ b/src/app/lens/copyButton.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useState, useTransition } from 'react'
+
+import { copyLens } from './actions'
+import styles from './lens.module.css'
+
+// "Save a copy": fork a shared lens's query into the viewer's own list, then
+// land them in the editor. Rendered on the viewer page for flagged non-owners
+// and in the shared-with-me list on /lens.
+export const CopyLensButton = ({ lensId, share }: { lensId: string; share?: string }) => {
+  const router = useRouter()
+  const [error, setError] = useState<string | null>(null)
+  const [pending, startTransition] = useTransition()
+
+  const copy = () =>
+    startTransition(async () => {
+      setError(null)
+      const copied = await copyLens(lensId, share)
+      if (copied.error) setError(copied.error)
+      else router.push('/lens')
+    })
+
+  return (
+    <>
+      <button type="button" onClick={copy} disabled={pending}>
+        {pending ? 'Copying…' : 'Save a copy'}
+      </button>
+      {error && <span className={styles.error}>{error}</span>}
+    </>
+  )
+}

--- a/src/app/lens/lensEditor.tsx
+++ b/src/app/lens/lensEditor.tsx
@@ -4,6 +4,8 @@ import { useRouter } from 'next/navigation'
 import { useState, useTransition } from 'react'
 
 import { deleteLens, previewLens, saveLens } from './actions'
+import { LensTable } from './lensTable'
+import { LENS_TEMPLATES, type LensTemplate } from './templates'
 import styles from './lens.module.css'
 
 const DEFAULT_QUERY = `{
@@ -18,24 +20,90 @@ const DEFAULT_QUERY = `{
   }
 }`
 
+// A template's labelled fields → the variables JSON the server actions already
+// accept — the fields are a friendlier pen for the same ink. Empty fields are
+// omitted (that's what makes an optional $owners mean "everything I own");
+// list fields split on commas.
+const serializeFields = (template: LensTemplate, values: Record<string, string>): string => {
+  const entries: Array<[string, unknown]> = (template.variableFields ?? []).flatMap(
+    (field): Array<[string, unknown]> => {
+      const raw = (values[field.name] ?? '').trim()
+      if (raw === '') return []
+      if (field.kind === 'int') {
+        const n = Number(raw)
+        return Number.isFinite(n) ? [[field.name, Math.floor(n)]] : []
+      }
+      if (field.kind === 'list') {
+        const list = raw
+          .split(',')
+          .map((e) => e.trim())
+          .filter((e) => e !== '')
+        return list.length > 0 ? [[field.name, list]] : []
+      }
+      return [[field.name, raw]]
+    }
+  )
+  return entries.length > 0 ? JSON.stringify(Object.fromEntries(entries), null, 2) : ''
+}
+
+// Seed the fields from the template's example variables, so picking one shows
+// a shape that runs (lists joined back to comma-separated text).
+const fieldValuesOf = (template: LensTemplate): Record<string, string> =>
+  Object.fromEntries(
+    (template.variableFields ?? []).map((f) => {
+      const v = template.variables?.[f.name]
+      return [f.name, Array.isArray(v) ? v.join(', ') : v == null ? '' : String(v)]
+    })
+  )
+
 type LensEditorProps = {
   // null = the create-new editor; otherwise the lens being edited.
   lens: { id: string; name: string; query: string; variables: string } | null
 }
 
-// Create/edit form for one lens: name, query, fixed variables, a run-as-me
-// preview (server action under the caller's own context — the same result the
-// audience will see), save, and delete. Sharing lives in the ShareDialog the
-// server component renders beside this.
+type PreviewResult = { data: unknown; errors: string[] }
+
+// Create/edit form for one lens: a template picker seeding the query, name,
+// the query text, variables (as labelled fields when the active template
+// declares them, raw JSON otherwise), a run-as-me preview rendered as the same
+// table the viewer page shows, save, and delete. Sharing lives in the
+// ShareDialog the server component renders beside this.
 export const LensEditor = ({ lens }: LensEditorProps) => {
   const router = useRouter()
   const [open, setOpen] = useState(lens === null)
   const [name, setName] = useState(lens?.name ?? '')
   const [query, setQuery] = useState(lens?.query ?? DEFAULT_QUERY)
   const [variables, setVariables] = useState(lens?.variables ?? '')
-  const [result, setResult] = useState('')
+  const [template, setTemplate] = useState<LensTemplate | null>(null)
+  const [fieldValues, setFieldValues] = useState<Record<string, string>>({})
+  const [result, setResult] = useState<PreviewResult | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [pending, startTransition] = useTransition()
+
+  const pickTemplate = (id: string) => {
+    const picked = LENS_TEMPLATES.find((t) => t.id === id) ?? null
+    setTemplate(picked)
+    setResult(null)
+    if (!picked) return
+    const seeded = fieldValuesOf(picked)
+    setQuery(picked.query)
+    setFieldValues(seeded)
+    setVariables(
+      picked.variableFields?.length
+        ? serializeFields(picked, seeded)
+        : picked.variables
+          ? JSON.stringify(picked.variables, null, 2)
+          : ''
+    )
+    if (name.trim() === '') setName(picked.label.replace(/ \(Sheets drop-in\)$/, ''))
+  }
+
+  const setField = (fieldName: string, value: string) => {
+    if (!template) return
+    const next = { ...fieldValues, [fieldName]: value }
+    setFieldValues(next)
+    setVariables(serializeFields(template, next))
+  }
 
   const save = () =>
     startTransition(async () => {
@@ -47,7 +115,9 @@ export const LensEditor = ({ lens }: LensEditorProps) => {
           setName('')
           setQuery(DEFAULT_QUERY)
           setVariables('')
-          setResult('')
+          setTemplate(null)
+          setFieldValues({})
+          setResult(null)
           setOpen(false)
         }
         router.refresh()
@@ -59,7 +129,7 @@ export const LensEditor = ({ lens }: LensEditorProps) => {
       setError(null)
       const ran = await previewLens({ query, variables })
       if (ran.error) setError(ran.error)
-      else setResult(ran.result ?? '')
+      else setResult({ data: ran.data ?? null, errors: ran.errors ?? [] })
     })
 
   const remove = () =>
@@ -78,8 +148,22 @@ export const LensEditor = ({ lens }: LensEditorProps) => {
     )
   }
 
+  const fields = template?.variableFields ?? []
+
   return (
     <div className={styles.editor}>
+      <label className={styles.field}>
+        Start from a prewritten query
+        <select className={styles.name} value={template?.id ?? ''} onChange={(e) => pickTemplate(e.target.value)}>
+          <option value="">Custom query</option>
+          {LENS_TEMPLATES.map((t) => (
+            <option key={t.id} value={t.id}>
+              {t.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      {template && <p className={styles.note}>{template.description}</p>}
       <label className={styles.field}>
         Name
         <input className={styles.name} value={name} onChange={(e) => setName(e.target.value)} />
@@ -94,16 +178,32 @@ export const LensEditor = ({ lens }: LensEditorProps) => {
           spellCheck={false}
         />
       </label>
-      <label className={styles.field}>
-        Variables (JSON, fixed — viewers can&apos;t change them)
-        <textarea
-          className={styles.variables}
-          value={variables}
-          onChange={(e) => setVariables(e.target.value)}
-          rows={2}
-          spellCheck={false}
-        />
-      </label>
+      {fields.length > 0 ? (
+        // The template names its variables, so they render as labelled inputs
+        // writing through to the same variables JSON the actions accept.
+        fields.map((field) => (
+          <label key={field.name} className={styles.field}>
+            {field.label}
+            <input
+              className={styles.name}
+              value={fieldValues[field.name] ?? ''}
+              onChange={(e) => setField(field.name, e.target.value)}
+            />
+            {field.hint && <span className={styles.note}>{field.hint}</span>}
+          </label>
+        ))
+      ) : (
+        <label className={styles.field}>
+          Variables (JSON, fixed — viewers can&apos;t change them)
+          <textarea
+            className={styles.variables}
+            value={variables}
+            onChange={(e) => setVariables(e.target.value)}
+            rows={2}
+            spellCheck={false}
+          />
+        </label>
+      )}
       <div className={styles.buttons}>
         <button type="button" onClick={save} disabled={pending || name.trim() === '' || query.trim() === ''}>
           {pending ? 'Working…' : 'Save'}
@@ -123,7 +223,16 @@ export const LensEditor = ({ lens }: LensEditorProps) => {
         )}
       </div>
       {error && <p className={styles.error}>{error}</p>}
-      {result !== '' && <pre className={styles.result}>{result}</pre>}
+      {result !== null && (
+        <>
+          {result.errors.length > 0 && <p className={styles.error}>{result.errors.join(' — ')}</p>}
+          <LensTable data={result.data} />
+          <details>
+            <summary className={styles.note}>Raw result</summary>
+            <pre className={styles.result}>{JSON.stringify({ data: result.data }, null, 2)}</pre>
+          </details>
+        </>
+      )}
     </div>
   )
 }

--- a/src/app/lens/lensTable.tsx
+++ b/src/app/lens/lensTable.tsx
@@ -1,0 +1,33 @@
+import { lensRows } from './flatten'
+import styles from './lens.module.css'
+
+// The result table the viewer page and the editor's preview both render — one
+// flattening (lensRows), one look. No hooks, so it serves server and client
+// components alike.
+export const LensTable = ({ data }: { data: unknown }) => {
+  const rows = lensRows(data)
+  if (rows.length === 0) return <p className={styles.note}>No rows.</p>
+  const headers = Object.keys(rows[0])
+  return (
+    <div className={styles.tableWrap}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            {headers.map((h) => (
+              <th key={h}>{h}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => (
+            <tr key={i}>
+              {headers.map((h) => (
+                <td key={h}>{row[h] == null ? '' : String(row[h])}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/app/lens/page.tsx
+++ b/src/app/lens/page.tsx
@@ -6,12 +6,30 @@ import { fetchShareAudiences, shareRowToState, type OwnRegistration } from '@/ap
 import { LENS_FLAG, hasFlag } from '@/flags'
 import { createClient } from '@/utils/supabase/server'
 
+import { siteUrl } from '@/utils/siteUrl'
+
 import { establishedUser } from '../account/lib/establishedUser'
 import { revokeLensShare, saveLensShare } from './actions'
 import { shortLensId } from './shortId'
+import { CopyLensButton } from './copyButton'
 import { LensEditor } from './lensEditor'
 import type { LensRecord } from './run'
 import styles from './lens.module.css'
+
+// The =IMPORTDATA() formula for a lens's CSV, when one would work from Google
+// Sheets: a signed link when the lens has one (Sheets carries no cookie), the
+// bare CSV path when the lens is fully public, nothing otherwise — a
+// corp/alliance-only share has no URL an anonymous fetcher could use. Mirrors
+// the legacy formulas /account/settings prints for the api_token routes.
+const importDataFormula = (
+  share: { shareParam: string | null; isPublic: boolean } | null,
+  shortId: string
+): string | null => {
+  if (!share) return null
+  if (share.shareParam) return `=IMPORTDATA("${siteUrl(`/lens/${shortId}/csv`)}?share=${share.shareParam}")`
+  if (share.isPublic) return `=IMPORTDATA("${siteUrl(`/lens/${shortId}/csv`)}")`
+  return null
+}
 
 // Dark-launched Lens editor (docs/sharing-layer/07-lens.md; no nav link):
 // saved GraphQL queries that run under YOUR context when someone you shared
@@ -30,13 +48,15 @@ const LensPage = async () => {
     redirect('/')
   }
 
-  // RLS also shows lenses others shared with the caller; the editor lists
-  // only their own.
+  // RLS shows the caller's own lenses AND ones shared with them (the audience
+  // policy) — one read, split into the editor list and the shared-with-me list.
   const [{ data: lensRows }, { data: regs }] = await Promise.all([
-    supabase.from('lens').select('*').eq('user_id', user.id).order('created_at'),
+    supabase.from('lens').select('*').order('created_at'),
     supabase.from('registration').select('id, corporation_id'),
   ])
-  const lenses = (lensRows ?? []) as LensRecord[]
+  const visible = (lensRows ?? []) as LensRecord[]
+  const lenses = visible.filter((l) => l.user_id === user.id)
+  const sharedWithMe = visible.filter((l) => l.user_id !== user.id)
   const audiences = await fetchShareAudiences(supabase, (regs ?? []) as OwnRegistration[])
   // The dialog's copyable URL carries the shortest id that resolves back to
   // each lens, so what people paste onward is the graceful form.
@@ -53,37 +73,70 @@ const LensPage = async () => {
 
       <LensEditor lens={null} />
 
-      {lenses.map((lens, i) => (
-        <section key={lens.id} className={styles.lens}>
-          <div className={styles.lensHeading}>
-            <h2>
-              <Link href={`/lens/${lens.id}`}>{lens.name}</Link>
-            </h2>
-            <ShareDialog
-              subjectLabel="lens"
-              urlPath={`/lens/${shortIds[i]}`}
-              hint="Whoever you share with can run this query and see its results — your data, live — until you stop sharing."
-              data={{
-                share: lens.enabled ? shareRowToState(lens) : null,
-                corporations: audiences.corporations,
-                alliances: audiences.alliances,
-                hasLegacyToken: false,
+      {lenses.map((lens, i) => {
+        const share = lens.enabled ? shareRowToState(lens) : null
+        const formula = importDataFormula(share, shortIds[i])
+        return (
+          <section key={lens.id} className={styles.lens}>
+            <div className={styles.lensHeading}>
+              <h2>
+                <Link href={`/lens/${lens.id}`}>{lens.name}</Link>
+              </h2>
+              <ShareDialog
+                subjectLabel="lens"
+                urlPath={`/lens/${shortIds[i]}`}
+                hint="Whoever you share with can run this query and see its results — your data, live — until you stop sharing."
+                data={{
+                  share,
+                  corporations: audiences.corporations,
+                  alliances: audiences.alliances,
+                  hasLegacyToken: false,
+                }}
+                save={saveLensShare.bind(null, lens.id)}
+                revoke={revokeLensShare.bind(null, lens.id)}
+              />
+            </div>
+            {formula && (
+              <p className={styles.note}>
+                Google Sheets: <code>{formula}</code>
+              </p>
+            )}
+            <LensEditor
+              lens={{
+                id: lens.id,
+                name: lens.name,
+                query: lens.query,
+                variables:
+                  lens.variables && Object.keys(lens.variables).length > 0
+                    ? JSON.stringify(lens.variables, null, 2)
+                    : '',
               }}
-              save={saveLensShare.bind(null, lens.id)}
-              revoke={revokeLensShare.bind(null, lens.id)}
             />
-          </div>
-          <LensEditor
-            lens={{
-              id: lens.id,
-              name: lens.name,
-              query: lens.query,
-              variables:
-                lens.variables && Object.keys(lens.variables).length > 0 ? JSON.stringify(lens.variables, null, 2) : '',
-            }}
-          />
-        </section>
-      ))}
+          </section>
+        )
+      })}
+
+      {sharedWithMe.length > 0 && (
+        <>
+          <h2>Shared with me</h2>
+          <p className={styles.note}>
+            Lenses others aimed at you. Opening one shows <em>their</em> results; saving a copy keeps the query as your
+            own lens, over your data.
+          </p>
+          {sharedWithMe.map((lens) => (
+            <section key={lens.id} className={styles.lens}>
+              <div className={styles.lensHeading}>
+                <h2>
+                  <Link href={`/lens/${lens.id}`}>{lens.name}</Link>
+                </h2>
+                <div className={styles.buttons}>
+                  <CopyLensButton lensId={lens.id} />
+                </div>
+              </div>
+            </section>
+          ))}
+        </>
+      )}
     </>
   )
 }

--- a/src/app/lens/run.ts
+++ b/src/app/lens/run.ts
@@ -32,12 +32,19 @@ export type LensResult = { data: unknown; errors: string[] }
 // served — the editor's preview, the create/update preflights.
 export type LensRunSurface = { surface: 'lens_csv' | 'lens_view'; route: string }
 
+export type LensRunOptions = {
+  timing?: LensRunSurface
+  // The CSV surface's cap raise (GraphqlContext.caps): a Sheets tab can't page,
+  // so exports run under EXPORT_CAP and the route refuses when even that bit.
+  exporting?: boolean
+}
+
 export const runLens = async (
   lens: Pick<LensRecord, 'user_id' | 'query' | 'variables'>,
-  timing?: LensRunSurface
+  { timing, exporting = false }: LensRunOptions = {}
 ): Promise<LensResult> => {
   const startedAt = Date.now()
-  const contextValue = await contextForUser(lens.user_id)
+  const contextValue = await contextForUser(lens.user_id, { exporting })
   const result = await graphql({
     schema,
     source: lens.query,

--- a/src/app/lens/run.ts
+++ b/src/app/lens/run.ts
@@ -8,6 +8,9 @@ import { graphql } from 'graphql'
 
 import { contextForUser } from '@/app/api/graphql/context'
 import { schema } from '@/app/api/graphql/schema'
+import { recordRequest } from '@/observability'
+import { lensRows } from './flatten'
+import { topLevelFieldOf } from './validate'
 
 export type LensRecord = {
   id: string
@@ -24,7 +27,16 @@ export type LensRecord = {
 
 export type LensResult = { data: unknown; errors: string[] }
 
-export const runLens = async (lens: Pick<LensRecord, 'user_id' | 'query' | 'variables'>): Promise<LensResult> => {
+// Which serving surface a run should report itself as, for the request.timing
+// metric (src/observability.js). Omitted for runs that aren't a request being
+// served — the editor's preview, the create/update preflights.
+export type LensRunSurface = { surface: 'lens_csv' | 'lens_view'; route: string }
+
+export const runLens = async (
+  lens: Pick<LensRecord, 'user_id' | 'query' | 'variables'>,
+  timing?: LensRunSurface
+): Promise<LensResult> => {
+  const startedAt = Date.now()
   const contextValue = await contextForUser(lens.user_id)
   const result = await graphql({
     schema,
@@ -32,5 +44,22 @@ export const runLens = async (lens: Pick<LensRecord, 'user_id' | 'query' | 'vari
     variableValues: lens.variables ?? {},
     contextValue,
   })
-  return { data: result.data ?? null, errors: (result.errors ?? []).map((e) => e.message) }
+  const out = { data: result.data ?? null, errors: (result.errors ?? []).map((e) => e.message) }
+  // The duration covers building the creator context plus executing the query —
+  // everything between "the lens is authorized" and "rows exist in memory",
+  // which is the DB-bound span the BRIN measurement wants. Lenses read only
+  // current data, so `served` is always 'live' here; the historical side of the
+  // comparison comes from the legacy at= routes.
+  if (timing) {
+    recordRequest({
+      route: timing.route,
+      surface: timing.surface,
+      field: topLevelFieldOf(lens.query),
+      served: 'live',
+      outcome: out.errors.length > 0 && out.data == null ? 'query_failed' : 'ok',
+      rows: lensRows(out.data).length,
+      durationMs: Date.now() - startedAt,
+    })
+  }
+  return out
 }

--- a/src/app/lens/templates.ts
+++ b/src/app/lens/templates.ts
@@ -1,0 +1,417 @@
+// The prewritten lens queries every editing surface offers: the /lens template
+// picker, the /graphql example buttons, and the MCP lens_schema examples all
+// read this one list, so the three can't drift. Pure data + graphql only —
+// test/lensTemplates.test.ts validates every query against the schema and pins
+// the drop-in templates' aliases to the legacy CSV routes' column lists.
+//
+// The seven "Sheets drop-in" templates supersede the api_token CSV routes
+// (docs/sharing-layer/09-sheets-parity.md): each aliases its selections to the
+// legacy route's snake_case columns IN ORDER, so the lens CSV's header row is
+// byte-identical and an existing =IMPORTDATA() tab re-points cleanly. GraphQL
+// aliases are what make this template authoring instead of resolver code.
+//
+// `variableFields` is what the editor renders as labelled inputs instead of
+// the raw variables JSON; each names a variable the query declares. `list`
+// fields take comma-separated input. Templates whose variables are structured
+// (restock targets) declare none and keep the JSON textarea.
+
+export type LensTemplateField = {
+  name: string
+  label: string
+  kind: 'text' | 'int' | 'list'
+  // Renders under the input; say what an empty field means when it's optional.
+  hint?: string
+}
+
+export type LensTemplate = {
+  id: string
+  label: string
+  // One sentence; doubles as the MCP examples' `intent`.
+  description: string
+  query: string
+  variables?: Record<string, unknown>
+  variableFields?: LensTemplateField[]
+}
+
+// Every drop-in takes an optional $owners: absent reads everything the creator
+// owns (characters AND corporations, where the root spans both) — the one
+// deliberate difference from the legacy routes, which split the two sides into
+// /api/character/* and /api/corp/*. Filling it narrows to named owners.
+const OWNERS_FIELD: LensTemplateField = {
+  name: 'owners',
+  label: 'Owners',
+  kind: 'list',
+  hint: 'Character or corporation names/ids, comma-separated; empty means everything you own.',
+}
+
+export const LENS_TEMPLATES: LensTemplate[] = [
+  {
+    id: 'sheets-character-assets',
+    label: 'Assets (Sheets drop-in)',
+    description:
+      'Every asset stack you own, with the /api/character/assets CSV columns — point an existing sheet tab at this lens.',
+    query: `query Assets($owners: [String!]) {
+  assets(owners: $owners) {
+    rows {
+      is_blueprint_copy: isBlueprintCopy
+      is_singleton: isSingleton
+      item_id: itemId
+      location_flag: locationFlag
+      location_id: locationId
+      location_type: locationType
+      quantity
+      type_id: typeId
+      character_name: characterName
+    }
+  }
+}`,
+    variableFields: [OWNERS_FIELD],
+  },
+  {
+    id: 'sheets-corp-assets',
+    label: 'Corp assets (Sheets drop-in)',
+    description: 'Corporation asset stacks with the /api/corp/assets CSV columns.',
+    query: `query CorpAssets($owners: [String!]) {
+  assets(owners: $owners) {
+    rows {
+      item_id: itemId
+      corporation_id: corporationId
+      type_id: typeId
+      location_id: locationId
+      location_flag: locationFlag
+      location_type: locationType
+      quantity
+      is_singleton: isSingleton
+      is_blueprint_copy: isBlueprintCopy
+    }
+  }
+}`,
+    variableFields: [
+      { ...OWNERS_FIELD, hint: 'Your corporation name or id; empty also includes your characters’ own hangars.' },
+    ],
+  },
+  {
+    id: 'sheets-character-blueprints',
+    label: 'Blueprints (Sheets drop-in)',
+    description: 'Blueprint stacks with the /api/character/blueprints CSV columns.',
+    query: `query Blueprints($owners: [String!]) {
+  blueprints(owners: $owners) {
+    rows {
+      item_id: itemId
+      location_flag: locationFlag
+      location_id: locationId
+      material_efficiency: materialEfficiency
+      quantity
+      runs
+      time_efficiency: timeEfficiency
+      type_id: typeId
+      character_name: characterName
+    }
+  }
+}`,
+    variableFields: [OWNERS_FIELD],
+  },
+  {
+    id: 'sheets-corp-blueprints',
+    label: 'Corp blueprints (Sheets drop-in)',
+    description: 'Corporation blueprint stacks with the /api/corp/blueprints CSV columns.',
+    query: `query CorpBlueprints($owners: [String!]) {
+  blueprints(owners: $owners) {
+    rows {
+      item_id: itemId
+      corporation_id: corporationId
+      location_flag: locationFlag
+      location_id: locationId
+      material_efficiency: materialEfficiency
+      quantity
+      runs
+      time_efficiency: timeEfficiency
+      type_id: typeId
+    }
+  }
+}`,
+    variableFields: [
+      { ...OWNERS_FIELD, hint: 'Your corporation name or id; empty also includes your characters’ own blueprints.' },
+    ],
+  },
+  {
+    id: 'sheets-character-orders',
+    label: 'Market orders (Sheets drop-in)',
+    description: 'Your open market orders with the /api/character/orders CSV columns.',
+    query: `query Orders($owners: [String!]) {
+  marketOrders(owners: $owners) {
+    duration
+    escrow
+    is_buy_order: isBuy
+    is_corporation: isCorporation
+    issued
+    location_id: locationId
+    min_volume: minVolume
+    order_id: orderId
+    price
+    range
+    region_id: regionId
+    type_id: typeId
+    volume_remain: volumeRemain
+    volume_total: volumeTotal
+    character_name: characterName
+  }
+}`,
+    variableFields: [
+      { ...OWNERS_FIELD, hint: 'Character names/ids; empty means all of yours (orders are character-owned).' },
+    ],
+  },
+  {
+    id: 'sheets-character-jobs',
+    label: 'Industry jobs (Sheets drop-in)',
+    description: 'In-flight industry jobs with the /api/character/jobs CSV columns.',
+    query: `query Jobs($owners: [String!]) {
+  industryJobs(owners: $owners) {
+    activity_id: activityId
+    blueprint_id: blueprintId
+    blueprint_location_id: blueprintLocationId
+    blueprint_type_id: blueprintTypeId
+    completed_character_id: completedCharacterId
+    completed_date: completedDate
+    cost
+    duration
+    end_date: endDate
+    facility_id: facilityId
+    installer_id: installerId
+    job_id: jobId
+    licensed_runs: licensedRuns
+    output_location_id: outputLocationId
+    pause_date: pauseDate
+    probability
+    product_type_id: productTypeId
+    runs
+    start_date: startDate
+    station_id: stationId
+    status
+    successful_runs: successfulRuns
+    character_name: characterName
+    blueprint_type_name: blueprintTypeName
+    product_type_name: productTypeName
+  }
+}`,
+    variableFields: [OWNERS_FIELD],
+  },
+  {
+    id: 'sheets-corp-jobs',
+    label: 'Corp industry jobs (Sheets drop-in)',
+    description: 'Corporation industry jobs with the /api/corp/jobs CSV columns.',
+    query: `query CorpJobs($owners: [String!]) {
+  industryJobs(owners: $owners) {
+    activity_id: activityId
+    blueprint_id: blueprintId
+    blueprint_location_id: blueprintLocationId
+    blueprint_type_id: blueprintTypeId
+    completed_character_id: completedCharacterId
+    completed_date: completedDate
+    corporation_id: corporationId
+    cost
+    duration
+    end_date: endDate
+    facility_id: facilityId
+    installer_id: installerId
+    job_id: jobId
+    licensed_runs: licensedRuns
+    output_location_id: outputLocationId
+    pause_date: pauseDate
+    probability
+    product_type_id: productTypeId
+    runs
+    start_date: startDate
+    station_id: stationId
+    status
+    successful_runs: successfulRuns
+    blueprint_type_name: blueprintTypeName
+    product_type_name: productTypeName
+  }
+}`,
+    variableFields: [
+      { ...OWNERS_FIELD, hint: 'Your corporation name or id; empty also includes your characters’ own jobs.' },
+    ],
+  },
+  {
+    id: 'wallet-balances',
+    label: 'Wallet balances',
+    description: 'Every character wallet, one row each.',
+    query: `{
+  walletBalances {
+    ownerName
+    balance
+    recordedAt
+  }
+}`,
+  },
+  {
+    id: 'stockpile-by-item',
+    label: 'Stockpile by item',
+    description: 'Where one item type sits across everything you own.',
+    query: `query Stockpile($item: String!) {
+  assets(type: $item) {
+    totalCount
+    truncated
+    rows {
+      typeName
+      quantity
+      locationName
+      ownerName
+    }
+  }
+}`,
+    variables: { item: 'Tritanium' },
+    variableFields: [
+      { name: 'item', label: 'Item', kind: 'text', hint: 'A name search — "Tritanium" matches wherever it appears.' },
+    ],
+  },
+  {
+    // The edges in anger: group/category and the location's solar system are
+    // reachable only through `type`/`location`, and each nests exactly one
+    // level, so the CSV still gives one line per row (type.groupName,
+    // location.systemName, …).
+    id: 'stockpile-nested',
+    label: 'Stockpile by group (nested)',
+    description: 'One item type with its group/category and solar system through the entity edges.',
+    query: `{
+  assets(type: "Tritanium") {
+    rows {
+      quantity
+      type {
+        name
+        groupName
+        categoryName
+        volume
+      }
+      location {
+        name
+        systemName
+      }
+      character {
+        name
+        corporationName
+      }
+    }
+  }
+}`,
+  },
+  {
+    id: 'open-orders',
+    label: 'Open orders',
+    description: 'Your open market orders, readably named.',
+    query: `{
+  marketOrders {
+    typeName
+    isBuy
+    price
+    volumeRemain
+    locationName
+    ownerName
+  }
+}`,
+  },
+  {
+    id: 'industry-jobs',
+    label: 'Industry jobs',
+    description: 'In-flight industry jobs, readably named.',
+    query: `{
+  industryJobs {
+    blueprintTypeName
+    productTypeName
+    activityId
+    runs
+    status
+    endDate
+    locationName
+    ownerName
+  }
+}`,
+  },
+  {
+    id: 'container-contents',
+    label: 'Container contents',
+    description: 'Everything sitting in one container or ship, by its item id.',
+    query: `query Container($container: [String!]) {
+  assets(locations: $container, limit: 500) {
+    totalCount
+    truncated
+    rows {
+      itemId
+      typeId
+      typeName
+      quantity
+      locationFlag
+      ownerName
+    }
+  }
+}`,
+    variables: { container: ['1046809423988'] },
+    variableFields: [
+      {
+        name: 'container',
+        label: 'Container',
+        kind: 'list',
+        hint: 'Item ids of containers or ships — a location id also matches what is nested inside it.',
+      },
+    ],
+  },
+  {
+    id: 'types-anywhere',
+    label: 'Certain item types',
+    description: 'Only certain item types, wherever they are — e.g. the inputs to a fuel block.',
+    query: `query Types($types: [String!]) {
+  assets(types: $types, limit: 500) {
+    totalCount
+    rows {
+      typeId
+      typeName
+      quantity
+      locationName
+      ownerName
+    }
+  }
+}`,
+    variables: { types: ['16273', '17887', '16275', '9832', '44'] },
+    variableFields: [{ name: 'types', label: 'Types', kind: 'list', hint: 'SDE type ids or whole item names, mixed.' }],
+  },
+  {
+    id: 'types-in-container',
+    label: 'Types in a container',
+    description:
+      'Both at once: those types, but only inside that container. Variables keep the ids out of the query text.',
+    query: `query Stock($container: [String!], $types: [String!]) {
+  assets(locations: $container, types: $types, limit: 500) {
+    totalCount
+    rows {
+      typeId
+      typeName
+      quantity
+    }
+  }
+}`,
+    variables: { container: ['1046809423988'], types: ['16273', '17887'] },
+  },
+  {
+    id: 'restock',
+    label: 'Restock list',
+    description:
+      'How much to buy of each item to get back up to a supply buffer. The targets ARE the lens — a viewer cannot change them, so the buffer levels stay yours.',
+    query: `query Restock($targets: [RestockTarget!]!) {
+  restock(targets: $targets) {
+    typeName
+    groupName
+    target
+    onHand
+    delta
+    toBuy
+  }
+}`,
+    variables: {
+      targets: [
+        { type: 'Nitrogen Fuel Block', quantity: 10000 },
+        { type: 'Tritanium', quantity: 1000000 },
+      ],
+    },
+  },
+]

--- a/src/app/lens/validate.ts
+++ b/src/app/lens/validate.ts
@@ -16,7 +16,16 @@
 //
 // Pure module: `graphql` + the SDL only (relative .ts import so `node --test`
 // can load it — see test/lensValidate.test.ts).
-import { buildSchema, parse, validate, visit, Kind, type DocumentNode } from 'graphql'
+import {
+  buildSchema,
+  parse,
+  validate,
+  visit,
+  Kind,
+  type DocumentNode,
+  type FieldNode,
+  type OperationDefinitionNode,
+} from 'graphql'
 
 import { typeDefs } from '../api/graphql/schema.graphql.ts'
 
@@ -83,6 +92,24 @@ export const validateLensQuery = (query: string): LensValidation => {
   }
 
   return { ok: true }
+}
+
+// The single top-level field a lens query selects — the `field` dimension of
+// the request.timing metric (src/observability.js). Total on any query that
+// passed validateLensQuery (which enforces exactly one top-level field);
+// answers null rather than throwing on anything else, since a metric label is
+// never worth failing a request over.
+export const topLevelFieldOf = (query: string): string | null => {
+  try {
+    const document = parse(query)
+    const operation = document.definitions.find(
+      (d): d is OperationDefinitionNode => d.kind === Kind.OPERATION_DEFINITION
+    )
+    const field = operation?.selectionSet.selections.find((s): s is FieldNode => s.kind === Kind.FIELD)
+    return field?.name.value ?? null
+  } catch {
+    return null
+  }
 }
 
 // The stored variables must be a JSON object (fixed by the creator at save

--- a/src/app/sheets/market/[market]/route.ts
+++ b/src/app/sheets/market/[market]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { RequestTiming, withRequestTiming } from '@/app/api/requestTiming'
 import { TRACKED_MARKETS } from '@/gnfMarket.js'
 import { AT_PARAM_ERROR, parseAtParam } from '@/utils/atParam'
 import { toCsv } from '@/utils/csv'
@@ -46,9 +47,10 @@ const HEADER = 'TypeID,Updated,Buy,Sell,Since,Strategy'
 // "nothing has ever recorded it".
 const MARKETS = new Set<string>(TRACKED_MARKETS)
 
-export const GET = async (
+const handler = async (
   request: NextRequest,
-  { params }: { params: Promise<{ market: string }> }
+  { params }: { params: Promise<{ market: string }> },
+  timing: RequestTiming
 ): Promise<NextResponse> => {
   const market = stripExtension(decodeURIComponent((await params).market))
   if (!MARKETS.has(market)) {
@@ -106,6 +108,8 @@ export const GET = async (
   // "live" and must not be.
   const historical = at !== null && at.ok && at.iso < new Date().toISOString()
 
+  timing.rows = (rows ?? []).length
+  if (historical) timing.served = 'historical'
   return new NextResponse(body, {
     headers: {
       'Content-Type': 'text/csv; charset=utf-8',
@@ -113,3 +117,11 @@ export const GET = async (
     },
   })
 }
+
+// The one public CSV in the timing metric: market_price_over_time is the table
+// whose BRIN index the others are standardizing toward, so its live/historical
+// split is the control the comparison reads (docs/brin-indexes/README.md).
+export const GET = withRequestTiming(
+  { route: '/sheets/market/[market]', surface: 'public_csv', field: 'market_price_snapshot' },
+  handler
+)

--- a/src/observability.js
+++ b/src/observability.js
@@ -61,6 +61,47 @@ export const recordPeakRss = ({ job, entry = null }) => {
   })
 }
 
+// One inbound data-serving request — the CSV/lens/GraphQL surfaces (see
+// src/app/api/requestTiming.ts and docs/brin-indexes/README.md, whose
+// measurement protocol reads these). Group by (route, field, served) and chart
+// p50/p95 duration_ms; `served` splits live reads from SCD-2 time travel
+// (`at=`), which is the axis the BRIN index work moves.
+//   route: the static route template (/api/character/assets, /lens/[id]/csv,
+//     /api/graphql) — never a per-lens id, so cardinality stays flat
+//   surface: 'legacy_csv' | 'lens_csv' | 'lens_view' | 'graphql' | 'public_csv'
+//   field: the GraphQL root field a lens/graphql request selected, or the
+//     Postgres function a CSV route called
+//   served: 'live' (current rows) | 'historical' (an explicit at= / time travel)
+//   outcome: 'ok' | 'bad_request' | 'unauthorized' | 'not_found' | 'query_failed'
+//   status: the HTTP status answered, or null where the emitter never sees it
+//     (the in-process lens run, the GraphQL execution phase)
+//   rows: rows in the response, or null when the request never produced any
+/**
+ * @param {{ route: string, surface: string, field?: string | null,
+ *   served?: 'live' | 'historical', outcome: string, status?: number | null,
+ *   rows?: number | null, durationMs: number }} request
+ */
+export const recordRequest = ({
+  route,
+  surface,
+  field = null,
+  served = 'live',
+  outcome,
+  status = null,
+  rows = null,
+  durationMs,
+}) =>
+  recordMetric('request.timing', {
+    route,
+    surface,
+    field,
+    served,
+    outcome,
+    status,
+    rows,
+    duration_ms: durationMs,
+  })
+
 // One Discord interaction outcome — see src/app/api/discord/interactions/route.ts.
 // Group by (type, outcome) to watch signature rejections (portal validation and
 // spoof attempts) and, later, command traffic.

--- a/test/graphqlSchema.test.ts
+++ b/test/graphqlSchema.test.ts
@@ -164,6 +164,21 @@ test('the flat scalar beside each edge survives', () => {
   assert.equal(String(job.productTypeName.type), 'String')
 })
 
+// The columns the legacy /api/{character,corp}/jobs CSV routes serve and the
+// lens drop-in templates select (docs/sharing-layer/09-sheets-parity.md).
+// output_count is deliberately absent: it's an SQL join against
+// sde_blueprint_product in the RPCs, and opt-in-only on the legacy routes.
+test('IndustryJob carries the Sheets-parity columns', () => {
+  const schema = buildSchema(typeDefs)
+  const fields = objectType(schema, 'IndustryJob').getFields()
+  assert.equal(String(fields.blueprintId.type), 'String!')
+  assert.equal(String(fields.blueprintLocationId.type), 'String!')
+  assert.equal(String(fields.outputLocationId.type), 'String!')
+  assert.equal(String(fields.facilityId.type), 'String!')
+  assert.equal(String(fields.pauseDate.type), 'String')
+  assert.equal(String(fields.completedCharacterId.type), 'String')
+})
+
 test('Character exposes the EVE character id distinctly from the registration id', () => {
   const schema = buildSchema(typeDefs)
   const character = objectType(schema, 'Character').getFields()

--- a/test/graphqlSchema.test.ts
+++ b/test/graphqlSchema.test.ts
@@ -177,6 +177,8 @@ test('IndustryJob carries the Sheets-parity columns', () => {
   assert.equal(String(fields.facilityId.type), 'String!')
   assert.equal(String(fields.pauseDate.type), 'String')
   assert.equal(String(fields.completedCharacterId.type), 'String')
+  const order = objectType(schema, 'MarketOrder').getFields()
+  assert.equal(String(order.isCorporation.type), 'Boolean!')
 })
 
 test('Character exposes the EVE character id distinctly from the registration id', () => {

--- a/test/lensTemplates.test.ts
+++ b/test/lensTemplates.test.ts
@@ -1,0 +1,85 @@
+// The shared template list (src/app/lens/templates.ts) is the load-bearing
+// drift guard between three surfaces — the /lens picker, the /graphql example
+// buttons, and the MCP lens_schema examples — and the legacy CSV routes it
+// supersedes: a schema change that breaks a template, or a column drifting
+// from its legacy counterpart, fails here before a user pastes a dead formula.
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { Kind, parse, type FieldNode, type OperationDefinitionNode } from 'graphql'
+
+import {
+  CHARACTER_ASSET_COLUMNS,
+  CHARACTER_BLUEPRINT_COLUMNS,
+  CHARACTER_JOB_COLUMNS,
+  CHARACTER_ORDER_COLUMNS,
+  CORP_ASSET_COLUMNS,
+  CORP_BLUEPRINT_COLUMNS,
+  CORP_JOB_COLUMNS,
+} from '../src/app/api/csvColumns.ts'
+import { LENS_TEMPLATES } from '../src/app/lens/templates.ts'
+import { validateLensQuery } from '../src/app/lens/validate.ts'
+
+// The CSV header a template produces: response keys follow the selection
+// aliases in order, so this is the root field's selections — or its `rows`
+// sub-selection when the root returns a page object (assets, blueprints).
+const csvColumnsOf = (query: string): string[] => {
+  const document = parse(query)
+  const operation = document.definitions.find((d): d is OperationDefinitionNode => d.kind === Kind.OPERATION_DEFINITION)
+  const root = operation?.selectionSet.selections.find((s): s is FieldNode => s.kind === Kind.FIELD)
+  const rows = root?.selectionSet?.selections.find(
+    (s): s is FieldNode => s.kind === Kind.FIELD && s.name.value === 'rows'
+  )
+  const source = rows?.selectionSet ?? root?.selectionSet
+  return (source?.selections ?? [])
+    .filter((s): s is FieldNode => s.kind === Kind.FIELD)
+    .map((s) => s.alias?.value ?? s.name.value)
+}
+
+const templateById = (id: string) => {
+  const found = LENS_TEMPLATES.find((t) => t.id === id)
+  assert.ok(found, `template ${id} exists`)
+  return found
+}
+
+test('template ids are unique', () => {
+  assert.equal(new Set(LENS_TEMPLATES.map((t) => t.id)).size, LENS_TEMPLATES.length)
+})
+
+test('every template passes lens validation against the live schema', () => {
+  for (const t of LENS_TEMPLATES) {
+    assert.deepEqual(validateLensQuery(t.query), { ok: true }, t.id)
+  }
+})
+
+test('every labelled field names a variable its query declares', () => {
+  for (const t of LENS_TEMPLATES) {
+    const declared = new Set(
+      (
+        parse(t.query).definitions.find((d): d is OperationDefinitionNode => d.kind === Kind.OPERATION_DEFINITION)
+          ?.variableDefinitions ?? []
+      ).map((v) => v.variable.name.value)
+    )
+    for (const field of t.variableFields ?? []) {
+      assert.ok(declared.has(field.name), `${t.id}: $${field.name}`)
+    }
+  }
+})
+
+// The Sheets drop-ins: alias-for-alias equal to the legacy routes' default
+// column lists, so the lens CSV's header row is byte-identical and an existing
+// =IMPORTDATA() tab re-points cleanly (docs/sharing-layer/09-sheets-parity.md).
+test('the drop-in templates match the legacy CSV columns exactly', () => {
+  const parity: Array<[string, readonly string[]]> = [
+    ['sheets-character-assets', CHARACTER_ASSET_COLUMNS],
+    ['sheets-character-blueprints', CHARACTER_BLUEPRINT_COLUMNS],
+    ['sheets-character-orders', CHARACTER_ORDER_COLUMNS],
+    ['sheets-character-jobs', CHARACTER_JOB_COLUMNS],
+    ['sheets-corp-assets', CORP_ASSET_COLUMNS],
+    ['sheets-corp-blueprints', CORP_BLUEPRINT_COLUMNS],
+    ['sheets-corp-jobs', CORP_JOB_COLUMNS],
+  ]
+  for (const [id, columns] of parity) {
+    assert.deepEqual(csvColumnsOf(templateById(id).query), [...columns], id)
+  }
+})

--- a/test/lensValidate.test.ts
+++ b/test/lensValidate.test.ts
@@ -4,7 +4,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { parseLensVariables, validateLensQuery } from '../src/app/lens/validate.ts'
+import { parseLensVariables, topLevelFieldOf, validateLensQuery } from '../src/app/lens/validate.ts'
 
 test('a plain single-field query passes', () => {
   const result = validateLensQuery(`{ walletBalances { ownerName balance } }`)
@@ -66,4 +66,17 @@ test('non-object variables are rejected', () => {
   assert.equal(parseLensVariables('[1, 2]').ok, false)
   assert.equal(parseLensVariables('"x"').ok, false)
   assert.equal(parseLensVariables('not json').ok, false)
+})
+
+test('topLevelFieldOf names the single root field of a saved lens', () => {
+  assert.equal(topLevelFieldOf(`{ walletBalances { balance } }`), 'walletBalances')
+  assert.equal(
+    topLevelFieldOf(`query Stockpile($item: String!) { assets(type: $item) { rows { quantity } } }`),
+    'assets'
+  )
+})
+
+test('topLevelFieldOf answers null rather than throwing on anything unnamed', () => {
+  assert.equal(topLevelFieldOf(`{ walletBalances {`), null)
+  assert.equal(topLevelFieldOf(``), null)
 })


### PR DESCRIPTION
Three connected pieces, sequenced so each enables the next (design doc: `docs/sharing-layer/09-sheets-parity.md`; rewritten plan: `docs/brin-indexes/README.md`).

## 1. `request.timing` instrumentation (lands first, so a baseline window opens)

- `recordRequest` in `src/observability.js` — one stdout JSON line per served request, ingested by Vercel Observability. Dimensions: `route` (static template), `surface` (`legacy_csv | lens_csv | lens_view | graphql | public_csv`), `field` (RPC or GraphQL root field), **`served` (`live | historical`)** — the axis the BRIN measurement pivots on — plus outcome/status/rows/duration_ms.
- The seven api_token CSV routes and `/sheets/market/[market]` wrap in `withRequestTiming` (`src/app/api/requestTiming.ts`); `runLens` times the creator-context execution for the lens viewer/CSV surfaces; a yoga plugin times each executed `/api/graphql` operation by root field.

## 2. GraphQL/lens parity with the Sheets routes

- `IndustryJob` gains the six plain columns the legacy jobs CSVs serve (`blueprintId`, `blueprintLocationId`, `outputLocationId`, `facilityId`, `pauseDate`, `completedCharacterId`); `MarketOrder` gains `isCorporation`. `output_count` deliberately stays behind (opt-in SQL join in the RPCs) — recorded in the design doc.
- Per-list caps move onto the GraphQL context: the lens CSV export runs under `EXPORT_CAP` (50k) via `contextForUser(userId, { exporting: true })`, and the route answers **400 rather than a silently shortened CSV** when even that bound bites. Interactive caps unchanged.
- **No time travel in lenses** — the schema stays current-data-only; `at=` history remains a legacy-route capability, which is load-bearing for the measurement below.

## 3. Lens creator UI

- One shared prewritten-query list (`src/app/lens/templates.ts`) feeds the `/lens` template picker, the `/graphql` example buttons, and the MCP `lens_schema` examples — three surfaces, one text.
- Seven **Sheets drop-in templates** alias their selections to the legacy routes' snake_case columns, so the lens CSV header row is byte-identical and an existing `=IMPORTDATA()` tab re-points cleanly. Pinned by `test/lensTemplates.test.ts` against the routes' own column lists (now shared from `src/app/api/csvColumns.ts`).
- Editor: template picker, labelled variable fields writing through to the same variables JSON, table preview matching the viewer page (shared `lensTable.tsx`), and a copyable `=IMPORTDATA()` formula for link-shared/public lenses.
- "Save a copy" forks a shared lens's query into the viewer's own list (same two-door authorization as viewing); `/lens` gains a shared-with-me section.

## 4. Deprecation

The seven token routes answer `Deprecation: true`, and `/account/settings` steers lens-flagged accounts to lenses, moving the token URLs under a Deprecated heading. The routes stay live — they are the `served=historical` measurement instrument, and unflagged accounts see no change. No removal.

## 5. The rewritten BRIN plan

`docs/brin-indexes/README.md` moves from "measure, and possibly stop" to **standardize, measured**: a BRIN `(valid_from) with (pages_per_range = 32)` on all 13 `*_over_time` tables (the `market_price_over_time` precedent: 60 MB btree → 40 kB, correlation 0.9996 after churn), keeping entity btrees and `is_current` partials, owner btrees demoted to evidence-gated drop candidates. The per-table measurement protocol reads the live `request.timing` series (baseline window → apply → comparison window, with a synthetic `at=` probe where organic history traffic is thin) plus `EXPLAIN (ANALYZE, BUFFERS)` at production row counts. Index migrations are follow-up PRs per that doc — none in this PR.

## Testing

- `pnpm run lint`, `pnpm test` (349 passing, including the new `lensTemplates` header-parity guard, `topLevelFieldOf`, and drift-guard additions), `pnpm run build` — all green after rebasing on `main`.
- No schema/migration changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoRCbEZR7TmDFCauhVW4y2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoRCbEZR7TmDFCauhVW4y2)_