### PR TITLE
Fix /link Preview erroring on any query that returns data

### DIFF
--- a/src/app/link/actions.ts
+++ b/src/app/link/actions.ts
@@ -92,7 +92,16 @@ export const previewLink = async (input: {
 
   const contextValue = await contextForUser(userId)
   const result = await graphql({ schema, source: input.query, variableValues: variables.variables, contextValue })
-  return { data: result.data ?? null, errors: (result.errors ?? []).map((e) => e.message) }
+  return {
+    // graphql-js builds its result maps with Object.create(null), and a server
+    // action's return value must be React-serializable — null-prototype
+    // objects are rejected at the boundary. The JSON round-trip yields plain
+    // objects, exactly what this action's old pre-stringified return produced
+    // implicitly. (The viewer page and CSV route consume the result entirely
+    // server-side, so only this action needs it.)
+    data: result.data == null ? null : JSON.parse(JSON.stringify(result.data)),
+    errors: (result.errors ?? []).map((e) => e.message),
+  }
 }
 
 // Fork a link someone shared with you into your own list: same query and


### PR DESCRIPTION
Regression from #906's editor upgrade, reported on the live /link page. `previewLink` (`src/app/link/actions.ts`) switched from returning a pre-stringified JSON blob to returning the structured GraphQL result so the editor could render the shared table — but graphql-js builds its execution-result maps with `Object.create(null)`, and a **server action's return value must be React-serializable**: null-prototype objects are rejected at the boundary ("Only plain objects … can be passed to Client Components"). So Preview errored the moment a query returned any rows.

**Fix**: round-trip `result.data` through `JSON.parse(JSON.stringify(…))` before returning — plain objects, exactly what the old pre-stringified return produced implicitly, while keeping the structured shape the table preview needs. One call site: the viewer page (`/link/[id]`) and the CSV route consume the result entirely server-side and never cross this boundary, and no other action returns raw GraphQL data.

## Testing

- `pnpm run lint`, `pnpm test` (349 passing), `pnpm run build` — green.
- Manual after deploy: /link → pick any template or the default query → Preview → the result table renders instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoRCbEZR7TmDFCauhVW4y2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoRCbEZR7TmDFCauhVW4y2)_