### PR TITLE
feat(graphql): resolve a location by system prefix and structure words

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -4289,6 +4289,11 @@ create index universe_structure_unresolved_at_idx
   on public.universe_structure (unresolved_at)
   where unresolved_at is not null;
 
+-- "Every structure in this system": the GraphQL location filter's name match
+-- (src/app/api/graphql/structureMatch.ts) reads a whole system at a time.
+create index universe_structure_system_id_idx
+  on public.universe_structure (system_id);
+
 alter table public.universe_structure enable row level security;
 -- Readable by any *established* account — a member, not an account still
 -- mid-flow on an anonymous session (see is_established_account() above).

--- a/src/app/api/graphql/locationSearch.ts
+++ b/src/app/api/graphql/locationSearch.ts
@@ -19,6 +19,7 @@ import { searchSdeSystems } from '@/sdeSystems'
 import { escapeLike } from '@/utils/escapeLike'
 import { sdeSupabase } from '@/utils/supabase/sde'
 import type { NamedRef } from './filters'
+import { pickLocation, pickSystem, systemPrefixPattern, tokenize } from './structureMatch'
 
 // Per source. A term matching more than this many places is a term worth
 // narrowing, and the cap keeps one filter from becoming an unbounded `in`.
@@ -26,6 +27,7 @@ const PER_SOURCE = 200
 
 type StructureRow = { structure_id: number | string; name: string | null }
 type StationRow = { station_id: number | string; name: string | null }
+type SystemRow = { system_id: number | string; name: string | null }
 
 const named = (rows: Array<{ id: number | string; name: string | null }>): NamedRef[] =>
   rows.filter((r) => r.name != null).map((r) => ({ id: String(r.id), name: r.name as string }))
@@ -54,4 +56,47 @@ export const searchLocationCandidates = async (term: string, supabase: SupabaseC
   // precedence resolveLocations applies when it renders the same location.
   const byId = new Map(candidates.map((c): [string, NamedRef] => [c.id, c]).reverse())
   return [...byId.values()]
+}
+
+// The fallback the substring search above can't be: "TKD Reactions" is nobody's
+// substring, but it is a system prefix and a word out of a structure's name.
+// Only reached when the plain search found nothing, so this widens what
+// resolves without changing what already did. The rules — and every refusal —
+// live in structureMatch.ts; this is the two queries they need.
+//
+// Same "searching is not reading" caveat as above: it resolves a name to an id
+// the caller then filters their OWN rows by.
+export const resolveLocationByTokens = async (term: string, supabase: SupabaseClient): Promise<NamedRef | null> => {
+  const tokens = tokenize(term)
+  if (tokens.length === 0) return null
+
+  const { data: systemRows } = await sdeSupabase()
+    .from('sde_kspace_system')
+    .select('system_id, name')
+    .ilike('name', systemPrefixPattern(tokens[0]))
+    .limit(PER_SOURCE)
+  const system = pickSystem(
+    tokens[0],
+    named(((systemRows ?? []) as SystemRow[]).map((r) => ({ id: r.system_id, name: r.name })))
+  )
+  if (system.kind !== 'match') return null
+
+  const rest = tokens.slice(1)
+  if (rest.length === 0) return system.ref
+
+  const systemId = Number(system.ref.id)
+  const [corpStructures, cachedStructures, stations] = await Promise.all([
+    supabase.from('corp_structure').select('structure_id, name').eq('system_id', systemId).limit(PER_SOURCE),
+    supabase.from('universe_structure').select('structure_id, name').eq('system_id', systemId).limit(PER_SOURCE),
+    sdeSupabase().from('sde_station').select('station_id, name').eq('system_id', systemId).limit(PER_SOURCE),
+  ])
+  const inSystem = [
+    ...named(((corpStructures.data ?? []) as StructureRow[]).map((r) => ({ id: r.structure_id, name: r.name }))),
+    ...named(((cachedStructures.data ?? []) as StructureRow[]).map((r) => ({ id: r.structure_id, name: r.name }))),
+    ...named(((stations.data ?? []) as StationRow[]).map((r) => ({ id: r.station_id, name: r.name }))),
+  ]
+  // Same de-dupe (and same corp-name-wins precedence) as the search above.
+  const byId = new Map(inSystem.map((c): [string, NamedRef] => [c.id, c]).reverse())
+
+  return pickLocation(rest, system.ref, [...byId.values()])
 }

--- a/src/app/api/graphql/resolvers.ts
+++ b/src/app/api/graphql/resolvers.ts
@@ -21,9 +21,9 @@ import { guessLocationRef, resolveTypeFilter } from '@/app/api/mcp/lib'
 import { resolveLocations, type LocationRef, type ResolvedLocations } from '@/app/resolveLocations'
 import { getSdeTypes, searchSdeTypesAll, type SdeType } from '@/sdeTypes'
 import { clampLimit, matchExactNames, matchOwnerFilter, parseRefFilter, parseSince, splitRefEntries } from './filters'
-import { searchLocationCandidates } from './locationSearch'
+import { resolveLocationByTokens, searchLocationCandidates } from './locationSearch'
 import { resolveTargets, restockLines, type Stack } from './restock'
-import type { OwnerScopes } from './filters'
+import type { NamedRef, OwnerScopes } from './filters'
 import type { GraphqlContext } from './context'
 
 const badRequest = (message: string): never => {
@@ -69,6 +69,9 @@ const typeIdsFor = async (args: {
 // The location dimension → location ids, or null for no filter. `location`
 // searches names (station, structure or system — see locationSearch.ts) and
 // keeps everything it matched; `locations` takes exact ids and whole names.
+// Either way, a term that resolves to nothing gets a second read as a system
+// prefix plus words from a structure's name ("TKD Reactions"), which is how a
+// link ends up filtering by a structure somebody can actually type.
 const locationIdsFor = async (
   ctx: GraphqlContext,
   args: { location?: string | null; locations?: readonly string[] | null }
@@ -79,8 +82,10 @@ const locationIdsFor = async (
   if (query.kind === 'none') return null
   if (query.kind === 'search') {
     const candidates = await searchLocationCandidates(query.term, ctx.supabase)
-    if (candidates.length === 0) return badRequest(`No location matched "${query.term}".`)
-    return candidates.map((c) => c.id)
+    if (candidates.length > 0) return candidates.map((c) => c.id)
+    const guessed = await resolveLocationByTokens(query.term, ctx.supabase)
+    if (guessed === null) return badRequest(`No location matched "${query.term}".`)
+    return [guessed.id]
   }
 
   const { ids, names } = splitRefEntries(query.entries)
@@ -89,10 +94,19 @@ const locationIdsFor = async (
   )
   const byName = new Map(found)
   const matched = matchExactNames(names, (name) => byName.get(name) ?? [])
-  if (matched.unmatched.length > 0) {
-    return badRequest(`No location matched ${matched.unmatched.map((u) => `"${u}"`).join(', ')}.`)
+  // A whole name is what the plural asks for, but "TK-DLH - CUDDLES T2
+  // Composite Reactions" typed from memory is rarely whole. What didn't match
+  // one gets the same system-prefix-plus-tokens read the singular falls back to
+  // (locationSearch.ts), which lands on ONE location or none — so an entry
+  // still either names something or is an error, as the plural promises.
+  const guessed = await Promise.all(
+    matched.unmatched.map(async (name) => [name, await resolveLocationByTokens(name, ctx.supabase)] as const)
+  )
+  const stillUnmatched = guessed.filter(([, ref]) => ref === null).map(([name]) => name)
+  if (stillUnmatched.length > 0) {
+    return badRequest(`No location matched ${stillUnmatched.map((u) => `"${u}"`).join(', ')}.`)
   }
-  return [...new Set([...ids, ...matched.ids])]
+  return [...new Set([...ids, ...matched.ids, ...guessed.map(([, ref]) => (ref as NamedRef).id)])]
 }
 
 // Page a filtered select up to `cap` rows — PostgREST caps a single request at

--- a/src/app/api/graphql/schema.graphql.ts
+++ b/src/app/api/graphql/schema.graphql.ts
@@ -217,6 +217,14 @@ export const typeDefs = /* GraphQL */ `
   that system's rows and a station name that station's. \`locations:\` is an
   exact list of \`locationId\`s and whole names, mixed. Neither widens what you
   can read: a name you don't own resolves to an id none of your rows carry.
+
+  A term that matches nothing that way gets read as a structure the way people
+  say one: the first word is a prefix of the SOLAR SYSTEM, punctuation ignored
+  ("TKD", "TK-D" and "TK-DLH" all reach TK-DLH), and the words after it pick the
+  structure in that system matching the most of them — so \`location: "TKD
+  Reactions T2"\` finds "TK-DLH - CUDDLES T2 Composite Reactions". Ambiguity is
+  refused rather than guessed at, in both halves: a prefix answering to two
+  systems, or two structures matching the same words, matches nothing.
   """
   type Location {
     locationId: String!

--- a/src/app/api/graphql/structureMatch.ts
+++ b/src/app/api/graphql/structureMatch.ts
@@ -1,0 +1,127 @@
+// Pure name matching for the `location:`/`locations:` filters, for the shape a
+// structure name actually has in game: "TK-DLH - CUDDLES T2 Composite
+// Reactions". Nobody types that. They type "TKD Reactions", and a link that
+// only accepts the location id (or the whole name, byte for byte) is a link
+// they have to build from an id they had to look up somewhere else.
+//
+// The rule, in two halves, matching how the name itself is built:
+//
+//   FIRST TOKEN → THE SOLAR SYSTEM. Compared against system names with the
+//   punctuation removed from both sides, so "TKD", "TK-D" and "tkdlh" are the
+//   same question. It is a PREFIX, not a substring: "TK-DLH" starts with
+//   "TKD". Two systems sharing the prefix is a refusal, never a guess — a
+//   filter that quietly picks one of two systems is worse than one that says
+//   it doesn't know. A prefix matching NOTHING is shortened a character at a
+//   time (down to MIN_SYSTEM_PREFIX) until exactly one system answers, which
+//   is what quietly corrects a typo in the tail: "TK-DLS" → "TKDL" → TK-DLH.
+//
+//   THE REST → WHICH STRUCTURE IN IT. Split on spaces, and the structure
+//   matching the most of those tokens wins. That makes the full name work
+//   ("TK-DLH - CUDDLES T2 Composite Reactions" scores every token), a suffix
+//   work ("TKD Reactions"), and a couple of words scattered through the name
+//   work too ("TKD Reactions T2" beats the Reprocessing tower next door). A
+//   tie is a refusal for the same reason an ambiguous system is.
+//
+// No I/O — the candidate rows are fetched by locationSearch.ts. Tested in
+// test/graphqlStructureMatch.test.ts.
+import { descend, head, sortWith, splitEvery } from 'ramda'
+
+export type NamedRef = { id: string; name: string }
+
+// Both sides of every comparison. EVE writes system names with a hyphen
+// ("TK-DLH") and structure names with spaces and punctuation around them;
+// neither is something a person retypes reliably, and none of it carries
+// meaning we'd want to match on.
+export const normalizeIdent = (s: string): string => s.toUpperCase().replace(/[^A-Z0-9]/g, '')
+
+// Split on whitespace, dropping anything that normalizes away — the lone "-"
+// in "TK-DLH - CUDDLES" is punctuation, not a token to score.
+export const tokenize = (term: string): string[] => term.split(/\s+/).filter((t) => normalizeIdent(t) !== '')
+
+// Below this, a prefix stops being a name and starts being a letter. It bounds
+// the typo correction (how far the first token may be shortened) and the
+// candidate query (how much of it reaches the database).
+export const MIN_SYSTEM_PREFIX = 3
+
+// The `ilike` pattern that fetches the system candidates: the first
+// MIN_SYSTEM_PREFIX characters with a `%` after each, anchored at the start.
+// "TKD" → "T%K%D%", which is every system whose name begins with those three
+// characters in order however it punctuates them ("TK-DLH", "TKD-2N") — a
+// superset of the real answer, narrowed exactly by pickSystem below. Deliberately
+// a superset: the database can't see through the hyphen, so JS does.
+export const systemPrefixPattern = (token: string): string =>
+  splitEvery(1, normalizeIdent(token).slice(0, MIN_SYSTEM_PREFIX))
+    .map((c) => `${c}%`)
+    .join('')
+
+export type SystemPick =
+  | { kind: 'match'; ref: NamedRef }
+  // Several systems answer to the prefix — say so rather than picking one.
+  | { kind: 'ambiguous'; names: string[] }
+  | { kind: 'none' }
+
+const startingWith = (candidates: readonly NamedRef[], prefix: string): NamedRef[] =>
+  candidates.filter((c) => normalizeIdent(c.name).startsWith(prefix))
+
+// The first token against the systems the pattern turned up. Shortening on a
+// miss is the whole typo story: every shorter prefix is still a prefix of the
+// same names, so the candidate set never needs re-fetching.
+export const pickSystem = (token: string, candidates: readonly NamedRef[]): SystemPick => {
+  const wanted = normalizeIdent(token)
+  const at = (length: number): SystemPick => {
+    if (length < MIN_SYSTEM_PREFIX || length > wanted.length) return { kind: 'none' }
+    const hits = startingWith(candidates, wanted.slice(0, length))
+    if (hits.length === 1) return { kind: 'match', ref: hits[0] }
+    if (hits.length > 1) return { kind: 'ambiguous', names: hits.map((h) => h.name) }
+    return at(length - 1)
+  }
+  return at(wanted.length)
+}
+
+// How many of the query's tokens this name accounts for. A token counts once,
+// against any word of the name it starts — a prefix so "Compo" finds
+// "Composite", counted once so repeating a word can't inflate a score.
+export const scoreName = (tokens: readonly string[], name: string): number => {
+  const words = tokenize(name).map(normalizeIdent)
+  return tokens.filter((t) => {
+    const wanted = normalizeIdent(t)
+    return words.some((w) => w.startsWith(wanted))
+  }).length
+}
+
+export type StructurePick =
+  | { kind: 'match'; ref: NamedRef }
+  // Two structures account for the same tokens; the caller has to say more.
+  | { kind: 'ambiguous'; names: string[] }
+  | { kind: 'none' }
+
+// The best-scoring structure in the system, or a refusal. Ordered by score and
+// then by name so the tie check reads the same rows in the same order every
+// run — an ambiguity that resolved differently per request would be worse than
+// either answer.
+export const pickStructure = (tokens: readonly string[], candidates: readonly NamedRef[]): StructurePick => {
+  if (tokens.length === 0 || candidates.length === 0) return { kind: 'none' }
+  const scored = candidates.map((ref) => ({ ref, score: scoreName(tokens, ref.name) })).filter((s) => s.score > 0)
+  const ranked = sortWith<{ ref: NamedRef; score: number }>(
+    [descend((s) => s.score), (a, b) => a.ref.name.localeCompare(b.ref.name)],
+    scored
+  )
+  const best = head(ranked)
+  if (best === undefined) return { kind: 'none' }
+  const tied = ranked.filter((s) => s.score === best.score)
+  if (tied.length > 1) return { kind: 'ambiguous', names: tied.map((s) => s.ref.name) }
+  return { kind: 'match', ref: best.ref }
+}
+
+// The whole term, given what the two halves turned up: the structure when the
+// tokens after the system name single one out, and the system itself when
+// there are none (a bare "TKD" is a question about the system).
+export const pickLocation = (
+  rest: readonly string[],
+  system: NamedRef,
+  structures: readonly NamedRef[]
+): NamedRef | null => {
+  if (rest.length === 0) return system
+  const picked = pickStructure(rest, structures)
+  return picked.kind === 'match' ? picked.ref : null
+}

--- a/supabase/migrations/20260823061056_universe_structure_system_id_idx.sql
+++ b/supabase/migrations/20260823061056_universe_structure_system_id_idx.sql
@@ -1,0 +1,7 @@
+-- The GraphQL location filter now resolves a structure by system prefix plus
+-- words from its name ("TKD Reactions"), which asks universe_structure for
+-- every structure in ONE system — a predicate the table had no index for, and
+-- it holds every player structure we have ever resolved. corp_structure is
+-- small enough not to care; this one isn't.
+create index if not exists universe_structure_system_id_idx
+  on public.universe_structure (system_id);

--- a/test/graphqlStructureMatch.test.ts
+++ b/test/graphqlStructureMatch.test.ts
@@ -1,0 +1,114 @@
+// Unit coverage for the location filter's name matching
+// (src/app/api/graphql/structureMatch.ts): the shape a structure name has in
+// game against the shape a person types. The refusals matter as much as the
+// matches — an ambiguous system or a tie between two structures must resolve to
+// nothing rather than to a guess, since the answer becomes a saved link.
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  MIN_SYSTEM_PREFIX,
+  normalizeIdent,
+  pickLocation,
+  pickStructure,
+  pickSystem,
+  scoreName,
+  systemPrefixPattern,
+  tokenize,
+} from '../src/app/api/graphql/structureMatch.ts'
+
+const TKDLH = { id: '30000001', name: 'TK-DLH' }
+const TKDAB = { id: '30000002', name: 'TK-DAB' }
+const JITA = { id: '30000142', name: 'Jita' }
+
+const REACTIONS = { id: '1000000000001', name: 'TK-DLH - CUDDLES T2 Composite Reactions' }
+const REPROCESSING = { id: '1000000000002', name: 'TK-DLH - CUDDLES T2 Reprocessing' }
+
+test('normalizeIdent drops the punctuation neither side types reliably', () => {
+  assert.equal(normalizeIdent('TK-DLH'), 'TKDLH')
+  assert.equal(normalizeIdent('tk d lh'), 'TKDLH')
+  assert.equal(normalizeIdent('-'), '')
+})
+
+test('tokenize splits on spaces and drops punctuation-only tokens', () => {
+  assert.deepEqual(tokenize('TK-DLH - CUDDLES T2 Composite Reactions'), [
+    'TK-DLH',
+    'CUDDLES',
+    'T2',
+    'Composite',
+    'Reactions',
+  ])
+  assert.deepEqual(tokenize('   '), [])
+})
+
+test('systemPrefixPattern asks the database for a superset, punctuation-blind', () => {
+  assert.equal(systemPrefixPattern('TKD'), 'T%K%D%')
+  assert.equal(systemPrefixPattern('TK-DLH'), 'T%K%D%')
+  assert.equal(systemPrefixPattern('Ji'), 'J%I%')
+})
+
+test('pickSystem matches a prefix, hyphen or not', () => {
+  assert.deepEqual(pickSystem('TKD', [TKDLH]), { kind: 'match', ref: TKDLH })
+  assert.deepEqual(pickSystem('TK-D', [TKDLH]), { kind: 'match', ref: TKDLH })
+  assert.deepEqual(pickSystem('tkdlh', [TKDLH]), { kind: 'match', ref: TKDLH })
+  assert.deepEqual(pickSystem('Jita', [JITA]), { kind: 'match', ref: JITA })
+})
+
+test('pickSystem refuses when two systems share the prefix', () => {
+  assert.deepEqual(pickSystem('TKD', [TKDLH, TKDAB]), { kind: 'ambiguous', names: ['TK-DLH', 'TK-DAB'] })
+})
+
+test('pickSystem quietly corrects a wrong tail by shortening the prefix', () => {
+  // TKDLS matches nothing; TKDL matches TK-DLH alone.
+  assert.deepEqual(pickSystem('TK-DLS', [TKDLH]), { kind: 'match', ref: TKDLH })
+  // ...but only while the shortened prefix still names one system.
+  assert.deepEqual(pickSystem('TK-DLS', [TKDLH, { id: '3', name: 'TK-DLQ' }]), {
+    kind: 'ambiguous',
+    names: ['TK-DLH', 'TK-DLQ'],
+  })
+})
+
+test('pickSystem stops shortening at MIN_SYSTEM_PREFIX', () => {
+  assert.equal(MIN_SYSTEM_PREFIX, 3)
+  // "TZ" is nobody's prefix here and there's nothing left to shorten to.
+  assert.deepEqual(pickSystem('TZ', [TKDLH]), { kind: 'none' })
+  assert.deepEqual(pickSystem('QQQZZ', [TKDLH]), { kind: 'none' })
+})
+
+test('scoreName counts each query token once, by word prefix', () => {
+  assert.equal(scoreName(['Reactions'], REACTIONS.name), 1)
+  assert.equal(scoreName(['Reactions', 'T2'], REACTIONS.name), 2)
+  assert.equal(scoreName(['Compo'], REACTIONS.name), 1)
+  assert.equal(scoreName(['CUDDLES', 'CUDDLES'], REACTIONS.name), 2)
+  assert.equal(scoreName(['Refinery'], REACTIONS.name), 0)
+})
+
+test('pickStructure takes the structure matching the most tokens', () => {
+  const structures = [REACTIONS, REPROCESSING]
+  assert.deepEqual(pickStructure(['Reactions'], structures), { kind: 'match', ref: REACTIONS })
+  assert.deepEqual(pickStructure(['Reactions', 'T2'], structures), { kind: 'match', ref: REACTIONS })
+  assert.deepEqual(pickStructure(['Reprocessing'], structures), { kind: 'match', ref: REPROCESSING })
+})
+
+test('pickStructure scores the whole name a person pasted', () => {
+  assert.deepEqual(pickStructure(tokenize('- CUDDLES T2 Composite Reactions'), [REACTIONS, REPROCESSING]), {
+    kind: 'match',
+    ref: REACTIONS,
+  })
+})
+
+test('pickStructure refuses a tie and refuses matching nothing', () => {
+  // Both structures account for CUDDLES and T2 and nothing else.
+  assert.deepEqual(pickStructure(['CUDDLES', 'T2'], [REACTIONS, REPROCESSING]), {
+    kind: 'ambiguous',
+    names: [REACTIONS.name, REPROCESSING.name],
+  })
+  assert.deepEqual(pickStructure(['Refinery'], [REACTIONS, REPROCESSING]), { kind: 'none' })
+  assert.deepEqual(pickStructure([], [REACTIONS]), { kind: 'none' })
+})
+
+test('pickLocation falls back to the system when no tokens follow it', () => {
+  assert.deepEqual(pickLocation([], TKDLH, [REACTIONS]), TKDLH)
+  assert.deepEqual(pickLocation(['Reactions'], TKDLH, [REACTIONS, REPROCESSING]), REACTIONS)
+  assert.equal(pickLocation(['Refinery'], TKDLH, [REACTIONS, REPROCESSING]), null)
+})


### PR DESCRIPTION
A link built against a structure had to carry its location id, because the only names the location filter accepted were substrings of the whole in-game name — `TK-DLH - CUDDLES T2 Composite Reactions`, byte for byte, or nothing.

Both `location:` and `locations:` now fall back to reading a term the way somebody says a structure out loud.

**The first token is the solar system**, as a prefix with punctuation ignored on both sides — `TKD`, `TK-D` and `tk-dlh` are the same question, and all three reach `TK-DLH`. A prefix that matches nothing is shortened one character at a time (down to three) until exactly one system answers, which is what quietly corrects a wrong tail: `TK-DLS` → `TKDL` → TK-DLH.

**The tokens after it pick the structure**, scored against every structure we know about in that system: a token counts once, against any word of the name it prefixes. That makes the whole pasted name work, a suffix work (`TKD Reactions`), and a couple of scattered words work — `TKD Reactions T2` lands on `TK-DLH - CUDDLES T2 Composite Reactions` rather than the Reprocessing tower next door.

**Ambiguity is refused, never guessed at**, in both halves: two systems sharing the prefix, or two structures accounting for the same tokens, resolve to nothing. The answer here becomes a saved link, so picking one of two would be wrong for a year rather than for a request.

This is only reached when the existing substring search found nothing, so nothing that resolved before resolves differently — it widens what a link can be built from without moving anything that already works. Searching is still not reading: it resolves a name to an id the caller then filters their own rows by, and the resolvers' `registration_id` leak guard is untouched.

## Layout

- `src/app/api/graphql/structureMatch.ts` — new, pure: normalization, tokenizing, the system prefix rule (including the candidate `ilike` pattern the database gets, a deliberate superset that JS narrows), and the token scoring.
- `src/app/api/graphql/locationSearch.ts` — `resolveLocationByTokens`, the two queries the rules need (systems by pattern; then structures, cached structures and NPC stations in the one system).
- `src/app/api/graphql/resolvers.ts` — the fallback, on both the singular search and the plural exact list. A plural entry still either names something or is an error.
- `supabase/migrations/20260823061056_universe_structure_system_id_idx.sql` + `schema.sql` — "every structure in this system" is a new predicate against a table holding every structure we've ever resolved, so it gets an index.
- SDL docs updated, since `link_schema` and the editor read them.

## Testing

- `pnpm test` — 526 pass, including the new `test/graphqlStructureMatch.test.ts` (matches and, as much, the refusals).
- `pnpm run lint`, `pnpm run build` clean.
- The DB-touching half (`resolveLocationByTokens`) is I/O like the rest of the resolvers and isn't unit-tested; worth trying `location: "TKD Reactions"` against a real link before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZ377vMwSDLYYEdnwVMZif

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZ377vMwSDLYYEdnwVMZif)_