### PR TITLE
Emit Server-Timing headers for slow backend work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ Functions take `(accessToken, id, ...)`; return raw ESI JSON (paged wrappers ret
 ### `src/utils/`
 
 - `apiToken.ts` — `resolvePlayer(token)` for Sheets endpoints → `{ ok, supabase, registrationIds }` or error
+- `supabase/timedFetch.ts` — `timedSupabaseFetch(label)`, the instrumented `fetch` every Supabase client factory installs so each round trip becomes a Server-Timing span
 - `csv.ts` — `toCsv(rows)` (RFC 4180); `atParam.ts` — `parseAtParam(raw)` for the `at=` time-travel param (pads partial ISO dates)
 - `queue.ts` — region-pinned `@vercel/queue` client (default `sfo1`) + `send`/`handleCallback`
 - `cron.ts` — `requireCronSecret`; `runDirectCronJob` kept only for the `esf-data`/`sheet-csv` bootstrap routes
@@ -225,4 +226,5 @@ Key Postgres functions (RPC or SQL):
 
 - **ESI conditional requests (ETags):** the single-request snapshot jobs (character-orders, -wallet-transactions, -industry-jobs, -fittings) send the last ETag as `If-None-Match` (`esiConditionalJson`). On `304` the job skips its reconcile; on `200` it reconciles and stores the new ETag **after** the write commits, so a mid-run failure never skips a fetch whose data wasn't persisted. Only applied to endpoints returning the whole collection in one request (a `304` unambiguously means nothing changed); paginated endpoints are deliberately unconditional. Each request emits an `esi.conditional_request` metric (`recordEsiConditional` in `src/observability.js`).
 - **Observability metrics:** `src/observability.js` emits single-line JSON metrics to stdout, ingested from Vercel function logs — zero-dependency, the single seam to later swap in real OTel.
+- **Server-Timing headers** (`docs/server-timing.md`): `src/serverTiming.ts` holds a request-scoped span collector (`AsyncLocalStorage`); `withRequestTiming` and `withServerTiming(handler)` open the scope and stamp the response, so the browser's network panel shows *which* query was slow. Spans arrive free for every Supabase round trip — each client factory passes `timedSupabaseFetch(label)` as supabase-js's `global.fetch` (`db.<rpc|table>`, `sde.*`, `auth.*`) — plus explicit `timed(name, fn)` around the appraisal/GraphQL/link phases. Publicly cacheable responses go unstamped (a CDN would serve the first caller's timing to everyone). **Pages can't carry it** — App Router server components have no response-header seam; the collector is simply inert under a render. Because it imports `node:async_hooks`, a client component transitively importing a Supabase factory is now a build error (why `src/flagCatalog.ts` exists, split out of `@/flags`).
 - **Name resolution:** `universe_name` caches ESI `universeNames`; `resolveBatch()` bisects on error. Type names come from `src/sdeTypes.ts`.

--- a/docs/server-timing.md
+++ b/docs/server-timing.md
@@ -1,0 +1,99 @@
+# Server-Timing headers
+
+Every request-serving surface that does real backend work now answers with a
+`Server-Timing` header breaking that work down, so the browser's network panel
+(Chrome/Edge devtools → Network → Timing) shows _which_ query made a response
+slow instead of only that it was.
+
+```
+Server-Timing: total;dur=215.1, db.character_asset_snapshot_at;dur=123.3,
+               db.user_settings;dur=44.4, db.registration;dur=43.6
+```
+
+It complements, and does not replace, the `request.timing` metric line
+(`src/observability.js`): that one is for aggregate p50/p95 over days in Vercel
+Observability; this one is for the single request you are looking at right now.
+Same clock, different audience.
+
+## How it works
+
+`src/serverTiming.ts` holds a request-scoped span collector in an
+`AsyncLocalStorage`. A route handler opens the scope; anything it awaits — five
+frames down, through code that knows nothing about timing — can contribute a
+span. Outside a scope every entry point is a no-op costing one storage lookup,
+which is what happens during a page render, a cron job, or a workflow step.
+
+Spans arrive two ways:
+
+1. **Automatically, per Supabase round trip.** Each client factory under
+   `src/utils/supabase/` passes `timedSupabaseFetch(label)` as supabase-js's
+   `global.fetch` (`src/utils/supabase/timedFetch.ts`). That one function sees
+   both the URL and the clock, so it names the span from the path:
+   `db.<rpc-or-table>` for the caller-scoped clients (cookie session, service
+   role, MCP bearer), `sde.<rpc-or-table>` for the public SDE mirror, `auth.*`
+   for GoTrue. This is where the time goes on nearly every surface here —
+   `docs/page-load-performance.md`'s measurement found a single RPC accounting
+   for 3.2 s — so it is worth having without touching a call site.
+2. **Explicitly**, wrapping anything else worth naming in `timed(name, fn)`:
+   `appraise.price` (the innomin.at call, which blocks on a global throttle
+   queue), `appraise.walk`, `graphql.context` / `graphql.execute`,
+   `link.context` / `link.execute`.
+
+Repeats of a name fold into one metric carrying a count (`db.link;dur=88;desc="4×"`),
+durations are summed, the list is sorted slowest-first, and anything past 24
+distinct metrics folds into one `other` entry — a header a proxy drops shows
+nothing at all. `total` always leads.
+
+## Where the header appears
+
+- Everything wrapped by `withRequestTiming` (`src/app/api/requestTiming.ts`) —
+  the api_token CSV routes under `/api/character/*` and `/api/corp/*`, and
+  `/sheets/market/[market]`. The wrapper opens the scope, so no route needed
+  changing.
+- `/link/[id]/csv`, `/api/graphql`, `/api/appraisal`, `/api/type/search` —
+  each opts in with `withServerTiming(handler)`.
+
+Two deliberate omissions:
+
+**Publicly cacheable responses go unstamped.** A response carrying `public` or
+`s-maxage` is served to later callers unchanged, header included, so stamping
+it would hand everybody after the first the first request's timing dressed up
+as their own. `/sheets/market/[market]`'s CDN entry lives up to a week. The
+`request.timing` metric still covers those.
+
+**Pages carry no header, and can't.** App Router server components have no
+access to the response — there is no supported API for setting a header from a
+page render, and middleware (`src/proxy.ts`) runs before the render, when there
+is nothing to report yet. This is the frustrating half: the heaviest work in
+this app is on pages like `/asset/[locationId]`. The instrumentation is still
+live under those renders (it just finds no scope and does nothing); if Next
+ever grows a response-header seam for pages, wrapping the render in
+`collectServerTiming` is the whole change. Until then, page timing is measured
+the way `docs/page-load-performance.md` measured it: `EXPLAIN ANALYZE` and
+Vercel Observability.
+
+## Adding a span
+
+```ts
+import { timed } from '@/serverTiming'
+
+const rows = await timed('structure.fuel', () => computeFuelState(structures))
+```
+
+Name it `<area>.<thing>`; the serializer will sanitize anything that isn't an
+RFC 9110 token character, but a name that needed sanitizing reads badly. Keep
+the vocabulary small — a name per row would blow past the metric cap.
+
+To put the header on a route that doesn't have it yet, wrap the exported
+handler: `export const GET = withServerTiming(handler)`.
+
+## Caveat: node:async_hooks
+
+`src/serverTiming.ts` imports `node:async_hooks`, which has no browser
+counterpart — so any client component that transitively imports a Supabase
+client factory is now a hard build error rather than a silent oversize bundle.
+One existed: the Chancellor flag form imported `KNOWN_FLAGS` from `@/flags`,
+which imports the service-role client. The flag vocabulary moved to the
+dependency-free `src/flagCatalog.ts` (re-exported from `@/flags`, so server
+callers are unchanged). If a future build fails this way, the fix is the same
+shape: split the constants out, don't reach for a bundler alias.

--- a/src/app/account/settings/chancellor/flagForm.tsx
+++ b/src/app/account/settings/chancellor/flagForm.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { union, without } from 'ramda'
 
-import { KNOWN_FLAGS } from '@/flags'
+import { KNOWN_FLAGS } from '@/flagCatalog'
 
 import Dot from '../dot'
 import { AccountFlags, lookupAccountFlags, setAccountFlags } from './actions'

--- a/src/app/api/appraisal/route.ts
+++ b/src/app/api/appraisal/route.ts
@@ -13,6 +13,7 @@ import { NextResponse } from 'next/server'
 import { all, test, uniq } from 'ramda'
 
 import { appraise, appraisalUrl, MARKETS, type Market } from '@/innominate'
+import { timed, withServerTiming } from '@/serverTiming'
 import { createClient } from '@/utils/supabase/server'
 
 import { MAX_LINES } from './assetLines'
@@ -28,7 +29,11 @@ export const maxDuration = 60
 const fail = (status: number, error: string, extra: Record<string, unknown> = {}) =>
   NextResponse.json({ ok: false, error, ...extra }, { status })
 
-export async function POST(request: Request) {
+// Wrapped for Server-Timing (src/serverTiming.ts): this route has two very
+// different slow halves — the RLS-scoped subtree walk and the throttled
+// innomin.at call — and the panel that fires it is the one place a user
+// actually waits, so the split is worth surfacing.
+const handler = async (request: Request) => {
   const supabase = await createClient()
   const { data: auth, error: authError } = await supabase.auth.getUser()
   if (authError || !auth?.user) return fail(401, 'Sign in to appraise items.')
@@ -63,7 +68,9 @@ export async function POST(request: Request) {
   // Everything under the target, priced by name — the walk, the blueprint skip
   // and the name merge all live in ./assetLines so this route and the MCP
   // appraise_assets tool can't disagree about what's in a container.
-  const { lines, skippedBlueprints, unnamed } = await collectAssetLinesForTargets(supabase, targets)
+  const { lines, skippedBlueprints, unnamed } = await timed('appraise.walk', () =>
+    collectAssetLinesForTargets(supabase, targets)
+  )
 
   if (lines.length === 0) {
     return fail(422, 'Nothing here can be appraised.', {
@@ -106,3 +113,5 @@ export async function POST(request: Request) {
     ...(appraisal.rateLimitRemaining != null && { rate_limit_remaining: appraisal.rateLimitRemaining }),
   })
 }
+
+export const POST = withServerTiming(handler)

--- a/src/app/api/graphql/route.ts
+++ b/src/app/api/graphql/route.ts
@@ -2,6 +2,7 @@ import { createYoga } from 'graphql-yoga'
 import type { NextRequest } from 'next/server'
 
 import { GRAPHQL_FLAG, hasFlag } from '@/flags'
+import { timed, withServerTiming } from '@/serverTiming'
 import { createClient } from '@/utils/supabase/server'
 import { buildContext } from './context'
 import { schema } from './schema'
@@ -32,7 +33,9 @@ const graphiqlForRequest = async (): Promise<boolean> => {
 
 const { handleRequest } = createYoga({
   schema,
-  context: ({ request }) => buildContext(request),
+  // Timed apart from execution: context building is auth + flag lookups, the
+  // execution phase is the resolvers' DB work (timingPlugin.ts spans it).
+  context: ({ request }) => timed('graphql.context', () => buildContext(request)),
   graphqlEndpoint: '/api/graphql',
   fetchAPI: { Response },
   // GraphiQL for schema-aware autocomplete and the docs explorer; the /graphql
@@ -59,7 +62,11 @@ const { handleRequest } = createYoga({
 })
 
 // Thin wrapper only to satisfy Next's route-handler signature (yoga's second
-// parameter is its own server context, not Next's { params }).
-const handler = (request: NextRequest): Promise<Response> => Promise.resolve(handleRequest(request, {}))
+// parameter is its own server context, not Next's { params }) — plus the
+// Server-Timing scope, so the in-browser editor's network panel shows which
+// resolvers a slow query spent its time in (src/serverTiming.ts).
+const handler = withServerTiming((request: NextRequest): Promise<Response> =>
+  Promise.resolve(handleRequest(request, {}))
+)
 
 export { handler as GET, handler as POST, handler as OPTIONS }

--- a/src/app/api/graphql/timingPlugin.ts
+++ b/src/app/api/graphql/timingPlugin.ts
@@ -2,6 +2,7 @@ import { Kind, type DocumentNode, type FieldNode, type OperationDefinitionNode }
 import type { Plugin } from 'graphql-yoga'
 
 import { recordRequest } from '@/observability'
+import { recordServerTimingSpan } from '@/serverTiming'
 
 // The request.timing emitter for /api/graphql (src/observability.js): one
 // metric line per executed operation, timed over the execution phase — the
@@ -29,6 +30,10 @@ export const timingPlugin: Plugin = {
         // Incremental delivery (@defer/@stream) answers an AsyncIterable; not
         // enabled on this endpoint, so skip rather than misreport a partial.
         if (Symbol.asyncIterator in result) return
+        // Also as a Server-Timing span, named by the root fields so a query
+        // selecting several shows which combination cost what
+        // (src/serverTiming.ts). Same clock, same phase, different audience.
+        recordServerTimingSpan('graphql.execute', Date.now() - startedAt, field)
         recordRequest({
           route: '/api/graphql',
           surface: 'graphql',

--- a/src/app/api/requestTiming.ts
+++ b/src/app/api/requestTiming.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { recordRequest } from '@/observability'
+import { applyServerTiming, collectServerTiming } from '@/serverTiming'
 
 // Wraps a route handler so every return path emits one `request.timing` metric
 // (src/observability.js) — the measurement seam the BRIN index project reads
@@ -9,6 +10,10 @@ import { recordRequest } from '@/observability'
 // live vs historical) through the mutable `timing` it receives, so a route
 // stays a one-line change: wrap the handler, set `timing.rows`/`timing.served`
 // where they become known.
+//
+// It also opens the Server-Timing collection scope (src/serverTiming.ts), so
+// every wrapped route answers with a per-request breakdown of its Supabase
+// round trips alongside the aggregate metric line.
 
 export type RequestTiming = {
   // Rows in the response; stays null on requests that never produce any.
@@ -44,34 +49,35 @@ const outcomeOf = (status: number): string => {
 
 export const withRequestTiming =
   <C>(meta: TimingMeta, handler: (request: NextRequest, context: C, timing: RequestTiming) => Promise<NextResponse>) =>
-  async (request: NextRequest, context: C): Promise<NextResponse> => {
-    const startedAt = Date.now()
-    const timing: RequestTiming = { rows: null, served: 'live' }
-    try {
-      const response = await handler(request, context, timing)
-      if (meta.deprecated) response.headers.set('Deprecation', 'true')
-      recordRequest({
-        route: meta.route,
-        surface: meta.surface,
-        field: meta.field,
-        served: timing.served,
-        outcome: outcomeOf(response.status),
-        status: response.status,
-        rows: timing.rows,
-        durationMs: Date.now() - startedAt,
-      })
-      return response
-    } catch (error) {
-      recordRequest({
-        route: meta.route,
-        surface: meta.surface,
-        field: meta.field,
-        served: timing.served,
-        outcome: 'query_failed',
-        status: 500,
-        rows: null,
-        durationMs: Date.now() - startedAt,
-      })
-      throw error
-    }
-  }
+  (request: NextRequest, context: C): Promise<NextResponse> =>
+    collectServerTiming(async () => {
+      const startedAt = Date.now()
+      const timing: RequestTiming = { rows: null, served: 'live' }
+      try {
+        const response = applyServerTiming(await handler(request, context, timing))
+        if (meta.deprecated) response.headers.set('Deprecation', 'true')
+        recordRequest({
+          route: meta.route,
+          surface: meta.surface,
+          field: meta.field,
+          served: timing.served,
+          outcome: outcomeOf(response.status),
+          status: response.status,
+          rows: timing.rows,
+          durationMs: Date.now() - startedAt,
+        })
+        return response
+      } catch (error) {
+        recordRequest({
+          route: meta.route,
+          surface: meta.surface,
+          field: meta.field,
+          served: timing.served,
+          outcome: 'query_failed',
+          status: 500,
+          rows: null,
+          durationMs: Date.now() - startedAt,
+        })
+        throw error
+      }
+    })

--- a/src/app/api/type/search/route.ts
+++ b/src/app/api/type/search/route.ts
@@ -3,10 +3,14 @@
 // (src/app/blueprint/typeSearch.tsx via src/app/blueprint/actions.ts).
 import { NextRequest, NextResponse } from 'next/server'
 
+import { withServerTiming } from '@/serverTiming'
 import { searchSdeTypes } from '@/sdeTypes'
 
-export async function GET(req: NextRequest) {
+// Wrapped for Server-Timing (src/serverTiming.ts): the autocomplete fires on
+// every keystroke, so its `sde.sde_search_type` span is the cheapest read on
+// how the search RPC is behaving under real typing.
+export const GET = withServerTiming(async (req: NextRequest) => {
   const q = req.nextUrl.searchParams.get('q')
   if (!q) return NextResponse.json([])
   return NextResponse.json(await searchSdeTypes(q))
-}
+})

--- a/src/app/link/[id]/csv/route.ts
+++ b/src/app/link/[id]/csv/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { EXPORT_CAP } from '@/app/api/graphql/filters'
 import { recordRequest } from '@/observability'
+import { withServerTiming } from '@/serverTiming'
 import { toCsv } from '@/utils/csv'
 import { resolveLink } from '../../access'
 import { csvRows } from '../../flatten'
@@ -16,7 +17,7 @@ import { runLink } from '../../run'
 export const dynamic = 'force-dynamic'
 export const maxDuration = 60
 
-export const GET = async (
+const handler = async (
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ): Promise<NextResponse> => {
@@ -67,3 +68,10 @@ export const GET = async (
     headers: { 'content-type': 'text/csv; charset=utf-8' },
   })
 }
+
+// Wrapped rather than exported directly so the response carries the
+// Server-Timing breakdown of the link's execution (src/serverTiming.ts) — the
+// per-request twin of the request.timing metric runLink emits. The api_token
+// CSV routes get it from withRequestTiming; this route does its own metric
+// bookkeeping, so it opts in here.
+export const GET = withServerTiming(handler)

--- a/src/app/link/run.ts
+++ b/src/app/link/run.ts
@@ -9,6 +9,7 @@ import { graphql } from 'graphql'
 import { contextForUser } from '@/app/api/graphql/context'
 import { schema } from '@/app/api/graphql/schema'
 import { recordRequest } from '@/observability'
+import { timed } from '@/serverTiming'
 import { linkRows } from './flatten'
 import { topLevelFieldOf } from './validate'
 
@@ -44,13 +45,18 @@ export const runLink = async (
   { timing, exporting = false }: LinkRunOptions = {}
 ): Promise<LinkResult> => {
   const startedAt = Date.now()
-  const contextValue = await contextForUser(link.user_id, { exporting })
-  const result = await graphql({
-    schema,
-    source: link.query,
-    variableValues: link.variables ?? {},
-    contextValue,
-  })
+  // Split into two spans because they fail differently: building the creator
+  // context is a handful of fixed lookups, while execution is the resolvers'
+  // (unbounded) query work. A slow link is nearly always the second.
+  const contextValue = await timed('link.context', () => contextForUser(link.user_id, { exporting }))
+  const result = await timed('link.execute', () =>
+    graphql({
+      schema,
+      source: link.query,
+      variableValues: link.variables ?? {},
+      contextValue,
+    })
+  )
   const out = { data: result.data ?? null, errors: (result.errors ?? []).map((e) => e.message) }
   // The duration covers building the creator context plus executing the query —
   // everything between "the link is authorized" and "rows exist in memory",

--- a/src/flagCatalog.ts
+++ b/src/flagCatalog.ts
@@ -1,0 +1,24 @@
+// The dark-launch flag vocabulary, with no dependencies of its own.
+//
+// Split out of src/flags.ts so the Chancellor's checkbox form — a client
+// component — can name the flags without dragging that module's service-role
+// Supabase client into the browser bundle. That was always the wrong shape;
+// it became a hard build error once the client factories started importing
+// the Server-Timing collector, which needs node:async_hooks (a Node built-in
+// with no browser counterpart). Server code keeps importing everything from
+// '@/flags', which re-exports these.
+
+// Flag names live here so callers can't typo them apart.
+export const GRAPHQL_FLAG = 'graphql'
+export const LINK_FLAG = 'link'
+export const FIT_UI_FLAG = 'fit-ui'
+
+// Every flag the Chancellor tools offer as a checkbox, with the copy shown
+// beside it. A flag an account already carries that isn't listed here still
+// renders (as an unlabelled checkbox), so a hand-set flag is never silently
+// dropped when a Chancellor saves.
+export const KNOWN_FLAGS: { flag: string; label: string }[] = [
+  { flag: GRAPHQL_FLAG, label: 'GraphQL API and its playground (/graphql)' },
+  { flag: LINK_FLAG, label: 'Links — Data Links, saved queries issued to others (/link)' },
+  { flag: FIT_UI_FLAG, label: 'Our own ship-fitting stack, in progress (/item/[itemId])' },
+]

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -1,19 +1,9 @@
 import { createServiceClient } from '@/utils/supabase/service'
 
-// Dark-launch flag names live here so callers can't typo them apart.
-export const GRAPHQL_FLAG = 'graphql'
-export const LINK_FLAG = 'link'
-export const FIT_UI_FLAG = 'fit-ui'
-
-// Every flag the Chancellor tools offer as a checkbox, with the copy shown
-// beside it. A flag an account already carries that isn't listed here still
-// renders (as an unlabelled checkbox), so a hand-set flag is never silently
-// dropped when a Chancellor saves.
-export const KNOWN_FLAGS: { flag: string; label: string }[] = [
-  { flag: GRAPHQL_FLAG, label: 'GraphQL API and its playground (/graphql)' },
-  { flag: LINK_FLAG, label: 'Links — Data Links, saved queries issued to others (/link)' },
-  { flag: FIT_UI_FLAG, label: 'Our own ship-fitting stack, in progress (/item/[itemId])' },
-]
+// The flag names and catalog live in src/flagCatalog.ts (dependency-free, so
+// client components can import them); re-exported here so every server caller
+// keeps its single '@/flags' import.
+export { FIT_UI_FLAG, GRAPHQL_FLAG, KNOWN_FLAGS, LINK_FLAG } from '@/flagCatalog'
 
 // user_settings.flags is the per-user dark-launch flag list (see the
 // add_user_settings_flags migration, whose comment points at this module).

--- a/src/innominate.ts
+++ b/src/innominate.ts
@@ -19,6 +19,7 @@
 // dev (no VERCEL) skips the queue and calls directly — a single developer isn't
 // a threat to the shared budget, and it keeps `pnpm run dev` working.
 import { requestKeyFor } from '@/innominateKey'
+import { timed } from '@/serverTiming'
 import { send } from '@/utils/queue'
 import { createServiceClient } from '@/utils/supabase/service'
 
@@ -370,13 +371,18 @@ export const appraise = async (
   // Local dev has no Vercel queue infrastructure and is a single developer, so
   // it calls directly (bypassing the shared-budget throttle); production routes
   // every call through the throttled queue.
+  // Both paths are spanned for Server-Timing (src/serverTiming.ts) under the
+  // same name and told apart by their description: on a queued call the number
+  // is mostly time spent waiting for the global throttle to reach this
+  // request, not innomin.at's own latency, and reading a 12 s appraisal
+  // without that distinction sends you debugging the wrong system.
   if (process.env.VERCEL !== '1') {
-    const result = await callInnominate(items, market, save)
+    const result = await timed('appraise.price', () => callInnominate(items, market, save), 'innomin.at direct')
     if (result.ok) cacheSet(key, result.appraisal)
     return result
   }
 
-  return appraiseViaQueue(items, market, save, key)
+  return timed('appraise.price', () => appraiseViaQueue(items, market, save, key), 'innomin.at queued')
 }
 
 // ---- Queue consumer entry point -------------------------------------------

--- a/src/serverTiming.ts
+++ b/src/serverTiming.ts
@@ -1,0 +1,193 @@
+// Server-Timing: the request-scoped span collector whose output rides back to
+// the browser as a `Server-Timing` response header, so the network panel shows
+// *where* a slow response spent its time instead of just how long it took.
+//
+// Relationship to src/observability.js: `recordRequest` emits one metric line
+// per request for aggregate analysis in Vercel Observability (p50/p95 over
+// days). This is the per-request, client-visible complement — the same clock,
+// a different audience. Neither replaces the other, and this module never
+// logs.
+//
+// Two ways a span gets recorded:
+//
+//   1. Automatically, for every Supabase/PostgREST round trip, via the
+//      instrumented `fetch` the client factories pass to supabase-js
+//      (src/utils/supabase/timedFetch.ts). This is where the time goes on
+//      nearly every surface here — docs/page-load-performance.md's measurement
+//      found a single RPC accounting for 3.2 s of a page — so it is worth
+//      having for free rather than per call site.
+//   2. Explicitly, wrapping anything else worth naming in `timed()` — the
+//      innomin.at appraisal (which blocks on a global queue), a GraphQL
+//      execution phase.
+//
+// Collection is scoped by AsyncLocalStorage, so a helper five frames down
+// contributes a span without the caller threading anything through. Outside a
+// scope every entry point here is a no-op that adds one Map lookup — which is
+// what happens during a page render, since App Router server components have
+// no response headers to set (see docs/server-timing.md).
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { forEach, sum } from 'ramda'
+
+export type ServerTimingSpan = {
+  // Serialized as the Server-Timing metric name, so it must survive
+  // `metricName` below (RFC 9110 token characters only).
+  name: string
+  description: string | null
+  durationMs: number
+}
+
+type Collector = { spans: ServerTimingSpan[]; startedAt: number }
+
+const storage = new AsyncLocalStorage<Collector>()
+
+// A runaway loop (the appraisal queue poller wakes once a second for ~50 s)
+// must not grow this unbounded. Spans past the cap are dropped, not summarized:
+// by then the metric they'd land in already has enough samples to be the
+// obvious culprit.
+const MAX_SPANS = 500
+
+// How many distinct metrics reach the header. Everything past it folds into one
+// `other` metric, so a pathological request answers a bounded header rather than
+// a multi-kilobyte one that proxies may drop.
+const MAX_METRICS = 24
+
+export const isCollectingServerTiming = (): boolean => storage.getStore() !== undefined
+
+// Record a span that was timed elsewhere. Silently ignored outside a scope.
+export const recordServerTimingSpan = (name: string, durationMs: number, description: string | null = null): void => {
+  const collector = storage.getStore()
+  if (!collector || collector.spans.length >= MAX_SPANS) return
+  collector.spans.push({ name, description, durationMs })
+}
+
+// Time `run` as one span. Returns exactly what `run` returns, and records the
+// span even when it throws — a failed 30 s upstream call is the most
+// interesting entry in the header, not one to omit.
+export const timed = async <T>(name: string, run: () => Promise<T>, description: string | null = null): Promise<T> => {
+  if (!isCollectingServerTiming()) return run()
+  const startedAt = performance.now()
+  try {
+    return await run()
+  } finally {
+    recordServerTimingSpan(name, performance.now() - startedAt, description)
+  }
+}
+
+// RFC 9110 token characters. Anything else (a `/` from a URL path, a space)
+// becomes `_`, since a malformed metric name makes the whole header
+// unparseable in devtools rather than just that entry.
+const metricName = (raw: string): string => {
+  const cleaned = raw.replace(/[^A-Za-z0-9!#$%&'*+\-.^_`|~]/g, '_').slice(0, 48)
+  return cleaned === '' ? 'span' : cleaned
+}
+
+// desc is a quoted-string; only `"` and `\` need escaping inside one.
+const quote = (raw: string): string => `"${raw.replace(/[\\"]/g, '\\$&').slice(0, 120)}"`
+
+const round = (ms: number): number => Math.round(ms * 10) / 10
+
+type Metric = { name: string; description: string | null; durationMs: number; count: number }
+
+// Fold repeats of the same name into one metric: eight `db.character_asset`
+// round trips read better as one 240 ms entry saying `8×` than as eight
+// same-named entries devtools stacks on top of each other. Durations are
+// summed, which over-counts concurrent spans — accepted, because the question
+// this answers is "how much of the response is this dependency worth", not
+// "what does the wall clock look like".
+export const aggregateSpans = (spans: ServerTimingSpan[]): Metric[] => {
+  const byName = new Map<string, Metric>()
+  forEach((span: ServerTimingSpan) => {
+    const name = metricName(span.name)
+    const existing = byName.get(name)
+    if (!existing) {
+      byName.set(name, { name, description: span.description, durationMs: span.durationMs, count: 1 })
+      return
+    }
+    existing.durationMs += span.durationMs
+    existing.count += 1
+    // Descriptions of repeats are dropped rather than joined: the count is
+    // the useful part, and a joined list is what blows the header up.
+    if (existing.description !== span.description) existing.description = null
+  }, spans)
+  return [...byName.values()]
+}
+
+// Slowest first, so the entry that explains the response is the first one read
+// — and so that what falls off the MAX_METRICS cliff is the noise.
+const bounded = (metrics: Metric[]): Metric[] => {
+  const sorted = [...metrics].sort((a, b) => b.durationMs - a.durationMs)
+  if (sorted.length <= MAX_METRICS) return sorted
+  const kept = sorted.slice(0, MAX_METRICS - 1)
+  const rest = sorted.slice(MAX_METRICS - 1)
+  return [
+    ...kept,
+    {
+      name: 'other',
+      description: `${rest.length} smaller metrics`,
+      // Count 1 so the renderer doesn't append a redundant `(n×)` — the
+      // description already says how many folded in.
+      count: 1,
+      durationMs: sum(rest.map((m) => m.durationMs)),
+    },
+  ]
+}
+
+const render = (metric: Metric): string => {
+  const note =
+    metric.count > 1
+      ? metric.description
+        ? `${metric.description} (${metric.count}×)`
+        : `${metric.count}×`
+      : metric.description
+  return `${metric.name};dur=${round(metric.durationMs)}${note ? `;desc=${quote(note)}` : ''}`
+}
+
+// The whole header value: `total` first (the number the browser already knows,
+// repeated so the parts have something to add up against), then the parts.
+// Pure, so test/serverTiming.test.ts can pin the grammar.
+export const serializeServerTiming = (spans: ServerTimingSpan[], totalMs: number): string =>
+  [
+    render({ name: 'total', description: null, durationMs: totalMs, count: 1 }),
+    ...bounded(aggregateSpans(spans)).map(render),
+  ].join(', ')
+
+// A response a shared cache may keep (`public`, or any `s-maxage`) is served
+// to later callers unchanged — header included. Stamping one would hand
+// everybody after the first the *first* request's timing, dressed up as their
+// own, which is worse than no header at all: the /sheets/market CDN cache
+// holds an answer for up to a week. So those go unstamped, and the timing for
+// them lives in the request.timing metric instead.
+const publiclyCached = (response: Response): boolean => {
+  const cacheControl = response.headers.get('cache-control')?.toLowerCase() ?? ''
+  return cacheControl.includes('s-maxage') || /(^|[\s,])public([\s,]|$)/.test(cacheControl)
+}
+
+// Set the header on a response built inside a collection scope. A no-op
+// outside one, and tolerant of an immutable Headers (a redirect, a response
+// proxied straight from fetch) — timing is diagnostic, never worth a 500.
+export const applyServerTiming = <R extends Response>(response: R): R => {
+  const collector = storage.getStore()
+  if (!collector || publiclyCached(response)) return response
+  try {
+    response.headers.set(
+      'Server-Timing',
+      serializeServerTiming(collector.spans, performance.now() - collector.startedAt)
+    )
+  } catch {
+    // Immutable headers; nothing to do and nothing worth failing over.
+  }
+  return response
+}
+
+// Run `run` in a fresh collection scope. Callers that answer a Response should
+// prefer `withServerTiming` below, which also stamps it.
+export const collectServerTiming = <T>(run: () => Promise<T>): Promise<T> =>
+  storage.run({ spans: [], startedAt: performance.now() }, run)
+
+// Wrap a route handler so everything it awaits is collected and the response it
+// answers carries the header. Signature-transparent, so it composes with the
+// framework's `(request, context)` handlers and with withRequestTiming.
+export const withServerTiming =
+  <A extends unknown[], R extends Response>(handler: (...args: A) => Promise<R>) =>
+  (...args: A): Promise<R> =>
+    collectServerTiming(async () => applyServerTiming(await handler(...args)))

--- a/src/utils/supabase/bearer.ts
+++ b/src/utils/supabase/bearer.ts
@@ -1,5 +1,7 @@
 import { createClient } from '@supabase/supabase-js'
 
+import { timedSupabaseFetch } from './timedFetch'
+
 // Supabase client authenticated by an OAuth 2.1 access token (issued by
 // Supabase Auth acting as the authorization server — see /api/mcp). The token
 // rides along as the Authorization header on every PostgREST call, so RLS
@@ -7,6 +9,6 @@ import { createClient } from '@supabase/supabase-js'
 // persistence: each MCP tool call is stateless and builds a fresh client.
 export const createBearerClient = (accessToken: string) =>
   createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!, {
-    global: { headers: { Authorization: `Bearer ${accessToken}` } },
+    global: { headers: { Authorization: `Bearer ${accessToken}` }, fetch: timedSupabaseFetch('db') },
     auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
   })

--- a/src/utils/supabase/sde.ts
+++ b/src/utils/supabase/sde.ts
@@ -1,5 +1,7 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js'
 
+import { timedSupabaseFetch } from './timedFetch'
+
 // The SDE mirror tables (sde_*) are public-read static data — RLS grants
 // SELECT to anon — so one module-level anon client serves every context
 // (server components, route handlers, MCP tools, anonymous share pages)
@@ -15,6 +17,11 @@ export const sdeSupabase = (): SupabaseClient => {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL
   const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? process.env.SUPABASE_KEY
   if (!url || !key) throw new Error('sde: missing NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY')
-  client = createClient(url, key, { auth: { persistSession: false, autoRefreshToken: false } })
+  // Labelled apart from the caller-scoped clients so a slow header entry
+  // says whether the static mirror or the player's own data was the cost.
+  client = createClient(url, key, {
+    global: { fetch: timedSupabaseFetch('sde') },
+    auth: { persistSession: false, autoRefreshToken: false },
+  })
   return client
 }

--- a/src/utils/supabase/server.ts
+++ b/src/utils/supabase/server.ts
@@ -2,10 +2,14 @@ import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
 import { sessionCookieOptions } from './cookieOptions'
+import { timedSupabaseFetch } from './timedFetch'
 
 export const createClient = async () => {
   const cookieStore = await cookies()
   return createServerClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!, {
+    // Every query this client makes becomes a Server-Timing span when the
+    // caller is collecting them (src/serverTiming.ts); a no-op otherwise.
+    global: { fetch: timedSupabaseFetch('db') },
     cookies: {
       getAll() {
         return cookieStore.getAll()

--- a/src/utils/supabase/service.ts
+++ b/src/utils/supabase/service.ts
@@ -1,5 +1,7 @@
 import { createClient } from '@supabase/supabase-js'
 
+import { timedSupabaseFetch } from './timedFetch'
+
 // Service-role Supabase client for server-only code paths that can't rely on the
 // caller's session — notably the /api/character/assets IMPORTDATA endpoint, which is
 // authenticated by an opaque api_token rather than a Supabase auth cookie. It
@@ -8,6 +10,7 @@ import { createClient } from '@supabase/supabase-js'
 // URL var (same project) alongside the server-only service key.
 export const createServiceClient = () =>
   createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_KEY!, {
+    global: { fetch: timedSupabaseFetch('db') },
     auth: {
       autoRefreshToken: false,
       persistSession: false,

--- a/src/utils/supabase/timedFetch.ts
+++ b/src/utils/supabase/timedFetch.ts
@@ -1,0 +1,48 @@
+import { isCollectingServerTiming, recordServerTimingSpan } from '@/serverTiming'
+
+// The `global.fetch` every Supabase client factory here installs, so that each
+// PostgREST/GoTrue round trip becomes one Server-Timing span without a single
+// call site changing (src/serverTiming.ts). supabase-js routes every request
+// through this one function, which makes it the only place that sees both the
+// URL (i.e. *which* query) and the wall clock.
+//
+// Outside a collection scope — a page render, a cron job, a workflow step —
+// this is the platform fetch plus one AsyncLocalStorage lookup.
+
+// `db.character_asset_snapshot_at` (an RPC), `db.character_asset` (a table),
+// `auth.user` (a session check). The label separates the SDE mirror's public
+// anon client from the caller-scoped ones, because "the static data was slow"
+// and "this player's hangar was slow" are different problems.
+const spanNameFor = (label: string, url: string): string => {
+  const path = (() => {
+    try {
+      return new URL(url).pathname
+    } catch {
+      return ''
+    }
+  })()
+  const rpc = path.match(/\/rest\/v\d+\/rpc\/([^/?]+)/)
+  if (rpc) return `${label}.${rpc[1]}`
+  const rest = path.match(/\/rest\/v\d+\/([^/?]+)/)
+  if (rest) return `${label}.${rest[1]}`
+  const auth = path.match(/\/auth\/v\d+\/(.+)/)
+  if (auth) return `auth.${auth[1]}`
+  return label
+}
+
+const urlOf = (input: RequestInfo | URL): string =>
+  typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+
+export const timedSupabaseFetch =
+  (label: string): typeof fetch =>
+  async (input, init) => {
+    if (!isCollectingServerTiming()) return fetch(input, init)
+    const startedAt = performance.now()
+    try {
+      return await fetch(input, init)
+    } finally {
+      // Recorded in `finally` so a timed-out or refused query — the slowest
+      // thing a request can do — still shows up in the header.
+      recordServerTimingSpan(spanNameFor(label, urlOf(input)), performance.now() - startedAt)
+    }
+  }

--- a/test/serverTiming.test.ts
+++ b/test/serverTiming.test.ts
@@ -1,0 +1,122 @@
+// Unit coverage for the Server-Timing header serializer (src/serverTiming.ts).
+// What's worth pinning is the grammar: a metric name the spec allows, a
+// quoted description, and the folding/bounding that keeps the header small —
+// a header a browser can't parse shows nothing at all, so a malformed name is
+// not a cosmetic bug.
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  aggregateSpans,
+  applyServerTiming,
+  collectServerTiming,
+  isCollectingServerTiming,
+  recordServerTimingSpan,
+  serializeServerTiming,
+  timed,
+  type ServerTimingSpan,
+} from '../src/serverTiming.ts'
+
+const span = (name: string, durationMs: number, description: string | null = null): ServerTimingSpan => ({
+  name,
+  description,
+  durationMs,
+})
+
+test('total always leads, and parts follow slowest first', () => {
+  const header = serializeServerTiming([span('db.assets', 10), span('sde.types', 90)], 120)
+  assert.equal(header, 'total;dur=120, sde.types;dur=90, db.assets;dur=10')
+})
+
+test('repeats of one name fold into a summed metric carrying the count', () => {
+  const header = serializeServerTiming([span('db.assets', 10), span('db.assets', 30), span('db.assets', 5)], 50)
+  assert.equal(header, 'total;dur=50, db.assets;dur=45;desc="3×"')
+})
+
+test('a shared description survives folding; differing ones drop out', () => {
+  assert.match(serializeServerTiming([span('x', 1, 'jita'), span('x', 1, 'jita')], 2), /desc="jita \(2×\)"/)
+  assert.equal(
+    serializeServerTiming([span('x', 1, 'jita'), span('x', 1, 'amarr')], 2),
+    'total;dur=2, x;dur=2;desc="2×"'
+  )
+})
+
+// A metric name is an RFC 9110 token — no slashes, spaces or quotes. Span names
+// are built from URL paths (src/utils/supabase/timedFetch.ts), so this is the
+// guard that a table name with a slash in it can't corrupt the header.
+test('names are sanitized to token characters and descriptions are escaped', () => {
+  assert.match(serializeServerTiming([span('rest/v1 assets', 1)], 1), /rest_v1_assets;dur=1/)
+  assert.equal(
+    serializeServerTiming([span('x', 1, 'say "hi"\\now')], 1),
+    'total;dur=1, x;dur=1;desc="say \\"hi\\"\\\\now"'
+  )
+})
+
+test('durations round to a tenth of a millisecond', () => {
+  assert.equal(serializeServerTiming([span('x', 1.26)], 3.041), 'total;dur=3, x;dur=1.3')
+})
+
+// The cap keeps a pathological request (one span per row) from answering a
+// header large enough for a proxy to drop — the fold has to be lossless in
+// total, or the header lies about where the time went.
+test('past the metric cap the tail folds into one `other` entry', () => {
+  const many = Array.from({ length: 40 }, (_, i) => span(`db.t${i}`, i + 1))
+  const header = serializeServerTiming(many, 1000)
+  const metrics = header.split(', ')
+  assert.equal(metrics.length, 25) // total + MAX_METRICS
+  assert.match(header, /other;dur=153;desc="17 smaller metrics"/)
+  assert.equal(
+    metrics.slice(1).reduce((sum, m) => sum + Number(m.match(/dur=([\d.]+)/)![1]), 0),
+    (40 * 41) / 2
+  )
+})
+
+test('aggregation preserves every span exactly once', () => {
+  const metrics = aggregateSpans([span('a', 1), span('b', 2), span('a', 3)])
+  assert.deepEqual(
+    metrics.map((m) => [m.name, m.durationMs, m.count]),
+    [
+      ['a', 4, 2],
+      ['b', 2, 1],
+    ]
+  )
+})
+
+// Outside a scope every entry point is inert: a cron job or a page render calls
+// the same helpers and must neither collect nor throw.
+test('recording outside a collection scope is a no-op', async () => {
+  assert.equal(isCollectingServerTiming(), false)
+  recordServerTimingSpan('db.assets', 5)
+  assert.equal(await timed('db.assets', async () => 'value'), 'value')
+})
+
+test('a scope collects spans from anything it awaits, including throws', async () => {
+  const header = await collectServerTiming(async () => {
+    assert.equal(isCollectingServerTiming(), true)
+    await timed('ok', async () => undefined)
+    await assert.rejects(
+      timed('boom', async () => {
+        throw new Error('upstream down')
+      })
+    )
+    recordServerTimingSpan('manual', 7)
+    return serializeServerTiming([span('manual', 7)], 7)
+  })
+  assert.match(header, /manual;dur=7/)
+})
+
+// A CDN-held response would serve the first caller's timing to everyone after
+// them; no header is better than a header that lies about whose request it is.
+test('a publicly cacheable response goes unstamped', async () => {
+  const stamp = (cacheControl: string | null) =>
+    collectServerTiming(async () => {
+      recordServerTimingSpan('db.assets', 5)
+      const response = new Response('body', { headers: cacheControl ? { 'cache-control': cacheControl } : {} })
+      return applyServerTiming(response).headers.get('Server-Timing')
+    })
+
+  assert.equal(await stamp('public, max-age=300, s-maxage=900'), null)
+  assert.equal(await stamp('public, max-age=86400, immutable'), null)
+  assert.match((await stamp('private, no-store')) ?? '', /db\.assets;dur=5/)
+  assert.match((await stamp(null)) ?? '', /db\.assets;dur=5/)
+})


### PR DESCRIPTION
Every request-serving surface that does real backend work now answers with a `Server-Timing` header breaking that work down, so the browser's network panel shows *which* query made a response slow instead of only that it was.

```
Server-Timing: total;dur=215.1, db.character_asset_snapshot_at;dur=123.3,
               db.user_settings;dur=44.4, db.registration;dur=43.6
```

This complements rather than replaces the `request.timing` metric line (`src/observability.js`): that one is aggregate p50/p95 over days in Vercel Observability, this one is the single request you are looking at right now.

## How it works

`src/serverTiming.ts` holds a request-scoped span collector in an `AsyncLocalStorage`. A route handler opens the scope; anything it awaits, five frames down through code that knows nothing about timing, can contribute a span. Outside a scope every entry point is a no-op costing one storage lookup.

Spans arrive two ways:

1. **Free, per Supabase round trip.** Each client factory under `src/utils/supabase/` passes `timedSupabaseFetch(label)` as supabase-js's `global.fetch` (`src/utils/supabase/timedFetch.ts`). That one function sees both the URL and the clock, so it names the span from the path: `db.<rpc-or-table>` for the caller-scoped clients, `sde.*` for the public SDE mirror, `auth.*` for GoTrue. This is where the time actually goes — `docs/page-load-performance.md`'s measurement found a single RPC accounting for 3.2 s — so it is worth having without touching a call site.
2. **Explicitly**, via `timed(name, fn)`: `appraise.price` (the innomin.at call, which blocks on a global throttle queue), `appraise.walk`, `graphql.context` / `graphql.execute`, `link.context` / `link.execute`.

Repeats of a name fold into one metric carrying a count, the list sorts slowest-first, and anything past 24 distinct metrics folds into one `other` entry — a header a proxy drops shows nothing at all.

## Where the header appears

- Everything already wrapped by `withRequestTiming` — the api_token CSV routes under `/api/character/*` and `/api/corp/*`, and `/sheets/market/[market]`. The wrapper opens the scope, so no route needed changing.
- `/link/[id]/csv`, `/api/graphql`, `/api/appraisal`, `/api/type/search` opt in with `withServerTiming(handler)`.

Two deliberate omissions, both documented:

- **Publicly cacheable responses go unstamped.** A response carrying `public` or `s-maxage` is served to later callers unchanged, header included, so stamping it would hand everybody behind the first the first request's timing dressed up as their own. `/sheets/market/[market]`'s CDN entry lives up to a week.
- **Pages carry no header, and can't.** App Router server components have no access to the response — there is no supported API for setting a header from a page render, and middleware runs before the render, when there is nothing to report yet. This is the frustrating half, since the heaviest work in this app is on pages like `/asset/[locationId]`. The instrumentation is live under those renders and simply finds no scope; if Next grows a response-header seam for pages, wrapping the render in `collectServerTiming` is the whole change.

## Incidental fix

`node:async_hooks` has no browser counterpart, which turned one latent client-bundle mistake into a hard build error: the Chancellor flag form imports `KNOWN_FLAGS` from `@/flags`, which imports the service-role Supabase client — so the service client was being pulled into browser JS. The flag vocabulary moved to the dependency-free `src/flagCatalog.ts`, re-exported from `@/flags` so every server caller is unchanged.

## Verification

- `pnpm run lint`, `pnpm test` (361 pass, 10 new in `test/serverTiming.test.ts` pinning the header grammar, the folding/bounding, the no-scope no-op and the cache guard), `pnpm run build` — all green, rebased on `main`.
- Ran the built app against a stub PostgREST to confirm the header end to end: `/api/type/search` → `total;dur=148.1, sde.sde_search_type;dur=141.1`; `/api/character/assets` → the three-query breakdown quoted above; `/link/[id]/csv` and `/api/graphql` stamped on their error paths too; `/sheets/market/jita` correctly unstamped under its `s-maxage`.

Docs: `docs/server-timing.md`, plus a CLAUDE.md entry beside the observability-metrics pattern.

---
_Generated by [Claude Code](https://claude.ai/code/session_019P3UmZgWoRbhrkp8dzyTgQ)_