### PR TITLE
ci(renovate): wait out pnpm's release-age policy before opening a branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,13 +3,16 @@
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "description": [
     "Automerge relies on GitHub's native auto-merge (Settings -> General -> Pull Requests -> Allow auto-merge). Without it Renovate can only merge during its own hourly run, and the PR has to be green at that exact moment.",
-    "rebaseWhen=conflicted keeps that window open: main moves several times a day, and rebasing an open PR every time restarts its Vercel deploy, so the branch is rarely green when Renovate looks. Nothing here requires a PR to be up to date with main, so merging slightly behind is fine."
+    "rebaseWhen=conflicted keeps that window open: main moves several times a day, and rebasing an open PR every time restarts its Vercel deploy, so the branch is rarely green when Renovate looks. Nothing here requires a PR to be up to date with main, so merging slightly behind is fine.",
+    "minimumReleaseAge holds a branch back until the release is old enough for pnpm's supply-chain policy to accept it. pnpm 11 refuses a lockfile entry published within the last 24h (ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION), which is what sank #938: Renovate wrote a perfectly correct lockfile for next@16.3.2 about sixteen hours after it was published, and `pnpm install --frozen-lockfile` rejected it in CI. Three days rather than the bare 24h so the margin survives clock skew and Renovate's hourly granularity, and so a package yanked shortly after release never reaches a branch here. Renovate's default internalChecksFilter of strict already holds a whole group back until every update in it has aged out, so nothing slips through a grouped PR.",
+    "This cannot cover a transitive version that lockFileMaintenance or pnpmDedupe pulls in fresh — Renovate ages the dependency it is updating, not the whole resolution. Such a PR fails the same check and simply does not automerge; rerunning it once the release ages out is enough."
   ],
   "schedule": ["every weekend"],
   "semanticCommits": "enabled",
   "dependencyDashboard": true,
   "dependencyDashboardTitle": "Independency Dashboard",
   "transitiveRemediation": true,
+  "minimumReleaseAge": "3 days",
   "labels": ["dependencies"],
   "prConcurrentLimit": 10,
   "platformAutomerge": true,


### PR DESCRIPTION
#938 did not fail for want of a lockfile update — Renovate wrote one, and it was correct. It failed pnpm 11's supply-chain policy, which checks *every* entry in `pnpm-lock.yaml`, not just the one that changed:

```
✗ Lockfile failed supply-chain policy check (683 entries in 6.1s)
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 10 lockfile entries failed verification:
  next@16.3.2 was published at 2026-08-21T09:38:38.000Z, within the minimumReleaseAge cutoff (2026-08-21T02:03:18.042Z)
  … and the nine @next/* platform packages
```

The cutoff sits exactly 24h before the run — pnpm's default. Renovate opened the branch about sixteen hours after `next@16.3.2` was published, so `pnpm install --frozen-lockfile` refused it and the `unit` job went red before reaching lint or the tests.

## Change

Set `minimumReleaseAge: "3 days"` in `.github/renovate.json`, so a branch is not created until the release is old enough for the policy to accept it. Three days rather than the bare one leaves margin for clock skew and Renovate's hourly granularity, and keeps a package yanked shortly after release from ever reaching a branch here. Grouped updates need nothing extra: Renovate's default `internalChecksFilter` of `strict` holds a whole group back until every member has aged out.

The `description` array records the reasoning, in keeping with the rest of the file.

## Limits

This ages the dependency Renovate is updating, not the whole resolution — a transitive version that `lockFileMaintenance` or the `pnpmDedupe` post-update pulls in fresh can still trip the same check. Such a PR fails CI and simply does not automerge; re-running it once the release ages out is enough. No Renovate option covers that case.

## Verification

- `renovate-config-validator .github/renovate.json` → `INFO: Config validated successfully`
- `minimumReleaseAge` confirmed against `renovate-schema.json` (`type: ["string","null"]`, duration strings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WMQ2ta94JjQ82sxgJSJpnT


---
_Generated by [Claude Code](https://claude.ai/code/session_01WMQ2ta94JjQ82sxgJSJpnT)_