### PR TITLE
docs: phase plan for merging /character and /jobs into /registration

### DIFF
--- a/docs/registrations-page/00-design-import.md
+++ b/docs/registrations-page/00-design-import.md
@@ -1,0 +1,63 @@
+# Phase 0 — import the design mockup
+
+## Status: blocked on a user action
+
+The source of truth for the page's layout is the Claude Design project
+
+    https://claude.ai/design/p/de18d8e9-89f2-4cbd-bf90-48d4454a18d1?file=Registrations+v2.dc.html
+
+The remote session that wrote this plan could not read it: the claude_design
+MCP authenticates via `/design-login`, which needs an interactive terminal,
+and the URL itself 403s unauthenticated. **The user needs to get the files
+into reach** — either Claude Design's *"Send to Claude Code Web"* (seeds the
+project into the workspace), or exporting/pasting the files, or running the
+import from an interactive session that can `/design-login`.
+
+## Files to import
+
+From the design project (the whole project is readable; these are the ones
+that matter):
+
+- `Registrations v2.dc.html` — the artboard being implemented
+- `_ds/edencom-link-design-80a92c6f-29aa-4e04-8f29-c0c9bc110814/_ds_bundle.js`
+- `_ds/edencom-link-design-80a92c6f-29aa-4e04-8f29-c0c9bc110814/fonts/fonts.css`
+- `_ds/edencom-link-design-80a92c6f-29aa-4e04-8f29-c0c9bc110814/styles.css`
+- `_ds/edencom-link-design-80a92c6f-29aa-4e04-8f29-c0c9bc110814/tokens/colors.css`
+- `_ds/edencom-link-design-80a92c6f-29aa-4e04-8f29-c0c9bc110814/tokens/interactions.css`
+- `ios-frame.jsx`
+- `support.js`
+
+Commit them verbatim under `docs/registrations-page/design/` (flatten the
+`_ds/...` hash directory to `design/_ds/`). They are reference material, not
+shipped code — nothing imports them at runtime.
+
+## Deliverable: the extraction
+
+With the files in hand, write `docs/registrations-page/00a-design-extraction.md`
+recording, so later phases never need to re-open the HTML:
+
+1. **Page structure** — the section order and hierarchy of the artboard
+   (where the character cards sit relative to the job tables; what is a card,
+   a table, a collapsible; what the `<h1>`/section headings say).
+2. **Per-character card contents** — which of the `/character` tile fields the
+   mockup shows, where, and what it *adds* (freshness? per-character refresh?).
+   Any old-page field the mockup omits goes in a "parity gaps" list for the
+   user to rule on (constraint: parity wins by default).
+3. **Jobs presentation** — how the mockup renders the three job sections and
+   recent activity, vs. today's tables.
+4. **Token mapping** — each `tokens/colors.css` / `styles.css` value mapped to
+   the existing custom properties in `src/app/globals.css` (`--serif`,
+   `--sans`, `--mono`, and the color tokens). The implementation uses the
+   app's tokens, not the design bundle's; net-new tokens are added to
+   `globals.css` with a comment naming this design as their origin.
+   Remember the house typography rule: one face per heading, whole heading.
+5. **Interactions** — anything `interactions.css` / `support.js` imply
+   (hover, expand/collapse, transitions) worth carrying over. `ios-frame.jsx`
+   is the mockup's device frame — presentation chrome only, never implemented.
+6. **Responsive intent** — the artboard is one viewport; note what should
+   stack/collapse at narrow widths, since the real page must work on mobile.
+
+The extraction doc is what phases 2–4 build from. If the design cannot be
+obtained, phases 2–4 fall back to composing the existing `/character` and
+`/jobs` markup under the new route with only layout-level changes — parity is
+already guaranteed either way; only the visual ambition changes.

--- a/docs/registrations-page/01-shared-data-seams.md
+++ b/docs/registrations-page/01-shared-data-seams.md
@@ -1,0 +1,99 @@
+# Phase 1 — extract the data seams (pure refactor, zero behavior change)
+
+Both old pages assemble their data inline in their `page.tsx`. The new page
+needs the same data; copying the assembly would let the three pages drift.
+This phase moves the assembly into shared server modules, leaving each old
+page a thin render over the same objects `/registration` will later consume.
+
+**This phase changes no rendered byte.** Review it as a pure refactor; the
+old pages' HTML output before and after must be identical.
+
+## 1a. `src/app/character/characterData.ts`
+
+Extract from `src/app/character/page.tsx` (currently ~180 lines of fetching
+and folding) a single entry point:
+
+```ts
+export type CharacterOverview = {
+  id: string                 // registration uuid
+  characterId: number | null // EVE bigint id (may be null pre-callback)
+  name: string
+  balance: string | null            // raw; formatBisk at render
+  locationSystem: string | null
+  ship: { itemId: string; label: string } | null
+  cloneSystems: string[]            // sorted, uniq, fetchSystemPaths shapes
+  implants: string[]                // resolved type names
+  slots: { counts: SlotCounts; max: SlotMax } | null // null = skills not shared
+}
+
+export const fetchCharacterOverviews = async (
+  supabase: SupabaseClient
+): Promise<{ characters: CharacterOverview[]; error: PostgrestError | null; status: number; statusText: string }>
+```
+
+Everything the current page computes moves in: the wallet latest-balance fold,
+location→system-name map, clone system paths (uniq + sorted), implant type
+names, current ship label (`"<name> (<type>)"` collapse rule), and the
+job-slot fold — including the corp-jobs contribution via
+`countJobSlots` and the `slotMax` skill fold. Keep the existing comments;
+they carry load (e.g. why corp jobs count against the installer's slots, why
+`slotMax.has()` gates the bubbles).
+
+`page.tsx` keeps: the auth gate (`establishedUser` → `redirect('/')`), the
+`getEnabledScopes`/`hasNoOptionalScopes` warning computation (or move it too —
+implementer's call, the new page needs it as well), and all JSX including
+`JobSlots`. **Move `JobSlots` into its own file**
+(`src/app/character/jobSlotBubbles.tsx` — name it to not collide with
+`src/app/industry/jobSlots.ts`) so `/registration` can render the identical
+bubbles; it keeps using `character.module.css` classes for now (phase 2 may
+restyle on the new page only).
+
+## 1b. `src/app/jobs/jobsData.ts`
+
+Extract from `src/app/jobs/page.tsx` everything between the four parallel
+queries and the JSX:
+
+```ts
+export type JobsOverview = {
+  registrations: { id: string; name: string; corporation_id: number | null }[]
+  characterEntities: Record<string, EntityRun[]>    // job → per-registration rows
+  corporationEntities: Record<string, EntityRun[]>  // job → per-corp rows (runsAs et al.)
+  accountBeats: Map<string, Beat>                   // shared-universe section
+  runFor: (job: string, key: string, beat: Beat | undefined) => Omit<EntityRun, 'id' | 'name'>
+  activity: ReturnType<typeof activityRows>
+  anyActive: boolean                                // drives RefreshPoller
+  chancellor: boolean
+  now: number
+}
+
+export const fetchJobsOverview = async (supabase: SupabaseClient, userId: string): Promise<JobsOverview>
+```
+
+Moves in verbatim: the `Beat`/`OpenBeat`/`Task` types, the three time floors,
+the four-way `Promise.all`, the `charBeats`/`corpBeats`/`accountBeats`/
+`corpRunsAs` fold (with its corp-newest-wins and skipped-never-claims-Runs-as
+rules), `openCells`, `taskByCell` (with the corp-job re-keying through
+`corporationOf`), the `corporations` grouping, the `universe_name` corp-name
+lookup, and the `characterEntities`/`corporationEntities` construction with
+its representative-picking comments. `isChancellor` moves in too (the new
+page needs it for the shared-universe kick gating).
+
+`page.tsx` keeps: auth gate, all JSX (`Cell`, `Status`, `JobLabel`,
+`EntityJobTable`, `PlainAge`, the four sections, `RefreshPoller`), and
+`export const dynamic = 'force-dynamic'`.
+
+Note `rows.ts`, `registry.ts`, `schedule.ts` are already pure and tested —
+untouched. The presentational components (`Cell`, `EntityJobTable`, `Status`,
+`nextRun.tsx`, `refreshButton.tsx`, `poller.tsx`) stay where they are in this
+phase; phase 3 decides which are shared vs. re-styled.
+
+## Verification
+
+- `pnpm run lint`, `pnpm test`, `pnpm run build` — all green.
+- Manual: `/character` and `/jobs` render identically (the refactor moves
+  code, not behavior; diff the built HTML if in doubt).
+- The extracted modules take `supabase` as a parameter (the codebase's
+  existing pattern for MCP-shareable helpers — see `owners.ts` et al.) rather
+  than creating their own client; both callers pass the cookie client.
+
+One PR, titled as a refactor. Commit onto `claude/jobs-registrations-merge-ue96so`.

--- a/docs/registrations-page/02-page-shell-and-characters.md
+++ b/docs/registrations-page/02-page-shell-and-characters.md
@@ -1,0 +1,63 @@
+# Phase 2 — `/registration` shell + character section at parity
+
+Adds `src/app/registration/page.tsx` (+ `registration.module.css`, and a
+`loading.tsx` mirroring `/jobs`'s skeleton pattern) rendering the page shell
+from the phase-0 extraction and the character section over
+`fetchCharacterOverviews` from phase 1. Jobs sections come in phase 3 — the
+shell should leave their slots visibly stubbed only if the mockup demands the
+full frame; otherwise ship the character section alone.
+
+## Route mechanics
+
+- Server component, like both parents. Auth gate: `establishedUser`; redirect
+  target `'/'` (what `/character` does — the register CTA lives there).
+- It will need `export const dynamic = 'force-dynamic'` once the poller lands
+  in phase 3; adding it now is fine and harmless.
+- No nav link yet (phase 5). The page is reachable by URL for anyone signed
+  in — same posture `/jobs` had while it was being built. No dark-launch flag
+  needed unless the user asks; if they do, `user_settings.flags` +
+  `KNOWN_FLAGS` in `src/flags.ts` is the mechanism (import from
+  `flagCatalog.ts` in anything clientside — see the server-timing note in
+  CLAUDE.md).
+
+## Character-section parity checklist (from `/character` today)
+
+Every line below must hold on `/registration`, whatever the mockup's layout:
+
+- [ ] One card/tile per `registration` row, in the query's order
+- [ ] Portrait from `images.evetech.net/characters/{character_id}/portrait?size=128`;
+      an empty `aria-hidden` placeholder when `character_id` is null
+- [ ] Name
+- [ ] Job-slot bubbles (`JobSlots` markup): three rows
+      manufacturing/research/reactions; filled = running, ready = delivered-
+      awaiting, empty = free; row widens past `max` rather than clipping
+      (never hide a job); `title` tooltip text preserved; rendered **only**
+      when the character has skill rows (`slotMax.has(id)` — no guessing)
+- [ ] ISK: latest wallet balance via `formatBisk`, `—` when absent
+- [ ] Location: current system name, `—` when absent
+- [ ] Ship: link to `/ship/{itemId}`, label `"<name> (<type>)"` collapsing to
+      the type name when they match; `—` when absent
+- [ ] Clone systems: uniq, sorted, system *paths* (region-qualified, from
+      `fetchSystemPaths`), rendered only when non-empty
+- [ ] Implants: resolved type names, only when non-empty
+- [ ] The "Limited access selected" warning (`role="alert"`) when the account
+      has enabled no optional ESI scopes, linking `/settings/grants`
+- [ ] The Supabase error dump block on query failure (status/statusText/
+      code/message/pretty JSON) — keep it; it has debugged real incidents
+- [ ] **Add Character** button posting to the `register` server action
+      (`src/app/character/actions.ts`) — reused, not copied; the action's
+      grants-detour and anonymous-session behavior are untouched
+
+## Styling
+
+Implement the mockup's card design with the app's existing tokens per the
+phase-0 token mapping. House rules that override the mockup where they
+conflict: one typeface per heading (globals.css note); character portraits
+are not `TypeIcon` (different image path, fine as a plain `<img>`, as today).
+
+## Verification
+
+`lint` + `build`; manual side-by-side against `/character` with a
+multi-character account, ticking the checklist. `/character` itself must be
+byte-identical to before this PR (it shares phase 1's modules; this phase
+must not touch them except additively).

--- a/docs/registrations-page/03-jobs-parity.md
+++ b/docs/registrations-page/03-jobs-parity.md
@@ -1,0 +1,62 @@
+# Phase 3 — jobs sections at parity
+
+Adds the extract-jobs half of `/registration`, over `fetchJobsOverview` from
+phase 1, presented per the phase-0 extraction. Whatever the mockup's visual
+treatment, the information and actions are exactly `/jobs`'s.
+
+## Reuse vs. restyle
+
+`nextRun.tsx` (client countdown), `refreshButton.tsx` (`RefreshButton`,
+`RefreshAllButton` — server-action dispatchers over
+`src/app/jobs/actions.ts`), and `poller.tsx` (`RefreshPoller`) are wired
+machinery: **reuse them as imports.** The table/row presentation (`Cell`,
+`Status`, `EntityJobTable`) may be reimplemented to match the mockup — but if
+the mockup's presentation is table-shaped anyway, import those too and style
+via the new module CSS. Never fork `rows.ts`/`registry.ts`/`schedule.ts`.
+
+## Parity checklist (from `/jobs` today)
+
+- [ ] **Characters section** — one row per per-character job
+      (`jobsInSection('character')`), each showing: label + `<code>` job
+      name; entity count with "N lagging" note; collapsible per-character
+      breakdown; **Last run = oldest** character's run (freshness dot);
+      row status via `rowStatus`; next run countdown or `overdue` (title text
+      preserved) via `isOverdue`/`nextRunFor`
+- [ ] Per-character cells: running/queued/failed/skipped states win over the
+      freshness dot; refresh button appears only when kickable, not in
+      flight, not `skipped`, and (dot off green or last run failed)
+- [ ] **Refresh all** button inside the breakdown when kickable === 'always'
+      and >1 character
+- [ ] **Corporations section** (rendered only when the account has corps):
+      per-corp rows with the **Runs as** column — one corp shows the token's
+      character name or "a corpmate's"; several show "per corp" collapsed;
+      breakdown rows name each corp's runs-as; `skipped` renders
+      "— not a director" and never claims Runs as; refresh dispatches against
+      the representative registration
+- [ ] **Shared universe section**: plain relative ages (no freshness dot —
+      the nightly-cadence rationale in the page copy), status, next-run/
+      overdue; kick gated to Chancellors for `kickable === 'chancellor'`
+      (`industry-systems`), server-side re-check untouched in `refreshCell`
+- [ ] **Recent activity**: caller's `refresh_task` rows from the last 24h,
+      newest first, batch-grouped (enqueued time only on `firstOfBatch`),
+      job, character, status (incl. `abandoned` via `isAbandoned`), error
+      text, duration seconds
+- [ ] `RefreshPoller` re-polling while `anyActive`; page stays
+      `force-dynamic`
+- [ ] The zero-registrations state points at adding a character —
+      on this page that target is the page's own Add Character button, not
+      `/character` (the one deliberate copy change; note it in the PR)
+- [ ] Status vocabulary/glyphs preserved (`STATUS_LABEL`) unless the mockup
+      restyles them, in which case every state still has a distinct rendering
+      including `skipped`, `abandoned`, `queued` vs `pending`
+- [ ] Explanatory paragraph copy: keep the load-bearing explanations
+      (oldest-of-your-characters, runs-as, not-a-director, UTC schedules,
+      nothing-starts-on-page-open) in some form the mockup accommodates —
+      tooltips/details are fine, deletion is not
+
+## Verification
+
+`lint` + `build` + `pnpm test` (rows/schedule tests must still pass
+untouched). Manual: kick a refresh on `/registration`, watch it poll to done;
+confirm the same task shows on old `/jobs` too (same `refresh_task` table) —
+that cross-visibility is expected and fine.

--- a/docs/registrations-page/04-integration.md
+++ b/docs/registrations-page/04-integration.md
@@ -1,0 +1,33 @@
+# Phase 4 — the actually-combined parts
+
+Phases 2–3 could, at worst, ship two pages stacked under one URL. This phase
+delivers the reason for merging: the connections between a character and the
+jobs that feed their data. Exact scope comes from the phase-0 extraction —
+build what the mockup fuses, and only that. Candidates, in likely order:
+
+1. **Per-character freshness on the character card.** Each card shows how
+   fresh *that character's* data is — derivable from `characterEntities`
+   (phase 1's `JobsOverview`): the oldest `lastRunAt` across the
+   per-character jobs for that registration id, rendered with the existing
+   `Freshness` component. If the mockup has a per-card refresh control, it
+   dispatches `dispatchRefresh` for that one registration (the per-character
+   equivalent of Refresh all — `src/app/jobs/actions.ts` may need a thin new
+   server action wrapping the existing dispatch path; add it beside the
+   current ones, do not modify them).
+2. **Job breakdown rows link back to cards** (anchor per registration id) and
+   vice versa, if the mockup indicates it.
+3. **One data pass.** `page.tsx` calls `fetchCharacterOverviews` and
+   `fetchJobsOverview` in `Promise.all`. If profiling (Server-Timing spans
+   arrive free — docs/server-timing.md) shows redundant queries — both fetch
+   `registration` — de-duplicate by letting the page fetch registrations once
+   and pass them in as an optional parameter to both. Optional-parameter,
+   defaulting to self-fetch, so the old pages' call sites don't change.
+
+Rules: no schema changes; no new RPCs unless a fold over already-fetched rows
+genuinely can't express it; anything speculative the mockup doesn't show is
+out of scope.
+
+## Verification
+
+`lint`/`build`; the phase 2 and 3 checklists still fully tick (integration
+must not regress parity).

--- a/docs/registrations-page/05-launch.md
+++ b/docs/registrations-page/05-launch.md
@@ -1,0 +1,29 @@
+# Phase 5 — launch (additive only)
+
+The sunset of `/character` and `/jobs` is explicitly **not** this phase, this
+plan, or this decision. This phase makes `/registration` findable without
+taking anything away.
+
+1. **Nav.** Add `registration` to the signed-in nav in
+   `src/app/layout/header.tsx`. Do **not** remove `characters`; do not change
+   the header's `[refresh]` link target (`/jobs`) yet. Where exactly it slots
+   in the nav order is the user's call — ask, or default to replacing nothing
+   and sitting beside `characters`.
+2. **Docs.** Update `docs/jobs-page.md` and this folder's README with a
+   pointer note ("superseded-by-candidate: /registration; old pages remain
+   live"). Update the CLAUDE.md routes list to include `/registration`.
+3. **Parity sign-off.** Run the phase 2 + phase 3 checklists top to bottom on
+   production data (multi-character account, an account with corps, a
+   Chancellor account, a zero-registration account) and record the result in
+   the PR description. Any unticked line blocks this phase.
+4. **Hand the user the sunset decision** as a short list of what a future
+   sunset PR would touch, discovered during this project — at minimum:
+   redirects for `/character` and `/jobs` (permanent, in the app or
+   `next.config.mjs` alongside the existing ones), the header `[refresh]`
+   link, the `href="/character"` / `href="/jobs"` references in
+   `src/app/structure/page.tsx`, `structure/[structureId]/page.tsx`,
+   `asset/assetsTable.tsx`, `account/invite/page.tsx`,
+   `settings/grants/page.tsx`, `page.tsx` (front page CTA),
+   `fitting/fittingMatrix.tsx`, the `revalidatePath('/character')` in
+   `account/settings/actions.ts`, and the `?from=characters` grants detour in
+   `character/actions.ts`. Record it here; act on none of it.

--- a/docs/registrations-page/README.md
+++ b/docs/registrations-page/README.md
@@ -1,0 +1,64 @@
+# `/registration` — one page for characters and their extract jobs
+
+> **Planned.** Nothing here is built yet. These documents are the project plan
+> for combining `/character` (the character tiles) and `/jobs` (the extract-job
+> matrix) into a single page at **`/registration`**, laid out per the Claude
+> Design mockup **`Registrations v2.dc.html`**. They are written to be executed
+> phase by phase in later sessions, possibly by a cheaper model — each phase
+> names the files it touches and the invariants it must not break.
+
+## Goal
+
+One page that answers, per linked character: who is this character, what state
+are they in (ISK, location, ship, clones, implants, job slots), and how fresh
+is the data behind all of it — with the refresh machinery of `/jobs` attached
+where the staleness actually is, instead of on a separate page.
+
+## Hard constraints
+
+1. **Functional parity, exactly.** Every capability of `/character` and `/jobs`
+   exists on `/registration`, behaving identically. The parity inventories in
+   phases 2 and 3 are checklists, not summaries — an implementer ticks every
+   line.
+2. **The old pages keep working, unchanged.** `/character` and `/jobs` stay
+   live and identical in behavior until a separate, later sunset decision that
+   is **out of scope for this plan**. No redirects, no nav changes to them,
+   until phase 5 — and phase 5 only *adds* the new page to the nav, it removes
+   nothing.
+3. **Parity by construction, not by copying.** Phase 1 extracts the data
+   assembly out of the two `page.tsx` files into shared modules that both the
+   old page and the new page import. After that, the old pages cannot drift
+   from the new one — they render the same data objects.
+4. The visual layer comes from the design mockup (phase 0). Where the mockup
+   and parity conflict — the mockup omits a capability the old pages have —
+   parity wins and the gap is listed in the phase's notes for the user to rule
+   on, rather than silently dropped.
+
+## Naming
+
+The route is **`/registration`** (singular, matching the `registration` table
+and the "registration = one linked EVE character on an account" vocabulary —
+see the id-naming note in CLAUDE.md). The design file says "Registrations";
+the on-page `<h1>` copy can say whatever the mockup says.
+
+## Phases
+
+| Phase | Doc | What lands | Depends on |
+| ----- | --- | ---------- | ---------- |
+| 0 | [00-design-import.md](00-design-import.md) | The design mockup + its `_ds` bundle committed under `docs/registrations-page/design/`, and a written extraction of its structure | user action (seed the design) |
+| 1 | [01-shared-data-seams.md](01-shared-data-seams.md) | `characterData.ts` / `jobsData.ts` extraction; old pages refactored onto them with **zero** behavior change | nothing — can start now |
+| 2 | [02-page-shell-and-characters.md](02-page-shell-and-characters.md) | `/registration` route, page shell per the mockup, character section at full parity | 0, 1 |
+| 3 | [03-jobs-parity.md](03-jobs-parity.md) | Jobs sections (characters / corporations / shared universe / recent activity), refresh buttons, poller — full parity | 1, 2 |
+| 4 | [04-integration.md](04-integration.md) | The actually-combined parts: per-character freshness on the character cards, cross-links, whatever the mockup fuses | 2, 3 |
+| 5 | [05-launch.md](05-launch.md) | Nav entry, docs updates, parity sign-off checklist | 2–4 |
+
+Phases 2 and 3 are separately shippable PRs; phase 1 is its own PR (a pure
+refactor, easy to review as such). Do not fold phase 1 into phase 2 — the
+zero-behavior-change claim is only checkable when the refactor stands alone.
+
+## What this plan is deliberately not
+
+- Not a sunset plan for `/character` or `/jobs` (later project).
+- Not a redesign of the refresh machinery (`dispatchRefresh`, `refresh_task`,
+  heartbeats) — all reused as-is.
+- Not a schema change. No migrations anywhere in this plan.


### PR DESCRIPTION
Project plan (docs only, no code) for combining `/character` and `/jobs` into one page at `/registration`, implementing the Claude Design mockup `Registrations v2.dc.html`. Written to be executed phase by phase in later sessions.

Six documents under `docs/registrations-page/`:

- **README** — goal, hard constraints (strict functional parity; old pages stay live and untouched until a separate sunset decision; parity by construction via shared data modules), phase table.
- **Phase 0 — design import.** Blocked on getting the design files into the repo: the claude_design MCP needs an interactive `/design-login` this remote session can't run, and the project URL 403s unauthenticated. The doc lists the files to commit under `docs/registrations-page/design/` and specifies the extraction doc (structure, token mapping onto `globals.css`, interactions, parity-gap list) the later phases build from.
- **Phase 1 — shared data seams.** Pure refactor: extract `fetchCharacterOverviews` and `fetchJobsOverview` out of the two `page.tsx` files so old and new pages render the same objects and can't drift. Zero-behavior-change PR on its own.
- **Phase 2 — shell + character section**, with a line-by-line parity checklist of everything `/character` shows today (slot bubbles incl. the never-hide-a-job widening, scopes warning, error dump, Add Character reusing the existing server action).
- **Phase 3 — jobs sections**, parity checklist for all four sections (characters / corporations with Runs-as / shared universe with the Chancellor gate / recent activity), refresh buttons, poller, `force-dynamic`.
- **Phase 4 — integration** — the actually-fused parts (per-card freshness, per-character refresh, single data pass), scoped to what the mockup shows.
- **Phase 5 — launch, additive only** — nav entry beside `characters`, docs pointers, parity sign-off, and a recorded (not acted-on) inventory of what a future sunset PR would touch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNLt3QGWHjLNLoPcQek8mV)_