### PR TITLE
Cap market overview at half the viewport, show sales in ISK

### DIFF
--- a/src/app/isk.ts
+++ b/src/app/isk.ts
@@ -11,8 +11,8 @@ export const formatKisk = (raw: string | number | null) => {
   return value === '—' ? value : `${value} kISK`
 }
 
-// Money in raw ISK as a bare number, e.g. "1,234". Reserved for structure
-// taxable events (industry job tax), which are kept in ISK rather than kISK.
+// Money in raw ISK as a bare number, e.g. "1,234". Used for structure taxable
+// events (industry job tax) and the market page, which show ISK rather than kISK.
 export const formatIskValue = (raw: string | number | null) => {
   if (raw === null) return '—'
   return Number(raw).toLocaleString('en-US', { maximumFractionDigits: 0 })

--- a/src/app/market/loading.tsx
+++ b/src/app/market/loading.tsx
@@ -3,8 +3,8 @@ import { LoadingShell, SkeletonTable } from '../skeleton'
 const MarketLoading = () => (
   <LoadingShell title="Market">
     <SkeletonTable
-      columns={['Seller', 'Type', 'Qty', 'Unit (kISK)', 'Total (kISK)', 'Sold', 'Seen']}
-      numeric={['Qty', 'Unit (kISK)', 'Total (kISK)']}
+      columns={['Seller', 'Type', 'Qty', 'Unit (ISK)', 'Total (ISK)', 'Sold', 'Seen']}
+      numeric={['Qty', 'Unit (ISK)', 'Total (ISK)']}
       rows={12}
     />
   </LoadingShell>

--- a/src/app/market/market.module.css
+++ b/src/app/market/market.module.css
@@ -36,6 +36,9 @@
   grid-template-columns: repeat(4, 1fr);
   gap: 12pt;
   margin: 16pt 0;
+  /* The overview pane is capped at half the viewport; lists scroll inside
+   * their tiles instead of growing the page. */
+  height: 50vh;
 }
 
 .tileWide {
@@ -45,6 +48,8 @@
 @media (max-width: 720px) {
   .overview {
     grid-template-columns: 1fr;
+    /* Stacked single-column tiles can't share 50vh; let them size naturally. */
+    height: auto;
   }
 
   .tileWide {
@@ -61,6 +66,8 @@
   border-radius: var(--radius);
   background: var(--paper-raised);
   min-width: 0;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .tileHead {
@@ -89,6 +96,9 @@
   padding: 0;
   display: flex;
   flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .topRow {

--- a/src/app/market/marketOverview.tsx
+++ b/src/app/market/marketOverview.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react'
 
-import { formatKisk, formatKiskValue } from '../isk'
+import { formatIsk, formatIskValue } from '../isk'
 import { TypeName } from '../typeName'
 import { bucketSales, topTypesByValue, type Bucket, type TypeTotal } from './aggregate'
 import type { Sale } from './recentSales'
@@ -52,8 +52,8 @@ const TopItems = ({
             <span className={styles.topQty} title={`${it.quantity.toLocaleString('en-US')} sold`}>
               ×{it.quantity.toLocaleString('en-US')}
             </span>
-            <span className={styles.topValue} title={formatKisk(it.total)}>
-              {formatKiskValue(it.total)}
+            <span className={styles.topValue} title={formatIsk(it.total)}>
+              {formatIskValue(it.total)}
             </span>
           </li>
         ))}
@@ -71,7 +71,7 @@ const bucketTip = (b: Bucket, bucketHours: number) => {
   const start = new Date(b.start)
   // Sub-day buckets need the hour to disambiguate; daily buckets just the date.
   const when = bucketHours < 24 ? start.toISOString().slice(0, 16).replace('T', ' ') : start.toISOString().slice(0, 10)
-  return `${when} — ${formatKisk(b.total)}`
+  return `${when} — ${formatIsk(b.total)}`
 }
 
 const SalesBars = ({ buckets, bucketHours }: { buckets: Bucket[]; bucketHours: number }) => {
@@ -111,7 +111,7 @@ export const MarketOverview = ({ now, sales, windowDays, typeNamesPromise }: Mar
       <TopItems
         wide
         title="Top sellers"
-        subtitle={`per total sales volume (in kISK) over the last ${opt.label}`}
+        subtitle={`per total sales volume (in ISK) over the last ${opt.label}`}
         items={current}
         typeNamesPromise={typeNamesPromise}
       />

--- a/src/app/market/recentSales.tsx
+++ b/src/app/market/recentSales.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { DateTime } from '../DateTime'
-import { formatKiskValue } from '../isk'
+import { formatIskValue } from '../isk'
 import { Name } from '../names'
 import { TypeName } from '../typeName'
 import styles from './market.module.css'
@@ -138,8 +138,8 @@ export const RecentSales = ({ now, sales, characters, corpNames, typeNamesPromis
               <th>Seller</th>
               <th>Type</th>
               <th>Qty</th>
-              <th>Unit (kISK)</th>
-              <th>Total (kISK)</th>
+              <th>Unit (ISK)</th>
+              <th>Total (ISK)</th>
               <th>Sold</th>
               <th>Seen</th>
             </tr>
@@ -154,8 +154,8 @@ export const RecentSales = ({ now, sales, characters, corpNames, typeNamesPromis
                   <TypeName id={Number(s.type_id)} promise={typeNamesPromise} />
                 </td>
                 <td>{s.quantity}</td>
-                <td>{formatKiskValue(s.unit_price)}</td>
-                <td>{formatKiskValue(Number(s.unit_price) * Number(s.quantity))}</td>
+                <td>{formatIskValue(s.unit_price)}</td>
+                <td>{formatIskValue(Number(s.unit_price) * Number(s.quantity))}</td>
                 <td>
                   <DateTime value={s.date} />
                 </td>


### PR DESCRIPTION
## Summary

- The market overview pane (Top sellers / Sales over time / Previous period tiles) is now capped at **50vh**. Tiles clip their overflow and the top-seller lists scroll inside their tiles instead of growing the page; on narrow screens (≤720px single-column stack) the height resets to `auto`.
- All money on the market page now shows **raw ISK instead of kISK**: the top-seller tile values and hover titles, the bar-chart tooltips, the Recent Sales `Unit (ISK)` / `Total (ISK)` columns, and the loading skeleton headers. The "Top sellers" subtitle now reads "(in ISK)".
- Updated the stale comment on `formatIskValue` in `src/app/isk.ts`, which claimed the ISK formatters were reserved for structure taxable events.

## Validation

- `pnpm run lint` passes.
- `pnpm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J63ThDZRX8tBXftoSzEbKW

---
_Generated by [Claude Code](https://claude.ai/code/session_01J63ThDZRX8tBXftoSzEbKW)_