### PR TITLE
Add the standard BRIN time-travel index to the five small SCD tables

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1971,6 +1971,10 @@ create unique index character_clone_over_time_current_jump_idx
   on public.character_clone_over_time (registration_id, jump_clone_id) where is_current and not is_home;
 create unique index character_clone_over_time_current_home_idx
   on public.character_clone_over_time (registration_id) where is_current and is_home;
+-- Time travel: valid_from climbs with physical order (the reconcile appends),
+-- so BRIN serves `valid_from <= as_of` at ~kB size (docs/brin-indexes/README.md).
+create index character_clone_over_time_asof_idx
+  on public.character_clone_over_time using brin (valid_from) with (pages_per_range = 32);
 
 alter table public.character_clone_over_time enable row level security;
 create policy "Users read own clones"
@@ -2040,6 +2044,10 @@ create table public.character_skill_over_time (
 create index character_skill_over_time_registration_id_idx on public.character_skill_over_time (registration_id);
 create unique index character_skill_over_time_current_idx
   on public.character_skill_over_time (registration_id, skill_id) where is_current;
+-- Time travel: valid_from climbs with physical order (the reconcile appends),
+-- so BRIN serves `valid_from <= as_of` at ~kB size (docs/brin-indexes/README.md).
+create index character_skill_over_time_asof_idx
+  on public.character_skill_over_time using brin (valid_from) with (pages_per_range = 32);
 
 alter table public.character_skill_over_time enable row level security;
 create policy "Users read own skills"
@@ -2085,6 +2093,10 @@ create table public.character_ship_over_time (
 create index character_ship_over_time_registration_id_idx on public.character_ship_over_time (registration_id);
 create unique index character_ship_over_time_current_idx
   on public.character_ship_over_time (registration_id) where is_current;
+-- Time travel: valid_from climbs with physical order (the reconcile appends),
+-- so BRIN serves `valid_from <= as_of` at ~kB size (docs/brin-indexes/README.md).
+create index character_ship_over_time_asof_idx
+  on public.character_ship_over_time using brin (valid_from) with (pages_per_range = 32);
 
 alter table public.character_ship_over_time enable row level security;
 create policy "Users read own ship"
@@ -2152,6 +2164,10 @@ create index character_fitting_over_time_registration_id_idx
 -- At most one live row per fit; also the collision guard the reconcile relies on.
 create unique index character_fitting_over_time_current_idx
   on public.character_fitting_over_time (registration_id, fitting_id) where is_current;
+-- Time travel: valid_from climbs with physical order (the reconcile appends),
+-- so BRIN serves `valid_from <= as_of` at ~kB size (docs/brin-indexes/README.md).
+create index character_fitting_over_time_asof_idx
+  on public.character_fitting_over_time using brin (valid_from) with (pages_per_range = 32);
 
 alter table public.character_fitting_over_time enable row level security;
 create policy "Users read own fittings"
@@ -2280,6 +2296,10 @@ create unique index character_mercenary_den_over_time_current_idx
 -- Time-travel lookups walking a den's version history.
 create index character_mercenary_den_over_time_den_idx
   on public.character_mercenary_den_over_time (registration_id, den_id, valid_until desc);
+-- Time travel: valid_from climbs with physical order (the reconcile appends),
+-- so BRIN serves `valid_from <= as_of` at ~kB size (docs/brin-indexes/README.md).
+create index character_mercenary_den_over_time_asof_idx
+  on public.character_mercenary_den_over_time using brin (valid_from) with (pages_per_range = 32);
 
 alter table public.character_mercenary_den_over_time enable row level security;
 -- Base policy: a user reads their own characters' dens. The sharing policy that

--- a/supabase/migrations/20260816170000_brin_small_tables.sql
+++ b/supabase/migrations/20260816170000_brin_small_tables.sql
@@ -1,0 +1,40 @@
+-- BRIN standardization, batch 1: the small SCD-2 tables
+-- (docs/brin-indexes/README.md — "standardize, measured").
+--
+-- Every *_over_time reconcile appends its new row versions at the end of the
+-- heap, so valid_from climbs with physical position — the correlation BRIN
+-- summarises well. The time-travel predicate these serve
+-- (valid_from <= as_of and (is_current or valid_until >= as_of)) is
+-- btree-hostile (the OR) and BRIN-shaped (the range half). Measured precedent
+-- on market_price_over_time at 2M rows: btree 60 MB vs BRIN 40 kB for ~2.5 ms
+-- on deep history, correlation 0.9996 after 60 simulated churn cycles
+-- (20260816040000_market_price.sql, docs/market-prices/README.md "Storage").
+--
+-- These five are batched — unlike the large tables, which ship one per PR
+-- against a request.timing baseline — because they are bounded by character
+-- count times a small per-character set (clones, learned skills, one ship,
+-- fittings, dens), so the index costs kilobytes, no serving RPC exists yet to
+-- regress, and standardizing them now means they are already correct if they
+-- grow. Evidence for this batch is plan-level only, per the doc's sequencing.
+-- Deliberately absent: character_blueprint_over_time (size is a production
+-- fact — it joins a later PR once the doc's sizing query has run) and the
+-- large tables (assets, orders, industry jobs).
+--
+-- Plain create index, not concurrently: the CLI applies migrations
+-- transactionally, and a BRIN build is one sequential heap pass over small
+-- tables — the writers it could briefly block are the 6-hourly extract jobs.
+
+create index character_clone_over_time_asof_idx
+  on public.character_clone_over_time using brin (valid_from) with (pages_per_range = 32);
+
+create index character_skill_over_time_asof_idx
+  on public.character_skill_over_time using brin (valid_from) with (pages_per_range = 32);
+
+create index character_ship_over_time_asof_idx
+  on public.character_ship_over_time using brin (valid_from) with (pages_per_range = 32);
+
+create index character_fitting_over_time_asof_idx
+  on public.character_fitting_over_time using brin (valid_from) with (pages_per_range = 32);
+
+create index character_mercenary_den_over_time_asof_idx
+  on public.character_mercenary_den_over_time using brin (valid_from) with (pages_per_range = 32);


### PR DESCRIPTION
Batch 1 of the BRIN standardization adopted in `docs/brin-indexes/README.md` (#906): the five small SCD-2 histories each gain the standard time-travel index —

```sql
create index <table>_asof_idx on public.<table>
  using brin (valid_from) with (pages_per_range = 32);
```

for `character_clone_over_time`, `character_skill_over_time`, `character_ship_over_time`, `character_fitting_over_time`, and `character_mercenary_den_over_time`, in migration `20260816170000_brin_small_tables.sql` with matching `schema.sql` edits (dual-write rule).

**Why batched** (unlike the one-PR-per-table rule for the large tables): these are bounded by character count × a small per-character set, so the index costs kilobytes, and no snapshot RPC serves them yet — there is nothing measurable to regress, so evidence is plan-level only, exactly as the doc's sequencing prescribes. The write pattern is the same append-ordered reconcile as every SCD table, so `valid_from` correlates with physical order (the `market_price_over_time` precedent measured 0.9996 after churn).

**Deliberately absent:**
- `character_blueprint_over_time` — the doc says "possibly blueprints"; its size is a production fact, so it joins a later PR once the doc's sizing query has run (this environment has no production DB access to run it).
- The large tables (assets, orders, industry jobs) — one PR each, after the ≥7-day `request.timing` baseline window that opened with #906 closes, per the measurement protocol.

## Testing

- `node .github/scripts/check-migrations.mjs origin/main` — no ordering problems.
- `pnpm run lint`, `pnpm test` (349 passing), `pnpm run build` — green (no code changes; the gate anyway).
- This PR touches `supabase/migrations/**`, so CI's `test:branch` applies the migration against an ephemeral Supabase preview branch — the real proof the SQL is valid.

## Post-merge follow-up (needs production access)

Run the doc's sizing query to confirm these five are small and record `pg_relation_size` of the new indexes; that same query also decides blueprints and orders the large-table PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoRCbEZR7TmDFCauhVW4y2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoRCbEZR7TmDFCauhVW4y2)_