### PR TITLE
Copy buttons and a "Rates" heading on the shipping calculator

### DIFF
--- a/src/app/asset/shipping/copyValue.tsx
+++ b/src/app/asset/shipping/copyValue.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+// A clipboard button for one value on the shipping calculator, following the
+// mercenary-dens ping button: borderless 📋 that flashes ✓, and fails silently
+// because it is a convenience, not the only way to get the value (it is right
+// there on screen to select by hand).
+//
+// The reason these exist at all is that the figures are displayed grouped
+// ("264,750,000 ISK") but a courier contract's fields take bare digits, so the
+// value on screen is not the value you can paste. What lands on the clipboard
+// is therefore the plain number, separators and unit stripped — never what is
+// rendered.
+import { useRef, useState } from 'react'
+
+import styles from './shipping.module.css'
+
+export const CopyValue = ({ value, label }: { value: string; label: string }) => {
+  const [copied, setCopied] = useState(false)
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const onClick = async () => {
+    try {
+      await navigator.clipboard.writeText(value)
+      setCopied(true)
+      if (resetTimer.current) clearTimeout(resetTimer.current)
+      resetTimer.current = setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Denied permissions or an insecure context — say nothing rather than
+      // alerting over a shortcut.
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      className={styles.copyButton}
+      onClick={onClick}
+      title={`Copy ${label}`}
+      aria-label={`Copy ${label}`}
+    >
+      {copied ? '✓' : '📋'}
+    </button>
+  )
+}

--- a/src/app/asset/shipping/loading.tsx
+++ b/src/app/asset/shipping/loading.tsx
@@ -19,6 +19,7 @@ const ShippingLoading = () => (
         <div className={styles.textarea} aria-hidden="true" />
       </div>
       <div className={styles.pane}>
+        <span className={styles.label}>Rates</span>
         <SkeletonLines count={3} />
       </div>
     </div>

--- a/src/app/asset/shipping/shipping.module.css
+++ b/src/app/asset/shipping/shipping.module.css
@@ -183,3 +183,21 @@
   font-weight: 600;
   color: var(--danger);
 }
+
+/* Clipboard button beside a figure or the destination name. Borderless and
+   quiet, matching the mercenary-dens ping button — it sits inside a line of
+   text and must not become the thing the eye lands on. */
+.copyButton {
+  border: none;
+  background: none;
+  padding: 0 2pt;
+  margin-left: 4pt;
+  font-size: 9pt;
+  line-height: 1;
+  cursor: pointer;
+  vertical-align: middle;
+}
+
+.copyButton:hover {
+  opacity: 0.7;
+}

--- a/src/app/asset/shipping/shippingCalculator.tsx
+++ b/src/app/asset/shipping/shippingCalculator.tsx
@@ -96,7 +96,13 @@ export const ShippingCalculator = () => {
           placeholder={'Tritanium\t1,000\nRifter x5\nDamage Control II'}
         />
       </div>
-      <div className={styles.pane}>
+      <div className={styles.pane} aria-labelledby="rates-heading">
+        {/* The counterpart to the textarea's "Items" — it sits outside the
+            Suspense boundary so the column is titled in every state, including
+            while the loader is up. */}
+        <span className={styles.label} id="rates-heading">
+          Rates
+        </span>
         {request == null ? (
           <Placeholder />
         ) : (

--- a/src/app/asset/shipping/shippingResults.tsx
+++ b/src/app/asset/shipping/shippingResults.tsx
@@ -15,14 +15,23 @@ import { use } from 'react'
 import { formatIsk } from '../../isk'
 
 import type { QuotedDirection, ShippingEstimate } from './actions'
+import { CopyValue } from './copyValue'
 import styles from './shipping.module.css'
 
 const formatVolume = (m3: number) => `${m3.toLocaleString('en-US', { maximumFractionDigits: 1 })} m³`
 
-const Figure = ({ label, isk, strong }: { label: string; isk: number; strong?: boolean }) => (
+// `copy` marks the figures that get typed into a courier contract. What is
+// copied is the bare integer — the rendered form carries thousands separators
+// and an "ISK" suffix, neither of which the game's fields want. Rounded UP:
+// both of these are amounts that must not come out short, and a fraction of an
+// ISK cannot be entered anyway.
+const Figure = ({ label, isk, strong, copy }: { label: string; isk: number; strong?: boolean; copy?: string }) => (
   <div className={strong ? `${styles.figure} ${styles.figureStrong}` : styles.figure}>
     <span className={styles.figureLabel}>{label}</span>
-    <span className={styles.figureValue}>{formatIsk(isk)}</span>
+    <span className={styles.figureValue}>
+      {formatIsk(isk)}
+      {copy ? <CopyValue value={String(Math.ceil(isk))} label={copy} /> : null}
+    </span>
   </div>
 )
 
@@ -32,13 +41,18 @@ const DirectionCard = ({ direction }: { direction: QuotedDirection }) => (
     {direction.ok ? (
       <>
         <Figure label="Total cost" isk={direction.totalIsk} strong />
-        <Figure label="Contract reward" isk={direction.rewardIsk} />
+        <Figure label="Contract reward" isk={direction.rewardIsk} copy="contract reward" />
         {direction.rushFeeIsk > 0 ? <Figure label="Rush fee" isk={direction.rushFeeIsk} /> : null}
         <p className={styles.cardNote}>
           {direction.lane} · tier {direction.tier} · {direction.rate}
           {direction.collateralFeePercent > 0 ? ` + ${direction.collateralFeePercent}% collateral` : ''}
         </p>
-        {direction.deliverTo ? <p className={styles.cardNote}>Deliver to {direction.deliverTo}</p> : null}
+        {direction.deliverTo ? (
+          <p className={styles.cardNote}>
+            Deliver to {direction.deliverTo}
+            <CopyValue value={direction.deliverTo} label="destination station" />
+          </p>
+        ) : null}
         {direction.collateralCapExceeded ? (
           <p className={styles.error}>This lane will not insure the full value — the tier has a collateral ceiling.</p>
         ) : null}
@@ -80,7 +94,7 @@ export const ShippingResults = ({ promise }: { promise: Promise<ShippingEstimate
         {/* The recommendation, not just a valuation: this is the number to
             type into the courier contract's collateral field, and every
             freight quote below was priced against it. */}
-        <Figure label="Recommended collateral (Jita sell)" isk={estimate.sellIsk} strong />
+        <Figure label="Recommended collateral (Jita sell)" isk={estimate.sellIsk} strong copy="collateral" />
         <Figure label="Jita buy" isk={estimate.buyIsk} />
         <p className={overCapacity ? styles.cardNoteAlert : styles.cardNote}>
           {formatVolume(estimate.volumeM3)}


### PR DESCRIPTION
Follow-up to #927.

## Copy buttons

A clipboard button beside three values on `/asset/shipping`:

- the **recommended collateral** on the cargo card,
- each lane's **contract reward**,
- the **destination station** name.

Same borderless 📋 → ✓ as `mercenary-dens/copyDiscordPing.tsx`, resetting after 2s, silent when the clipboard is unavailable (denied permission, insecure context) — the value is on screen to select by hand either way, so an alert would be worse than nothing.

**What gets copied is deliberately not what is rendered.** The figures are displayed grouped and suffixed — `264,750,000 ISK` — because that is how a human reads them, but a courier contract's fields take bare digits. The button copies the plain integer, separators and unit stripped. It rounds **up**: both of these are amounts that must not come out short, and a fraction of an ISK can't be entered in the client anyway. (`sellIsk` is already `Math.ceil`'d in the action; the reward is rounded here for the same reason.)

The station name copies verbatim — `C-J6MT - 1st Taj Mahgoon` — which is what you paste into the contract's destination search.

## "Rates" heading

The right column gains a heading matching the textarea's "Items". It sits **outside** the Suspense boundary so the column stays titled in every state — placeholder, loader, and results alike — rather than appearing only once an estimate lands. `loading.tsx` carries it too, so it doesn't show up late on first paint. The pane is `aria-labelledby` it, naming the region whose content swaps.

## Files

| file | |
| --- | --- |
| `src/app/asset/shipping/copyValue.tsx` | new — the clipboard button |
| `src/app/asset/shipping/shippingResults.tsx` | `Figure` takes an optional `copy` label; buttons on collateral, reward, destination |
| `src/app/asset/shipping/shippingCalculator.tsx` | the "Rates" heading + `aria-labelledby` |
| `src/app/asset/shipping/loading.tsx` | same heading in the fallback |
| `src/app/asset/shipping/shipping.module.css` | `.copyButton` |

## Testing

`pnpm test` 421 pass · `pnpm run lint` clean · `pnpm run build` clean, `/asset/shipping` in the route listing.

No new tests: this is presentational, and the one piece of logic worth pinning — that the copied string is the bare rounded-up integer rather than the formatted one — is a single expression with no seam of its own. Worth a click on the preview to confirm the clipboard actually receives `264750000` and not `264,750,000 ISK`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TifVtQZz7F49Xfo8MmcTRb)_