### PR TITLE
ci: one-shot workflow to repair the wedged migration history

### DIFF
--- a/.github/workflows/repair-migration-history.yml
+++ b/.github/workflows/repair-migration-history.yml
@@ -1,0 +1,62 @@
+name: Repair migration history
+
+# ONE-SHOT, MANUAL ONLY. Unwedges `supabase db push` after the 20260822120000
+# timestamp collision — see docs/bpo-share-collision.md for the full story.
+#
+# Why a workflow rather than a migration: the collision breaks the CLI's own
+# bookkeeping, so `db push` aborts before it applies anything. No migration file
+# can fix it from the inside; the history table has to be corrected out of band,
+# and this is the only place the credentials for that live.
+#
+# The statement is hardcoded rather than an input, so this can only ever do the
+# one thing it documents, and it is `on conflict do nothing`, so running it
+# twice is a no-op. Delete this workflow once the Migrate run is green again.
+on:
+  workflow_dispatch:
+
+# Share Migrate's concurrency group: repairing the history while a push is
+# reading it is exactly the race worth avoiding.
+concurrency:
+  group: migrate
+  cancel-in-progress: false
+
+jobs:
+  repair:
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+      # The repo's own pinned CLI (a devDependency), not setup-cli's 2.102.0:
+      # `supabase db query` — which runs SQL through the Management API, so it
+      # needs only the access token and no database password — is newer than the
+      # version the Migrate workflow pins.
+      - run: pnpm install --frozen-lockfile
+
+      - name: Link project
+        run: pnpm exec supabase link --project-ref "$SUPABASE_PROJECT_REF"
+
+      - name: Show migration history before
+        run: |
+          pnpm exec supabase db query --linked \
+            "select version, name from supabase_migrations.schema_migrations where version >= '20260819000000' order by version, name;"
+
+      # Records 20260822120000_bpo_share as applied WITHOUT running it. Its DDL
+      # is superseded by 20260823005000_create_bpo_share.sql, which `db push`
+      # applies once this row stops the CLI mismatching the two files that share
+      # version 20260822120000.
+      - name: Record the stranded migration as applied
+        run: |
+          pnpm exec supabase db query --linked \
+            "insert into supabase_migrations.schema_migrations (version, name, statements) values ('20260822120000', 'bpo_share', array[]::text[]) on conflict (version, name) do nothing;"
+
+      - name: Show migration history after
+        run: |
+          pnpm exec supabase db query --linked \
+            "select version, name from supabase_migrations.schema_migrations where version >= '20260819000000' order by version, name;"

--- a/docs/bpo-share-collision.md
+++ b/docs/bpo-share-collision.md
@@ -45,7 +45,18 @@ first.
 
 ## Repair
 
-One statement, run once against production (Supabase SQL editor, or any
+Either route runs the same statement; pick whichever is less friction.
+
+**From CI (no credentials of your own needed).** Actions → *Repair migration
+history* → Run workflow. That one-shot workflow
+(`.github/workflows/repair-migration-history.yml`) runs the statement through
+`supabase db query --linked`, which goes via the Management API and so needs
+only the `SUPABASE_ACCESS_TOKEN` secret the Migrate workflow already uses — no
+database password. It prints the history table before and after. Then re-run
+*Migrate* (it has `workflow_dispatch`). Delete the repair workflow once Migrate
+is green.
+
+**By hand.** One statement against production (Supabase SQL editor, or any
 service-role psql session). It records the stranded file as applied **without
 running it** — its content is superseded by
 `20260823005000_create_bpo_share.sql`, which does the actual DDL:


### PR DESCRIPTION
Gives me a way to run the `bpo_share` repair without you having to open a SQL editor. **Merge this and I'll take it from there** — I'll dispatch the repair, re-run Migrate, and verify the table exists.

## Why this exists

You said I could run the commands directly, so I checked what this environment actually has. It has only the **anon** key — no service key, no `SUPABASE_ACCESS_TOKEN`, no database password. I verified rather than assumed:

```
$ curl .../rest/v1/schema_migrations -H "Accept-Profile: supabase_migrations"
{"code":"PGRST106","message":"Invalid schema: supabase_migrations. Only the following schemas are exposed: public, graphql_public"}
```

So the anon key provably cannot touch the migration history. The same probe does confirm the table is still missing in production, while its siblings are present:

```
$ curl .../rest/v1/bpo_share
{"code":"PGRST205","message":"Could not find the table 'public.bpo_share' in the schema cache"}
$ curl .../rest/v1/character_fitting_share    → 200, rows
```

The credentials that *can* do this already live in this repo's Actions secrets. Hence a workflow.

## Confirmation that #947 alone wasn't enough

The Migrate run after #947 failed exactly as predicted — `create_bpo_share` was queued but never reached, because the entry ahead of it aborts:

```
Do you want to push these migrations to the remote database?
 • 20260822120000_structure_tax_revenue_split_signs.sql
 • 20260823005000_create_bpo_share.sql

Applying migration 20260822120000_structure_tax_revenue_split_signs.sql...
ERROR: duplicate key value violates unique constraint "schema_migrations_pkey"
Key (version, name)=(20260822120000, structure_tax_revenue_split_signs) already exists.
```

No migration file can fix this from the inside — the abort is in the CLI's own bookkeeping insert, before any DDL runs. The history has to be corrected out of band.

## What the workflow does

Records the stranded `20260822120000_bpo_share` as applied **without running it** — its DDL is superseded by `20260823005000_create_bpo_share.sql`, which `db push` then applies once the CLI stops mismatching the two files at that version. It prints the history table before and after.

It runs the statement via `supabase db query --linked`, which goes through the Management API and so needs only `SUPABASE_ACCESS_TOKEN` — a secret Migrate already uses — with no database password. It uses the repo's own pinned CLI rather than setup-cli's 2.102.0, since `db query` is newer than that version.

Safety properties, deliberate:

- **`workflow_dispatch` only** — never fires on push.
- **The statement is hardcoded**, not a workflow input, so it can only ever do the one thing it documents.
- **`on conflict (version, name) do nothing`** — a second run is a no-op.
- **Shares Migrate's concurrency group**, so it cannot race a push.
- **Deletable** — it's a one-shot; remove it once Migrate is green.

## If you'd rather not merge a workflow

The equivalent by hand is still one statement in the Supabase SQL editor, and `docs/bpo-share-collision.md` now documents both routes:

```sql
insert into supabase_migrations.schema_migrations (version, name, statements)
values ('20260822120000', 'bpo_share', array[]::text[])
on conflict (version, name) do nothing;
```

Either way, ping me or just merge — I'll re-dispatch Migrate and confirm `bpo_share` exists.

## Testing

- Workflow file structure checked (no tabs, required keys present); `supabase db query --linked` flags verified against the repo's pinned CLI 2.115.0.
- Production state verified by the two `curl` probes above.
- Not executed: dispatching requires the workflow to exist on the default branch, which is what merging does.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZ97xVxNTvvAeF9d1JsUnv)_