### PR TITLE
Add a shipping calculator at /asset/shipping

### DIFF
--- a/src/app/asset/page.tsx
+++ b/src/app/asset/page.tsx
@@ -131,6 +131,9 @@ const Locations = async () => {
           <Link href={`/corpses/${mainCharacterId}`}>View frozen corpses</Link>
         </p>
       )}
+      <p className={styles.corpses}>
+        <Link href="/asset/shipping">Shipping calculator</Link>
+      </p>
       <AssetSearchForm />
       <AssetsTable locations={locations} owners={owners} />
       <p className={styles.lastRun}>

--- a/src/app/asset/shipping/actions.ts
+++ b/src/app/asset/shipping/actions.ts
@@ -1,0 +1,144 @@
+'use server'
+
+// The shipping calculator's one server action: a pasted list of items in, a
+// Jita-sell appraisal plus a freight quote in each direction out.
+//
+// It leaves the deployment twice — innomin.at for the prices (item names and
+// quantities only, nothing about the caller's account) and kumgo.space for the
+// freight (route, volume, collateral) — and reads no DB beyond the auth check.
+// Both third parties are reached through their single-module wrappers, the same
+// ones the MCP tools use, so the throttle, timeouts and error shapes stay in
+// one place.
+//
+// Never throws: the client renders whatever comes back, and a rejected promise
+// inside a Suspense boundary would be an error boundary's problem instead of a
+// message the player can read.
+import { appraise } from '@/innominate'
+import { fetchShippingRoutes, requestShippingQuote } from '@/kumgo'
+
+import { establishedUser } from '../../account/lib/establishedUser'
+import { resolveShippingRoute, describeRoute } from '../../api/mcp/shippingQuery'
+
+import { MAX_LINES, parseManifest } from './manifest'
+
+// The two lanes this page answers for. Endpoint names are matched as
+// substrings against KumGo's active route list (resolveShippingRoute), so
+// "c-j6" keeps working whether the lane is named C-J6MT or C-J6MT VI.
+const DIRECTIONS = [
+  { label: 'Jita → C-J6', origin: 'jita', destination: 'c-j6' },
+  { label: 'C-J6 → Jita', origin: 'c-j6', destination: 'jita' },
+] as const
+
+export type QuotedDirection = {
+  label: string
+} & (
+  | {
+      ok: true
+      route: string
+      deliverTo: string | null
+      freightIsk: number
+      rushFeeIsk: number
+      totalIsk: number
+      rewardIsk: number
+    }
+  | { ok: false; message: string }
+)
+
+export type ShippingEstimate =
+  | { ok: false; message: string }
+  | {
+      ok: true
+      // What the load is worth and how big it is — the two numbers every quote
+      // below is derived from.
+      sellIsk: number
+      buyIsk: number
+      volumeM3: number
+      lineCount: number
+      cached: boolean
+      // Lines innomin.at could not price, with its own suggestions. The quote
+      // is still shown (a typo shouldn't blank the page) but the collateral
+      // only covers what priced, which the page says out loud.
+      unpriced: Array<{ name: string; suggestions: string[] }>
+      ignored: string[]
+      directions: QuotedDirection[]
+    }
+
+export const quoteShipping = async (raw: string): Promise<ShippingEstimate> => {
+  // A server action is a public endpoint; the page's gate doesn't cover it.
+  const user = await establishedUser()
+  if (!user) return { ok: false, message: 'Sign in to price a shipment.' }
+
+  const { lines, ignored } = parseManifest(raw)
+  if (lines.length === 0) return { ok: false, message: 'Paste a list of items to price.' }
+  if (lines.length > MAX_LINES) {
+    return {
+      ok: false,
+      message: `That's ${lines.length} distinct items — more than one appraisal can carry (limit ${MAX_LINES}). Split the list.`,
+    }
+  }
+
+  // Jita sell: what replacing the cargo actually costs at the market it all
+  // comes from, which is what the collateral has to cover. save: false — a
+  // shipping estimate must leave no appraisal record on innomin.at's side.
+  const appraisal = await appraise(lines, 'jita', false)
+  if (!appraisal.ok) {
+    if (appraisal.kind === 'unconfigured') return { ok: false, message: "Appraisals aren't configured here." }
+    if (appraisal.kind === 'rate_limited') {
+      const retry = appraisal.retryAfterSeconds != null ? ` Try again in ${appraisal.retryAfterSeconds}s.` : ''
+      return { ok: false, message: `The appraisal service is busy — the request budget is shared site-wide.${retry}` }
+    }
+    return { ok: false, message: appraisal.message }
+  }
+
+  const priced = appraisal.appraisal
+  const volumeM3 = priced.totalVol
+  // The collateral is the Jita sell total, rounded up to a whole ISK: a
+  // courier contract can't carry fractions, and rounding down would insure the
+  // load for fractionally less than it's worth.
+  const collateralIsk = Math.ceil(priced.totalSellValue)
+
+  const routes = await fetchShippingRoutes()
+  const directions: QuotedDirection[] =
+    volumeM3 <= 0
+      ? DIRECTIONS.map(({ label }) => ({
+          label,
+          ok: false as const,
+          message: 'Nothing here has a volume to ship.',
+        }))
+      : !routes.ok
+        ? DIRECTIONS.map(({ label }) => ({ label, ok: false as const, message: routes.message }))
+        : await Promise.all(
+            DIRECTIONS.map(async ({ label, origin, destination }): Promise<QuotedDirection> => {
+              const match = resolveShippingRoute(routes.routes, { origin, destination })
+              if (!match.ok) return { label, ok: false, message: match.message }
+              // rush: false — the rush fee is a large flat charge nobody asked
+              // for, and this page quotes the ordinary service.
+              const quote = await requestShippingQuote(match.route.id, volumeM3, collateralIsk, false)
+              if (!quote.ok) return { label, ok: false, message: quote.message }
+              return {
+                label,
+                ok: true,
+                route: describeRoute(quote.route),
+                deliverTo: quote.route.destinationFullName,
+                freightIsk: quote.quote.freightIsk,
+                rushFeeIsk: quote.quote.rushFeeIsk,
+                totalIsk: quote.quote.totalIsk,
+                rewardIsk: quote.quote.rewardIsk,
+              }
+            })
+          )
+
+  return {
+    ok: true,
+    sellIsk: collateralIsk,
+    buyIsk: priced.totalBuyValue,
+    volumeM3,
+    lineCount: lines.length,
+    cached: priced.cached,
+    unpriced: priced.items
+      .filter((item) => item.error != null)
+      .map((item) => ({ name: item.name, suggestions: item.possibleMatches })),
+    ignored,
+    directions,
+  }
+}

--- a/src/app/asset/shipping/manifest.ts
+++ b/src/app/asset/shipping/manifest.ts
@@ -1,0 +1,116 @@
+// Turning a pasted block of text into the lines an appraisal sends upstream.
+//
+// The pure half of the shipping calculator: everything here is string work, so
+// what counts as an item, a quantity, or a line to ignore is unit-testable
+// without innomin.at or kumgo.space (see test/shippingManifest.test.ts). The
+// action next door does the I/O.
+//
+// Relative + .ts, like assetLines.ts and rigs.ts: `pnpm test` runs Node's
+// stripped-types loader, which resolves no path aliases.
+import { reduce } from 'ramda'
+
+import { MAX_LINES } from '../../api/appraisal/assetLines.ts'
+
+export type ManifestLine = { name: string; quantity: number }
+
+export type ParsedManifest = {
+  // Merged by name, in first-seen order — one appraisal is one upstream
+  // request, so the same item pasted twice must not become two lines.
+  lines: ManifestLine[]
+  // Lines deliberately dropped (fitting headers and the like), reported back
+  // so the page can say what it skipped rather than silently eating input.
+  ignored: string[]
+}
+
+// One appraisal is always exactly one upstream request (see assetLines.ts), so
+// the same ceiling applies to a pasted list as to a walked hangar.
+export { MAX_LINES }
+
+// A fitting paste opens with "[Rifter, My Fit]" — a header, not an item.
+const FITTING_HEADER = /^\[.*\]$/
+
+// A count: either bare digits, or digit groups separated by whatever the
+// client's locale uses for thousands (comma, apostrophe, a space of some
+// width). The grouped form is spelled out rather than "digits and separators
+// in any arrangement" so a space only reads as a separator when exactly three
+// digits follow it — otherwise "Mexallon 1 234" would quietly become 234 of
+// something called "Mexallon 1", and being wrong about how much cargo there is
+// quotes the wrong freighter.
+const COUNT = String.raw`(?:\d{1,3}(?:[,'\u00a0\u202f ]\d{3})+|\d+)`
+
+// "Tritanium 1,000", "Tritanium x1000" — the count trails the name, optionally
+// x-prefixed. A name ending in digits is safe: they're never preceded by a
+// space ("Zainou 'Gypsy' KNS-1000", "425mm AutoCannon II").
+const TRAILING_QUANTITY = new RegExp(String.raw`^(.*?\S)\s+x?\s*(${COUNT})$`, 'i')
+// "1000x Tritanium" — the other way round, as multibuy also accepts.
+const LEADING_QUANTITY = new RegExp(String.raw`^(${COUNT})\s*x\s+(.*\S)$`, 'i')
+
+// Thousands separators vary by client locale (comma, apostrophe, thin space);
+// none of them survive into the number. Anything that isn't a whole positive
+// count isn't a quantity at all — the caller then keeps the token as part of
+// the item name rather than guessing.
+const parseQuantity = (raw: string): number | null => {
+  const cleaned = raw.replace(/[,'\s\u00a0\u202f]/g, '')
+  if (!/^[0-9]+$/.test(cleaned)) return null
+  const quantity = Number(cleaned)
+  return Number.isSafeInteger(quantity) && quantity > 0 ? quantity : null
+}
+
+// One line → an item and how many, or null if there's nothing on it. The three
+// shapes a player can paste, in the order they're told apart:
+//
+//   1. An inventory copy, tab-separated: name, quantity, group, category, …
+//   2. Multibuy, "name quantity" / "name xquantity" / "quantity x name"
+//   3. A bare name (a fitting or contract paste) — one of it
+const parseLine = (line: string): ManifestLine | null => {
+  const trimmed = line.trim()
+  if (trimmed === '' || FITTING_HEADER.test(trimmed)) return null
+
+  // The inventory paste is unambiguous — the columns say which field is which
+  // — so it's tested first and never falls through to the name heuristics.
+  if (line.includes('\t')) {
+    const cells = line.split('\t')
+    const name = cells[0].trim()
+    if (name === '') return null
+    // A singleton (an assembled ship, a fitted module) pastes with an empty
+    // quantity column rather than a 1.
+    return { name, quantity: parseQuantity(cells[1] ?? '') ?? 1 }
+  }
+
+  const trailing = TRAILING_QUANTITY.exec(trimmed)
+  const trailingQuantity = trailing ? parseQuantity(trailing[2]) : null
+  if (trailing && trailingQuantity != null) return { name: trailing[1].trim(), quantity: trailingQuantity }
+
+  const leading = LEADING_QUANTITY.exec(trimmed)
+  const leadingQuantity = leading ? parseQuantity(leading[1]) : null
+  if (leading && leadingQuantity != null) return { name: leading[2].trim(), quantity: leadingQuantity }
+
+  return { name: trimmed, quantity: 1 }
+}
+
+// Names are merged case-insensitively (the paste may mix an inventory copy with
+// something typed by hand) but the first spelling seen is what gets sent, since
+// that's the one the player will recognise in the unpriced list.
+export const parseManifest = (raw: string): ParsedManifest => {
+  const merged = new Map<string, ManifestLine>()
+  const ignored: string[] = []
+
+  reduce(
+    (_acc, line: string) => {
+      const parsed = parseLine(line)
+      if (parsed == null) {
+        const trimmed = line.trim()
+        if (trimmed !== '') ignored.push(trimmed)
+        return _acc
+      }
+      const key = parsed.name.toLowerCase()
+      const existing = merged.get(key)
+      merged.set(key, { name: existing?.name ?? parsed.name, quantity: (existing?.quantity ?? 0) + parsed.quantity })
+      return _acc
+    },
+    null,
+    raw.split(/\r?\n/)
+  )
+
+  return { lines: [...merged.values()], ignored }
+}

--- a/src/app/asset/shipping/page.tsx
+++ b/src/app/asset/shipping/page.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+
+import { createClient } from '@/utils/supabase/server'
+
+import { establishedUser } from '../../account/lib/establishedUser'
+
+import styles from './shipping.module.css'
+import { ShippingCalculator } from './shippingCalculator'
+
+// The action this page fires calls innomin.at through the site-wide throttle,
+// where appraise() blocks polling the shared row for up to 50s
+// (POLL_BUDGET_MS in src/innominate.ts). Server actions run under the route
+// that invoked them, so the limit is declared here rather than inherited from
+// a platform default that could truncate a queued appraisal mid-poll.
+export const maxDuration = 60
+
+export const metadata: Metadata = {
+  title: 'Shipping — Edencom Link',
+}
+
+// Static except for the auth gate — everything the page shows comes from the
+// action the textarea fires, so there is nothing to fetch on the way in.
+const ShippingPage = async () => {
+  const supabase = await createClient()
+  const user = await establishedUser(supabase)
+  if (!user) {
+    redirect('/')
+  }
+
+  return (
+    <>
+      <h1>Shipping</h1>
+      <p className={styles.muted}>
+        Paste what you want hauled. It&apos;s appraised at Jita sell — that value is the collateral to put on the
+        courier contract — and quoted both ways between Jita and C-J6. <Link href="/asset">Back to assets</Link>
+      </p>
+      <ShippingCalculator />
+    </>
+  )
+}
+
+export default ShippingPage

--- a/src/app/asset/shipping/shipping.module.css
+++ b/src/app/asset/shipping/shipping.module.css
@@ -1,0 +1,176 @@
+/*
+ * Shipping calculator: the paste box and the estimate, side by side.
+ *
+ * Two equal columns, because the left one holds a wide, tall textarea (an
+ * inventory paste is both) and the right one holds the answer to what's in it —
+ * neither is a sidebar. Below the breakpoint they stack, box first.
+ */
+
+.split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16pt;
+  align-items: start;
+  margin: 16px 0;
+}
+
+@media (max-width: 900px) {
+  .split {
+    grid-template-columns: 1fr;
+  }
+}
+
+.pane {
+  min-width: 0;
+}
+
+.label {
+  display: block;
+  font-size: 10pt;
+  color: var(--ink-soft);
+  margin-bottom: 4pt;
+}
+
+/* Monospace so a pasted inventory's tab columns still line up, and tall enough
+   for a real list (30 rows) without scrolling — resizable for a longer one. */
+.textarea {
+  display: block;
+  width: 100%;
+  min-height: 28em;
+  padding: 8pt;
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--ink);
+  background: var(--paper-raised);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  resize: vertical;
+  tab-size: 8;
+}
+
+.textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: 12pt;
+}
+
+/* One card per thing being reported: the cargo itself, then each lane. */
+.card {
+  padding: 10pt 12pt;
+  background: var(--paper-raised);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+}
+
+.cardTitle {
+  display: flex;
+  align-items: center;
+  gap: 8pt;
+  margin: 0 0 8pt;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink-soft);
+}
+
+.cardNote {
+  margin: 6pt 0 0;
+  font-size: 11px;
+  color: var(--ink-faint);
+}
+
+/* Label left, figure right: the numbers stack into a column the eye can read
+   down, which is the whole reason the two lanes are separate cards. */
+.figure {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12pt;
+  padding: 2pt 0;
+}
+
+.figureLabel {
+  font-size: 11px;
+  color: var(--ink-soft);
+}
+
+.figureValue {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 13px;
+  white-space: nowrap;
+  cursor: help;
+}
+
+/* The figure the card exists to report — the collateral, the total. */
+.figureStrong .figureValue {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.badge {
+  padding: 1pt 6pt;
+  border: 1px solid var(--line);
+  border-radius: 3pt;
+  font-size: 9pt;
+  font-weight: 400;
+  color: var(--ink-faint);
+}
+
+.warning {
+  padding: 8pt 12pt;
+  border: 1px solid var(--danger);
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  color: var(--ink);
+}
+
+.warning p {
+  margin: 0 0 4pt;
+}
+
+.warning ul {
+  margin: 0;
+  padding-left: 16pt;
+}
+
+.error {
+  font-size: 12px;
+  color: var(--danger);
+}
+
+.muted {
+  font-size: 11px;
+  color: var(--ink-faint);
+}
+
+.pending {
+  display: flex;
+  flex-direction: column;
+  gap: 8pt;
+}
+
+.pendingLabel {
+  margin: 0;
+  font-size: 12px;
+  color: var(--ink-soft);
+}
+
+/* Announced, not drawn — the skeleton beside it is the visible half. */
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/app/asset/shipping/shippingCalculator.tsx
+++ b/src/app/asset/shipping/shippingCalculator.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+// The whole page's interaction: a wide textarea on the left, a Suspense
+// boundary on the right.
+//
+// The point of the Suspense boundary here is timing. The estimate is a server
+// action whose promise is created in the debounce timer, so `setRequest` is a
+// plain state update (deliberately NOT wrapped in startTransition — a
+// transition would keep the previous results on screen while the new ones
+// load, and the whole ask is that the loader appear the moment typing stops).
+// The boundary is keyed on the request id so each new paste remounts it and
+// re-suspends rather than reusing the settled tree from the last one.
+import { Suspense, useEffect, useRef, useState } from 'react'
+
+import { SkeletonLines } from '../../skeleton'
+
+import { quoteShipping, type ShippingEstimate } from './actions'
+import styles from './shipping.module.css'
+import { ShippingResults } from './shippingResults'
+
+// How long the textarea has to be quiet before anything is priced. Every
+// estimate is one innomin.at request against a site-wide budget plus two
+// kumgo.space quotes, so this is a real throttle, not just polish — a paste
+// followed by an edit must not cost two appraisals.
+const DEBOUNCE_MS = 250
+
+type Request = { id: number; promise: Promise<ShippingEstimate> }
+
+// Nothing is priced until the box has something in it, so the right half needs
+// something to say in the meantime.
+const Placeholder = () => (
+  <p className={styles.muted}>
+    Paste a list — an inventory copy, a multibuy list, or one item name per line — and the Jita-sell value, the
+    collateral to put on the contract, and both freight quotes appear here.
+  </p>
+)
+
+// The loader. `aria-busy` + a live region so it's announced, not just drawn.
+const Pending = () => (
+  <div className={styles.pending} aria-busy="true">
+    <span className={styles.srOnly} role="status">
+      Pricing…
+    </span>
+    <p className={styles.pendingLabel}>
+      Appraising and quoting freight…
+      <br />
+      <span className={styles.muted}>Appraisals share one queue site-wide, so this can wait its turn.</span>
+    </p>
+    <SkeletonLines count={6} />
+  </div>
+)
+
+export const ShippingCalculator = () => {
+  const [text, setText] = useState('')
+  const [request, setRequest] = useState<Request | null>(null)
+  // Monotonic, so a request that resolves out of order can never be mistaken
+  // for the current one — the boundary's key changes with it.
+  const nextId = useRef(0)
+
+  useEffect(() => {
+    if (text.trim() === '') {
+      setRequest(null)
+      return
+    }
+    const timer = setTimeout(() => {
+      nextId.current += 1
+      setRequest({
+        id: nextId.current,
+        // The action never throws on its own, but a dropped connection would
+        // reject the call itself — caught here so `use()` always resolves and
+        // the failure reads as a message rather than an error boundary.
+        promise: quoteShipping(text).catch((): ShippingEstimate => ({
+          ok: false,
+          message: 'Could not reach the server — try again.',
+        })),
+      })
+    }, DEBOUNCE_MS)
+    // Every keystroke re-runs this effect, so the pending timer is cleared and
+    // the 250 ms starts over: only the last edit of a burst is ever priced.
+    return () => clearTimeout(timer)
+  }, [text])
+
+  return (
+    <div className={styles.split}>
+      <div className={styles.pane}>
+        <label className={styles.label} htmlFor="manifest">
+          Items
+        </label>
+        <textarea
+          id="manifest"
+          className={styles.textarea}
+          value={text}
+          onChange={(event) => setText(event.target.value)}
+          spellCheck={false}
+          rows={30}
+          placeholder={'Tritanium\t1,000\nRifter x5\nDamage Control II'}
+        />
+      </div>
+      <div className={styles.pane}>
+        {request == null ? (
+          <Placeholder />
+        ) : (
+          <Suspense key={request.id} fallback={<Pending />}>
+            <ShippingResults promise={request.promise} />
+          </Suspense>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/asset/shipping/shippingResults.tsx
+++ b/src/app/asset/shipping/shippingResults.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+// The right-hand half: whatever the pending estimate resolves to.
+//
+// A client component rather than a server one because the promise it reads is
+// minted in an event (the debounce timer), not by a navigation — `use()` on
+// that promise is what suspends the boundary around it, which is what puts the
+// loader on screen the instant the typing stops.
+import { use } from 'react'
+
+import { formatBisk, formatIsk } from '../../isk'
+
+import type { QuotedDirection, ShippingEstimate } from './actions'
+import styles from './shipping.module.css'
+
+// Volume runs from a few m³ (a crate of ammo) to hundreds of thousands (a
+// freighter load), so it gets ordinary separators and at most one decimal —
+// enough to tell 0.9 m³ from nothing at all.
+const formatVolume = (m3: number) => `${m3.toLocaleString('en-US', { maximumFractionDigits: 1 })} m³`
+
+// bISK for the headline figures, which are read against each other; the exact
+// ISK is one hover away, because a courier contract is typed in whole ISK.
+const Figure = ({ label, isk, strong }: { label: string; isk: number; strong?: boolean }) => (
+  <div className={strong ? `${styles.figure} ${styles.figureStrong}` : styles.figure}>
+    <span className={styles.figureLabel}>{label}</span>
+    <span className={styles.figureValue} title={formatIsk(isk)}>
+      {formatBisk(isk)}
+    </span>
+  </div>
+)
+
+const DirectionCard = ({ direction }: { direction: QuotedDirection }) => (
+  <section className={styles.card}>
+    <h3 className={styles.cardTitle}>{direction.label}</h3>
+    {direction.ok ? (
+      <>
+        <Figure label="Total cost" isk={direction.totalIsk} strong />
+        <Figure label="Contract reward" isk={direction.rewardIsk} />
+        {direction.rushFeeIsk > 0 ? <Figure label="Rush fee" isk={direction.rushFeeIsk} /> : null}
+        <p className={styles.cardNote}>{direction.route}</p>
+        {direction.deliverTo ? <p className={styles.cardNote}>Deliver to {direction.deliverTo}</p> : null}
+      </>
+    ) : (
+      <p className={styles.error}>{direction.message}</p>
+    )}
+  </section>
+)
+
+export const ShippingResults = ({ promise }: { promise: Promise<ShippingEstimate> }) => {
+  const estimate = use(promise)
+
+  if (!estimate.ok) return <p className={styles.error}>{estimate.message}</p>
+
+  return (
+    <div className={styles.results}>
+      <section className={styles.card}>
+        <h3 className={styles.cardTitle}>
+          Cargo
+          {estimate.cached ? <span className={styles.badge}>cached</span> : null}
+        </h3>
+        {/* The recommendation, not just a valuation: this is the number to
+            type into the courier contract's collateral field, and every
+            freight quote below was priced against it. */}
+        <Figure label="Recommended collateral (Jita sell)" isk={estimate.sellIsk} strong />
+        <Figure label="Jita buy" isk={estimate.buyIsk} />
+        <p className={styles.cardNote}>
+          {formatVolume(estimate.volumeM3)} · {estimate.lineCount} item{estimate.lineCount === 1 ? '' : 's'}
+        </p>
+      </section>
+
+      {estimate.directions.map((direction) => (
+        <DirectionCard key={direction.label} direction={direction} />
+      ))}
+
+      {/* An unpriced line doesn't blank the page — a single typo in a
+          forty-line paste shouldn't — but the collateral above then covers
+          less than the load, which is worth saying plainly. */}
+      {estimate.unpriced.length > 0 ? (
+        <section className={styles.warning}>
+          <p>
+            {estimate.unpriced.length} line{estimate.unpriced.length === 1 ? '' : 's'} could not be priced, so the
+            collateral above does not cover {estimate.unpriced.length === 1 ? 'it' : 'them'}:
+          </p>
+          <ul>
+            {estimate.unpriced.map((line) => (
+              <li key={line.name}>
+                {line.name}
+                {line.suggestions.length > 0 ? (
+                  <span className={styles.muted}> — did you mean {line.suggestions.join(', ')}?</span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {estimate.ignored.length > 0 ? (
+        <p className={styles.muted}>
+          Ignored {estimate.ignored.length} line{estimate.ignored.length === 1 ? '' : 's'}:{' '}
+          {estimate.ignored.join(', ')}
+        </p>
+      ) : null}
+
+      <p className={styles.muted}>
+        Prices from innomin.at, freight quoted live by kumgo.space. Set the courier contract reward to the contract
+        reward and its collateral to the recommended collateral.
+      </p>
+    </div>
+  )
+}

--- a/test/shippingManifest.test.ts
+++ b/test/shippingManifest.test.ts
@@ -1,0 +1,64 @@
+// Unit coverage for the shipping calculator's paste parser. What's worth
+// pinning is that the three shapes a player can paste — an inventory copy, a
+// multibuy list, a bare list of names — all land as the same lines, and that
+// nothing in a name is mistaken for a quantity: an item silently priced 1000×
+// would quote a freighter's worth of freight for a crate of ammo.
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { parseManifest } from '../src/app/asset/shipping/manifest.ts'
+
+test('an inventory paste takes its quantity from the second column', () => {
+  const { lines } = parseManifest(
+    ['Tritanium\t1,000\tMineral\tAsteroid\t0.01 m3', 'Rifter\t\tFrigate\tShip\t2,500 m3'].join('\n')
+  )
+  assert.deepEqual(lines, [
+    { name: 'Tritanium', quantity: 1000 },
+    // An assembled ship pastes with an empty quantity column, meaning one.
+    { name: 'Rifter', quantity: 1 },
+  ])
+})
+
+test('multibuy quantities are read trailing, x-prefixed, or leading', () => {
+  const { lines } = parseManifest(
+    ['Tritanium 1000', 'Nanite Repair Paste x25', '12x Rifter', 'Damage Control II'].join('\n')
+  )
+  assert.deepEqual(lines, [
+    { name: 'Tritanium', quantity: 1000 },
+    { name: 'Nanite Repair Paste', quantity: 25 },
+    { name: 'Rifter', quantity: 12 },
+    { name: 'Damage Control II', quantity: 1 },
+  ])
+})
+
+test('thousands separators are stripped whatever the client locale used', () => {
+  const { lines } = parseManifest("Tritanium 1,234\nPyerite 1'234\nMexallon 1 234")
+  assert.deepEqual(
+    lines.map((l) => l.quantity),
+    [1234, 1234, 1234]
+  )
+})
+
+test('a name ending in digits keeps them', () => {
+  // The hyphen is what saves it: a quantity is always preceded by whitespace.
+  const { lines } = parseManifest("Zainou 'Gypsy' KNS-1000\n425mm AutoCannon II")
+  assert.deepEqual(lines, [
+    { name: "Zainou 'Gypsy' KNS-1000", quantity: 1 },
+    { name: '425mm AutoCannon II', quantity: 1 },
+  ])
+})
+
+test('repeated items merge, keeping the first spelling', () => {
+  const { lines } = parseManifest('Tritanium 100\ntritanium 50\nTRITANIUM x1')
+  assert.deepEqual(lines, [{ name: 'Tritanium', quantity: 151 }])
+})
+
+test('blank lines vanish and a fitting header is reported as ignored', () => {
+  const { lines, ignored } = parseManifest('[Rifter, Solo]\n\n  \nDamage Control II\n')
+  assert.deepEqual(lines, [{ name: 'Damage Control II', quantity: 1 }])
+  assert.deepEqual(ignored, ['[Rifter, Solo]'])
+})
+
+test('nothing pasted is no lines at all', () => {
+  assert.deepEqual(parseManifest('   \n\n').lines, [])
+})


### PR DESCRIPTION
Paste a list of items on the left; 250 ms after the box goes quiet, the right half suspends and fills in with what the load is worth and what it costs to haul.

## What it does

- **Left half:** a wide monospace textarea (30 rows, resizable, `tab-size: 8` so a pasted inventory's columns line up).
- **Right half:** a `<Suspense>` boundary. 250 ms after the last keystroke the debounce timer mints the estimate promise and the loader appears.
- The estimate is one server action (`actions.ts`):
  1. parse the paste into item lines,
  2. appraise at **Jita sell** via `@/innominate` (`save: false` — a quote leaves no record on innomin.at),
  3. quote **both** KumGo lanes with that value as collateral and the appraised volume: Jita → C-J6 and C-J6 → Jita.
- The Jita sell total is shown as **Recommended collateral** — the number that goes on the courier contract, and the one both quotes were priced against. Jita buy, volume and item count sit beside it.

## Notes on the approach

- The Suspense boundary is keyed on a monotonic request id and the state update is deliberately **not** wrapped in `startTransition`: a transition would keep the previous answer on screen while the new one loads, and the point is that the loader appears the moment typing stops.
- The action never throws, and the client `.catch()`es the call itself, so `use()` always resolves — a failure reads as a message, not an error boundary.
- The action re-checks `establishedUser()`: a server action is a public endpoint, so the page's gate doesn't cover it.
- `maxDuration = 60` on the page, matching `POST /api/appraisal` — `appraise()` blocks up to 50 s polling the shared row while the site-wide throttle drains, and server actions run under the route that invoked them.
- Third parties are reached only through the existing single-module wrappers (`src/innominate.ts`, `src/kumgo.ts`) and the existing `resolveShippingRoute` seam, so the throttle, timeouts and error shapes stay in one place. Nothing about the caller's account is sent to either.

## Parsing

`manifest.ts` is the pure seam (`test/shippingManifest.test.ts`, 7 cases). Inventory copies (tab-separated), multibuy lists (`Name 1000`, `Name x25`, `12x Name`) and bare names all land as the same lines; duplicates merge case-insensitively keeping the first spelling; fitting headers are reported as ignored rather than silently eaten.

A count is only read off a name when it genuinely is one: a space reads as a thousands separator only ahead of exactly three digits, so `Mexallon 1 234` is 1234 Mexallon rather than 234 of "Mexallon 1", and names ending in digits (`Zainou 'Gypsy' KNS-1000`, `425mm AutoCannon II`) stay whole. Getting this wrong quotes the wrong freighter, which is why it's the tested part.

## Unpriced lines

A typo in a forty-line paste doesn't blank the page — the quote still shows, with a warning naming the lines the collateral does **not** cover. That's a deliberate difference from the `shipping_quote` MCP tool, which refuses outright: here the player can see what went wrong and fix the line.

## Files

| file | |
| --- | --- |
| `src/app/asset/shipping/page.tsx` | auth gate + heading; static otherwise |
| `src/app/asset/shipping/shippingCalculator.tsx` | textarea, debounce, Suspense boundary |
| `src/app/asset/shipping/shippingResults.tsx` | `use(promise)` → cargo card + one card per lane |
| `src/app/asset/shipping/actions.ts` | the server action |
| `src/app/asset/shipping/manifest.ts` | pure parser |
| `src/app/asset/shipping/shipping.module.css` | the two-column split (stacks under 900 px) |
| `src/app/asset/page.tsx` | a link to it, next to the corpses link |

## Testing

- `pnpm test` — 394 pass, including the 7 new parser cases
- `pnpm run lint` — clean
- `pnpm run build` — clean; `/asset/shipping` in the route listing

---
_Generated by [Claude Code](https://claude.ai/code/session_01TifVtQZz7F49Xfo8MmcTRb)_