### PR TITLE
refactor: shared data seams for /character and /jobs (registrations phase 1)

### DIFF
--- a/src/app/character/characterData.ts
+++ b/src/app/character/characterData.ts
@@ -1,0 +1,187 @@
+// Per-character overview assembly, shared by /character and (from phase 2 of
+// docs/registrations-page) /registration. Nothing here renders — the page owns
+// the JSX, this owns "what do we know about each linked character": ISK,
+// location, ship, clones, implants, and the industry job slots they occupy.
+//
+// The caller passes its own Supabase client (the codebase's pattern for
+// helpers a second surface may reuse — see owners.ts), so RLS scoping stays
+// wherever the caller established it.
+import type { PostgrestError, SupabaseClient } from '@supabase/supabase-js'
+import { ascend, reduce, sort, uniq } from 'ramda'
+
+import {
+  baseSlotMax,
+  countJobSlots,
+  emptyCounts,
+  SKILL_FAMILY,
+  SLOT_SKILL_IDS,
+  type CharacterJobRow,
+  type CorpJobRow,
+  type SlotCounts,
+  type SlotMax,
+} from '../industry/jobSlots'
+import { fetchSystemNames, fetchSystemPaths } from '../systemNames'
+import { fetchTypeNames } from '../typeNames'
+import { requiredScopes } from './scopes'
+import { getEnabledScopes } from './userScopes'
+
+export type CharacterOverview = {
+  id: string // registration uuid
+  characterId: number | null // EVE bigint id (may be null pre-callback)
+  name: string
+  balance: string | null // raw; formatBisk at render
+  locationSystem: string | null
+  ship: { itemId: string; label: string } | null
+  cloneSystems: string[]
+  implants: string[]
+  // null when the character hasn't shared skills — slot capacity is never
+  // guessed, the bubbles are simply not drawn.
+  slots: { counts: SlotCounts; max: SlotMax } | null
+}
+
+export type CharacterOverviews = {
+  characters: CharacterOverview[]
+  error: PostgrestError | null
+  status: number
+  statusText: string
+}
+
+export const fetchCharacterOverviews = async (supabase: SupabaseClient): Promise<CharacterOverviews> => {
+  const { data: characters, status, statusText, error } = await supabase.from('registration').select()
+
+  const { data: wallets } = await supabase
+    .from('character_wallet')
+    .select('registration_id, balance, recorded_at')
+    .order('recorded_at', { ascending: false })
+
+  const latestBalance = reduce(
+    (acc, w) => (acc.has(w.registration_id) ? acc : acc.set(w.registration_id, w.balance)),
+    new Map<string, string>(),
+    wallets ?? []
+  )
+
+  const { data: locations } = await supabase.from('character_location').select('registration_id, solar_system_id')
+  const systemNames = await fetchSystemNames((locations ?? []).map((l) => Number(l.solar_system_id)))
+  const locationSystem = new Map(
+    (locations ?? []).map((l) => [
+      l.registration_id as string,
+      systemNames[Number(l.solar_system_id)] ?? `System #${l.solar_system_id}`,
+    ])
+  )
+
+  const { data: clones } = await supabase.from('character_clone').select('registration_id, system_id')
+  const cloneSystemPaths = await fetchSystemPaths((clones ?? []).map((c) => Number(c.system_id)))
+  const cloneSystemsByCharacter = reduce(
+    (acc, c) => {
+      const system =
+        c.system_id != null ? (cloneSystemPaths[Number(c.system_id)] ?? `System #${c.system_id}`) : 'Unknown'
+      const existing = acc.get(c.registration_id as string) ?? []
+      acc.set(c.registration_id as string, uniq([...existing, system]))
+      return acc
+    },
+    new Map<string, string[]>(),
+    clones ?? []
+  )
+  const cloneSystems = new Map(
+    [...cloneSystemsByCharacter.entries()].map(([characterId, systems]) => [
+      characterId,
+      sort(
+        ascend((s: string) => s),
+        systems
+      ),
+    ])
+  )
+
+  const { data: implantRows } = await supabase.from('character_implant').select('registration_id, type_ids')
+  const implantTypeNames = await fetchTypeNames((implantRows ?? []).flatMap((r) => (r.type_ids ?? []).map(Number)))
+  const implantsByCharacter = new Map(
+    (implantRows ?? []).map((r) => [
+      r.registration_id as string,
+      (r.type_ids ?? []).map((id: number) => implantTypeNames[id] ?? `Type #${id}`),
+    ])
+  )
+
+  const { data: shipRows } = await supabase
+    .from('character_ship')
+    .select('registration_id, ship_item_id, ship_type_id, ship_name')
+  const shipTypeNames = await fetchTypeNames((shipRows ?? []).map((r) => Number(r.ship_type_id)))
+  const currentShip = new Map(
+    (shipRows ?? []).map((r) => {
+      const typeName = shipTypeNames[Number(r.ship_type_id)] ?? `Type #${r.ship_type_id}`
+      return [
+        r.registration_id as string,
+        {
+          itemId: String(r.ship_item_id),
+          label: r.ship_name && r.ship_name !== typeName ? `${r.ship_name} (${typeName})` : typeName,
+        },
+      ]
+    })
+  )
+
+  // Jobs that still hold a slot: running (status 'active') or ready to deliver
+  // (status 'ready'). Corp jobs count against the installing character's slots
+  // as well, so both listings feed the shared fold; RLS already scopes the corp
+  // view to the caller's corporations.
+  const [{ data: industryJobs }, { data: corpIndustryJobs }] = await Promise.all([
+    supabase
+      .from('character_industry_job')
+      .select('job_id, registration_id, activity_id, status, end_date')
+      .in('status', ['active', 'ready']),
+    supabase
+      .from('corp_industry_job')
+      .select('job_id, installer_id, activity_id, status, end_date')
+      .in('status', ['active', 'ready']),
+  ])
+  const jobSlotCounts = countJobSlots({
+    characterJobs: (industryJobs ?? []) as CharacterJobRow[],
+    corpJobs: (corpIndustryJobs ?? []) as CorpJobRow[],
+    registrationByCharacterId: new Map(
+      (characters ?? []).filter((c) => c.character_id != null).map((c) => [String(c.character_id), c.id as string])
+    ),
+  })
+
+  // Per-character slot ceilings, derived from the two skills behind each family.
+  const { data: skillRows } = await supabase
+    .from('character_skill')
+    .select('registration_id, skill_id, active_skill_level')
+    .in('skill_id', SLOT_SKILL_IDS)
+  const slotMax = reduce(
+    (acc, r) => {
+      const family = SKILL_FAMILY[Number(r.skill_id)]
+      if (family) {
+        const max = acc.get(r.registration_id as string) ?? baseSlotMax()
+        max[family] += Number(r.active_skill_level) || 0
+        acc.set(r.registration_id as string, max)
+      }
+      return acc
+    },
+    new Map<string, SlotMax>(),
+    skillRows ?? []
+  )
+
+  return {
+    characters: (characters ?? []).map((c) => ({
+      id: c.id as string,
+      characterId: c.character_id == null ? null : Number(c.character_id),
+      name: c.name as string,
+      balance: latestBalance.has(c.id) ? latestBalance.get(c.id)! : null,
+      locationSystem: locationSystem.get(c.id) ?? null,
+      ship: currentShip.get(c.id) ?? null,
+      cloneSystems: cloneSystems.get(c.id) ?? [],
+      implants: implantsByCharacter.get(c.id) ?? [],
+      // slotMax has an entry only when character_skill rows exist, so without
+      // the scope we don't guess a capacity, we show nothing.
+      slots: slotMax.has(c.id) ? { counts: jobSlotCounts.get(c.id) ?? emptyCounts(), max: slotMax.get(c.id)! } : null,
+    })),
+    error,
+    status,
+    statusText,
+  }
+}
+
+// If the player has turned off every optional ESI scope, characters they add
+// grant nothing beyond identification, so almost no features will work.
+export const hasNoOptionalScopes = async (supabase: SupabaseClient, userId: string): Promise<boolean> => {
+  const enabledScopes = await getEnabledScopes(supabase, userId)
+  return enabledScopes.every((scope) => requiredScopes.includes(scope))
+}

--- a/src/app/character/jobSlotBubbles.tsx
+++ b/src/app/character/jobSlotBubbles.tsx
@@ -1,0 +1,40 @@
+// The industry job-slot bubbles on a character tile: one row per slot family,
+// one bubble per slot, filled for a running job and "ready" for one waiting to
+// be delivered. Split out of the /character page so /registration can render
+// the identical bubbles (docs/registrations-page/01-shared-data-seams.md).
+// Named for the bubbles rather than the slots so it doesn't read as a second
+// src/app/industry/jobSlots.ts, which is where the arithmetic lives.
+import { range } from 'ramda'
+
+import { type SlotCounts, type SlotFamily, type SlotMax } from '../industry/jobSlots'
+import styles from './character.module.css'
+
+const SLOT_ROWS: { family: SlotFamily; label: string }[] = [
+  { family: 'manufacturing', label: 'Manufacturing' },
+  { family: 'research', label: 'Research' },
+  { family: 'reaction', label: 'Reactions' },
+]
+
+export const JobSlots = ({ counts, max }: { counts: SlotCounts; max: SlotMax }) => (
+  <div className={styles.slots}>
+    {SLOT_ROWS.map(({ family, label }) => {
+      const { running, finished } = counts[family]
+      // Never hide a job: if skill data lags behind reality, widen the row to
+      // fit every occupied slot rather than clip it.
+      const slotCount = Math.max(max[family], running + finished)
+      return (
+        <div
+          key={family}
+          className={`${styles.slotRow} ${styles[family]}`}
+          title={`${label}: ${running} running, ${finished} ready of ${max[family]} slot${max[family] === 1 ? '' : 's'}`}
+        >
+          {range(0, slotCount).map((i) => {
+            if (i < running) return <span key={i} className={`${styles.slot} ${styles.slotFilled}`} />
+            if (i < running + finished) return <span key={i} className={`${styles.slot} ${styles.slotReady}`} />
+            return <span key={i} className={styles.slot} />
+          })}
+        </div>
+      )
+    })}
+  </div>
+)

--- a/src/app/character/page.tsx
+++ b/src/app/character/page.tsx
@@ -1,59 +1,14 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
-import { ascend, range, reduce, sort, uniq } from 'ramda'
 
 import { createClient } from '@/utils/supabase/server'
 
 import { establishedUser } from '../account/lib/establishedUser'
-import {
-  baseSlotMax,
-  countJobSlots,
-  emptyCounts,
-  SKILL_FAMILY,
-  SLOT_SKILL_IDS,
-  type CharacterJobRow,
-  type CorpJobRow,
-  type SlotCounts,
-  type SlotFamily,
-  type SlotMax,
-} from '../industry/jobSlots'
 import { formatBisk } from '../isk'
-import { fetchSystemNames, fetchSystemPaths } from '../systemNames'
-import { fetchTypeNames } from '../typeNames'
 import { register } from './actions'
-import { requiredScopes } from './scopes'
-import { getEnabledScopes } from './userScopes'
+import { fetchCharacterOverviews, hasNoOptionalScopes } from './characterData'
+import { JobSlots } from './jobSlotBubbles'
 import styles from './character.module.css'
-
-const SLOT_ROWS: { family: SlotFamily; label: string }[] = [
-  { family: 'manufacturing', label: 'Manufacturing' },
-  { family: 'research', label: 'Research' },
-  { family: 'reaction', label: 'Reactions' },
-]
-
-const JobSlots = ({ counts, max }: { counts: SlotCounts; max: SlotMax }) => (
-  <div className={styles.slots}>
-    {SLOT_ROWS.map(({ family, label }) => {
-      const { running, finished } = counts[family]
-      // Never hide a job: if skill data lags behind reality, widen the row to
-      // fit every occupied slot rather than clip it.
-      const slotCount = Math.max(max[family], running + finished)
-      return (
-        <div
-          key={family}
-          className={`${styles.slotRow} ${styles[family]}`}
-          title={`${label}: ${running} running, ${finished} ready of ${max[family]} slot${max[family] === 1 ? '' : 's'}`}
-        >
-          {range(0, slotCount).map((i) => {
-            if (i < running) return <span key={i} className={`${styles.slot} ${styles.slotFilled}`} />
-            if (i < running + finished) return <span key={i} className={`${styles.slot} ${styles.slotReady}`} />
-            return <span key={i} className={styles.slot} />
-          })}
-        </div>
-      )
-    })}
-  </div>
-)
 
 const CharacterPage = async () => {
   const supabase = await createClient()
@@ -63,127 +18,13 @@ const CharacterPage = async () => {
     redirect('/')
   }
 
-  const { data: characters, status, statusText, error } = await supabase.from('registration').select()
-
-  const { data: wallets } = await supabase
-    .from('character_wallet')
-    .select('registration_id, balance, recorded_at')
-    .order('recorded_at', { ascending: false })
-
-  const latestBalance = reduce(
-    (acc, w) => (acc.has(w.registration_id) ? acc : acc.set(w.registration_id, w.balance)),
-    new Map<string, string>(),
-    wallets ?? []
-  )
-
-  const { data: locations } = await supabase.from('character_location').select('registration_id, solar_system_id')
-  const systemNames = await fetchSystemNames((locations ?? []).map((l) => Number(l.solar_system_id)))
-  const locationSystem = new Map(
-    (locations ?? []).map((l) => [
-      l.registration_id as string,
-      systemNames[Number(l.solar_system_id)] ?? `System #${l.solar_system_id}`,
-    ])
-  )
-
-  const { data: clones } = await supabase.from('character_clone').select('registration_id, system_id')
-  const cloneSystemPaths = await fetchSystemPaths((clones ?? []).map((c) => Number(c.system_id)))
-  const cloneSystemsByCharacter = reduce(
-    (acc, c) => {
-      const system =
-        c.system_id != null ? (cloneSystemPaths[Number(c.system_id)] ?? `System #${c.system_id}`) : 'Unknown'
-      const existing = acc.get(c.registration_id as string) ?? []
-      acc.set(c.registration_id as string, uniq([...existing, system]))
-      return acc
-    },
-    new Map<string, string[]>(),
-    clones ?? []
-  )
-  const cloneSystems = new Map(
-    [...cloneSystemsByCharacter.entries()].map(([characterId, systems]) => [
-      characterId,
-      sort(
-        ascend((s: string) => s),
-        systems
-      ),
-    ])
-  )
-
-  const { data: implantRows } = await supabase.from('character_implant').select('registration_id, type_ids')
-  const implantTypeNames = await fetchTypeNames((implantRows ?? []).flatMap((r) => (r.type_ids ?? []).map(Number)))
-  const implantsByCharacter = new Map(
-    (implantRows ?? []).map((r) => [
-      r.registration_id as string,
-      (r.type_ids ?? []).map((id: number) => implantTypeNames[id] ?? `Type #${id}`),
-    ])
-  )
-
-  const { data: shipRows } = await supabase
-    .from('character_ship')
-    .select('registration_id, ship_item_id, ship_type_id, ship_name')
-  const shipTypeNames = await fetchTypeNames((shipRows ?? []).map((r) => Number(r.ship_type_id)))
-  const currentShip = new Map(
-    (shipRows ?? []).map((r) => {
-      const typeName = shipTypeNames[Number(r.ship_type_id)] ?? `Type #${r.ship_type_id}`
-      return [
-        r.registration_id as string,
-        {
-          itemId: String(r.ship_item_id),
-          label: r.ship_name && r.ship_name !== typeName ? `${r.ship_name} (${typeName})` : typeName,
-        },
-      ]
-    })
-  )
-
-  // Jobs that still hold a slot: running (status 'active') or ready to deliver
-  // (status 'ready'). Corp jobs count against the installing character's slots
-  // as well, so both listings feed the shared fold; RLS already scopes the corp
-  // view to the caller's corporations.
-  const [{ data: industryJobs }, { data: corpIndustryJobs }] = await Promise.all([
-    supabase
-      .from('character_industry_job')
-      .select('job_id, registration_id, activity_id, status, end_date')
-      .in('status', ['active', 'ready']),
-    supabase
-      .from('corp_industry_job')
-      .select('job_id, installer_id, activity_id, status, end_date')
-      .in('status', ['active', 'ready']),
-  ])
-  const jobSlotCounts = countJobSlots({
-    characterJobs: (industryJobs ?? []) as CharacterJobRow[],
-    corpJobs: (corpIndustryJobs ?? []) as CorpJobRow[],
-    registrationByCharacterId: new Map(
-      (characters ?? []).filter((c) => c.character_id != null).map((c) => [String(c.character_id), c.id as string])
-    ),
-  })
-
-  // Per-character slot ceilings, derived from the two skills behind each family.
-  const { data: skillRows } = await supabase
-    .from('character_skill')
-    .select('registration_id, skill_id, active_skill_level')
-    .in('skill_id', SLOT_SKILL_IDS)
-  const slotMax = reduce(
-    (acc, r) => {
-      const family = SKILL_FAMILY[Number(r.skill_id)]
-      if (family) {
-        const max = acc.get(r.registration_id as string) ?? baseSlotMax()
-        max[family] += Number(r.active_skill_level) || 0
-        acc.set(r.registration_id as string, max)
-      }
-      return acc
-    },
-    new Map<string, SlotMax>(),
-    skillRows ?? []
-  )
-
-  // If the player has turned off every optional ESI scope, characters they add
-  // grant nothing beyond identification, so almost no features will work.
-  const enabledScopes = await getEnabledScopes(supabase, user.id)
-  const hasNoOptionalScopes = enabledScopes.every((scope) => requiredScopes.includes(scope))
+  const { characters, status, statusText, error } = await fetchCharacterOverviews(supabase)
+  const noOptionalScopes = await hasNoOptionalScopes(supabase, user.id)
 
   return (
     <>
       <h1>Characters</h1>
-      {hasNoOptionalScopes && (
+      {noOptionalScopes && (
         <div className={styles.warning} role="alert">
           <strong className={styles.warningTitle}>Limited access selected</strong>
           <p className={styles.warningBody}>
@@ -194,12 +35,12 @@ const CharacterPage = async () => {
         </div>
       )}
       <ul className={styles.grid}>
-        {characters?.map((c) => (
+        {characters.map((c) => (
           <li key={`character-${c.id}`} className={styles.tile}>
-            {c.character_id ? (
+            {c.characterId ? (
               <img
                 className={styles.avatar}
-                src={`https://images.evetech.net/characters/${c.character_id}/portrait?size=128`}
+                src={`https://images.evetech.net/characters/${c.characterId}/portrait?size=128`}
                 alt={c.name}
               />
             ) : (
@@ -208,42 +49,36 @@ const CharacterPage = async () => {
             <div className={styles.body}>
               <div className={styles.name}>{c.name}</div>
               {/* Only show the job-slot bubbles for characters who have shared their
-                  skills — slotMax has an entry only when character_skill rows exist,
-                  so without the scope we don't guess a capacity, we show nothing. */}
-              {slotMax.has(c.id) && (
-                <JobSlots counts={jobSlotCounts.get(c.id) ?? emptyCounts()} max={slotMax.get(c.id)!} />
-              )}
+                  skills — slots is null unless character_skill rows exist, so without
+                  the scope we don't guess a capacity, we show nothing. */}
+              {c.slots && <JobSlots counts={c.slots.counts} max={c.slots.max} />}
               <div className={styles.meta}>
                 <span className={styles.metaLabel}>ISK:</span>
-                {latestBalance.has(c.id) ? formatBisk(latestBalance.get(c.id)!) : '—'}
+                {c.balance === null ? '—' : formatBisk(c.balance)}
               </div>
               <div className={styles.meta}>
                 <span className={styles.metaLabel}>Location:</span>
-                {locationSystem.get(c.id) ?? '—'}
+                {c.locationSystem ?? '—'}
               </div>
               <div className={styles.meta}>
                 <span className={styles.metaLabel}>Ship:</span>
-                {currentShip.has(c.id) ? (
-                  <Link href={`/ship/${currentShip.get(c.id)!.itemId}`}>{currentShip.get(c.id)!.label}</Link>
-                ) : (
-                  '—'
-                )}
+                {c.ship ? <Link href={`/ship/${c.ship.itemId}`}>{c.ship.label}</Link> : '—'}
               </div>
-              {(cloneSystems.get(c.id)?.length ?? 0) > 0 && (
+              {c.cloneSystems.length > 0 && (
                 <div className={styles.metaBlock}>
                   <span className={styles.metaLabel}>Clone systems:</span>
                   <ul className={`${styles.bulletList} ${styles.cloneList}`}>
-                    {cloneSystems.get(c.id)!.map((system) => (
+                    {c.cloneSystems.map((system) => (
                       <li key={system}>{system}</li>
                     ))}
                   </ul>
                 </div>
               )}
-              {(implantsByCharacter.get(c.id)?.length ?? 0) > 0 && (
+              {c.implants.length > 0 && (
                 <div className={styles.metaBlock}>
                   <span className={styles.metaLabel}>Implants:</span>
                   <ul className={styles.bulletList}>
-                    {implantsByCharacter.get(c.id)!.map((name: string, i: number) => (
+                    {c.implants.map((name: string, i: number) => (
                       <li key={i}>{name}</li>
                     ))}
                   </ul>

--- a/src/app/jobs/jobsData.ts
+++ b/src/app/jobs/jobsData.ts
@@ -1,0 +1,219 @@
+// The /jobs data assembly: heartbeats (completed and open), the caller's
+// refresh_task rows and the registrations/corporations they belong to, folded
+// into the per-job entity rows the page renders. Split out of page.tsx so
+// /registration renders the same objects rather than a copy of this logic
+// (docs/registrations-page/01-shared-data-seams.md).
+//
+// RLS scopes all of it: own registrations, own characters' and corps'
+// heartbeats, the shared user_id-null rows every signed-in account sees. The
+// caller passes its own client, following owners.ts.
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { reduce } from 'ramda'
+
+import { isChancellor } from '../account/settings/chancellor/chancellor'
+import { jobsInSection } from './registry'
+import { type ActivityTask, type EntityRun, OVERLAY_MINUTES, activityRows, isAbandoned, statusOf } from './rows'
+
+export type Beat = {
+  job: string
+  registration_id: string | null
+  corporation_id: number | null
+  ended_at: string
+  ok: boolean | null
+  error: string | null
+  // Set (with ok true) when the run was a permitted no-op: a corp endpoint the
+  // character holds no in-game role for. See heartbeat.skipped_reason.
+  skipped_reason: string | null
+}
+
+export type OpenBeat = { job: string; registration_id: string | null; corporation_id: number | null }
+
+export type Task = ActivityTask & { registration_id: string | null }
+
+export type Registration = { id: string; name: string; corporation_id: number | null }
+
+export type JobsOverview = {
+  registrations: Registration[]
+  characterEntities: Record<string, EntityRun[]>
+  corporationEntities: Record<string, EntityRun[]>
+  accountBeats: Map<string, Beat>
+  runFor: (job: string, key: string, beat: Beat | undefined) => Omit<EntityRun, 'id' | 'name'>
+  activity: ReturnType<typeof activityRows>
+  // Whether any corporation rows exist at all — the section is hidden without.
+  corporationCount: number
+  anyActive: boolean
+  chancellor: boolean
+  now: number
+}
+
+export const fetchJobsOverview = async (supabase: SupabaseClient, userId: string): Promise<JobsOverview> => {
+  const chancellor = await isChancellor(userId)
+
+  const now = Date.now()
+  const openFloor = new Date(now - 60 * 60_000).toISOString()
+  // Recent activity keeps a day; the per-cell overlay is much tighter, so an
+  // on-demand error from this morning doesn't outrank a scheduled pull that has
+  // since succeeded.
+  const activityFloor = new Date(now - 24 * 60 * 60_000).toISOString()
+  const overlayFloor = new Date(now - OVERLAY_MINUTES * 60_000).toISOString()
+
+  const [{ data: registrationsData }, { data: beatsData }, { data: openData }, { data: tasksData }] = await Promise.all(
+    [
+      supabase.from('registration').select('id, name, corporation_id').order('created_at', { ascending: true }),
+      supabase.rpc('latest_heartbeats'),
+      // Open runs — started, not yet ended. This is what makes a *scheduled* run
+      // visible as running; latest_heartbeats() returns completed rows only. The
+      // floor drops rows whose end step never landed, which would otherwise read
+      // as permanently running.
+      supabase
+        .from('heartbeat')
+        .select('job, registration_id, corporation_id')
+        .is('ended_at', null)
+        .not('started_at', 'is', null)
+        .gte('ran_at', openFloor),
+      supabase
+        .from('refresh_task')
+        .select('id, batch_id, job, registration_id, character_name, status, error, created_at, started_at, ended_at')
+        .gte('created_at', activityFloor)
+        .order('created_at', { ascending: true }),
+    ]
+  )
+
+  const registrations = (registrationsData ?? []) as Registration[]
+  const beats = (beatsData ?? []) as Beat[]
+  const openBeats = (openData ?? []) as OpenBeat[]
+  const tasks = (tasksData ?? []) as Task[]
+
+  const corporationOf = new Map(registrations.map((r) => [r.id, r.corporation_id]))
+
+  // latest_heartbeats returns one row per job per owner. Character- and
+  // account-scoped rows are already unique per cell; corp rows can appear once
+  // per character that has ever run the corp's pull, so keep the newest — its
+  // registration_id is whose token the extract actually ran under last time.
+  const { charBeats, corpBeats, accountBeats, corpRunsAs } = reduce(
+    (acc, b: Beat) => {
+      if (b.corporation_id != null) {
+        const key = `${b.job}:${b.corporation_id}`
+        const prev = acc.corpBeats.get(key)
+        if (!prev || prev.ended_at < b.ended_at) acc.corpBeats.set(key, b)
+        // Whose token *worked*. A skipped row names a character who was turned
+        // away for want of the in-game role, which is precisely who didn't run
+        // it, so those never claim the Runs as column.
+        if (b.skipped_reason == null) {
+          const prevRun = acc.corpRunsAs.get(b.corporation_id)
+          if (!prevRun || prevRun.ended_at < b.ended_at) acc.corpRunsAs.set(b.corporation_id, b)
+        }
+      } else if (b.registration_id != null) {
+        acc.charBeats.set(`${b.job}:${b.registration_id}`, b)
+      } else {
+        acc.accountBeats.set(b.job, b)
+      }
+      return acc
+    },
+    {
+      charBeats: new Map<string, Beat>(),
+      corpBeats: new Map<string, Beat>(),
+      accountBeats: new Map<string, Beat>(),
+      corpRunsAs: new Map<number, Beat>(),
+    },
+    beats
+  )
+
+  // Same keying for the open rows: a corp run's heartbeat carries the
+  // corporation, a per-character run its registration, a shared run neither.
+  const openCells = new Set(openBeats.map((b) => `${b.job}:${b.corporation_id ?? b.registration_id ?? ''}`))
+
+  // Index the just-kicked tasks by cell, later rows winning. A corp job's task
+  // row carries its representative character, so key those by the corp instead.
+  const corpJobNames = new Set(jobsInSection('corporation').map((entry) => entry.job))
+  const taskByCell = reduce(
+    (acc, t) => {
+      if (t.created_at < overlayFloor || isAbandoned(t, now)) return acc
+      const corpId = corpJobNames.has(t.job) && t.registration_id != null ? corporationOf.get(t.registration_id) : null
+      return acc.set(`${t.job}:${corpId ?? t.registration_id ?? ''}`, t)
+    },
+    new Map<string, Task>(),
+    tasks
+  )
+  const anyActive = tasks.some((t) => (t.status === 'pending' || t.status === 'running') && !isAbandoned(t, now))
+
+  // The user's corporations, each with the registered characters in it (in
+  // registration order — the representative dispatchRefresh would pick first).
+  const corporations = reduce(
+    (acc, r) => {
+      if (r.corporation_id == null) return acc
+      const group = acc.get(r.corporation_id)
+      if (group) group.push(r)
+      else acc.set(r.corporation_id, [r])
+      return acc
+    },
+    new Map<number, Registration[]>(),
+    registrations
+  )
+
+  const corporationIds = [...corporations.keys()]
+  const { data: corpNamesData } = corporationIds.length
+    ? await supabase.from('universe_name').select('id, name').in('id', corporationIds)
+    : { data: [] }
+  const corpName = new Map((corpNamesData ?? []).map((n) => [Number(n.id), n.name as string]))
+
+  const runFor = (job: string, key: string, beat: Beat | undefined): Omit<EntityRun, 'id' | 'name'> => ({
+    lastRunAt: beat?.ended_at ?? null,
+    ...statusOf({
+      task: taskByCell.get(`${job}:${key}`),
+      open: openCells.has(`${job}:${key}`),
+      beat: beat && { ok: beat.ok, error: beat.error, skippedReason: beat.skipped_reason },
+    }),
+  })
+
+  const characterEntities: Record<string, EntityRun[]> = Object.fromEntries(
+    jobsInSection('character').map((entry) => [
+      entry.job,
+      registrations.map((r) => ({
+        id: r.id,
+        name: r.name,
+        ...runFor(entry.job, r.id, charBeats.get(`${entry.job}:${r.id}`)),
+      })),
+    ])
+  )
+
+  const corporationEntities: Record<string, EntityRun[]> = Object.fromEntries(
+    jobsInSection('corporation').map((entry) => [
+      entry.job,
+      [...corporations.entries()].map(([corporationId, members]) => {
+        const runsAs = corpRunsAs.get(corporationId)
+        const owned = members.find((m) => m.id === runsAs?.registration_id)
+        // Kick new pulls as the character the last one succeeded under when
+        // it's ours; the workflow target carries the whole corp group either
+        // way, so this only picks the row's representative.
+        const representative = owned ?? members[0]
+        // Nobody has run it here yet → name who *would* run it, so the column
+        // still answers "under whose token" instead of blanking.
+        const runsAsCorpmate = runsAs != null && owned == null
+        return {
+          // The refresh button dispatches against a registration of ours, so
+          // the entity's id is the representative character's — the corp id is
+          // only how its heartbeats are keyed.
+          id: representative.id,
+          name: corpName.get(corporationId) ?? `#${corporationId}`,
+          runsAs: runsAsCorpmate ? null : representative.name,
+          runsAsCorpmate,
+          ...runFor(entry.job, String(corporationId), corpBeats.get(`${entry.job}:${corporationId}`)),
+        }
+      }),
+    ])
+  )
+
+  return {
+    registrations,
+    characterEntities,
+    corporationEntities,
+    accountBeats,
+    runFor,
+    activity: activityRows(tasks),
+    corporationCount: corporations.size,
+    anyActive,
+    chancellor,
+    now,
+  }
+}

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -10,53 +10,25 @@
 
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
-import { reduce } from 'ramda'
 
 import { createClient } from '@/utils/supabase/server'
 
 import { establishedUser } from '../account/lib/establishedUser'
 
-import { isChancellor } from '../account/settings/chancellor/chancellor'
 import { Freshness } from '../Freshness'
 import { freshnessLevel, relativeTime } from '../freshness'
 import { CharacterName, Name } from '../names'
+import { fetchJobsOverview } from './jobsData'
 import styles from './jobs.module.css'
 import { NextRun } from './nextRun'
 import { RefreshPoller } from './poller'
 import { RefreshAllButton, RefreshButton } from './refreshButton'
 import { type JobEntry, type Kickable, isOverdue, jobsInSection, nextRunFor } from './registry'
-import {
-  type ActivityTask,
-  type EntityRun,
-  OVERLAY_MINUTES,
-  activityRows,
-  isAbandoned,
-  laggingCount,
-  newestRun,
-  oldestRun,
-  rowStatus,
-  statusOf,
-} from './rows'
+import { type EntityRun, isAbandoned, laggingCount, newestRun, oldestRun, rowStatus } from './rows'
 
 // Always read fresh — the poller re-requests this server component every couple
 // of seconds while any kicked-off job is still in flight.
 export const dynamic = 'force-dynamic'
-
-type Beat = {
-  job: string
-  registration_id: string | null
-  corporation_id: number | null
-  ended_at: string
-  ok: boolean | null
-  error: string | null
-  // Set (with ok true) when the run was a permitted no-op: a corp endpoint the
-  // character holds no in-game role for. See heartbeat.skipped_reason.
-  skipped_reason: string | null
-}
-
-type OpenBeat = { job: string; registration_id: string | null; corporation_id: number | null }
-
-type Task = ActivityTask & { registration_id: string | null }
 
 const iso = (at: Date | null) => (at === null ? null : at.toISOString())
 
@@ -248,164 +220,18 @@ const JobsPage = async () => {
     redirect('/account/login')
   }
 
-  const chancellor = await isChancellor(user.id)
-
-  const now = Date.now()
-  const openFloor = new Date(now - 60 * 60_000).toISOString()
-  // Recent activity keeps a day; the per-cell overlay is much tighter, so an
-  // on-demand error from this morning doesn't outrank a scheduled pull that has
-  // since succeeded.
-  const activityFloor = new Date(now - 24 * 60 * 60_000).toISOString()
-  const overlayFloor = new Date(now - OVERLAY_MINUTES * 60_000).toISOString()
-
-  const [{ data: registrationsData }, { data: beatsData }, { data: openData }, { data: tasksData }] = await Promise.all(
-    [
-      supabase.from('registration').select('id, name, corporation_id').order('created_at', { ascending: true }),
-      supabase.rpc('latest_heartbeats'),
-      // Open runs — started, not yet ended. This is what makes a *scheduled* run
-      // visible as running; latest_heartbeats() returns completed rows only. The
-      // floor drops rows whose end step never landed, which would otherwise read
-      // as permanently running.
-      supabase
-        .from('heartbeat')
-        .select('job, registration_id, corporation_id')
-        .is('ended_at', null)
-        .not('started_at', 'is', null)
-        .gte('ran_at', openFloor),
-      supabase
-        .from('refresh_task')
-        .select('id, batch_id, job, registration_id, character_name, status, error, created_at, started_at, ended_at')
-        .gte('created_at', activityFloor)
-        .order('created_at', { ascending: true }),
-    ]
-  )
-
-  const registrations = registrationsData ?? []
-  const beats = (beatsData ?? []) as Beat[]
-  const openBeats = (openData ?? []) as OpenBeat[]
-  const tasks = (tasksData ?? []) as Task[]
-
-  const corporationOf = new Map(registrations.map((r) => [r.id, r.corporation_id]))
-
-  // latest_heartbeats returns one row per job per owner. Character- and
-  // account-scoped rows are already unique per cell; corp rows can appear once
-  // per character that has ever run the corp's pull, so keep the newest — its
-  // registration_id is whose token the extract actually ran under last time.
-  const { charBeats, corpBeats, accountBeats, corpRunsAs } = reduce(
-    (acc, b: Beat) => {
-      if (b.corporation_id != null) {
-        const key = `${b.job}:${b.corporation_id}`
-        const prev = acc.corpBeats.get(key)
-        if (!prev || prev.ended_at < b.ended_at) acc.corpBeats.set(key, b)
-        // Whose token *worked*. A skipped row names a character who was turned
-        // away for want of the in-game role, which is precisely who didn't run
-        // it, so those never claim the Runs as column.
-        if (b.skipped_reason == null) {
-          const prevRun = acc.corpRunsAs.get(b.corporation_id)
-          if (!prevRun || prevRun.ended_at < b.ended_at) acc.corpRunsAs.set(b.corporation_id, b)
-        }
-      } else if (b.registration_id != null) {
-        acc.charBeats.set(`${b.job}:${b.registration_id}`, b)
-      } else {
-        acc.accountBeats.set(b.job, b)
-      }
-      return acc
-    },
-    {
-      charBeats: new Map<string, Beat>(),
-      corpBeats: new Map<string, Beat>(),
-      accountBeats: new Map<string, Beat>(),
-      corpRunsAs: new Map<number, Beat>(),
-    },
-    beats
-  )
-
-  // Same keying for the open rows: a corp run's heartbeat carries the
-  // corporation, a per-character run its registration, a shared run neither.
-  const openCells = new Set(openBeats.map((b) => `${b.job}:${b.corporation_id ?? b.registration_id ?? ''}`))
-
-  // Index the just-kicked tasks by cell, later rows winning. A corp job's task
-  // row carries its representative character, so key those by the corp instead.
-  const corpJobNames = new Set(jobsInSection('corporation').map((entry) => entry.job))
-  const taskByCell = reduce(
-    (acc, t) => {
-      if (t.created_at < overlayFloor || isAbandoned(t, now)) return acc
-      const corpId = corpJobNames.has(t.job) && t.registration_id != null ? corporationOf.get(t.registration_id) : null
-      return acc.set(`${t.job}:${corpId ?? t.registration_id ?? ''}`, t)
-    },
-    new Map<string, Task>(),
-    tasks
-  )
-  const anyActive = tasks.some((t) => (t.status === 'pending' || t.status === 'running') && !isAbandoned(t, now))
-
-  // The user's corporations, each with the registered characters in it (in
-  // registration order — the representative dispatchRefresh would pick first).
-  const corporations = reduce(
-    (acc, r) => {
-      if (r.corporation_id == null) return acc
-      const group = acc.get(r.corporation_id)
-      if (group) group.push(r)
-      else acc.set(r.corporation_id, [r])
-      return acc
-    },
-    new Map<number, typeof registrations>(),
-    registrations
-  )
-
-  const corporationIds = [...corporations.keys()]
-  const { data: corpNamesData } = corporationIds.length
-    ? await supabase.from('universe_name').select('id, name').in('id', corporationIds)
-    : { data: [] }
-  const corpName = new Map((corpNamesData ?? []).map((n) => [Number(n.id), n.name as string]))
-
-  const runFor = (job: string, key: string, beat: Beat | undefined): Omit<EntityRun, 'id' | 'name'> => ({
-    lastRunAt: beat?.ended_at ?? null,
-    ...statusOf({
-      task: taskByCell.get(`${job}:${key}`),
-      open: openCells.has(`${job}:${key}`),
-      beat: beat && { ok: beat.ok, error: beat.error, skippedReason: beat.skipped_reason },
-    }),
-  })
-
-  const characterEntities: Record<string, EntityRun[]> = Object.fromEntries(
-    jobsInSection('character').map((entry) => [
-      entry.job,
-      registrations.map((r) => ({
-        id: r.id,
-        name: r.name,
-        ...runFor(entry.job, r.id, charBeats.get(`${entry.job}:${r.id}`)),
-      })),
-    ])
-  )
-
-  const corporationEntities: Record<string, EntityRun[]> = Object.fromEntries(
-    jobsInSection('corporation').map((entry) => [
-      entry.job,
-      [...corporations.entries()].map(([corporationId, members]) => {
-        const runsAs = corpRunsAs.get(corporationId)
-        const owned = members.find((m) => m.id === runsAs?.registration_id)
-        // Kick new pulls as the character the last one succeeded under when
-        // it's ours; the workflow target carries the whole corp group either
-        // way, so this only picks the row's representative.
-        const representative = owned ?? members[0]
-        // Nobody has run it here yet → name who *would* run it, so the column
-        // still answers "under whose token" instead of blanking.
-        const runsAsCorpmate = runsAs != null && owned == null
-        return {
-          // The refresh button dispatches against a registration of ours, so
-          // the entity's id is the representative character's — the corp id is
-          // only how its heartbeats are keyed.
-          id: representative.id,
-          name: corpName.get(corporationId) ?? `#${corporationId}`,
-          runsAs: runsAsCorpmate ? null : representative.name,
-          runsAsCorpmate,
-          ...runFor(entry.job, String(corporationId), corpBeats.get(`${entry.job}:${corporationId}`)),
-        }
-      }),
-    ])
-  )
-
-  const activity = activityRows(tasks)
+  const {
+    registrations,
+    characterEntities,
+    corporationEntities,
+    accountBeats,
+    runFor,
+    activity,
+    corporationCount,
+    anyActive,
+    chancellor,
+    now,
+  } = await fetchJobsOverview(supabase, user.id)
 
   return (
     <>
@@ -436,7 +262,7 @@ const JobsPage = async () => {
             offerRefreshAll
           />
 
-          {corporations.size > 0 && (
+          {corporationCount > 0 && (
             <>
               <h2>Corporations</h2>
               <p>


### PR DESCRIPTION
Phase 1 of [docs/registrations-page](docs/registrations-page/01-shared-data-seams.md): move the data assembly out of the two `page.tsx` files into shared server modules, so the coming `/registration` page renders the *same* objects instead of a copy that could drift.

**Pure refactor — no rendered byte changes.**

- `src/app/character/characterData.ts` — `fetchCharacterOverviews(supabase)` returns one `CharacterOverview` per registration (balance, location system, current ship, clone systems, implants, job slots), plus `hasNoOptionalScopes(supabase, userId)` for the limited-access warning. Everything moved verbatim: the wallet latest-balance fold, system/type name resolution, the clone uniq+sort, the ship label collapse rule, `countJobSlots` (corp jobs included) and the `slotMax` skill fold.
- `src/app/character/jobSlotBubbles.tsx` — the `JobSlots` bubbles, split out so the new page renders the identical component. Named for the bubbles so it doesn't read as a second `src/app/industry/jobSlots.ts`.
- `src/app/jobs/jobsData.ts` — `fetchJobsOverview(supabase, userId)` with the four-way `Promise.all`, the heartbeat fold (corp-newest-wins, skipped-never-claims-*Runs as*), `openCells`, the corp re-keyed `taskByCell`, corp grouping + representative picking, `runFor`, `activityRows`, and `isChancellor`.

Both pages keep their auth gate, `export const dynamic`, and all JSX. `rows.ts` / `registry.ts` / `schedule.ts` untouched.

## Verification

- `pnpm run lint` ✅, `pnpm test` ✅ (526 passing).
- `pnpm run build` fails identically **before and after** this branch, on clean `main` too: a macOS case-insensitivity collision between `src/app/freshness.ts` and `src/app/Freshness.tsx` (`TS1149`), hit from `layout/header.tsx` as well. Pre-existing and unrelated; no other type errors appear with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)