### PR TITLE
Fix /asset/shipping: tiered rates, load-size alert, full ISK, no login

### DIFF
--- a/src/app/api/mcp/shippingQuery.ts
+++ b/src/app/api/mcp/shippingQuery.ts
@@ -1,26 +1,104 @@
-// Route-resolution seam for the shipping_quote MCP tool. Like planetQuery.ts
-// this pulls in no I/O — the tool fetches the KumGo route list and hands it
-// here — so the fuzzy origin/destination matching is unit-testable without
-// the network (see test/shippingQuery.test.ts).
+// Route-resolution seam for the shipping_quote MCP tool and the
+// /asset/shipping page. Like planetQuery.ts this pulls in no I/O — callers
+// fetch the KumGo route list and hand it here — so the fuzzy origin/
+// destination matching, the tier arithmetic and the wording of a refusal are
+// unit-testable without the network (see test/shippingQuery.test.ts).
 //
-// Route types are declared structurally rather than imported from src/kumgo
-// so the seam stays free of that module's fetch plumbing.
+// Types are declared structurally rather than imported from src/kumgo so the
+// seam stays free of that module's fetch plumbing.
+
+// A route's pricing for one load-size class. Rates live here, never on the
+// route: a route enables the tiers it will haul, each with its own pricing.
+export type ShippingTierLike = {
+  tierId: number
+  enabled: boolean
+  pricingMode: string
+  ratePerM3: number | null
+  flatRateIsk: number | null
+  minFeeIsk: number | null
+  rushFeeIsk: number | null
+}
+
 export type ShippingRouteLike = {
   id: number
   originName: string
   destinationName: string
-  ratePerM3: number
   collateralFeePercent: number
+  tiers: ShippingTierLike[]
 }
+
+// The load-size classes themselves, shared by every route. A null ceiling
+// means the class is unbounded.
+export type TierClassLike = { id: number; name: string; maxVolumeM3: number | null }
+
+const ceilingOf = (tierId: number, classes: TierClassLike[]): number | null =>
+  classes.find((c) => c.id === tierId)?.maxVolumeM3 ?? null
+
+// Enabled tiers, smallest ceiling first, an unbounded one last — the order a
+// load should be fitted into them.
+const enabledByCeiling = <T extends ShippingTierLike>(route: { tiers: T[] }, classes: TierClassLike[]): T[] =>
+  route.tiers
+    .filter((t) => t.enabled)
+    .slice()
+    .sort((a, b) => {
+      const ca = ceilingOf(a.tierId, classes)
+      const cb = ceilingOf(b.tierId, classes)
+      if (ca === cb) return 0
+      if (ca == null) return 1
+      if (cb == null) return -1
+      return ca - cb
+    })
+
+// The biggest load this route has a standard rate for: the largest ceiling
+// among its enabled tiers, or null when one of them is unbounded. Null is
+// therefore "no ceiling", never "unknown" — a route with nothing enabled
+// returns 0, which refuses every load.
+export const maxQuotableVolumeM3 = (route: ShippingRouteLike, classes: TierClassLike[]): number | null => {
+  const tiers = enabledByCeiling(route, classes)
+  if (tiers.length === 0) return 0
+  const largest = tiers[tiers.length - 1]
+  return ceilingOf(largest.tierId, classes)
+}
+
+// The tier a given load is billed under: the smallest enabled one that still
+// fits it. Null when nothing does — the quote endpoint refuses those, and the
+// UI says so before asking.
+export const tierForVolume = (
+  route: ShippingRouteLike,
+  classes: TierClassLike[],
+  volumeM3: number
+): ShippingTierLike | null =>
+  enabledByCeiling(route, classes).find((t) => {
+    const ceiling = ceilingOf(t.tierId, classes)
+    return ceiling == null || volumeM3 <= ceiling
+  }) ?? null
+
+// A tier's headline price, in whatever mode it bills. Full ISK, never
+// abbreviated — these are numbers a player types into a contract.
+export const describeTier = (tier: ShippingTierLike): string =>
+  tier.pricingMode === 'flat'
+    ? `${(tier.flatRateIsk ?? 0).toLocaleString('en-US')} ISK flat`
+    : `${(tier.ratePerM3 ?? 0).toLocaleString('en-US')} ISK/m³`
 
 export type RouteMatch<R extends ShippingRouteLike> = { ok: true; route: R } | { ok: false; message: string }
 
-export const describeRoute = (r: ShippingRouteLike): string =>
-  `#${r.id} ${r.originName} → ${r.destinationName} (${r.ratePerM3} ISK/m³${
-    r.collateralFeePercent > 0 ? ` + ${r.collateralFeePercent}% collateral` : ''
-  })`
+// A route as a single line, for a refusal or a menu. The rate comes from the
+// route's enabled tiers — reading a rate off the route itself is what used to
+// print "0 ISK/m³" for every lane. Tiers that price alike are collapsed, since
+// every lane today enables exactly one.
+export const describeRoute = (r: ShippingRouteLike, classes: TierClassLike[] = []): string => {
+  const prices = [...new Set(enabledByCeiling(r, classes).map(describeTier))]
+  const cap = maxQuotableVolumeM3(r, classes)
+  const parts = [
+    prices.length > 0 ? prices.join(' / ') : 'no standard rate',
+    ...(cap != null && cap > 0 ? [`up to ${cap.toLocaleString('en-US')} m³`] : []),
+    ...(r.collateralFeePercent > 0 ? [`${r.collateralFeePercent}% collateral fee`] : []),
+  ]
+  return `#${r.id} ${r.originName} → ${r.destinationName} (${parts.join(', ')})`
+}
 
-const routeList = (routes: ShippingRouteLike[]): string => routes.map(describeRoute).join('; ')
+const routeList = (routes: ShippingRouteLike[], classes: TierClassLike[] = []): string =>
+  routes.map((r) => describeRoute(r, classes)).join('; ')
 
 // Resolve which route to quote: an explicit id wins, otherwise origin and
 // destination are matched as case-insensitive substrings of the endpoint
@@ -29,7 +107,13 @@ const routeList = (routes: ShippingRouteLike[]): string => routes.map(describeRo
 // (a handful of lanes) to show whole.
 export const resolveShippingRoute = <R extends ShippingRouteLike>(
   routes: R[],
-  { routeId, origin, destination }: { routeId?: number; origin?: string; destination?: string }
+  {
+    routeId,
+    origin,
+    destination,
+    // Only used to word a refusal's route list; matching itself ignores rates.
+    classes = [],
+  }: { routeId?: number; origin?: string; destination?: string; classes?: TierClassLike[] }
 ): RouteMatch<R> => {
   if (routes.length === 0) return { ok: false, message: 'The shipping service lists no active routes.' }
 
@@ -37,13 +121,16 @@ export const resolveShippingRoute = <R extends ShippingRouteLike>(
     const route = routes.find((r) => r.id === routeId)
     return route
       ? { ok: true, route }
-      : { ok: false, message: `No active route has id ${routeId}. Routes: ${routeList(routes)}.` }
+      : { ok: false, message: `No active route has id ${routeId}. Routes: ${routeList(routes, classes)}.` }
   }
 
   const from = (origin ?? '').trim().toLowerCase()
   const to = (destination ?? '').trim().toLowerCase()
   if (from === '' && to === '') {
-    return { ok: false, message: `Name an origin and destination (or a route_id). Routes: ${routeList(routes)}.` }
+    return {
+      ok: false,
+      message: `Name an origin and destination (or a route_id). Routes: ${routeList(routes, classes)}.`,
+    }
   }
 
   const matches = routes.filter(
@@ -57,8 +144,8 @@ export const resolveShippingRoute = <R extends ShippingRouteLike>(
     ok: false,
     message:
       matches.length === 0
-        ? `No route runs ${asked}. Routes: ${routeList(routes)}.`
-        : `${matches.length} routes match ${asked}: ${routeList(matches)}. Name both endpoints (or a route_id).`,
+        ? `No route runs ${asked}. Routes: ${routeList(routes, classes)}.`
+        : `${matches.length} routes match ${asked}: ${routeList(matches, classes)}. Name both endpoints (or a route_id).`,
   }
 }
 

--- a/src/app/api/mcp/shippingTools.ts
+++ b/src/app/api/mcp/shippingTools.ts
@@ -20,7 +20,10 @@ import {
   COLLATERAL_BASES,
   DEFAULT_COLLATERAL_BASIS,
   describeRoute,
+  describeTier,
+  maxQuotableVolumeM3,
   resolveShippingRoute,
+  tierForVolume,
   type CollateralBasis,
 } from './shippingQuery'
 
@@ -149,15 +152,19 @@ export const registerShippingTools = (server: McpServer): void => {
       // Nothing asked about at all → the caller wants the menu.
       if (route_id == null && !origin?.trim() && !destination?.trim() && volume_m3 == null && !items?.length) {
         return textResult({
-          routes: routes.map(describeRoute),
-          ...(settings.maxVolumeM3 != null && { max_volume_m3: settings.maxVolumeM3 }),
-          ...(settings.minRewardIsk != null && { min_reward_isk: settings.minRewardIsk }),
-          ...(settings.rushFeeIsk != null && { rush_fee_isk: settings.rushFeeIsk }),
+          routes: routes.map((route) => describeRoute(route, settings.tiers)),
+          // Rates are per load-size tier, so the tier ceilings are the thing a
+          // caller needs to know before asking: a load past the largest one a
+          // route enables has no standard rate and the quote is refused.
+          load_size_tiers: settings.tiers.map((tier) => ({
+            name: tier.name,
+            max_volume_m3: tier.maxVolumeM3,
+          })),
           note: 'Call again with origin, destination, and either volume_m3 + collateral_isk or an items manifest for a quote.',
         })
       }
 
-      const match = resolveShippingRoute(routes, { routeId: route_id, origin, destination })
+      const match = resolveShippingRoute(routes, { routeId: route_id, origin, destination, classes: settings.tiers })
       if (!match.ok) return textResult(match.message)
 
       // Explicit figures always win; the appraisal only fills the gaps. So a
@@ -179,7 +186,19 @@ export const registerShippingTools = (server: McpServer): void => {
 
       if (volume == null || volume <= 0) {
         return textResult(
-          `Matched ${describeRoute(match.route)} — pass volume_m3, or an items manifest to derive volume and collateral, for a quote.`
+          `Matched ${describeRoute(match.route, settings.tiers)} — pass volume_m3, or an items manifest to derive volume and collateral, for a quote.`
+        )
+      }
+
+      // Refused upstream anyway, but saying which ceiling was passed (and by
+      // how much) is more useful than relaying "no standard rate for this
+      // load size".
+      const cap = maxQuotableVolumeM3(match.route, settings.tiers)
+      if (cap != null && volume > cap) {
+        return textResult(
+          `${volume.toLocaleString('en-US')} m³ is past the largest load ${match.route.originName} → ${
+            match.route.destinationName
+          } has a standard rate for (${cap.toLocaleString('en-US')} m³). Split the shipment, or ask KumGo for a manual quote.`
         )
       }
 
@@ -187,8 +206,13 @@ export const registerShippingTools = (server: McpServer): void => {
       if (!result.ok) return textResult(result.message)
 
       const { quote, route } = result
+      const tier = tierForVolume(match.route, settings.tiers, volume)
       return textResult({
-        route: describeRoute(route),
+        route: describeRoute(route, settings.tiers),
+        ...(tier != null && {
+          load_size_tier: settings.tiers.find((t) => t.id === tier.tierId)?.name ?? String(tier.tierId),
+          tier_rate: describeTier(tier),
+        }),
         ...(route.destinationFullName != null && { deliver_to: route.destinationFullName }),
         volume_m3: volume,
         collateral_isk: collateral ?? 0,
@@ -198,6 +222,7 @@ export const registerShippingTools = (server: McpServer): void => {
         ...(quote.rushFeeIsk > 0 && { rush_fee_isk: quote.rushFeeIsk }),
         total_isk: quote.totalIsk,
         contract_reward_isk: quote.rewardIsk,
+        ...(quote.collateralCapExceeded && { collateral_cap_exceeded: true }),
         ...(notes.length && { notes }),
         note: 'Set the courier contract reward to contract_reward_isk and the collateral to collateral_isk. Quote computed live by kumgo.space.',
       })

--- a/src/app/asset/shipping/actions.ts
+++ b/src/app/asset/shipping/actions.ts
@@ -17,7 +17,7 @@ import { appraise } from '@/innominate'
 import { fetchShippingRoutes, requestShippingQuote } from '@/kumgo'
 
 import { establishedUser } from '../../account/lib/establishedUser'
-import { resolveShippingRoute, describeRoute } from '../../api/mcp/shippingQuery'
+import { describeTier, maxQuotableVolumeM3, resolveShippingRoute, tierForVolume } from '../../api/mcp/shippingQuery'
 
 import { MAX_LINES, parseManifest } from './manifest'
 
@@ -25,21 +25,27 @@ import { MAX_LINES, parseManifest } from './manifest'
 // substrings against KumGo's active route list (resolveShippingRoute), so
 // "c-j6" keeps working whether the lane is named C-J6MT or C-J6MT VI.
 const DIRECTIONS = [
-  { label: 'Jita → C-J6', origin: 'jita', destination: 'c-j6' },
-  { label: 'C-J6 → Jita', origin: 'c-j6', destination: 'jita' },
+  { label: 'Jita → C-J6', lane: 'Jita → C-J6MT', origin: 'jita', destination: 'c-j6' },
+  { label: 'C-J6 → Jita', lane: 'C-J6MT → Jita', origin: 'c-j6', destination: 'jita' },
 ] as const
 
 export type QuotedDirection = {
   label: string
+  lane: string
 } & (
   | {
       ok: true
-      route: string
+      // The tier the load actually bills under, and what that tier charges.
+      tier: string
+      rate: string
+      collateralFeePercent: number
       deliverTo: string | null
       freightIsk: number
       rushFeeIsk: number
       totalIsk: number
       rewardIsk: number
+      // The load is worth more than this tier will insure.
+      collateralCapExceeded: boolean
     }
   | { ok: false; message: string }
 )
@@ -55,6 +61,9 @@ export type ShippingEstimate =
       volumeM3: number
       lineCount: number
       cached: boolean
+      // The largest load either lane has a standard rate for, or null when a
+      // lane will take any size. Volume past it is the over-capacity alert.
+      maxVolumeM3: number | null
       // Lines innomin.at could not price, with its own suggestions. The quote
       // is still shown (a typo shouldn't blank the page) but the collateral
       // only covers what priced, which the page says out loud.
@@ -98,32 +107,60 @@ export const quoteShipping = async (raw: string): Promise<ShippingEstimate> => {
   const collateralIsk = Math.ceil(priced.totalSellValue)
 
   const routes = await fetchShippingRoutes()
+  const classes = routes.ok ? routes.settings.tiers : []
+
+  // Which lane is which, resolved once: the same match drives both the quote
+  // and the capacity ceiling the page alerts on.
+  const matched = routes.ok
+    ? DIRECTIONS.map((direction) => ({
+        direction,
+        match: resolveShippingRoute(routes.routes, {
+          origin: direction.origin,
+          destination: direction.destination,
+          classes,
+        }),
+      }))
+    : []
+
+  // The biggest load any resolved lane still has a standard rate for. Null
+  // means at least one lane is unbounded, so there is nothing to warn about.
+  // flatMap rather than filter+map so the match stays narrowed to its ok case.
+  const caps = matched.flatMap(({ match }) => (match.ok ? [maxQuotableVolumeM3(match.route, classes)] : []))
+  const maxVolumeM3 = caps.length === 0 || caps.some((c) => c == null) ? null : Math.max(...caps.map((c) => c ?? 0))
+
   const directions: QuotedDirection[] =
     volumeM3 <= 0
-      ? DIRECTIONS.map(({ label }) => ({
+      ? DIRECTIONS.map(({ label, lane }) => ({
           label,
+          lane,
           ok: false as const,
           message: 'Nothing here has a volume to ship.',
         }))
       : !routes.ok
-        ? DIRECTIONS.map(({ label }) => ({ label, ok: false as const, message: routes.message }))
+        ? DIRECTIONS.map(({ label, lane }) => ({ label, lane, ok: false as const, message: routes.message }))
         : await Promise.all(
-            DIRECTIONS.map(async ({ label, origin, destination }): Promise<QuotedDirection> => {
-              const match = resolveShippingRoute(routes.routes, { origin, destination })
-              if (!match.ok) return { label, ok: false, message: match.message }
+            matched.map(async ({ direction: { label, lane }, match }): Promise<QuotedDirection> => {
+              if (!match.ok) return { label, lane, ok: false, message: match.message }
+              const tier = tierForVolume(match.route, classes, volumeM3)
               // rush: false — the rush fee is a large flat charge nobody asked
               // for, and this page quotes the ordinary service.
               const quote = await requestShippingQuote(match.route.id, volumeM3, collateralIsk, false)
-              if (!quote.ok) return { label, ok: false, message: quote.message }
+              if (!quote.ok) return { label, lane, ok: false, message: quote.message }
               return {
                 label,
+                lane,
                 ok: true,
-                route: describeRoute(quote.route),
+                // The tier is named from the shared classes, since the route's
+                // own tier entry carries only its id.
+                tier: classes.find((c) => c.id === tier?.tierId)?.name ?? '—',
+                rate: tier ? describeTier(tier) : 'no standard rate',
+                collateralFeePercent: match.route.collateralFeePercent,
                 deliverTo: quote.route.destinationFullName,
                 freightIsk: quote.quote.freightIsk,
                 rushFeeIsk: quote.quote.rushFeeIsk,
                 totalIsk: quote.quote.totalIsk,
                 rewardIsk: quote.quote.rewardIsk,
+                collateralCapExceeded: quote.quote.collateralCapExceeded,
               }
             })
           )
@@ -135,6 +172,7 @@ export const quoteShipping = async (raw: string): Promise<ShippingEstimate> => {
     volumeM3,
     lineCount: lines.length,
     cached: priced.cached,
+    maxVolumeM3,
     unpriced: priced.items
       .filter((item) => item.error != null)
       .map((item) => ({ name: item.name, suggestions: item.possibleMatches })),

--- a/src/app/asset/shipping/actions.ts
+++ b/src/app/asset/shipping/actions.ts
@@ -68,6 +68,11 @@ export type ShippingEstimate =
       // is still shown (a typo shouldn't blank the page) but the collateral
       // only covers what priced, which the page says out loud.
       unpriced: Array<{ name: string; suggestions: string[] }>
+      // Lines it priced as a DIFFERENT item than the one asked for. It matches
+      // names fuzzily and reports no error when it settles on something else,
+      // so a near miss silently re-prices the cargo. Surfaced rather than
+      // trusted.
+      substitutions: Array<{ input: string; priced: string }>
       ignored: string[]
       directions: QuotedDirection[]
     }
@@ -176,6 +181,15 @@ export const quoteShipping = async (raw: string): Promise<ShippingEstimate> => {
     unpriced: priced.items
       .filter((item) => item.error != null)
       .map((item) => ({ name: item.name, suggestions: item.possibleMatches })),
+    // The response carries one entry per requested line, in request order, and
+    // its `name` is what the service RESOLVED to — so zipping by index against
+    // what was sent is what catches "construction blocks" coming back priced
+    // as something else.
+    substitutions: lines.flatMap((line, index) => {
+      const item = priced.items[index]
+      if (item == null || item.error != null) return []
+      return item.name.toLowerCase() === line.name.toLowerCase() ? [] : [{ input: line.name, priced: item.name }]
+    }),
     ignored,
     directions,
   }

--- a/src/app/asset/shipping/actions.ts
+++ b/src/app/asset/shipping/actions.ts
@@ -4,11 +4,19 @@
 // Jita-sell appraisal plus a freight quote in each direction out.
 //
 // It leaves the deployment twice — innomin.at for the prices (item names and
-// quantities only, nothing about the caller's account) and kumgo.space for the
-// freight (route, volume, collateral) — and reads no DB beyond the auth check.
-// Both third parties are reached through their single-module wrappers, the same
-// ones the MCP tools use, so the throttle, timeouts and error shapes stay in
-// one place.
+// quantities only) and kumgo.space for the freight (route, volume,
+// collateral) — and reads no database at all. Both third parties are reached
+// through their single-module wrappers, the same ones the MCP tools use, so
+// the throttle, timeouts and error shapes stay in one place.
+//
+// **Unauthenticated on purpose**, matching the page. There is no account to
+// scope: every input arrives in the request and no row is read, so there is
+// nothing an anonymous caller could see that a signed-in one couldn't. What a
+// public action does expose is cost — each call is one innomin.at request
+// against a budget shared by the whole deployment — but that budget is already
+// defended where it has to be, by the global leaky-bucket throttle and shared
+// cache in src/innominate.ts rather than by who is asking. A flood queues; it
+// cannot outspend the budget.
 //
 // Never throws: the client renders whatever comes back, and a rejected promise
 // inside a Suspense boundary would be an error boundary's problem instead of a
@@ -16,7 +24,6 @@
 import { appraise } from '@/innominate'
 import { fetchShippingRoutes, requestShippingQuote } from '@/kumgo'
 
-import { establishedUser } from '../../account/lib/establishedUser'
 import { describeTier, maxQuotableVolumeM3, resolveShippingRoute, tierForVolume } from '../../api/mcp/shippingQuery'
 
 import { MAX_LINES, parseManifest } from './manifest'
@@ -78,10 +85,6 @@ export type ShippingEstimate =
     }
 
 export const quoteShipping = async (raw: string): Promise<ShippingEstimate> => {
-  // A server action is a public endpoint; the page's gate doesn't cover it.
-  const user = await establishedUser()
-  if (!user) return { ok: false, message: 'Sign in to price a shipment.' }
-
   const { lines, ignored } = parseManifest(raw)
   if (lines.length === 0) return { ok: false, message: 'Paste a list of items to price.' }
   if (lines.length > MAX_LINES) {

--- a/src/app/asset/shipping/loading.tsx
+++ b/src/app/asset/shipping/loading.tsx
@@ -1,0 +1,27 @@
+import { LoadingShell, SkeletonLines } from '../../skeleton'
+
+import styles from './shipping.module.css'
+
+// Without this, the segment falls back to ../loading.tsx — "Assets" over a
+// System/Location/Items skeleton — which is flushed before the auth check
+// resolves and makes this page look like it landed on the assets browser
+// (or on /asset/[locationId], which is what it gets mistaken for). Every
+// other subpage under /asset carries its own for the same reason.
+//
+// It holds the real two-column split, so the textarea doesn't jump across the
+// page when the client component takes over: the same class the real box uses
+// gives a ghost of exactly its size.
+const ShippingLoading = () => (
+  <LoadingShell title="Shipping">
+    <div className={styles.split}>
+      <div className={styles.pane}>
+        <span className={styles.label}>Items</span>
+        <div className={styles.textarea} aria-hidden="true" />
+      </div>
+      <div className={styles.pane}>
+        <SkeletonLines count={3} />
+      </div>
+    </div>
+  </LoadingShell>
+)
+export default ShippingLoading

--- a/src/app/asset/shipping/manifest.ts
+++ b/src/app/asset/shipping/manifest.ts
@@ -42,8 +42,17 @@ const COUNT = String.raw`(?:\d{1,3}(?:[,'\u00a0\u202f ]\d{3})+|\d+)`
 // x-prefixed. A name ending in digits is safe: they're never preceded by a
 // space ("Zainou 'Gypsy' KNS-1000", "425mm AutoCannon II").
 const TRAILING_QUANTITY = new RegExp(String.raw`^(.*?\S)\s+x?\s*(${COUNT})$`, 'i')
-// "1000x Tritanium" — the other way round, as multibuy also accepts.
-const LEADING_QUANTITY = new RegExp(String.raw`^(${COUNT})\s*x\s+(.*\S)$`, 'i')
+// "1000x Tritanium", "1000 x Tritanium", "25000 Construction Blocks" — the
+// count leads. The x is optional, because a count in front of a name is how
+// people actually write a shopping list, and reading "25000 Construction
+// Blocks" as one item named that is how a whole line of cargo ends up priced
+// as a single unit of whatever the appraiser fuzzily matched it to.
+//
+// What keeps this off the many item names that START with digits — "425mm
+// AutoCannon II", "1600mm Steel Plates II", "10MN Afterburner II" — is the
+// required whitespace: in a name the digits are glued to the letters, never
+// separated by a space.
+const LEADING_QUANTITY = new RegExp(String.raw`^(${COUNT})\s*x?\s+(.*\S)$`, 'i')
 
 // Thousands separators vary by client locale (comma, apostrophe, thin space);
 // none of them survive into the number. Anything that isn't a whole positive

--- a/src/app/asset/shipping/page.tsx
+++ b/src/app/asset/shipping/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { redirect } from 'next/navigation'
 
 import { createClient } from '@/utils/supabase/server'
 
@@ -20,21 +19,27 @@ export const metadata: Metadata = {
   title: 'Shipping — Edencom Link',
 }
 
-// Static except for the auth gate — everything the page shows comes from the
-// action the textarea fires, so there is nothing to fetch on the way in.
+// **Deliberately public** — no gate, unlike every other page under /asset.
+// Nothing here is anyone's data: the estimate is computed entirely from what
+// the visitor pastes in, priced by innomin.at and quoted by kumgo.space, and
+// the action reads no table at all. Signing in adds nothing to the answer, so
+// requiring it only kept the alliance's haulers out of a calculator that could
+// serve them.
+//
+// The only account lookup left decides whether to offer the way back to the
+// assets browser, which IS gated — the call is request-cached and the header
+// already makes it, so it costs nothing.
 const ShippingPage = async () => {
   const supabase = await createClient()
   const user = await establishedUser(supabase)
-  if (!user) {
-    redirect('/')
-  }
 
   return (
     <>
       <h1>Shipping</h1>
       <p className={styles.muted}>
         Paste what you want hauled. It&apos;s appraised at Jita sell — that value is the collateral to put on the
-        courier contract — and quoted both ways between Jita and C-J6. <Link href="/asset">Back to assets</Link>
+        courier contract — and quoted both ways between Jita and C-J6.{' '}
+        {user ? <Link href="/asset">Back to assets</Link> : null}
       </p>
       <ShippingCalculator />
     </>

--- a/src/app/asset/shipping/shipping.module.css
+++ b/src/app/asset/shipping/shipping.module.css
@@ -174,3 +174,12 @@
   white-space: nowrap;
   border: 0;
 }
+
+/* The volume line when the load is past the largest tier KumGo will quote —
+   the same sentence, but no longer a quiet footnote. */
+.cardNoteAlert {
+  margin: 6pt 0 0;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--danger);
+}

--- a/src/app/asset/shipping/shippingResults.tsx
+++ b/src/app/asset/shipping/shippingResults.tsx
@@ -6,26 +6,23 @@
 // minted in an event (the debounce timer), not by a navigation — `use()` on
 // that promise is what suspends the boundary around it, which is what puts the
 // loader on screen the instant the typing stops.
+//
+// Every figure here is full ISK, never abbreviated: these are numbers a player
+// types into a courier contract, and "1.234 bISK" is not something you can
+// type into the collateral field.
 import { use } from 'react'
 
-import { formatBisk, formatIsk } from '../../isk'
+import { formatIsk } from '../../isk'
 
 import type { QuotedDirection, ShippingEstimate } from './actions'
 import styles from './shipping.module.css'
 
-// Volume runs from a few m³ (a crate of ammo) to hundreds of thousands (a
-// freighter load), so it gets ordinary separators and at most one decimal —
-// enough to tell 0.9 m³ from nothing at all.
 const formatVolume = (m3: number) => `${m3.toLocaleString('en-US', { maximumFractionDigits: 1 })} m³`
 
-// bISK for the headline figures, which are read against each other; the exact
-// ISK is one hover away, because a courier contract is typed in whole ISK.
 const Figure = ({ label, isk, strong }: { label: string; isk: number; strong?: boolean }) => (
   <div className={strong ? `${styles.figure} ${styles.figureStrong}` : styles.figure}>
     <span className={styles.figureLabel}>{label}</span>
-    <span className={styles.figureValue} title={formatIsk(isk)}>
-      {formatBisk(isk)}
-    </span>
+    <span className={styles.figureValue}>{formatIsk(isk)}</span>
   </div>
 )
 
@@ -37,8 +34,14 @@ const DirectionCard = ({ direction }: { direction: QuotedDirection }) => (
         <Figure label="Total cost" isk={direction.totalIsk} strong />
         <Figure label="Contract reward" isk={direction.rewardIsk} />
         {direction.rushFeeIsk > 0 ? <Figure label="Rush fee" isk={direction.rushFeeIsk} /> : null}
-        <p className={styles.cardNote}>{direction.route}</p>
+        <p className={styles.cardNote}>
+          {direction.lane} · tier {direction.tier} · {direction.rate}
+          {direction.collateralFeePercent > 0 ? ` + ${direction.collateralFeePercent}% collateral` : ''}
+        </p>
         {direction.deliverTo ? <p className={styles.cardNote}>Deliver to {direction.deliverTo}</p> : null}
+        {direction.collateralCapExceeded ? (
+          <p className={styles.error}>This lane will not insure the full value — the tier has a collateral ceiling.</p>
+        ) : null}
       </>
     ) : (
       <p className={styles.error}>{direction.message}</p>
@@ -51,8 +54,24 @@ export const ShippingResults = ({ promise }: { promise: Promise<ShippingEstimate
 
   if (!estimate.ok) return <p className={styles.error}>{estimate.message}</p>
 
+  // KumGo prices by load-size tier and has no standard rate past the largest
+  // one it enables — 350,000 m³ today, which is also about where a jump
+  // freighter's hold ends. Past it every lane below refuses, so the reason is
+  // stated once, up top, instead of only as two identical refusals.
+  const overCapacity = estimate.maxVolumeM3 != null && estimate.volumeM3 > estimate.maxVolumeM3
+
   return (
     <div className={styles.results}>
+      {overCapacity ? (
+        <section className={styles.warning} role="alert">
+          <p>
+            <strong>{formatVolume(estimate.volumeM3)} is too big to ship in one contract.</strong> The largest standard
+            load is {formatVolume(estimate.maxVolumeM3 ?? 0)} — about a jump freighter&apos;s hold. Split the list, or
+            ask KumGo on Discord for a manual quote.
+          </p>
+        </section>
+      ) : null}
+
       <section className={styles.card}>
         <h3 className={styles.cardTitle}>
           Cargo
@@ -63,8 +82,10 @@ export const ShippingResults = ({ promise }: { promise: Promise<ShippingEstimate
             freight quote below was priced against it. */}
         <Figure label="Recommended collateral (Jita sell)" isk={estimate.sellIsk} strong />
         <Figure label="Jita buy" isk={estimate.buyIsk} />
-        <p className={styles.cardNote}>
-          {formatVolume(estimate.volumeM3)} · {estimate.lineCount} item{estimate.lineCount === 1 ? '' : 's'}
+        <p className={overCapacity ? styles.cardNoteAlert : styles.cardNote}>
+          {formatVolume(estimate.volumeM3)}
+          {estimate.maxVolumeM3 != null ? ` of ${formatVolume(estimate.maxVolumeM3)} max` : ''} · {estimate.lineCount}{' '}
+          item{estimate.lineCount === 1 ? '' : 's'}
         </p>
       </section>
 

--- a/src/app/asset/shipping/shippingResults.tsx
+++ b/src/app/asset/shipping/shippingResults.tsx
@@ -93,6 +93,25 @@ export const ShippingResults = ({ promise }: { promise: Promise<ShippingEstimate
         <DirectionCard key={direction.label} direction={direction} />
       ))}
 
+      {/* The appraiser matches names fuzzily and reports no error when it
+          settles on a different item, which silently re-prices the cargo —
+          so every substitution is named rather than trusted. */}
+      {estimate.substitutions.length > 0 ? (
+        <section className={styles.warning} role="alert">
+          <p>
+            {estimate.substitutions.length === 1 ? 'One line was' : `${estimate.substitutions.length} lines were`}{' '}
+            priced as a different item than asked for:
+          </p>
+          <ul>
+            {estimate.substitutions.map((swap) => (
+              <li key={swap.input}>
+                &ldquo;{swap.input}&rdquo; <span className={styles.muted}>priced as</span> {swap.priced}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
       {/* An unpriced line doesn't blank the page — a single typo in a
           forty-line paste shouldn't — but the collateral above then covers
           less than the load, which is worth saying plainly. */}

--- a/src/app/layout/header.tsx
+++ b/src/app/layout/header.tsx
@@ -65,6 +65,10 @@ const Header = async () => {
           <span className={styles.bracket}>[</span>
           {!user ? (
             <>
+              {/* The one page that works signed out, so it needs a way in
+                  from here — /asset, where it otherwise lives, is gated. */}
+              <Link href="/asset/shipping">shipping</Link>
+              <span className={styles.sep}>|</span>
               <Link href="/account/login">login</Link>
               <span className={styles.sep}>|</span>
               <Link href="/account/register">register</Link>

--- a/src/kumgo.ts
+++ b/src/kumgo.ts
@@ -2,28 +2,55 @@
 // (https://kumgo.space) — a public, unauthenticated quote API for the
 // alliance's shipping routes. Like src/innominate.ts this is a deliberate,
 // narrow exception to the "UI/MCP read the DB, never call a third-party"
-// rule: freight rates aren't in our DB, so the shipping_quote MCP tool calls
-// kumgo.space server-side at request time. Nothing is persisted, nothing
-// about the caller's account is sent — only route id, volume, collateral,
-// and the rush flag. The API publishes no rate limit and quotes are pure
-// arithmetic on its side, so unlike innomin.at there is no queue/throttle.
+// rule: freight rates aren't in our DB, so the shipping_quote MCP tool and
+// /asset/shipping call kumgo.space server-side at request time. Nothing is
+// persisted, nothing about the caller's account is sent — only route id,
+// volume, collateral, and the rush flag. The API publishes no rate limit and
+// quotes are pure arithmetic on its side, so unlike innomin.at there is no
+// queue/throttle.
+//
+// Rates are per *tier*, not per route. A tier is a load-size class — the
+// settings payload names them and gives each a volume ceiling (S ≤13,000 m³,
+// M ≤67,000 m³, L ≤350,000 m³, XL unbounded at the time of writing) — and each
+// route enables the tiers it will actually haul, each with its own pricing.
+// A load bigger than any enabled tier's ceiling has no standard rate and the
+// quote endpoint refuses it. (The earlier flat `ratePerM3` on the route itself
+// is gone; reading it left every rate showing as 0.)
+
+export type ShippingTier = {
+  tierId: number
+  enabled: boolean
+  // 'per_m3' bills ratePerM3 × volume; 'flat' bills flatRateIsk regardless.
+  pricingMode: string
+  ratePerM3: number | null
+  flatRateIsk: number | null
+  // Floor under the whole reward — a tiny load still pays this.
+  minFeeIsk: number | null
+  // Null means the tier will cover any collateral.
+  maxCollateralIsk: number | null
+  rushFeeIsk: number | null
+}
+
 export type ShippingRoute = {
   id: number
   originName: string
   destinationName: string
   // Only the quote response carries the full station/structure name.
   destinationFullName: string | null
-  ratePerM3: number
   collateralFeePercent: number
-  flatRateIsk: number | null
-  smallLoadMaxVolumeM3: number | null
-  smallLoadRatePerM3: number | null
+  tiers: ShippingTier[]
+}
+
+// A load-size class, shared by every route; `tierId` on a route's tier refers
+// to one of these. A null ceiling means the class is unbounded.
+export type ShippingTierClass = {
+  id: number
+  name: string
+  maxVolumeM3: number | null
 }
 
 export type ShippingSettings = {
-  minRewardIsk: number | null
-  maxVolumeM3: number | null
-  rushFeeIsk: number | null
+  tiers: ShippingTierClass[]
 }
 
 export type ShippingQuote = {
@@ -31,6 +58,9 @@ export type ShippingQuote = {
   rewardIsk: number
   rushFeeIsk: number
   totalIsk: number
+  // The load's value ran past the tier's collateral ceiling, so the quote
+  // covers less than the cargo is worth.
+  collateralCapExceeded: boolean
 }
 
 export type ShippingRoutesResult =
@@ -46,20 +76,34 @@ const TIMEOUT_MS = 10_000
 
 const num = (v: unknown): number | null => (typeof v === 'number' && Number.isFinite(v) ? v : null)
 
+const mapTier = (t: Record<string, unknown>): ShippingTier => ({
+  tierId: num(t.tierId) ?? 0,
+  enabled: t.enabled === true,
+  pricingMode: typeof t.pricingMode === 'string' ? t.pricingMode : 'per_m3',
+  ratePerM3: num(t.ratePerM3),
+  flatRateIsk: num(t.flatRateIsk),
+  minFeeIsk: num(t.minFeeIsk),
+  maxCollateralIsk: num(t.maxCollateralIsk),
+  rushFeeIsk: num(t.rushFeeIsk),
+})
+
 const mapRoute = (r: Record<string, unknown>): ShippingRoute => ({
   id: num(r.id) ?? 0,
   originName: typeof r.originName === 'string' ? r.originName : '',
   destinationName: typeof r.destinationName === 'string' ? r.destinationName : '',
   destinationFullName: typeof r.destinationFullName === 'string' ? r.destinationFullName : null,
-  ratePerM3: num(r.ratePerM3) ?? 0,
   collateralFeePercent: num(r.collateralFeePercent) ?? 0,
-  flatRateIsk: num(r.flatRateIsk),
-  smallLoadMaxVolumeM3: num(r.smallLoadMaxVolumeM3),
-  smallLoadRatePerM3: num(r.smallLoadRatePerM3),
+  tiers: Array.isArray(r.tiers) ? r.tiers.map(mapTier) : [],
+})
+
+const mapTierClass = (t: Record<string, unknown>): ShippingTierClass => ({
+  id: num(t.id) ?? 0,
+  name: typeof t.name === 'string' ? t.name : '',
+  maxVolumeM3: num(t.maxVolumeM3),
 })
 
 // Never throws — a network error, timeout, or surprise payload becomes a
-// clean { ok: false } the MCP tool can hand to the model verbatim.
+// clean { ok: false } the caller can hand to the user verbatim.
 const kumgoFetch = async (
   path: string,
   init?: RequestInit
@@ -77,7 +121,7 @@ const kumgoFetch = async (
   const body = await response.json().catch(() => null)
   if (!response.ok) {
     // The API reports request problems as { ok: false, error } with a 4xx;
-    // pass its own wording through (e.g. the max-volume message).
+    // pass its own wording through (e.g. the over-size message).
     const message = typeof body?.error === 'string' ? body.error : `KumGo returned ${response.status}.`
     return { ok: false, message }
   }
@@ -92,11 +136,7 @@ export const fetchShippingRoutes = async (): Promise<ShippingRoutesResult> => {
   return {
     ok: true,
     routes: raw.routes.map(mapRoute),
-    settings: {
-      minRewardIsk: num(raw.settings?.minRewardIsk),
-      maxVolumeM3: num(raw.settings?.maxVolumeM3),
-      rushFeeIsk: num(raw.settings?.rushFeeIsk),
-    },
+    settings: { tiers: Array.isArray(raw.settings?.tiers) ? raw.settings.tiers.map(mapTierClass) : [] },
   }
 }
 
@@ -112,8 +152,8 @@ export const requestShippingQuote = async (
   })
   if (!result.ok) return result
   const raw = result.body ?? {}
-  // A refused quote (unknown route, over the volume cap) comes back as
-  // { ok: false, error } on a 200 as well as on 4xx — treat both alike.
+  // A refused quote (unknown route, a load past every enabled tier) comes back
+  // as { ok: false, error } on a 200 as well as on 4xx — treat both alike.
   if (raw.ok !== true || raw.quote == null || raw.route == null) {
     const message = typeof raw.error === 'string' ? raw.error : 'KumGo returned an unexpected quote payload.'
     return { ok: false, message }
@@ -125,6 +165,7 @@ export const requestShippingQuote = async (
       rewardIsk: num(raw.quote.rewardIsk) ?? 0,
       rushFeeIsk: num(raw.quote.rushFeeIsk) ?? 0,
       totalIsk: num(raw.quote.totalIsk) ?? 0,
+      collateralCapExceeded: raw.quote.collateralCapExceeded === true,
     },
     route: mapRoute(raw.route),
   }

--- a/test/shippingManifest.test.ts
+++ b/test/shippingManifest.test.ts
@@ -62,3 +62,41 @@ test('blank lines vanish and a fitting header is reported as ignored', () => {
 test('nothing pasted is no lines at all', () => {
   assert.deepEqual(parseManifest('   \n\n').lines, [])
 })
+
+// A count in front of the name, with no "x", is how people actually write a
+// shopping list. Reading "25000 Construction Blocks" as a single item named
+// that is what sent the whole string to the appraiser, which fuzzily matched
+// it to a different item entirely and priced one of it.
+test('a bare leading count is a quantity', () => {
+  const { lines } = parseManifest('25000 Construction Blocks\n1000 x Tritanium\n12 Rifter')
+  assert.deepEqual(lines, [
+    { name: 'Construction Blocks', quantity: 25000 },
+    { name: 'Tritanium', quantity: 1000 },
+    { name: 'Rifter', quantity: 12 },
+  ])
+})
+
+test('names that start with digits are not eaten by the leading count', () => {
+  // The digits are glued to the letters in every one of these, and it is that
+  // missing space — not a list of exceptions — that keeps them whole.
+  const { lines } = parseManifest(
+    ['425mm AutoCannon II', '1600mm Steel Plates II', '10MN Afterburner II', '800mm Repeating Cannon II'].join('\n')
+  )
+  assert.deepEqual(
+    lines.map((l) => l.quantity),
+    [1, 1, 1, 1]
+  )
+  assert.equal(lines[0].name, '425mm AutoCannon II')
+  assert.equal(lines[2].name, '10MN Afterburner II')
+})
+
+test('an item starting with x survives an optional-x leading count', () => {
+  const { lines } = parseManifest('10 Xenon Gas\n10 x Xenon Gas')
+  assert.deepEqual(lines, [{ name: 'Xenon Gas', quantity: 20 }])
+})
+
+test('a trailing count still wins over a leading one', () => {
+  // "1600mm" is part of the name; the 5 at the end is the count.
+  const { lines } = parseManifest('1600mm Steel Plates II 5')
+  assert.deepEqual(lines, [{ name: '1600mm Steel Plates II', quantity: 5 }])
+})

--- a/test/shippingQuery.test.ts
+++ b/test/shippingQuery.test.ts
@@ -11,16 +11,47 @@ import {
   COLLATERAL_BASES,
   DEFAULT_COLLATERAL_BASIS,
   describeRoute,
+  describeTier,
+  maxQuotableVolumeM3,
   resolveShippingRoute,
+  tierForVolume,
 } from '../src/app/api/mcp/shippingQuery.ts'
 
+// The real load-size classes as of writing: only L is enabled on any lane, so
+// 350,000 m³ is where a standard quote stops.
+const CLASSES = [
+  { id: 1, name: 'S', maxVolumeM3: 13_000 },
+  { id: 2, name: 'M', maxVolumeM3: 67_000 },
+  { id: 3, name: 'L', maxVolumeM3: 350_000 },
+  { id: 4, name: 'XL', maxVolumeM3: null },
+]
+
+const tier = (tierId: number, enabled: boolean, ratePerM3: number) => ({
+  tierId,
+  enabled,
+  pricingMode: 'per_m3',
+  ratePerM3,
+  flatRateIsk: null,
+  minFeeIsk: 5_000_000,
+  rushFeeIsk: 250_000_000,
+})
+
 // The real lanes as of writing: every origin appears as a destination too, so
-// a one-endpoint query is genuinely ambiguous.
+// a one-endpoint query is genuinely ambiguous. Rates live on the tiers, never
+// on the route.
+const lane = (id: number, originName: string, destinationName: string, rate: number, collateralFeePercent = 0) => ({
+  id,
+  originName,
+  destinationName,
+  collateralFeePercent,
+  tiers: [tier(1, false, rate), tier(2, false, rate), tier(3, true, rate), tier(4, false, rate)],
+})
+
 const ROUTES = [
-  { id: 1, originName: 'C-J6MT', destinationName: 'Jita', ratePerM3: 900, collateralFeePercent: 0.5 },
-  { id: 2, originName: 'Jita', destinationName: 'C-J6MT', ratePerM3: 700, collateralFeePercent: 0 },
-  { id: 3, originName: 'C-J6MT', destinationName: 'N-HK93', ratePerM3: 700, collateralFeePercent: 0 },
-  { id: 4, originName: 'N-HK93', destinationName: 'Jita', ratePerM3: 600, collateralFeePercent: 0.5 },
+  lane(1, 'C-J6MT', 'Jita', 900, 0.5),
+  lane(2, 'Jita', 'C-J6MT', 700),
+  lane(3, 'C-J6MT', 'N-HK93', 700),
+  lane(4, 'N-HK93', 'Jita', 600, 0.5),
 ]
 
 test('route id wins and must exist', () => {
@@ -72,8 +103,11 @@ test('no endpoints and no id asks for them', () => {
 })
 
 test('describeRoute shows the collateral fee only when charged', () => {
-  assert.equal(describeRoute(ROUTES[1]), '#2 Jita → C-J6MT (700 ISK/m³)')
-  assert.equal(describeRoute(ROUTES[0]), '#1 C-J6MT → Jita (900 ISK/m³ + 0.5% collateral)')
+  assert.equal(describeRoute(ROUTES[1], CLASSES), '#2 Jita → C-J6MT (700 ISK/m³, up to 350,000 m³)')
+  assert.equal(
+    describeRoute(ROUTES[0], CLASSES),
+    '#1 C-J6MT → Jita (900 ISK/m³, up to 350,000 m³, 0.5% collateral fee)'
+  )
 })
 
 // Every basis must map to exactly the market and total its name says — a
@@ -92,4 +126,53 @@ test('collateral bases pick the named market and total', () => {
       ['cj6mt_split', 'cj6mt', 200],
     ]
   )
+})
+
+// ── Load-size tiers ───────────────────────────────────────────────────────
+//
+// Rates moved onto per-route tiers; reading them off the route itself is what
+// made every lane quote "0 ISK/m³". These pin the arithmetic that replaced it,
+// and the ceiling the page alerts on.
+
+test('a route describes the rate of its enabled tier, not a rate of its own', () => {
+  const described = describeRoute(ROUTES[1], CLASSES)
+  assert.match(described, /700 ISK\/m³/)
+  assert.match(described, /up to 350,000 m³/)
+  // The disabled S/M/XL tiers price identically here and must not each be listed.
+  assert.equal(described.match(/700 ISK\/m³/g)?.length, 1)
+})
+
+test('the ceiling is the largest ENABLED tier, not the largest tier', () => {
+  // XL is unbounded but disabled, so the lane still stops at L's 350,000 m³.
+  assert.equal(maxQuotableVolumeM3(ROUTES[1], CLASSES), 350_000)
+})
+
+test('an enabled unbounded tier means no ceiling at all', () => {
+  const unbounded = { ...ROUTES[1], tiers: [tier(3, true, 700), tier(4, true, 900)] }
+  assert.equal(maxQuotableVolumeM3(unbounded, CLASSES), null)
+})
+
+test('a route with nothing enabled quotes nothing', () => {
+  const closed = { ...ROUTES[1], tiers: [tier(3, false, 700)] }
+  assert.equal(maxQuotableVolumeM3(closed, CLASSES), 0)
+  assert.equal(tierForVolume(closed, CLASSES, 1), null)
+})
+
+test('a load bills under the smallest enabled tier that fits it', () => {
+  const tiered = { ...ROUTES[1], tiers: [tier(1, true, 1200), tier(2, true, 900), tier(3, true, 700)] }
+  assert.equal(tierForVolume(tiered, CLASSES, 12_000)?.tierId, 1)
+  assert.equal(tierForVolume(tiered, CLASSES, 13_000)?.tierId, 1) // the ceiling itself still fits
+  assert.equal(tierForVolume(tiered, CLASSES, 13_001)?.tierId, 2)
+  assert.equal(tierForVolume(tiered, CLASSES, 350_000)?.tierId, 3)
+  // Past every enabled ceiling there is no tier — this is the over-capacity case.
+  assert.equal(tierForVolume(tiered, CLASSES, 350_001), null)
+})
+
+test('a flat-rate tier describes its flat fee, not a per-m³ rate', () => {
+  const flat = { ...tier(3, true, 0), pricingMode: 'flat', ratePerM3: null, flatRateIsk: 90_000_000 }
+  assert.equal(describeTier(flat), '90,000,000 ISK flat')
+})
+
+test('rates are never abbreviated', () => {
+  assert.equal(describeTier(tier(3, true, 1_250)), '1,250 ISK/m³')
 })


### PR DESCRIPTION
Follow-ups to #926, from using the page.

## 1. The loading shell (why it looked like the wildcard caught it)

The route matches fine — `/asset/shipping` is a static segment and beats the dynamic sibling; its own `<title>` is served while `/asset/12345` gets the dynamic route's. What was wrong is the body under that title: #926 never added a `loading.tsx`, so the segment fell back to `src/app/asset/loading.tsx` — heading **"Assets"** over a 10-row *System / Location / Items* skeleton. That shell is flushed before the auth check resolves, so the served HTML's only `<h1>` was `Assets` with no textarea in it. `/asset/search` and `/asset/[locationId]` both carry their own; this was the one missing.

## 2. "0 ISK/m³" was real — KumGo's API changed shape

Rates moved onto per-route **tiers**:

```jsonc
{ "id": 2, "originName": "Jita", "destinationName": "C-J6MT", "collateralFeePercent": 0,
  "tiers": [{ "tierId": 3, "enabled": true, "pricingMode": "per_m3",
              "ratePerM3": 700, "flatRateIsk": null, "minFeeIsk": 5000000,
              "maxCollateralIsk": null, "rushFeeIsk": 250000000 }, …] }
```

`src/kumgo.ts` was still reading `ratePerM3` off the route itself, where it no longer exists — hence every lane describing itself as free. The **totals were never wrong** (KumGo computes those server-side); only the rate printed beside them was.

The same stale mapping had silently emptied the settings payload, so the MCP tool's `max_volume_m3` / `min_reward_isk` / `rush_fee_isk` had been *absent* rather than merely wrong. `smallLoadMaxVolumeM3` / `smallLoadRatePerM3` are gone from the API and go with it; `collateralCapExceeded` is new and now surfaces on both the page and the tool.

## 3. The 350,000 m³ alert is the service's own ceiling

Tiers are load-size classes, named in the settings payload: **S** ≤13,000 · **M** ≤67,000 · **L** ≤350,000 · **XL** unbounded. Every lane enables only **L**, so anything bigger has no standard rate — verified against the live API:

```
vol=350,000  → {"freightIsk":245000000,"rewardIsk":245000000,…}
vol=350,001  → "We don't have a standard rate for this load size on this
                route — message us on Discord for a manual quote."
```

So the alert is derived from the largest *enabled* tier rather than hardcoded to 350k: if XL is ever switched on, the page stops warning on its own.

## 4. Full ISK, and a parse fix

`formatBisk` is gone from this page — these are numbers a player types into a courier contract.

`25000 Construction Blocks` was parsed as one item literally named that, because a leading count was only recognised with an `x`. The whole string then went to innomin.at, which matched it fuzzily to a different item and priced a single unit of it. The `x` is now optional; what keeps this off names that *start* with digits (`425mm AutoCannon II`, `1600mm Steel Plates II`, `10MN Afterburner II`) is the required whitespace — in a name the digits are glued to the letters. A trailing count still wins.

That swap was also **silent**: the appraiser reports no error when it resolves to something else, only on an outright miss. Its response carries one entry per line in request order and that entry's `name` is what it resolved to, so zipping by index catches it. Any substituted line is now named on the page.

## 5. No login required

Nothing here is anyone's data: the estimate is computed entirely from what the visitor pastes, and the action reads no table at all. Both gates go — the page's redirect and the action's own check (a server action is a public endpoint, so it needed its own; without removing it, signed-out visitors would get a working textarea that answered "Sign in to price a shipment"). The header's signed-out nav gains a link, since `/asset` is gated and a URL-only page isn't meaningfully public.

What a public action exposes is cost, not data: each call is one innomin.at request against a deployment-wide budget. That budget is already defended by the global leaky-bucket throttle and shared 5-minute cache in `src/innominate.ts` rather than by who is asking — a flood queues, it cannot outspend the budget. A per-IP limit on the action is the lever if that ever bites.

## Verified against the live preview, signed out

```
GET  /asset/shipping                    → 200, <h1>Shipping</h1>, textarea present
POST (server action) "25000 construction blocks"
  → 1 line · 18,750 m³ (25,000 × 0.75) · substitutions: []
  → collateral 264,750,000 ISK · tier L
  → Jita → C-J6MT  13,125,000 ISK  (18,750 × 700)
  → C-J6MT → Jita  16,875,000 ISK  (18,750 × 900)
POST "500000 construction blocks"       → 375,000 m³ vs max 350,000, both lanes refused
```

No session cookie on any of those.

## Testing

Tier selection and parsing are pure and tested — 12 new cases across `test/shippingQuery.test.ts` and `test/shippingManifest.test.ts`: the ceiling comes from **enabled** tiers only, a load bills under the smallest enabled tier that fits it (boundary inclusive), past every ceiling there is no tier, flat-rate tiers describe a flat fee, rates are never abbreviated, a bare leading count is a quantity, and digit-prefixed names stay whole.

`pnpm test` 405 pass · `pnpm run lint` clean · `pnpm run build` clean.

**Not verified:** the substitution detector never fired in testing — the fuzzy probe came back as a hard `unpriced` miss instead. It can only add a warning, never suppress a quote.