### PR TITLE
Move Link sharing onto the Link, and make /link a directory listing

### DIFF
--- a/docs/sharing-layer/07-link.md
+++ b/docs/sharing-layer/07-link.md
@@ -92,11 +92,23 @@ assumes a service client.
 
 ## Surfaces
 
-- **`/link` — the editor, a new top-level route, dark-launched behind a
+- **`/link` — the directory, a new top-level route, dark-launched behind a
   feature flag** (`LINK_FLAG = 'link'` in `src/flags.ts`, the same
-  gate-and-redirect shape as `/graphql`): list your links, create/edit
-  (query textarea + variables + a Run-as-me preview reusing the `/graphql`
-  editor component), and the share dialog for the audience.
+  gate-and-redirect shape as `/graphql`): one line per Link — name, who it is
+  issued to (`issuance.ts`, tested), when it last changed — plus the
+  create-new editor at the top. **Amended after first use:** as built, this
+  page stacked a full editor _and_ a share dialog into every row, so ten Links
+  were a scroll rather than a look, and the audience controls for a query sat
+  next to a query you weren't reading. Per-link editing and sharing moved to
+  the Link's own page; the index is a listing and nothing else.
+- **`/link/[id]` for its owner — where a Link is administered.** CSV, Edit and
+  Share sit in one corner row of the heading, so issuing a Link happens while
+  looking at the results it will hand over. The Edit toggle lives in that row
+  but the form opens under the heading (`ownerPanel.tsx` holds the open state;
+  `LinkEditor` takes optional controlled `open`/`onOpenChange` for exactly
+  this), because a column form crushes inside a flex button row. The Sheets
+  `=IMPORTDATA()` formula moved here too — it only exists when the Link is
+  issued, so it belongs beside the control that issues it.
 - **`/link/[id]`** — the viewer: runs the link (per Execution above),
   renders the result as a table, shows the creator's name (via
   `character_directory`-safe display: link shares are user-scoped, so show
@@ -162,7 +174,7 @@ editor.
 
 Deleting a link stays in the web editor.
 
-`update_link` runs the query the link *would have* before writing it, and
+`update_link` runs the query the link _would have_ before writing it, and
 refuses the whole edit if it comes back with nothing at all: a link that
 already has an audience must never be broken underneath them. Zero rows is
 still a legitimate answer — an empty container is worth watching — so only a
@@ -193,7 +205,7 @@ other tool declares. What actually constrains it, as always, is not the hint:
 - they write on the **caller's own bearer client**, so RLS pins the row to them
   exactly as the editor's cookie session does — no service role anywhere in the
   path, no creating a link for someone else, and no editing one (`update_link`
-  additionally filters to `user_id`, so a link merely shared *with* the caller
+  additionally filters to `user_id`, so a link merely shared _with_ the caller
   is invisible to it);
 - the audience is resolved against the caller's **own** corporations and
   alliances (`src/app/link/audience.ts`, pure and unit-tested in

--- a/src/app/link/[id]/page.tsx
+++ b/src/app/link/[id]/page.tsx
@@ -1,21 +1,45 @@
-import Link from 'next/link'
 import { notFound } from 'next/navigation'
 
+import { ShareDialog } from '@/app/asset/shareDialog'
+import { fetchShareAudiences, shareRowToState, type OwnRegistration } from '@/app/asset/shareData'
 import { LINK_FLAG, hasFlag } from '@/flags'
 import { parseShareParam } from '@/shareToken'
 import { createClient } from '@/utils/supabase/server'
+import { siteUrl } from '@/utils/siteUrl'
 import { ShareUrlCleanup } from '../../shareUrlCleanup'
 import { resolveLink } from '../access'
+import { revokeLinkShare, saveLinkShare } from '../actions'
 import { CopyLinkButton } from '../copyButton'
 import { LinkTable } from '../linkTable'
+import { LinkOwnerPanel } from '../ownerPanel'
 import { runLink } from '../run'
+import { shortLinkId } from '../shortId'
 import styles from '../link.module.css'
+
+// The =IMPORTDATA() formula for this Link's CSV, when one would work from
+// Google Sheets: the signed share URL when the Link has one (Sheets carries no
+// cookie), the bare CSV path when the Link is fully public, nothing else — a
+// corp/alliance-only share has no URL an anonymous fetcher could use. Mirrors
+// the legacy formulas /account/settings prints for the api_token routes.
+const importDataFormula = (
+  share: { shareParam: string | null; isPublic: boolean } | null,
+  shortId: string
+): string | null => {
+  if (!share) return null
+  if (share.shareParam) return `=IMPORTDATA("${siteUrl(`/link/${shortId}/csv`)}?share=${share.shareParam}")`
+  if (share.isPublic) return `=IMPORTDATA("${siteUrl(`/link/${shortId}/csv`)}")`
+  return null
+}
 
 // The Link viewer (docs/sharing-layer/07-link.md): runs the stored query
 // under its CREATOR's security context and shows the result to anyone the
 // link is shared with — RLS decides for signed-in audiences (corporation/
 // alliance/public), a signed ?share= link for everyone else, including
 // signed-out. The viewer receives results, never access.
+//
+// For the owner this is also where the Link is administered: CSV, Edit and
+// Share all sit in the heading's corner, so issuing a Link is something you do
+// while looking at the one you're issuing rather than from the index.
 export const dynamic = 'force-dynamic'
 export const maxDuration = 60
 
@@ -40,20 +64,67 @@ const LinkViewerPage = async ({
 
   // "Save a copy" forks the query (not the data) into the viewer's own link
   // list — that's what a link shared with you being a "prewritten query" means.
-  const { data: auth } = await (await createClient()).auth.getUser()
+  const supabase = await createClient()
+  const { data: auth } = await supabase.auth.getUser()
   const canCopy = !viewerIsOwner && auth?.user != null && (await hasFlag(auth.user.id, LINK_FLAG))
+
+  // Only the owner gets the share dialog, and only the owner's read of
+  // `registration` can name the corporations a Link may be aimed at.
+  const owner = viewerIsOwner
+    ? await (async () => {
+        const [{ data: regs }, shortId] = await Promise.all([
+          supabase.from('registration').select('id, corporation_id'),
+          shortLinkId(link.id),
+        ])
+        const audiences = await fetchShareAudiences(supabase, (regs ?? []) as OwnRegistration[])
+        const shareState = link.enabled ? shareRowToState(link) : null
+        return { audiences, shortId, shareState, formula: importDataFormula(shareState, shortId) }
+      })()
+    : null
 
   return (
     <>
       {share && <ShareUrlCleanup />}
       <div className={styles.linkHeading}>
         <h1>{link.name}</h1>
-        <div className={styles.buttons}>
-          <a href={csvHref}>CSV</a>
-          {viewerIsOwner && <Link href="/link">Edit</Link>}
-          {canCopy && <CopyLinkButton linkId={link.id} share={cleanShare} />}
-        </div>
+        {owner ? (
+          <LinkOwnerPanel
+            link={{
+              id: link.id,
+              name: link.name,
+              query: link.query,
+              variables:
+                link.variables && Object.keys(link.variables).length > 0 ? JSON.stringify(link.variables, null, 2) : '',
+            }}
+          >
+            <a href={csvHref}>CSV</a>
+            <ShareDialog
+              subjectLabel="Link"
+              urlPath={`/link/${owner.shortId}`}
+              hint="Whoever this Link is issued to runs the query and reads its results — your data, current — until issuance is withdrawn. They receive the results only."
+              data={{
+                share: owner.shareState,
+                corporations: owner.audiences.corporations,
+                alliances: owner.audiences.alliances,
+                hasLegacyToken: false,
+              }}
+              save={saveLinkShare.bind(null, link.id)}
+              revoke={revokeLinkShare.bind(null, link.id)}
+            />
+          </LinkOwnerPanel>
+        ) : (
+          <div className={styles.buttons}>
+            <a href={csvHref}>CSV</a>
+            {canCopy && <CopyLinkButton linkId={link.id} share={cleanShare} />}
+          </div>
+        )}
       </div>
+
+      {owner?.formula && (
+        <p className={styles.note}>
+          Google Sheets: <code>{owner.formula}</code>
+        </p>
+      )}
 
       {result.errors.length > 0 && (
         <p className={styles.error}>

--- a/src/app/link/issuance.ts
+++ b/src/app/link/issuance.ts
@@ -1,0 +1,27 @@
+// Who a Link is currently issued to, as one short phrase for the listing.
+// Mirrors the Revision 3 audience reading (docs/sharing-layer/01-asset-share-table.md):
+// `enabled` is what keeps "not issued yet" distinct from "issued to everyone",
+// and an enabled row with no corporations, no alliances and no secret IS the
+// public state. Audiences compose, so a row can name corporations AND carry a
+// signed link; every part that applies is reported.
+export type IssuanceRow = {
+  enabled: boolean
+  corporation_ids: number[] | null
+  alliance_ids: number[] | null
+  secret: string | null
+}
+
+const plural = (n: number, noun: string) => `${n} ${noun}${n === 1 ? '' : 's'}`
+
+export const issuanceLabel = (link: IssuanceRow): string => {
+  if (!link.enabled) return 'Not issued'
+  const corporations = link.corporation_ids?.length ?? 0
+  const alliances = link.alliance_ids?.length ?? 0
+  if (corporations === 0 && alliances === 0 && link.secret == null) return 'Everyone'
+  const parts = [
+    corporations > 0 ? plural(corporations, 'corporation') : null,
+    alliances > 0 ? plural(alliances, 'alliance') : null,
+    link.secret != null ? 'signed link' : null,
+  ].filter((p): p is string => p !== null)
+  return parts.join(' · ')
+}

--- a/src/app/link/link.module.css
+++ b/src/app/link/link.module.css
@@ -95,3 +95,72 @@
   overflow-x: auto;
   margin-top: 8pt;
 }
+
+/* The Link index as a directory listing: fixed columns, one line per Link,
+   the name column carrying the glyph and the click target. Grid rather than a
+   table so the header and rows share one column definition and the whole
+   listing collapses to name-only on a narrow screen. */
+.listing {
+  list-style: none;
+  margin: 12pt 0 0;
+  padding: 0;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.listingHead,
+.row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 14em) minmax(0, 12em);
+  gap: 8pt;
+  align-items: baseline;
+  padding: 4pt 8pt;
+  font-size: 9pt;
+}
+
+.listingHead {
+  color: var(--ink-soft);
+  background: var(--paper-raised);
+  border-bottom: 1px solid var(--line);
+}
+
+.row + .row {
+  border-top: 1px solid var(--line);
+}
+
+.row:hover {
+  background: var(--paper-raised);
+}
+
+.rowName {
+  font-size: 10pt;
+  display: flex;
+  gap: 6pt;
+  align-items: baseline;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.glyph {
+  color: var(--ink-soft);
+}
+
+.rowQuiet {
+  color: var(--ink-soft);
+}
+
+.rowActions {
+  justify-self: start;
+}
+
+@media (max-width: 40em) {
+  .listingHead {
+    display: none;
+  }
+
+  .row {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 2pt;
+  }
+}

--- a/src/app/link/linkEditor.tsx
+++ b/src/app/link/linkEditor.tsx
@@ -59,6 +59,11 @@ const fieldValuesOf = (template: LinkTemplate): Record<string, string> =>
 type LinkEditorProps = {
   // null = the create-new editor; otherwise the link being edited.
   link: { id: string; name: string; query: string; variables: string } | null
+  // Optional controlled open state, for the Link page, where the Edit toggle
+  // sits in the heading's button row and the form opens underneath it rather
+  // than inside it. Uncontrolled (its own button) everywhere else.
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
 }
 
 type PreviewResult = { data: unknown; errors: string[] }
@@ -68,9 +73,11 @@ type PreviewResult = { data: unknown; errors: string[] }
 // declares them, raw JSON otherwise), a run-as-me preview rendered as the same
 // table the viewer page shows, save, and delete. Sharing lives in the
 // ShareDialog the server component renders beside this.
-export const LinkEditor = ({ link }: LinkEditorProps) => {
+export const LinkEditor = ({ link, open: openProp, onOpenChange }: LinkEditorProps) => {
   const router = useRouter()
-  const [open, setOpen] = useState(link === null)
+  const [selfOpen, setSelfOpen] = useState(link === null)
+  const open = openProp ?? selfOpen
+  const setOpen = onOpenChange ?? setSelfOpen
   const [name, setName] = useState(link?.name ?? '')
   const [query, setQuery] = useState(link?.query ?? DEFAULT_QUERY)
   const [variables, setVariables] = useState(link?.variables ?? '')

--- a/src/app/link/ownerPanel.tsx
+++ b/src/app/link/ownerPanel.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useState, type ReactNode } from 'react'
+
+import { LinkEditor } from './linkEditor'
+import styles from './link.module.css'
+
+type LinkOwnerPanelProps = {
+  link: { id: string; name: string; query: string; variables: string }
+  // The heading's other controls (CSV, Share), server-rendered and passed
+  // through so they sit in the same corner row as the Edit toggle.
+  children: ReactNode
+}
+
+// The owner's controls for one Link, on the Link's own page. The Edit toggle
+// belongs in the heading's button row next to CSV and Share, but the form it
+// opens is a column that would be crushed inside that row — so this holds the
+// open state, keeps the toggle up in the corner, and renders the editor
+// underneath the heading.
+export const LinkOwnerPanel = ({ link, children }: LinkOwnerPanelProps) => {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <div className={styles.buttons}>
+        {children}
+        <button type="button" onClick={() => setOpen(!open)}>
+          {open ? 'Close' : 'Edit'}
+        </button>
+      </div>
+      {open && <LinkEditor link={link} open onOpenChange={setOpen} />}
+    </>
+  )
+}

--- a/src/app/link/page.tsx
+++ b/src/app/link/page.tsx
@@ -1,40 +1,26 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
-import { ShareDialog } from '@/app/asset/shareDialog'
-import { fetchShareAudiences, shareRowToState, type OwnRegistration } from '@/app/asset/shareData'
 import { LINK_FLAG, hasFlag } from '@/flags'
 import { createClient } from '@/utils/supabase/server'
 
-import { siteUrl } from '@/utils/siteUrl'
-
+import { DateTime } from '../DateTime'
 import { establishedUser } from '../account/lib/establishedUser'
-import { revokeLinkShare, saveLinkShare } from './actions'
-import { shortLinkId } from './shortId'
 import { CopyLinkButton } from './copyButton'
+import { issuanceLabel } from './issuance'
 import { LinkEditor } from './linkEditor'
 import type { LinkRecord } from './run'
 import styles from './link.module.css'
 
-// The =IMPORTDATA() formula for a link's CSV, when one would work from Google
-// Sheets: the signed share URL when the Link has one (Sheets carries no
-// cookie), the bare CSV path when the Link is fully public, nothing else — a
-// corp/alliance-only share has no URL an anonymous fetcher could use. Mirrors
-// the legacy formulas /account/settings prints for the api_token routes.
-const importDataFormula = (
-  share: { shareParam: string | null; isPublic: boolean } | null,
-  shortId: string
-): string | null => {
-  if (!share) return null
-  if (share.shareParam) return `=IMPORTDATA("${siteUrl(`/link/${shortId}/csv`)}?share=${share.shareParam}")`
-  if (share.isPublic) return `=IMPORTDATA("${siteUrl(`/link/${shortId}/csv`)}")`
-  return null
-}
-
-// Dark-launched Link editor (docs/sharing-layer/07-link.md; no nav link):
+// Dark-launched Link index (docs/sharing-layer/07-link.md; no nav link):
 // saved GraphQL queries that run under YOUR context when someone you shared
 // them with opens them. Gated on the per-account `link` flag, the same
 // gate-and-redirect shape as /graphql.
+//
+// This page is a directory listing and nothing else: name, who it's issued to,
+// when it last changed. Opening one goes to its own page, where the query is
+// edited, exported and issued. It used to stack a full editor and a share
+// dialog per row, which made scanning ten Links a scroll rather than a look.
 export const dynamic = 'force-dynamic'
 
 const LinkPage = async () => {
@@ -49,18 +35,12 @@ const LinkPage = async () => {
   }
 
   // RLS shows the caller's own links AND ones shared with them (the audience
-  // policy) — one read, split into the editor list and the shared-with-me list.
-  const [{ data: linkRows }, { data: regs }] = await Promise.all([
-    supabase.from('link').select('*').order('created_at'),
-    supabase.from('registration').select('id, corporation_id'),
-  ])
+  // policy) — one read, split into the caller's own directory and the one of
+  // Links issued to them.
+  const { data: linkRows } = await supabase.from('link').select('*').order('name')
   const visible = (linkRows ?? []) as LinkRecord[]
   const links = visible.filter((l) => l.user_id === user.id)
   const sharedWithMe = visible.filter((l) => l.user_id !== user.id)
-  const audiences = await fetchShareAudiences(supabase, (regs ?? []) as OwnRegistration[])
-  // The dialog's copyable URL carries the shortest id that resolves back to
-  // each link, so what people paste onward is the graceful form.
-  const shortIds = await Promise.all(links.map((link) => shortLinkId(link.id)))
 
   return (
     <>
@@ -74,54 +54,33 @@ const LinkPage = async () => {
 
       <LinkEditor link={null} />
 
-      {links.length === 0 && (
+      {links.length === 0 ? (
         <p className={styles.note}>
           No Links registered. Observation is not currently delegated to anyone. This has been logged.
         </p>
+      ) : (
+        <ul className={styles.listing}>
+          <li className={styles.listingHead}>
+            <span>Name</span>
+            <span>Issued to</span>
+            <span>Updated</span>
+          </li>
+          {links.map((link) => (
+            <li key={link.id} className={styles.row}>
+              <Link href={`/link/${link.id}`} className={styles.rowName}>
+                <span aria-hidden="true" className={styles.glyph}>
+                  ▤
+                </span>
+                {link.name}
+              </Link>
+              <span className={link.enabled ? undefined : styles.rowQuiet}>{issuanceLabel(link)}</span>
+              <span className={styles.rowQuiet}>
+                <DateTime value={link.updated_at} />
+              </span>
+            </li>
+          ))}
+        </ul>
       )}
-
-      {links.map((link, i) => {
-        const share = link.enabled ? shareRowToState(link) : null
-        const formula = importDataFormula(share, shortIds[i])
-        return (
-          <section key={link.id} className={styles.link}>
-            <div className={styles.linkHeading}>
-              <h2>
-                <Link href={`/link/${link.id}`}>{link.name}</Link>
-              </h2>
-              <ShareDialog
-                subjectLabel="Link"
-                urlPath={`/link/${shortIds[i]}`}
-                hint="Whoever this Link is issued to runs the query and reads its results — your data, current — until issuance is withdrawn. They receive the results only."
-                data={{
-                  share,
-                  corporations: audiences.corporations,
-                  alliances: audiences.alliances,
-                  hasLegacyToken: false,
-                }}
-                save={saveLinkShare.bind(null, link.id)}
-                revoke={revokeLinkShare.bind(null, link.id)}
-              />
-            </div>
-            {formula && (
-              <p className={styles.note}>
-                Google Sheets: <code>{formula}</code>
-              </p>
-            )}
-            <LinkEditor
-              link={{
-                id: link.id,
-                name: link.name,
-                query: link.query,
-                variables:
-                  link.variables && Object.keys(link.variables).length > 0
-                    ? JSON.stringify(link.variables, null, 2)
-                    : '',
-              }}
-            />
-          </section>
-        )
-      })}
 
       {sharedWithMe.length > 0 && (
         <>
@@ -130,18 +89,29 @@ const LinkPage = async () => {
             Links other operators have issued to you. Opening one reports <em>their</em> holdings. Retaining a copy
             keeps the query, registered as your own Link and run against your own.
           </p>
-          {sharedWithMe.map((link) => (
-            <section key={link.id} className={styles.link}>
-              <div className={styles.linkHeading}>
-                <h2>
-                  <Link href={`/link/${link.id}`}>{link.name}</Link>
-                </h2>
-                <div className={styles.buttons}>
+          <ul className={styles.listing}>
+            <li className={styles.listingHead}>
+              <span>Name</span>
+              <span>Updated</span>
+              <span />
+            </li>
+            {sharedWithMe.map((link) => (
+              <li key={link.id} className={styles.row}>
+                <Link href={`/link/${link.id}`} className={styles.rowName}>
+                  <span aria-hidden="true" className={styles.glyph}>
+                    ▤
+                  </span>
+                  {link.name}
+                </Link>
+                <span className={styles.rowQuiet}>
+                  <DateTime value={link.updated_at} />
+                </span>
+                <span className={styles.rowActions}>
                   <CopyLinkButton linkId={link.id} />
-                </div>
-              </div>
-            </section>
-          ))}
+                </span>
+              </li>
+            ))}
+          </ul>
         </>
       )}
     </>

--- a/test/linkIssuance.test.ts
+++ b/test/linkIssuance.test.ts
@@ -1,0 +1,53 @@
+// Unit coverage for the phrase the Link directory prints in its "Issued to"
+// column. The listing is now the only place an owner sees a Link's audience
+// without opening it, so a wrong label here is a privacy tell: reading "Not
+// issued" over a Link that is in fact public is the failure that matters.
+//
+// The distinctions are the Revision 3 ones (docs/sharing-layer/01-asset-share-table.md):
+// `enabled` separates "not issued yet" from "issued to everyone", and audiences
+// compose, so corporations and a signed link can both be true at once.
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { issuanceLabel } from '../src/app/link/issuance.ts'
+
+const row = (over: Partial<Parameters<typeof issuanceLabel>[0]> = {}) => ({
+  enabled: true,
+  corporation_ids: [],
+  alliance_ids: [],
+  secret: null,
+  ...over,
+})
+
+test('a disabled link is not issued, whatever its audience columns say', () => {
+  assert.equal(issuanceLabel(row({ enabled: false })), 'Not issued')
+  // The audience survives a withdrawal in the row; the label must not.
+  assert.equal(issuanceLabel(row({ enabled: false, corporation_ids: [98000001], secret: 'abc' })), 'Not issued')
+})
+
+test('enabled with no audience at all is the public state', () => {
+  assert.equal(issuanceLabel(row()), 'Everyone')
+})
+
+test('a secret alone is a signed link, not public', () => {
+  assert.equal(issuanceLabel(row({ secret: 'abc' })), 'signed link')
+})
+
+test('counts are pluralized per audience kind', () => {
+  assert.equal(issuanceLabel(row({ corporation_ids: [1] })), '1 corporation')
+  assert.equal(issuanceLabel(row({ corporation_ids: [1, 2] })), '2 corporations')
+  assert.equal(issuanceLabel(row({ alliance_ids: [1] })), '1 alliance')
+  assert.equal(issuanceLabel(row({ alliance_ids: [1, 2] })), '2 alliances')
+})
+
+test('audiences compose rather than winning over each other', () => {
+  assert.equal(
+    issuanceLabel(row({ corporation_ids: [1, 2], alliance_ids: [3], secret: 'abc' })),
+    '2 corporations · 1 alliance · signed link'
+  )
+})
+
+test('null audience columns read as empty, not as a crash', () => {
+  assert.equal(issuanceLabel(row({ corporation_ids: null, alliance_ids: null })), 'Everyone')
+  assert.equal(issuanceLabel(row({ corporation_ids: null, alliance_ids: null, secret: 'abc' })), 'signed link')
+})


### PR DESCRIPTION
`/link` rendered a full editor **and** a share dialog for every Link the caller owned. Two problems compounded: ten Links became a scroll rather than a look, and the control deciding who may read a query sat beside a query you weren't reading. Sharing is a decision about one Link, so it belongs on that Link's page.

## `/link/[id]` is where an owner administers a Link

CSV, Edit and Share now sit in one corner row of the heading, next to the results the Link will hand over. The Sheets `=IMPORTDATA()` formula moves here too — it only exists once a Link is issued, so it belongs beside the control that issues it.

The Edit toggle sits in that corner row but its form opens *under* the heading: a column of textareas crushes inside a flex button row. `ownerPanel.tsx` holds the open state and passes the server-rendered CSV and Share controls through as `children`; `LinkEditor` grows an optional controlled `open`/`onOpenChange` pair and otherwise keeps its own state, so the create-new editor on the index is untouched.

Non-owners see what they saw before — CSV, and Save a copy where the flag allows it.

## `/link` is a listing

One line per Link: name, who it's issued to, when it last changed, ordered by name rather than creation. Grid-based so the header and rows share one column definition and it collapses to name-only under 40em. The per-row editors and share dialogs are gone; opening a Link goes to its own page.

## Testing

`issuanceLabel` is a pure seam with its own test file, because the listing is the one place an owner sees a Link's audience *without* opening it — reading "Not issued" over a public Link is the failure that matters. Pinned: `enabled` separating "not issued yet" from "issued to everyone", audiences composing rather than overriding (corporations + alliances + signed link), pluralization, and null audience columns.

`pnpm run lint`, `pnpm test` (367 pass, 6 new) and `pnpm run build` all clean.

`docs/sharing-layer/07-link.md` amended — it described the old per-row editor/share layout as shipped, so it now records what changed after first use and why.

## Note

`/link/[id]` previously carried an `Edit` link pointing back at `/link`, which worked only because the index held the editors. That link is now the in-place Edit toggle.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzC8mXTbKdsMrccVcSDzCZ)_