### PR TITLE
Expose KNOWN_FLAGS to Vercel's Flags Explorer via a discovery endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,11 @@ SUPABASE_TEST_BRANCH_URL=
 SUPABASE_TEST_BRANCH_ANON_KEY=
 SUPABASE_TEST_BRANCH_SERVICE_KEY=
 CRON_SECRET=random-secret-shared-with-vercel-cron
+
+# Authenticates Vercel's Flags Explorer against /.well-known/vercel/flags
+# (flag discovery for the Experimentation dashboard). Generate with:
+# node -e "console.log(crypto.randomBytes(32).toString('base64url'))"
+FLAGS_SECRET=
 # Salts share-link signatures (src/shareToken.ts): a URL token is an HMAC keyed
 # by the share row's secret AND this value, so a database dump alone can't mint
 # valid links. Any long random string; rotating it invalidates every share link.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@vercel/speed-insights": "2.0.0",
     "eve-industry": "0.1.0",
     "fast-shuffle": "^6.2.0",
+    "flags": "^4.3.0",
     "graphql": "^17.0.2",
     "graphql-yoga": "^5.21.2",
     "mcp-handler": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       fast-shuffle:
         specifier: ^6.2.0
         version: 6.2.1
+      flags:
+        specifier: ^4.3.0
+        version: 4.3.0(next@16.3.1(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       graphql:
         specifier: ^17.0.2
         version: 17.0.2
@@ -192,6 +195,10 @@ packages:
     engines: {bun: '>=1', deno: '>=2.7.10', node: '>=16'}
     peerDependencies:
       '@noble/ciphers': ^1.0.0
+
+  '@edge-runtime/cookies@5.0.2':
+    resolution: {integrity: sha512-Sd8LcWpZk/SWEeKGE8LT6gMm5MGfX/wm+GPnh1eBEtCpya3vYqn37wYknwAHw92ONoyyREl1hJwxV/Qx2DWNOg==}
+    engines: {node: '>=16'}
 
   '@emnapi/runtime@1.11.3':
     resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
@@ -2079,6 +2086,23 @@ packages:
     resolution: {integrity: sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==}
     engines: {node: '>=18'}
 
+  flags@4.3.0:
+    resolution: {integrity: sha512-e4L4QBxGCMNTFzwleCBP1dSl4tET6t3Iv2REfMtBdfMNsD700s0LbgDgS8SsxkRpWrtJamRhsVqaqUwZaCyhtQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
+      next: '*'
+      react: '*'
+      react-dom: '*'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
@@ -3389,6 +3413,8 @@ snapshots:
   '@ecies/ciphers@0.2.6(@noble/ciphers@1.3.0)':
     dependencies:
       '@noble/ciphers': 1.3.0
+
+  '@edge-runtime/cookies@5.0.2': {}
 
   '@emnapi/runtime@1.11.3':
     dependencies:
@@ -5359,6 +5385,15 @@ snapshots:
     dependencies:
       semver-regex: 4.0.5
       super-regex: 1.1.0
+
+  flags@4.3.0(next@16.3.1(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      '@edge-runtime/cookies': 5.0.2
+      jose: 5.10.0
+    optionalDependencies:
+      next: 16.3.1(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   flat-cache@4.0.1:
     dependencies:

--- a/src/app/.well-known/vercel/flags/route.ts
+++ b/src/app/.well-known/vercel/flags/route.ts
@@ -1,0 +1,39 @@
+import { fromPairs, map } from 'ramda'
+
+import type { ApiData } from 'flags'
+import { createFlagsDiscoveryEndpoint } from 'flags/next'
+
+import { KNOWN_FLAGS } from '@/flags'
+
+// Discovery endpoint for Vercel's Flags Explorer / Experimentation dashboard
+// (https://vercel.com/docs/flags/flags-explorer/reference). Vercel fetches
+// this (authenticated against FLAGS_SECRET) to learn which flags the app
+// actually uses, so the dashboard lists KNOWN_FLAGS instead of stale
+// hand-entered ones. Metadata only — evaluation stays per-user in
+// user_settings.flags via hasFlag(); the Flags Explorer can't override it.
+export const GET = createFlagsDiscoveryEndpoint(
+  async (): Promise<ApiData> => ({
+    definitions: fromPairs(
+      map(
+        ({ flag, label }) => [
+          flag,
+          {
+            description: label,
+            origin: 'https://edencom.link/account/settings/chancellor',
+            options: [
+              { value: false, label: 'Off' },
+              { value: true, label: 'On' },
+            ],
+          },
+        ],
+        KNOWN_FLAGS
+      )
+    ),
+    hints: [
+      {
+        key: 'per-user',
+        text: 'Flags are dark-launched per account in user_settings.flags; toggle them on /account/settings/chancellor, not here.',
+      },
+    ],
+  })
+)


### PR DESCRIPTION
## What

Vercel's Experimentation page only listed a stale, hand-entered `indexes` flag because the app never advertised the flags it actually uses. Vercel discovers an app's flags by fetching `/.well-known/vercel/flags` (the Flags Explorer discovery endpoint) — this PR adds that endpoint, driven directly by `KNOWN_FLAGS` in `src/flags.ts`, so `graphql`, `lens`, and `fit-ui` show up with their Chancellor-page labels as descriptions.

## How

- `src/app/.well-known/vercel/flags/route.ts` — `createFlagsDiscoveryEndpoint` from the `flags` package (authenticates the dashboard's request against `FLAGS_SECRET`), returning one definition per `KNOWN_FLAGS` entry plus a hint that flags are toggled per account on `/account/settings/chancellor`. Metadata only: evaluation stays per-user in `user_settings.flags` via `hasFlag()`, so the Flags Explorer can see the flags but not override them.
- `.env.example` — documents the new `FLAGS_SECRET` env var and how to generate it.
- `package.json` — adds the `flags` dependency.

## Setup after merge

1. Generate a secret (`node -e "console.log(crypto.randomBytes(32).toString('base64url'))"`) and set it as `FLAGS_SECRET` in the Vercel project env vars.
2. Delete the stale `indexes` flag by hand in the Vercel dashboard — discovery adds flags, it doesn't remove ones created there.

---
_Generated by [Claude Code](https://claude.ai/code/session_018ur8Rr67eLV1uBBsktyjKe)_