### PR TITLE
perf(assets): cache the location summary until the extract moves

### DIFF
--- a/src/app/asset/locationSummary.ts
+++ b/src/app/asset/locationSummary.ts
@@ -1,0 +1,113 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { unstable_cache } from 'next/cache'
+import { map } from 'ramda'
+
+// Bigint ids arrive from PostgREST as strings, so every id is kept as a string
+// and only converted to a number at the API/system-lookup boundary.
+type CharacterSummaryRow = {
+  location_id: number | string
+  location_type: string | null
+  registration_id: string
+  stacks: number | string
+}
+
+type CorpSummaryRow = {
+  location_id: number | string
+  location_type: string | null
+  corporation_id: number | string
+  stacks: number | string
+}
+
+// A summary row from either source, keyed by whoever owns the stacks: a
+// character (registration uuid) or a corporation (EVE corporation id).
+export type SummaryRow = {
+  location_id: number | string
+  location_type: string | null
+  owner_id: string
+  stacks: number | string
+}
+
+// The two extract jobs whose completion can move an asset's location bucket.
+const ASSET_JOBS = ['character-assets', 'corp-assets']
+
+// A stamp that changes exactly when the caller's asset data can have changed:
+// the most recent completion of either asset extract they can see. `ended_at`
+// only ever moves forward, so the max across both jobs is enough — there is no
+// need to track the two separately. RLS scopes the read the same way it scopes
+// the assets themselves (own character rows, plus corp rows for corps we have a
+// registered character in), so a corp extract another member's account
+// triggered still moves our stamp. Indexed by heartbeat_job_ended_at_idx.
+export const assetExtractStamp = async (supabase: SupabaseClient): Promise<string> => {
+  const { data } = await supabase
+    .from('heartbeat')
+    .select('ended_at')
+    .in('job', ASSET_JOBS)
+    .not('ended_at', 'is', null)
+    .order('ended_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  return data?.ended_at ?? 'never'
+}
+
+// character_asset_location_summary() and corp_asset_location_summary() walk
+// *every* current asset up its container chain to bucket it by location —
+// ~600ms and ~130ms on production (see the header of migration
+// 20260807010000_asset_location_summary_scope.sql). They were being paid on
+// every render, to produce ~1.5k rows from data that only changes when the
+// 6-hourly extract runs.
+//
+// So key the result on the caller plus that extract's completion stamp and put
+// it in the data cache. A new stamp is a new key, which is what makes this
+// safe: nothing is ever served across an extract, including an on-demand
+// "Refresh ESI" (the dispatched job writes a heartbeat when it finishes, after
+// its reconcile has landed). `revalidate` is only the backstop for a key that
+// somehow stops moving; an hour is far inside the 6-hour cadence.
+//
+// The user id is in the key because these rows are RLS-scoped to the caller and
+// the data cache is not — two accounts must never share an entry.
+//
+// This is the cheap half of the fix. The real one is to stop recomputing the
+// walk per request at all (a rollup table maintained by the extract job), which
+// would also help /asset/[locationId] and the MCP browse_assets tool; this
+// helps only what renders through here.
+const CACHE_TTL_SECONDS = 3600
+
+export const fetchLocationSummary = async (
+  supabase: SupabaseClient,
+  userId: string,
+  stamp: string
+): Promise<SummaryRow[]> => {
+  const load = unstable_cache(
+    async (): Promise<SummaryRow[]> => {
+      const [{ data: characterSummary, error: characterError }, { data: corpSummary, error: corpError }] =
+        await Promise.all([
+          supabase.rpc('character_asset_location_summary'),
+          supabase.rpc('corp_asset_location_summary'),
+        ])
+      // Throw rather than fall back to empty: an empty result is indistinguishable
+      // from "you own nothing", and caching that for an hour would turn a blip
+      // into an hour of a blank asset page. A rejected callback is not cached.
+      if (characterError) throw characterError
+      if (corpError) throw corpError
+      return [
+        ...map(
+          (row: CharacterSummaryRow): SummaryRow => ({ ...row, owner_id: row.registration_id }),
+          (characterSummary ?? []) as CharacterSummaryRow[]
+        ),
+        ...map(
+          (row: CorpSummaryRow): SummaryRow => ({ ...row, owner_id: String(row.corporation_id) }),
+          (corpSummary ?? []) as CorpSummaryRow[]
+        ),
+      ]
+    },
+    ['asset-location-summary', userId, stamp],
+    { revalidate: CACHE_TTL_SECONDS }
+  )
+
+  // The page rendered an empty table when these RPCs failed; keep that, but
+  // decide it out here so the failure never reaches the cache.
+  return load().catch((error) => {
+    console.error(`[asset] location summary failed: ${error?.message ?? error}`)
+    return []
+  })
+}

--- a/src/app/asset/page.tsx
+++ b/src/app/asset/page.tsx
@@ -1,3 +1,4 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import { map, reduce } from 'ramda'
@@ -11,31 +12,7 @@ import { resolveLocations, type LocationRef } from '../resolveLocations'
 import { AssetSearchForm } from './assetSearchForm'
 import styles from './assets.module.css'
 import { AssetsTable, type Location } from './assetsTable'
-
-// Bigint ids arrive from PostgREST as strings, so every id is kept as a string
-// and only converted to a number at the API/system-lookup boundary.
-type CharacterSummaryRow = {
-  location_id: number | string
-  location_type: string | null
-  registration_id: string
-  stacks: number | string
-}
-
-type CorpSummaryRow = {
-  location_id: number | string
-  location_type: string | null
-  corporation_id: number | string
-  stacks: number | string
-}
-
-// A summary row from either source, keyed by whoever owns the stacks: a
-// character (registration uuid) or a corporation (EVE corporation id).
-type SummaryRow = {
-  location_id: number | string
-  location_type: string | null
-  owner_id: string
-  stacks: number | string
-}
+import { assetExtractStamp, fetchLocationSummary } from './locationSummary'
 
 const AssetsPage = async () => {
   const supabase = await createClient()
@@ -49,55 +26,48 @@ const AssetsPage = async () => {
   // a name-resolution pass), so the wait is covered by ./loading.tsx — which
   // paints the instant the link is clicked, rather than only once the server
   // has started responding, as an in-page Suspense fallback did.
-  return <Locations />
+  //
+  // The client is handed down rather than made again so the summary's cache
+  // lookup runs against one whose session is already resolved in memory.
+  return <Locations supabase={supabase} userId={user.id} />
 }
 export default AssetsPage
 
-const Locations = async () => {
-  const supabase = await createClient()
-
+const Locations = async ({ supabase, userId }: { supabase: SupabaseClient; userId: string }) => {
   // A hangar can hold tens of thousands of nested items; paging them all into
   // Node and walking the location_id chains here timed the page out. The
   // *_asset_location_summary() functions do the walk in Postgres and return one
   // small row per location/owner pair instead (RLS still scopes character rows
   // to us and corp rows to corps we have a registered character in). The
   // "last refreshed" heartbeat doesn't depend on any of this, so it's fetched
-  // in the same batch instead of after everything else resolves.
-  const [{ data: characterSummary }, { data: corpSummary }, owners, { data: lastRun }, { data: mainCharacter }] =
-    await Promise.all([
-      supabase.rpc('character_asset_location_summary'),
-      supabase.rpc('corp_asset_location_summary'),
-      fetchOwners(),
-      supabase
-        .from('heartbeat')
-        .select('ended_at, run_url')
-        .eq('job', 'character-assets')
-        .not('ended_at', 'is', null)
-        .order('ended_at', { ascending: false })
-        .limit(1)
-        .maybeSingle(),
-      // The corpses share page is keyed on a character id; link the signed-in
-      // user to their own (their main character's), like the header used to.
-      supabase
-        .from('registration')
-        .select('character_id')
-        .order('is_main', { ascending: false })
-        .order('created_at', { ascending: true })
-        .limit(1)
-        .maybeSingle(),
-    ])
+  // in the same batch instead of after everything else resolves — alongside the
+  // cache stamp the summary itself is keyed on.
+  const [stamp, owners, { data: lastRun }, { data: mainCharacter }] = await Promise.all([
+    assetExtractStamp(supabase),
+    fetchOwners(),
+    supabase
+      .from('heartbeat')
+      .select('ended_at, run_url')
+      .eq('job', 'character-assets')
+      .not('ended_at', 'is', null)
+      .order('ended_at', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    // The corpses share page is keyed on a character id; link the signed-in
+    // user to their own (their main character's), like the header used to.
+    supabase
+      .from('registration')
+      .select('character_id')
+      .order('is_main', { ascending: false })
+      .order('created_at', { ascending: true })
+      .limit(1)
+      .maybeSingle(),
+  ])
   const mainCharacterId = mainCharacter?.character_id ?? null
 
-  const summary: SummaryRow[] = [
-    ...map(
-      (row: CharacterSummaryRow): SummaryRow => ({ ...row, owner_id: row.registration_id }),
-      (characterSummary ?? []) as CharacterSummaryRow[]
-    ),
-    ...map(
-      (row: CorpSummaryRow): SummaryRow => ({ ...row, owner_id: String(row.corporation_id) }),
-      (corpSummary ?? []) as CorpSummaryRow[]
-    ),
-  ]
+  // Served from the data cache unless an asset extract has completed since the
+  // last render; only then is the whole-hangar walk paid for again.
+  const summary = await fetchLocationSummary(supabase, userId, stamp)
 
   // Tally stacks per location, split by the owner (character or corporation)
   // of each stack so the client can filter by owner.


### PR DESCRIPTION
`/asset` blocked on `character_asset_location_summary()` and `corp_asset_location_summary()` on every render — ~600 ms and ~130 ms on production, walking every current asset up its container chain to produce ~1.5k rows from data that only changes when the 6-hourly extract runs.

## What changed

New `src/app/asset/locationSummary.ts`:

- `assetExtractStamp(supabase)` — the most recent completed heartbeat across `character-assets` and `corp-assets` that the caller can see. `ended_at` only moves forward, so one max across both jobs is enough to notice either finishing; it's an index scan on `heartbeat_job_ended_at_idx`, and RLS scopes it the same way it scopes the assets (own characters, plus corps we have a registered character in — so an extract another member's account triggered still moves our stamp).
- `fetchLocationSummary(supabase, userId, stamp)` — the two RPCs behind `unstable_cache`, keyed on `['asset-location-summary', userId, stamp]` with a 1-hour `revalidate` backstop.

`src/app/asset/page.tsx` fetches the stamp in the batch it already used for the "last refreshed" heartbeat, then reads the summary through the cache. The client and user id are handed down from `AssetsPage` instead of the client being created a second time, so the cached callback runs against one whose session is already resolved.

## Why it's safe to cache

A new stamp is a new key, so nothing is ever served across an extract — including an on-demand "Refresh ESI", since the dispatched job writes its heartbeat only after its reconcile lands. `revalidate` is just the backstop for a key that somehow stops moving, and an hour sits well inside the 6-hour cadence. The user id is in the key because these rows are RLS-scoped and the data cache is not.

The displayed "Assets last refreshed" line is deliberately left uncached, so the freshness indicator can't sit behind the counts.

## Behaviour change on failure

An RPC error now throws inside the cached callback and is caught outside it. The page still renders an empty table, as before, but a transient failure can never be cached — an empty result is indistinguishable from "you own nothing", and an hour of that would be worse than the blip.

## Scope

This is the cheap half. The real fix is to stop recomputing the walk per request at all — a rollup table maintained by the extract job, as the header of `20260807010000_asset_location_summary_scope.sql` already prescribes — which would also cover `/asset/[locationId]`'s system section and the MCP `browse_assets` tool. This helps only what renders through the index page.

## Testing

- `pnpm run lint` clean
- `pnpm run build` succeeds
- `pnpm test` — 514 pass, 0 fail

No migration, no schema change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGhRhskJzyQrvRsiAPLBej)_