### PR TITLE
Record where pages_per_range = 32 comes from and how to recalibrate it

### DIFF
--- a/docs/brin-indexes/README.md
+++ b/docs/brin-indexes/README.md
@@ -80,6 +80,43 @@ moment. (Tables with no snapshot function yet — clone/skill/ship/fitting/
 mercenary-den — are included for the same reason: the index is the cheap half;
 the RPC, when someone wants one, is the expensive half.)
 
+### Where `pages_per_range = 32` comes from, and how to recalibrate it
+
+**Provenance, honestly:** 32 is inherited from the `market_price_over_time`
+precedent. The market-prices sizing work ran its benchmarks *with* 32 — the
+5.1 ms / 181 ms numbers above were measured at that setting — but never A/B'd
+it against PostgreSQL's default of 128. It is a reasonable value carried
+forward, not a measured optimum, and the standard keeps it for uniformity
+until a measurement says otherwise.
+
+**What the knob trades.** A BRIN entry is one min/max summary per
+`pages_per_range` heap pages. At 32 that's one summary per 256 kB of heap —
+4× finer than the default. Finer granularity means a range predicate matches
+fewer irrelevant blocks, so the lossy recheck reads fewer heap pages per
+query; the cost is proportionally more summary entries, which at BRIN scale
+(~tens of bytes each) keeps the index in kilobytes at any plausible table
+size. That asymmetry — recheck I/O is the real cost, index bytes are nearly
+free — is why the standard errs fine rather than coarse.
+
+**Recalibrating, when the numbers ask for it:**
+
+- Run `EXPLAIN (ANALYZE, BUFFERS)` on the table's time-travel query at
+  production row counts and read the `Buffers: shared hit/read` line against
+  the rows the query actually returned. Heap pages read ≫ what the result
+  warrants means the summaries are too coarse for how the predicate selects —
+  **halve** `pages_per_range` and re-measure. (A BRIN rebuild is a cheap,
+  single-pass migration; ship it like any index change, numbers in the
+  comment.)
+- The index itself showing up meaningfully in the sizing query — which takes
+  extreme row counts at these entry sizes — is the signal to **raise** it.
+- Re-check whenever the periodic `pg_stats.correlation` health check runs (a
+  degrading correlation and a wrong granularity present the same way: more
+  blocks scanned per query), and after any change to a reconcile's write
+  order.
+- A per-table value is allowed when measured — the standard is "recorded and
+  reasoned", not "identical forever" — but the migration comment must carry
+  the before/after numbers like every other index choice here.
+
 ### What stays, what might go
 
 - **Keep** the `(<entity>_id, valid_until desc)` btrees: high-cardinality


### PR DESCRIPTION
Docs-only follow-up to #906/#912: every BRIN index in the standard carries `with (pages_per_range = 32)`, but no file recorded why — the value appeared bare in the market-price migration, `schema.sql`, and the plan doc. `docs/brin-indexes/README.md` gains a subsection under "The standard" covering:

- **Provenance, honestly**: 32 is inherited from the `market_price_over_time` precedent, whose benchmarks (the 5.1 ms / 181 ms numbers) ran *at* 32 but were never A/B'd against PostgreSQL's default of 128 — a reasonable value carried forward, not a measured optimum.
- **What the knob trades**: one min/max summary per N heap pages; 32 = one per 256 kB, 4× finer than default. Finer granularity cuts the lossy recheck's heap reads; the cost is more summary entries, which at ~tens of bytes each stay in kilobytes at any plausible table size. Recheck I/O is the real cost and index bytes are nearly free, so the standard errs fine.
- **Recalibration recipe**: read `EXPLAIN (ANALYZE, BUFFERS)` heap reads against rows returned — halve when reads outrun the result (a BRIN rebuild is a cheap single-pass migration), raise only if the sizing query ever shows the index itself, re-check alongside the periodic `pg_stats.correlation` health check and after any change to a reconcile's write order, and record any per-table deviation's before/after numbers in its migration comment like every other index choice.

The merged migrations themselves are untouched — a migration's content is history once applied; the doc is the durable home for this.

## Testing

- Docs-only. `pnpm run lint`, `pnpm test` (349 passing) — green after rebasing on main (including the lens→Link rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoRCbEZR7TmDFCauhVW4y2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoRCbEZR7TmDFCauhVW4y2)_