### PR TITLE
feat(registration): /registration shell + character rows (registrations phase 2)

### DIFF
--- a/src/app/registration/loading.tsx
+++ b/src/app/registration/loading.tsx
@@ -1,0 +1,11 @@
+import { LoadingShell, SkeletonLines } from '../skeleton'
+
+// The matrix's width depends on how many characters the caller has and, from
+// phase 3, how many job columns their grants earn — so bars rather than a
+// skeleton table with invented columns (same call /jobs makes).
+const RegistrationLoading = () => (
+  <LoadingShell title="Registrations & refresh">
+    <SkeletonLines count={6} />
+  </LoadingShell>
+)
+export default RegistrationLoading

--- a/src/app/registration/page.tsx
+++ b/src/app/registration/page.tsx
@@ -1,0 +1,170 @@
+// /registration — one page for the linked characters and the extract jobs that
+// keep their data fresh (docs/registrations-page). Laid out per the phase-0
+// design extraction: a page header over one bordered matrix, one row per
+// registration.
+//
+// Phase 2 ships the shell and the character rows at parity with /character;
+// the per-scope job columns, the axis refresh triggers and the poller land in
+// phase 3. /character and /jobs stay live and unchanged until a separate
+// sunset decision.
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+
+import { createClient } from '@/utils/supabase/server'
+
+import { establishedUser } from '../account/lib/establishedUser'
+import { register } from '../character/actions'
+import { fetchCharacterOverviews, hasNoOptionalScopes } from '../character/characterData'
+import { JobSlots } from '../character/jobSlotBubbles'
+import { formatBisk } from '../isk'
+import styles from './registration.module.css'
+
+// The phase-3 poller re-requests this server component while a kicked job is
+// in flight, so never serve it from the router cache.
+export const dynamic = 'force-dynamic'
+
+const RegistrationPage = async () => {
+  const supabase = await createClient()
+
+  const user = await establishedUser(supabase)
+  if (!user) {
+    redirect('/')
+  }
+
+  const { characters, status, statusText, error } = await fetchCharacterOverviews(supabase)
+  const noOptionalScopes = await hasNoOptionalScopes(supabase, user.id)
+
+  return (
+    <>
+      <div className={styles.header}>
+        <div className={styles.headerText}>
+          <h1>Registrations &amp; refresh</h1>
+          <div className={styles.status}>
+            <span className={styles.statusCount}>{characters.length}</span>{' '}
+            {characters.length === 1 ? 'character' : 'characters'}
+          </div>
+        </div>
+        <form className={styles.headerActions}>
+          <button formAction={register}>+ Register a character</button>
+        </form>
+      </div>
+
+      {noOptionalScopes && (
+        <div className={styles.warning} role="alert">
+          <strong className={styles.warningTitle}>Limited access selected</strong>
+          <p className={styles.warningBody}>
+            You haven&apos;t enabled any ESI permissions, so characters you add will only be identified — no wallet,
+            assets, industry, market, or structure data can be tracked. Choose what to share in{' '}
+            <Link href="/settings/grants">settings</Link>.
+          </p>
+        </div>
+      )}
+
+      <div className={styles.matrix}>
+        <div className={styles.headerRow}>
+          <span className={styles.columnLabel}>Character</span>
+          <span className={styles.columnLabel}>State</span>
+        </div>
+
+        {characters.length === 0 ? (
+          <>
+            {/* The empty state is the matrix, ghosted: one dashed row where the
+                first character will appear, so the CTA doesn't have to explain
+                what registering unlocks — the grid already does. */}
+            <div className={styles.ghostRow} aria-hidden="true">
+              <div className={styles.identity}>
+                <div className={styles.ghostAvatar} />
+                <div className={styles.ghostBar} />
+              </div>
+            </div>
+            <div className={styles.empty}>
+              <div className={styles.emptyTitle}>No characters registered yet</div>
+              <p className={styles.emptyBody}>
+                Register one through EVE&apos;s SSO and this row fills in — refresh jobs start within a minute of the
+                grant.
+              </p>
+              <form className={styles.emptyActions}>
+                <button formAction={register}>Register your first character</button>
+              </form>
+              <div className={styles.reassurance}>
+                Uses CCP&apos;s official login — we never see your password.{' '}
+                <Link href="/settings/grants">What each scope unlocks</Link>
+              </div>
+            </div>
+          </>
+        ) : (
+          characters.map((c) => (
+            <div key={c.id} className={styles.row}>
+              <div className={styles.identity}>
+                {c.characterId ? (
+                  <img
+                    className={styles.avatar}
+                    src={`https://images.evetech.net/characters/${c.characterId}/portrait?size=128`}
+                    alt={c.name}
+                  />
+                ) : (
+                  <div className={styles.avatar} aria-hidden="true" />
+                )}
+                <div className={styles.identityText}>
+                  <div className={styles.name}>{c.name}</div>
+                  {/* Only for characters who have shared their skills — slots is
+                      null unless character_skill rows exist, so without the scope
+                      we don't guess a capacity, we show nothing. */}
+                  {c.slots && <JobSlots counts={c.slots.counts} max={c.slots.max} />}
+                </div>
+              </div>
+              <div className={styles.state}>
+                <div className={styles.field}>
+                  <span className={styles.fieldLabel}>ISK:</span>
+                  {c.balance === null ? '—' : formatBisk(c.balance)}
+                </div>
+                <div className={styles.field}>
+                  <span className={styles.fieldLabel}>Location:</span>
+                  {c.locationSystem ?? '—'}
+                </div>
+                <div className={styles.field}>
+                  <span className={styles.fieldLabel}>Ship:</span>
+                  {c.ship ? <Link href={`/ship/${c.ship.itemId}`}>{c.ship.label}</Link> : '—'}
+                </div>
+                {c.cloneSystems.length > 0 && (
+                  <div className={styles.field}>
+                    <span className={styles.fieldLabel}>Clone systems:</span>
+                    <ul className={`${styles.list} ${styles.cloneList}`}>
+                      {c.cloneSystems.map((system) => (
+                        <li key={system}>{system}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {c.implants.length > 0 && (
+                  <div className={styles.field}>
+                    <span className={styles.fieldLabel}>Implants:</span>
+                    <ul className={styles.list}>
+                      {c.implants.map((name: string, i: number) => (
+                        <li key={i}>{name}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      {error && (
+        <>
+          <strong>
+            {status}: {statusText}
+          </strong>
+          <br />
+          <em>
+            {error.code}: {error.message}
+          </em>
+          <pre>{JSON.stringify(error, undefined, 2)}</pre>
+        </>
+      )}
+    </>
+  )
+}
+export default RegistrationPage

--- a/src/app/registration/registration.module.css
+++ b/src/app/registration/registration.module.css
@@ -1,0 +1,245 @@
+/* /registration — the registrations matrix from the phase-0 design extraction
+   (docs/registrations-page/00a-design-extraction.md §1, §4). Design tokens map
+   onto the app's own: bg-surface/canvas → --paper, bg-elevated → --paper-raised,
+   border-subtle → --line-soft, border-strong → --line, text-secondary/tertiary
+   → --ink-soft/--ink-faint.
+
+   Phase 2 builds the shell and the character rows; the per-scope job columns
+   land in phase 3, which widens .row's grid template rather than replacing it. */
+
+/* Page header: title + status line on the left, actions right, baseline-ish
+   aligned per the mockup's flex-end row. */
+.header {
+  display: flex;
+  align-items: flex-end;
+  gap: 14px;
+  flex-wrap: wrap;
+  margin-bottom: 18px;
+}
+
+.headerText {
+  flex: 1;
+  min-width: 0;
+}
+
+.header h1 {
+  margin: 0;
+}
+
+.status {
+  margin-top: 5px;
+  font-size: 9pt;
+  color: var(--ink-faint);
+}
+
+.statusCount {
+  font-family: var(--mono);
+  color: var(--ink);
+}
+
+.headerActions {
+  display: flex;
+  gap: 8pt;
+  margin: 0;
+}
+
+/* The matrix: one bordered, rounded container, rows separated by hairlines and
+   clipped to the radius. */
+.matrix {
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.columns {
+  display: grid;
+  /* Phase 3 inserts `repeat(N, 1fr)` for the scope columns between these two. */
+  grid-template-columns: 230px 1fr;
+  gap: 14px;
+  align-items: start;
+}
+
+.headerRow {
+  composes: columns;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--line-soft);
+  background: var(--paper-raised);
+}
+
+.columnLabel {
+  font-size: 8pt;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+.row {
+  composes: columns;
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--line-soft);
+  align-items: center;
+}
+
+.row:last-child {
+  border-bottom: none;
+}
+
+/* Identity cell: portrait, name, and the job-slot bubbles beneath it. */
+.identity {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  min-width: 0;
+}
+
+.avatar {
+  width: 40px;
+  height: 40px;
+  flex: none;
+  border-radius: 50%;
+  background: var(--line-soft);
+  border: 1px solid var(--line);
+}
+
+.identityText {
+  min-width: 0;
+}
+
+.name {
+  font-family: var(--serif);
+  font-weight: bold;
+  font-size: 11pt;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Character state — the fields the mockup's row omits and parity keeps
+   (docs/registrations-page/00a-design-extraction.md §2). Phase 4 rules on
+   where these finally live. */
+.state {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 24px;
+  min-width: 0;
+  font-size: 9pt;
+  color: var(--ink-soft);
+}
+
+.field {
+  min-width: 0;
+}
+
+.fieldLabel {
+  color: var(--ink-faint);
+  margin-right: 4pt;
+}
+
+.list {
+  margin: 2pt 0 0;
+  padding-left: 16pt;
+}
+
+.list li {
+  white-space: nowrap;
+}
+
+.cloneList {
+  list-style: none;
+  padding-left: 0;
+}
+
+/* First run: the matrix, ghosted — one dashed row where the first character
+   will appear, then the invitation (design extraction, "First-run empty
+   state"). */
+.ghostRow {
+  composes: columns;
+  padding: 11px 14px;
+  opacity: 0.45;
+}
+
+.ghostAvatar {
+  width: 40px;
+  height: 40px;
+  flex: none;
+  border-radius: 50%;
+  border: 1px dashed var(--line);
+}
+
+.ghostBar {
+  height: 10px;
+  width: 120px;
+  margin-top: 8px;
+  border: 1px dashed var(--line);
+  border-radius: var(--radius-sm);
+}
+
+.empty {
+  padding: 0 14px 18px;
+  text-align: center;
+}
+
+.emptyTitle {
+  font-family: var(--serif);
+  font-size: 11pt;
+}
+
+.emptyBody {
+  margin: 4pt auto 10pt;
+  max-width: 44em;
+  font-size: 9pt;
+  color: var(--ink-soft);
+}
+
+.emptyActions {
+  display: flex;
+  justify-content: center;
+  margin: 0;
+}
+
+.reassurance {
+  margin-top: 10pt;
+  font-size: 8.5pt;
+  color: var(--ink-faint);
+}
+
+/* Same treatment as /character's: an account that shares nothing optional gets
+   almost no data, so say so where characters are added. */
+.warning {
+  margin: 12pt 0;
+  padding: 10pt 12pt;
+  border: 1px solid #d9a441;
+  border-left-width: 3px;
+  border-radius: var(--radius);
+  background: color-mix(in srgb, #d9a441 12%, var(--paper-raised));
+}
+
+.warningTitle {
+  display: block;
+  font-family: var(--serif);
+  font-size: 10pt;
+}
+
+.warningBody {
+  margin: 4pt 0 0;
+  font-size: 9pt;
+  color: var(--ink-soft);
+}
+
+/* Narrow widths: the matrix becomes per-character cards (design extraction §6
+   — the responsive intent). The grid collapses to one column and the identity
+   block sits above the state fields. */
+@media (max-width: 720px) {
+  .columns {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+
+  .headerRow {
+    display: none;
+  }
+
+  .row {
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
Phase 2 of [docs/registrations-page](docs/registrations-page/02-page-shell-and-characters.md): the `/registration` route itself, laid out per the [phase-0 design extraction](docs/registrations-page/00a-design-extraction.md). Builds on #957's `fetchCharacterOverviews`.

- **Page header** — `<h1>` + character count (mono) + primary "register a character" action, per §1's header row.
- **The matrix** — one bordered, rounded, clipped container; one row per registration. Identity cell is portrait + name + the job-slot bubbles; the rest of the row carries the character-state fields.
- **Empty state** — the matrix ghosted: dashed row where the first character will appear, then "no characters registered yet", the CTA, and the "uses CCP's official login — we never see your password" line with the scope-explainer link.
- **`loading.tsx`** — bars, same call `/jobs` makes (column count isn't knowable statically, and will depend on grants from phase 3).

## Parity checklist (§"Character-section parity checklist")

- [x] One row per `registration`, in query order
- [x] Portrait at `?size=128`; `aria-hidden` placeholder when `character_id` is null
- [x] Name
- [x] Job-slot bubbles — the shared `JobSlots` component, rendered only when skill rows exist
- [x] ISK via `formatBisk`, `—` when absent
- [x] Location, `—` when absent
- [x] Ship linked to `/ship/{itemId}`, label collapse rule preserved, `—` when absent
- [x] Clone systems (uniq, sorted, region-qualified paths), only when non-empty
- [x] Implants, only when non-empty
- [x] "Limited access selected" warning (`role="alert"`) linking `/settings/grants`
- [x] Supabase error dump block
- [x] Add Character posts to the existing `register` action — reused, not copied

## Deliberately deferred

- Scope columns, template row, axis ↻ triggers, legend, `RefreshPoller` — **phase 3**. The grid template widens for them (`230px 1fr` → `230px repeat(N,1fr) 130px`) rather than being replaced. `dynamic = 'force-dynamic'` is set now, as the phase doc allows.
- Per-row **remove** and **re-auth** actions, and the corp-ticker mono subline — the mockup shows them but they're neither in this phase's checklist nor derivable from `CharacterOverview` today (no ticker/role data). Flagging for phase 3/4 to place.
- `--info` token (the blue "granted, not requested" ring) — a matrix-cell concern, so it lands with the cells.
- No nav link (phase 5). Reachable by URL, same posture `/jobs` had while it was built.

## Verification

- `pnpm run lint` ✅, `pnpm test` ✅.
- `pnpm run build`: no new type errors. The only failures are the pre-existing `freshness.ts` / `Freshness.tsx` macOS case collision (`TS1149`), which fails identically on clean `main` — see #957.
- `/registration` responds locally exactly as `/jobs` does (200 + streamed loading shell, then the `establishedUser` redirect for signed-out callers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)