### PR TITLE
Cover page: replace signup copy with a direct Add-a-character CTA

### DIFF
--- a/src/app/home.module.css
+++ b/src/app/home.module.css
@@ -63,6 +63,8 @@
 
 .primary,
 .secondary {
+  font-family: inherit;
+  cursor: pointer;
   padding: 10px 20px;
   border-radius: var(--radius-sm);
   font-size: 13px;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { createClient } from '@/utils/supabase/server'
 
 import { establishedUser } from './account/lib/establishedUser'
+import { register } from './character/actions'
 import styles from './home.module.css'
 
 // The lore is the frame, not the labels. Anything that exists in the EVE client
@@ -105,28 +106,26 @@ const Home = async () => {
           millennium shooting at each other to read one threat picture and trust it. Your eleven alts have the same
           problem. This is their datalink.
         </p>
-        <div className={styles.actions}>
-          {user ? (
-            <>
-              <Link href="/asset" className={styles.primary}>
-                Open your assets
-              </Link>
-              <Link href="/character/" className={styles.secondary}>
-                Add a character
-              </Link>
-            </>
-          ) : (
-            <>
-              <Link href="/account/register" className={styles.primary}>
-                Request access
-              </Link>
-              <Link href="/account/login" className={styles.secondary}>
-                Sign in
-              </Link>
-            </>
-          )}
-        </div>
-        <p className={styles.microcopy}>Invite-only · read-only ESI access · you choose the scopes</p>
+        {user ? (
+          <div className={styles.actions}>
+            <Link href="/asset" className={styles.primary}>
+              Open your assets
+            </Link>
+            <Link href="/character/" className={styles.secondary}>
+              Add a character
+            </Link>
+          </div>
+        ) : (
+          <form className={styles.actions}>
+            <button formAction={register} className={styles.primary}>
+              Add a character
+            </button>
+            <Link href="/account/login" className={styles.secondary}>
+              Sign in
+            </Link>
+          </form>
+        )}
+        <p className={styles.microcopy}>Read-only ESI access · you choose the scopes</p>
       </section>
 
       <section className={styles.stats}>
@@ -208,29 +207,27 @@ const Home = async () => {
         <p className={styles.closingBody}>
           {user
             ? 'You’re already on the net. Review what landed on the last sweep, or grant a scope you left dark when you added a character.'
-            : 'Registration is open, and you’re about a minute from a single picture of everything you own.'}
+            : 'Add a character and you’re about a minute from a single picture of everything you own.'}
         </p>
-        <div className={styles.actions}>
-          {user ? (
-            <>
-              <Link href="/jobs" className={styles.primary}>
-                Review pipeline status
-              </Link>
-              <Link href="/settings/grants" className={styles.secondary}>
-                Manage access grants
-              </Link>
-            </>
-          ) : (
-            <>
-              <Link href="/account/register" className={styles.primary}>
-                Request access
-              </Link>
-              <Link href="/account/login" className={styles.secondary}>
-                Sign in
-              </Link>
-            </>
-          )}
-        </div>
+        {user ? (
+          <div className={styles.actions}>
+            <Link href="/jobs" className={styles.primary}>
+              Review pipeline status
+            </Link>
+            <Link href="/settings/grants" className={styles.secondary}>
+              Manage access grants
+            </Link>
+          </div>
+        ) : (
+          <form className={styles.actions}>
+            <button formAction={register} className={styles.primary}>
+              Add a character
+            </button>
+            <Link href="/account/login" className={styles.secondary}>
+              Sign in
+            </Link>
+          </form>
+        )}
       </section>
     </main>
   )


### PR DESCRIPTION
Removes every trace of "Request access" / invite / registration language from the cover page. A signed-out visitor's path in is now simply **Add a character**:

- Both signed-out CTAs (hero and closing section) are now a form button wired to the existing `register` server action in `src/app/character/actions.ts`, which already mints an anonymous session for a cookie-less caller and redirects straight to EVE SSO (via the grants picker for brand-new players). No detour through `/account/register`.
- "Sign in" stays as the secondary action for returning users.
- Hero microcopy drops "Invite-only": now "Read-only ESI access · you choose the scopes".
- Closing copy no longer says "Registration is open" — it reads "Add a character and you're about a minute from a single picture of everything you own."
- `home.module.css` gives `.primary`/`.secondary` `font-family: inherit` and `cursor: pointer` so the CTA renders identically as a `<button>`.

The `/account/register` and login pages are untouched — email signup remains available as a way in, just no longer the front door.

Verified with `pnpm run lint` and `pnpm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eyg66S8PML8jr8zgwZCwQR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eyg66S8PML8jr8zgwZCwQR)_