### PR TITLE
Corporation-owned blueprint libraries on /bpos

### DIFF
--- a/docs/bpo-showcase-corp.md
+++ b/docs/bpo-showcase-corp.md
@@ -1,0 +1,182 @@
+# Plan: corp-owned BPO showcases (`/bpos/[name]` for a corporation)
+
+## Problem
+
+A player reports the showcase is empty for them because they keep their
+blueprint originals in a corp hangar. Anything deposited
+into a corp hangar becomes a **corporation** asset, so those BPOs land in
+`corp_blueprint` (via the daily `corp-blueprints` job) and never in
+`character_blueprint` — the showcase at `/bpos/[name]`, which reads only
+`character_blueprint` across the account's registrations, shows nothing.
+
+Extend the showcase so the URL segment can also name a **corporation**:
+`/bpos/some-mining-corp` lists that corp's blueprint originals, with the same
+private-by-default sharing model the account page has.
+
+## What already exists (nothing new to ingest)
+
+- `corp_blueprint_over_time` + `corp_blueprint` view already carry exactly the
+  columns the showcase needs (`type_id`, `material_efficiency`,
+  `time_efficiency`, `quantity`, `runs`), populated daily by `corp-blueprints`
+  from a Director-scoped token (`esi-corporations.read_blueprints.v1`).
+- RLS on it already answers "is the viewer in this corp": members read rows for
+  corps their registrations belong to.
+- `corporation` (world-readable, `corporation_id`, `name`, `alliance_id`) gives
+  us name → id resolution for the URL.
+- The pure seams are subject-agnostic already: `stack.ts` (original test,
+  stacking, sort orders) and `slug.ts` both operate on names and rows, not on
+  accounts.
+
+## Design
+
+### 1. URL namespace: one route, character first
+
+Keep the single `/bpos/[name]` route. Resolution order:
+
+1. `resolveBposAccount(slug, viewer)` — an account whose **main** character
+   slugifies to this (existing behavior, unchanged). Every URL in the wild today
+   keeps its meaning.
+2. Only if no account matches: a corporation whose **name** slugifies to this
+   (`corporation.name` probed with the same `slugLikePattern` `_`-wildcard
+   trick, then narrowed by exact `characterSlug()` comparison — corp names allow
+   the same space/dash ambiguity).
+3. Two corporations slugifying identically (shouldn't happen — EVE corp names
+   are unique — but the slug folds case and whitespace): resolve to nothing,
+   same coin-flip refusal as ambiguous accounts.
+
+A character-vs-corp name collision therefore hides the corp page behind the
+character's. Accepted: EVE disallows a corp taking an in-use character name, so
+real collisions are near-impossible, and the character-first order is the
+backward-compatible one. No `/bpos/corp/[name]` sub-route — one namespace, one
+URL shape to share.
+
+Refactor `access.ts` around a discriminated subject:
+
+```ts
+type BposSubject =
+  | { kind: 'account'; userId: string; registrations: BposRegistration[]; mainName: string }
+  | { kind: 'corporation'; corporationId: number; name: string }
+```
+
+`resolveBposSubject(slug, viewer)` tries account then corporation.
+`ts-pattern` `.exhaustive()` on `kind` where the page branches.
+
+### 2. New table: `corp_bpo_share`
+
+`bpo_share` is `user_id`-keyed ("everything this account owns"); the corp
+subject needs its own row. New table on the Revision 3 audience shape:
+
+```sql
+create table public.corp_bpo_share (
+  id uuid primary key default gen_random_uuid(),
+  corporation_id bigint not null unique,
+  corporation_ids bigint[] not null default '{}',
+  alliance_ids bigint[] not null default '{}',
+  secret text,
+  created_by uuid references auth.users(id) on delete set null,  -- audit only
+  created_at timestamptz not null default now()
+);
+```
+
+- One row per corporation (`unique`), exactly like `bpo_share`'s one row per
+  account. No row → page 404s for outsiders → a guessed corp name confirms
+  nothing.
+- **Manage policy:** any authenticated user with a registration in the corp
+  (`corporation_id in (select corporation_id from registration where user_id =
+  auth.uid())`). Rationale: that is precisely the set who can already read
+  `corp_blueprint` for the corp, so no one can share data they can't see.
+  - *Flagged decision:* this lets any member (not just Directors) publish the
+    corp's library. We don't track in-game roles; the alternative — restrict to
+    accounts holding a `esi-corporations.read_blueprints.v1` token — only
+    proves the scope was granted, not the Director role, and blocks the common
+    "alt holds the token, main manages the page" case. Recommend member-manage,
+    called out in the share dialog hint ("any member of the corp can change or
+    revoke this share").
+- **Audience read policy:** the standard load-bearing Revision 3 policy,
+  `using (public.share_audience_matches(corporation_ids, alliance_ids, secret))`
+  to `anon, authenticated` — identical to `bpo_share`'s. Fully-public rows are
+  still settled app-side through the service role (same reasoning as the
+  account page: no anon evaluation of `my_corporation_ids()`).
+
+Migration hygiene (per the hard-won rules): edit `schema.sql` **and** add one
+incremental migration scaffolded by `pnpm run db:new corp_bpo_share` — fresh
+clock timestamp, never copied, never renamed. The last `bpo_share` migration was
+lost to exactly this (docs/bpo-share-collision.md).
+
+### 3. Access rules (`bposAccess` for the corp subject)
+
+Mirror of the account ladder, with "member" replacing "owner":
+
+1. **`member`** — the viewer has a registration in the corp (service-role check
+   against `registration.corporation_id`, or equivalently a viewer-client probe
+   of `corp_blueprint`). Members always see the page; that's where the share
+   dialog lives.
+2. No `corp_bpo_share` row → `null` → 404.
+3. **`public`** — the row names no one (`secret is null`, both arrays empty).
+4. **`link`** — `?share=` verified by the existing `verifyShareToken` over the
+   row's `id`/`secret` (`src/shareToken.ts`, unchanged — it signs share ids,
+   not subjects).
+5. **`audience`** — viewer-client `select` on `corp_bpo_share` filtered to the
+   corp; the audience policy answers via `share_audience_matches`, so
+   membership math stays in Postgres.
+
+### 4. Data read
+
+New `fetchCorpBpoEntries(corporationId)` in `data.ts`: service-role,
+`corp_blueprint`, `.eq('corporation_id', ...)`, `.eq('runs', -1)`, range-paged
+at 1000 exactly like `readBlueprints`. Extract the SDE-dressing tail of
+`fetchBpoEntries` (stack → blueprint names → product categories) into a shared
+`dressStacks(rows)` both fetchers call — the row shape is identical, so
+`stackBpos` and `BpoEntry` are reused untouched.
+
+Note the corp mirror is **daily** (vs 6h for characters); worth a `Freshness`-
+style caveat only if someone asks — the showcase has no freshness UI today, so
+none added.
+
+### 5. Page and share dialog
+
+`[name]/page.tsx` branches on `subject.kind`:
+
+- Title: `The Blueprint Library of <corp name>` (serif h1, unchanged styles,
+  same count/subtitle/table/empty-state).
+- `generateMetadata` stays URL-derived (never confirms existence).
+- Share dialog renders for `access === 'owner' || access === 'member'`. New
+  `saveCorpBposShare(slug, corporationId, input)` / `revokeCorpBposShare` server
+  actions mirroring `shareActions.ts`: verify the caller has a registration in
+  the corp (the RLS manage policy enforces it too, but fail with a message
+  first), filter requested audience ids against the caller's own
+  corps/alliances via the existing `ownAudiences` helper, upsert
+  `onConflict: 'corporation_id'`. `fetchCorpBposShareDialogData` reads the row
+  through the **cookie client** (manage policy makes it visible to members).
+  Dialog `hint` notes any corp member can see and manage the share.
+
+### 6. What this deliberately does NOT do
+
+- **No union on the account page.** an account's page keeps showing only
+  character-owned BPOs; corp holdings live at the corp URL. Merging them would
+  let one member's personal share expose corp property (and vice versa), and
+  double-count when two members share the same corp.
+- No per-hangar/division filtering — the corp's whole original collection, same
+  as the account page pools alts.
+- No changes to extract jobs, ESI scopes, or `shareToken.ts`.
+
+## Work items
+
+1. Migration + `schema.sql`: `corp_bpo_share` (table, RLS, grants).
+   `pnpm run db:new corp_bpo_share`.
+2. `slug.ts`: nothing (helpers already name-agnostic); rename nothing.
+3. `access.ts`: `BposSubject`, `resolveBposSubject` (account → corp),
+   corp branch of `bposAccess` (`member` access kind).
+4. `data.ts`: shared `dressStacks`, new `fetchCorpBpoEntries`.
+5. `shareData.ts` / `shareActions.ts`: corp variants (`corp_bpo_share`,
+   `onConflict: 'corporation_id'`, membership check).
+6. `[name]/page.tsx`: branch on subject kind; wire corp share dialog.
+7. Tests:
+   - `test/bposSubject.test.ts` — pure resolution-order/narrowing logic if a
+     pure seam falls out (candidate: the "narrow probe rows by exact slug, pick
+     unique" step, shared by both resolvers).
+   - `test/sql/corp_bpo_share.sql` — RLS: member manages, non-member can't
+     write, audience policy matches corp/alliance arrays, link-only row
+     invisible to anon.
+8. Verify: `pnpm run lint`, `pnpm test`, `next build`; `test:sql` against a
+   throwaway DB.

--- a/docs/bpo-showcase-corp.md
+++ b/docs/bpo-showcase-corp.md
@@ -29,26 +29,27 @@ private-by-default sharing model the account page has.
 
 ## Design
 
-### 1. URL namespace: one route, character first
+### 1. URL namespace: one route, corporation first
 
 Keep the single `/bpos/[name]` route. Resolution order:
 
-1. `resolveBposAccount(slug, viewer)` — an account whose **main** character
-   slugifies to this (existing behavior, unchanged). Every URL in the wild today
-   keeps its meaning.
-2. Only if no account matches: a corporation whose **name** slugifies to this
-   (`corporation.name` probed with the same `slugLikePattern` `_`-wildcard
-   trick, then narrowed by exact `characterSlug()` comparison — corp names allow
-   the same space/dash ambiguity).
+1. A corporation whose **name** slugifies to this (`corporation.name` probed
+   with the same `slugLikePattern` `_`-wildcard trick, then narrowed by exact
+   `characterSlug()` comparison — corp names allow the same space/dash
+   ambiguity). Corp-first because there are far fewer corporations than
+   registrations: the common case settles on one cheap probe of a small,
+   world-readable table.
+2. Only if no corporation matches: `resolveBposAccount(slug, viewer)` — an
+   account whose **main** character slugifies to this (existing behavior,
+   unchanged).
 3. Two corporations slugifying identically (shouldn't happen — EVE corp names
    are unique — but the slug folds case and whitespace): resolve to nothing,
    same coin-flip refusal as ambiguous accounts.
 
-A character-vs-corp name collision therefore hides the corp page behind the
-character's. Accepted: EVE disallows a corp taking an in-use character name, so
-real collisions are near-impossible, and the character-first order is the
-backward-compatible one. No `/bpos/corp/[name]` sub-route — one namespace, one
-URL shape to share.
+A character-vs-corp name collision therefore hides the character's page behind
+the corp's. Accepted: EVE disallows a corp taking an in-use character name, so
+real collisions are near-impossible. No `/bpos/corp/[name]` sub-route — one
+namespace, one URL shape to share.
 
 Refactor `access.ts` around a discriminated subject:
 
@@ -58,7 +59,7 @@ type BposSubject =
   | { kind: 'corporation'; corporationId: number; name: string }
 ```
 
-`resolveBposSubject(slug, viewer)` tries account then corporation.
+`resolveBposSubject(slug, viewer)` tries corporation then account.
 `ts-pattern` `.exhaustive()` on `kind` where the page branches.
 
 ### 2. New table: `corp_bpo_share`
@@ -165,7 +166,7 @@ none added.
 1. Migration + `schema.sql`: `corp_bpo_share` (table, RLS, grants).
    `pnpm run db:new corp_bpo_share`.
 2. `slug.ts`: nothing (helpers already name-agnostic); rename nothing.
-3. `access.ts`: `BposSubject`, `resolveBposSubject` (account → corp),
+3. `access.ts`: `BposSubject`, `resolveBposSubject` (corp → account),
    corp branch of `bposAccess` (`member` access kind).
 4. `data.ts`: shared `dressStacks`, new `fetchCorpBpoEntries`.
 5. `shareData.ts` / `shareActions.ts`: corp variants (`corp_bpo_share`,

--- a/schema.sql
+++ b/schema.sql
@@ -136,6 +136,7 @@ drop table if exists public.refresh_task         cascade;
 drop table if exists public.shared_asset_token   cascade;
 drop table if exists public.link                 cascade;
 drop table if exists public.bpo_share            cascade;
+drop table if exists public.corp_bpo_share       cascade;
 drop table if exists public.discord_link_code    cascade;
 drop table if exists public.notification         cascade;
 drop table if exists public.discord_channel      cascade;
@@ -3134,6 +3135,67 @@ create policy "Audience reads bpo shares aimed at them"
 grant select                         on public.bpo_share to anon;
 grant select, insert, update, delete on public.bpo_share to authenticated;
 grant all                            on public.bpo_share to service_role;
+
+-- ── corp_bpo_share ────────────────────────────────────────────────────────
+-- The audience for one CORPORATION's blueprint-original showcase, the page at
+-- /bpos/[corporation-name]. Blueprints deposited into a corp hangar belong to
+-- the corporation, so they land in corp_blueprint and never appear on the
+-- account-scoped showcase; this is that collection's share row.
+--
+-- Standard Revision 3 audience shape, keyed one row per corporation the way
+-- bpo_share is keyed one row per account.
+--
+-- WHO MAY MANAGE IT. Any account with a character in the corporation — exactly
+-- the set that can already read corp_blueprint for it, so nobody can share data
+-- they cannot themselves see. In-game roles are not tracked anywhere in this
+-- deployment (a Director token proves a scope was granted, not that the holder
+-- is a Director), and gating on the token holder would break the common case of
+-- an alt carrying the scope while the main runs the page.
+create table public.corp_bpo_share (
+  id uuid primary key default gen_random_uuid(),
+  corporation_id bigint not null unique,
+  corporation_ids bigint[] not null default '{}',
+  alliance_ids bigint[] not null default '{}',
+  secret text,
+  -- Audit only: who first published it. Never read for authorization — a member
+  -- who leaves must not keep control, and one who joins must not be locked out.
+  created_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now()
+);
+
+alter table public.corp_bpo_share enable row level security;
+
+-- Members of the corporation manage its row. The subquery is the same
+-- membership test corp_blueprint_over_time's own read policy uses.
+create policy "Members manage corp bpo share"
+  on public.corp_bpo_share
+  for all
+  to authenticated
+  using (
+    corporation_id in (
+      select corporation_id from public.registration
+      where user_id = (select auth.uid()) and corporation_id is not null
+    )
+  )
+  with check (
+    corporation_id in (
+      select corporation_id from public.registration
+      where user_id = (select auth.uid()) and corporation_id is not null
+    )
+  );
+
+-- Audience discovery, the load-bearing array policy every Revision 3 share
+-- table carries (see bpo_share above for why the fully-public case is settled
+-- app-side through the service role rather than by an anon evaluation here).
+create policy "Audience reads corp bpo shares aimed at them"
+  on public.corp_bpo_share
+  for select
+  to anon, authenticated
+  using (public.share_audience_matches(corporation_ids, alliance_ids, secret));
+
+grant select                         on public.corp_bpo_share to anon;
+grant select, insert, update, delete on public.corp_bpo_share to authenticated;
+grant all                            on public.corp_bpo_share to service_role;
 
 -- ── character_clone_state ──────────────────────────────────────────────────
 -- Character-level fields from ESI /characters/{id}/clones/, written by the

--- a/src/app/bpos/[name]/page.tsx
+++ b/src/app/bpos/[name]/page.tsx
@@ -1,25 +1,29 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
+import { match } from 'ts-pattern'
 
 import { createClient } from '@/utils/supabase/server'
 
 import { ShareDialog } from '../../asset/shareDialog'
 import { ShareUrlCleanup } from '../../shareUrlCleanup'
-import { bposAccess, resolveBposAccount } from '../access'
+import { bposAccess, canManageShare, resolveBposSubject, type BposSubject } from '../access'
 import styles from '../bpos.module.css'
 import { BposTable } from '../bposTable'
-import { fetchBpoEntries } from '../data'
-import { fetchBposShareDialogData } from '../shareData'
-import { revokeBposShare, saveBposShare } from '../shareActions'
+import { fetchBpoEntries, fetchCorpBpoEntries } from '../data'
+import { fetchBposShareDialogData, fetchCorpBposShareDialogData } from '../shareData'
+import { revokeBposShare, revokeCorpBposShare, saveBposShare, saveCorpBposShare } from '../shareActions'
 import { characterSlug } from '../slug'
 import { totalBpos } from '../stack'
 
-// A showcase page for one person's blueprint originals, addressed by their main
-// character's name with spaces as dashes (/bpos/sir-cuddles). Private by
-// default: the owner always sees their own, and anyone else needs a share the
-// owner created — public, aimed at a corporation or alliance, or a signed link.
-// Without one the URL is a 404, so a guessed name reveals nothing, not even
-// that the account exists.
+// A showcase page for one collection of blueprint originals, addressed by name
+// with spaces as dashes (/bpos/sir-cuddles). The name is a CORPORATION's — the
+// case that matters when originals live in a corp hangar and so belong to the
+// corporation — or, failing that, a person's main character. Private by
+// default: the subject's own people always see it, and anyone else needs a
+// share they created — public, aimed at a corporation or alliance, or a signed
+// link. Without one the URL is a 404, so a guessed name reveals nothing, not
+// even that the collection exists.
 export const dynamic = 'force-dynamic'
 
 type PageProps = {
@@ -30,10 +34,38 @@ type PageProps = {
 export const generateMetadata = async ({ params }: PageProps): Promise<Metadata> => {
   // Deliberately not resolved against the database: a title is rendered before
   // access is decided, so deriving it from the URL keeps the 404 case from
-  // confirming whether the pilot exists.
+  // confirming whether the subject exists.
   const { name } = await params
   return { title: `Blueprint originals — ${decodeURIComponent(name)}` }
 }
+
+// Everything that differs between the two subjects, decided once: what the page
+// is called, where its blueprints come from, and the share plumbing behind the
+// dialog. `.exhaustive()` is what makes a third subject a build error rather
+// than a page that silently renders the wrong half.
+const viewOf = (subject: BposSubject, slug: string, supabase: SupabaseClient) =>
+  match(subject)
+    .with({ kind: 'corporation' }, ({ corporationId, name }) => ({
+      name,
+      entries: () => fetchCorpBpoEntries(corporationId),
+      shareData: () => fetchCorpBposShareDialogData(supabase, corporationId),
+      save: saveCorpBposShare.bind(null, slug, corporationId),
+      revoke: revokeCorpBposShare.bind(null, slug, corporationId),
+      hint:
+        'Whoever you share with can see every blueprint original in the corporation’s hangars — name, ME, TE and how many are held — live, until sharing stops. ' +
+        'Copies and everything else in the hangars stay private. Any member of the corporation can change or revoke this.',
+    }))
+    .with({ kind: 'account' }, ({ registrations, mainName }) => ({
+      name: mainName,
+      entries: () => fetchBpoEntries(registrations.map((r) => r.id)),
+      shareData: () => fetchBposShareDialogData(supabase),
+      save: saveBposShare.bind(null, slug),
+      revoke: revokeBposShare.bind(null, slug),
+      hint:
+        'Whoever you share with can see every blueprint original across all of your characters — name, ME, TE and how many you hold — live, until you stop sharing. ' +
+        'Copies and everything else in your hangars stay private.',
+    }))
+    .exhaustive()
 
 const BposPage = async ({ params, searchParams }: PageProps) => {
   const { name } = await params
@@ -46,24 +78,27 @@ const BposPage = async ({ params, searchParams }: PageProps) => {
   const { data: auth } = await supabase.auth.getUser()
   const viewer = auth?.user ?? null
 
-  const account = await resolveBposAccount(slug, viewer)
-  if (!account) notFound()
+  const subject = await resolveBposSubject(slug, viewer)
+  if (!subject) notFound()
 
-  const access = await bposAccess(account, viewer, supabase, shareParam)
+  const access = await bposAccess(subject, viewer, supabase, shareParam)
   if (!access) notFound()
 
-  const entries = await fetchBpoEntries(account.registrations.map((r) => r.id))
+  const view = viewOf(subject, slug, supabase)
+
+  const entries = await view.entries()
   const total = totalBpos(entries)
 
-  // The share dialog is the owner's own control, so it's fetched only for them.
-  const shareData = access === 'owner' ? await fetchBposShareDialogData(supabase) : null
+  // The share dialog is the subject's own control, so it's fetched only for the
+  // account's owner or a member of the corporation.
+  const shareData = canManageShare(access) ? await view.shareData() : null
 
   return (
     <>
       {shareParam && <ShareUrlCleanup />}
 
       <div className={styles.pageHeader}>
-        <h1>{`The Blueprint Library of ${account.mainName}`}</h1>
+        <h1>{`The Blueprint Library of ${view.name}`}</h1>
         {total > 0 && <span className={styles.count}>{total}</span>}
       </div>
 
@@ -77,9 +112,9 @@ const BposPage = async ({ params, searchParams }: PageProps) => {
             subjectLabel="blueprint library"
             urlPath={`/bpos/${slug}`}
             data={shareData}
-            save={saveBposShare.bind(null, slug)}
-            revoke={revokeBposShare.bind(null, slug)}
-            hint="Whoever you share with can see every blueprint original across all of your characters — name, ME, TE and how many you hold — live, until you stop sharing. Copies and everything else in your hangars stay private."
+            save={view.save}
+            revoke={view.revoke}
+            hint={view.hint}
           />
         )}
       </p>

--- a/src/app/bpos/access.ts
+++ b/src/app/bpos/access.ts
@@ -1,16 +1,18 @@
 // Who the /bpos/[name] URL names, and who is allowed to look.
 //
-// The showcase is account-scoped (every character's originals in one list), so
-// it reads through the service-role client like the /corpses share page does —
-// which means every query here is explicitly scoped to the owning account's
-// registrations, and the authorization is this module's job rather than RLS's.
+// The URL addresses one of two subjects: a CORPORATION (its blueprints live in
+// corp_blueprint, where anything deposited into a corp hangar ends up) or an
+// ACCOUNT (every character's originals in one list). Both read through the
+// service-role client like the /corpses share page does — which means every
+// query here is explicitly scoped to the subject, and the authorization is this
+// module's job rather than RLS's.
 import type { SupabaseClient, User } from '@supabase/supabase-js'
 import { groupBy } from 'ramda'
 
 import { parseShareParam, tokenSalt, verifyShareToken } from '@/shareToken'
 import { createServiceClient } from '@/utils/supabase/service'
 
-import { characterSlug, pickMain, slugLikePattern } from './slug'
+import { characterSlug, pickCorporation, pickMain, slugLikePattern, type CorporationCandidate } from './slug'
 
 export type BposRegistration = {
   id: string
@@ -28,6 +30,15 @@ export type BposAccount = {
   registrations: BposRegistration[]
   mainName: string
 }
+
+export type BposCorporation = {
+  corporationId: number
+  name: string
+}
+
+// What the URL resolved to. Discriminated so the page and the share plumbing
+// branch exhaustively rather than on the presence of a field.
+export type BposSubject = ({ kind: 'account' } & BposAccount) | ({ kind: 'corporation' } & BposCorporation)
 
 const REGISTRATION_COLUMNS = 'id, user_id, name, is_main, created_at'
 
@@ -73,10 +84,43 @@ export const resolveBposAccount = async (slug: string, viewer: User | null): Pro
   return accounts.find((a) => a.userId === viewer?.id) ?? (accounts.length === 1 ? accounts[0] : null)
 }
 
-// How a viewer got in, or null if they didn't. The owner always sees their own
-// page (that's where the share dialog lives), so 'owner' is checked before any
-// share row is read.
-export type BposAccess = 'owner' | 'public' | 'link' | 'audience'
+// Slug → the corporation carrying that name, over the world-readable
+// corporation directory. One hop: unlike an account, the subject IS the row the
+// probe found.
+export const resolveBposCorporation = async (slug: string): Promise<BposCorporation | null> => {
+  if (slug === '') return null
+
+  const { data } = await createServiceClient()
+    .from('corporation')
+    .select('corporation_id, name')
+    .ilike('name', slugLikePattern(slug))
+    .returns<CorporationCandidate[]>()
+
+  return pickCorporation(data ?? [], slug)
+}
+
+// Corporation first, then account. There are far fewer corporations than
+// registrations, so the corp probe is the cheap one and settles the common
+// case; the account resolver's two hops only run when no corporation answers.
+// A name collision therefore hides the character's page behind the corp's,
+// which EVE makes near-impossible by refusing a corporation an in-use character
+// name.
+export const resolveBposSubject = async (slug: string, viewer: User | null): Promise<BposSubject | null> => {
+  const corporation = await resolveBposCorporation(slug)
+  if (corporation) return { kind: 'corporation', ...corporation }
+
+  const account = await resolveBposAccount(slug, viewer)
+  return account ? { kind: 'account', ...account } : null
+}
+
+// How a viewer got in, or null if they didn't. The subject's own people always
+// see their page (that's where the share dialog lives), so 'owner' (the
+// account's holder) and 'member' (anyone with a character in the corporation)
+// are checked before any share row is read.
+export type BposAccess = 'owner' | 'member' | 'public' | 'link' | 'audience'
+
+// Whether the viewer may manage the share — the two "this is my page" kinds.
+export const canManageShare = (access: BposAccess): boolean => access === 'owner' || access === 'member'
 
 type ShareRow = {
   id: string
@@ -97,23 +141,16 @@ const linkMatches = (share: ShareRow, param: string | undefined): boolean => {
   }
 }
 
-export const bposAccess = async (
-  account: BposAccount,
+// The share ladder both subjects walk once their own people are ruled out:
+// no row → 404, fully public, signed link, then the audience arrays. `visible`
+// re-asks the same table as the VIEWER, so membership is Postgres's
+// share_audience_matches rather than a second implementation here.
+const shareAccess = async (
+  share: ShareRow | null,
   viewer: User | null,
-  // The viewer's own cookie-session client: the audience check runs as them, so
-  // the membership test is Postgres's (share_audience_matches) rather than a
-  // second implementation here.
-  viewerClient: SupabaseClient,
-  shareParam: string | undefined
+  shareParam: string | undefined,
+  visible: () => Promise<boolean>
 ): Promise<BposAccess | null> => {
-  if (viewer?.id === account.userId) return 'owner'
-
-  const service = createServiceClient()
-  const { data: share } = await service
-    .from('bpo_share')
-    .select('id, corporation_ids, alliance_ids, secret')
-    .eq('user_id', account.userId)
-    .maybeSingle<ShareRow>()
   if (!share) return null
 
   const corporationIds = share.corporation_ids ?? []
@@ -126,14 +163,69 @@ export const bposAccess = async (
 
   if (linkMatches(share, shareParam)) return 'link'
 
-  if (viewer) {
-    const { data: visible } = await viewerClient
-      .from('bpo_share')
-      .select('id')
-      .eq('user_id', account.userId)
-      .maybeSingle<{ id: string }>()
-    if (visible) return 'audience'
-  }
+  if (viewer && (await visible())) return 'audience'
 
   return null
+}
+
+export const bposAccess = async (
+  subject: BposSubject,
+  viewer: User | null,
+  // The viewer's own cookie-session client: the audience check runs as them, so
+  // the membership test is Postgres's (share_audience_matches) rather than a
+  // second implementation here.
+  viewerClient: SupabaseClient,
+  shareParam: string | undefined
+): Promise<BposAccess | null> => {
+  const service = createServiceClient()
+
+  if (subject.kind === 'account') {
+    if (viewer?.id === subject.userId) return 'owner'
+
+    const { data: share } = await service
+      .from('bpo_share')
+      .select('id, corporation_ids, alliance_ids, secret')
+      .eq('user_id', subject.userId)
+      .maybeSingle<ShareRow>()
+
+    return shareAccess(share, viewer, shareParam, async () => {
+      const { data } = await viewerClient
+        .from('bpo_share')
+        .select('id')
+        .eq('user_id', subject.userId)
+        .maybeSingle<{ id: string }>()
+      return data != null
+    })
+  }
+
+  // A member of the corporation always sees its page. Checked against the
+  // viewer's own registrations through the service role, because `registration`
+  // is RLS-hidden and the cookie client would answer only for rows it can see —
+  // which is the same set, but this keeps the check in one shape for both
+  // subjects.
+  if (viewer) {
+    const { data: membership } = await service
+      .from('registration')
+      .select('id')
+      .eq('user_id', viewer.id)
+      .eq('corporation_id', subject.corporationId)
+      .limit(1)
+      .maybeSingle<{ id: string }>()
+    if (membership) return 'member'
+  }
+
+  const { data: share } = await service
+    .from('corp_bpo_share')
+    .select('id, corporation_ids, alliance_ids, secret')
+    .eq('corporation_id', subject.corporationId)
+    .maybeSingle<ShareRow>()
+
+  return shareAccess(share, viewer, shareParam, async () => {
+    const { data } = await viewerClient
+      .from('corp_bpo_share')
+      .select('id')
+      .eq('corporation_id', subject.corporationId)
+      .maybeSingle<{ id: string }>()
+    return data != null
+  })
 }

--- a/src/app/bpos/data.ts
+++ b/src/app/bpos/data.ts
@@ -1,8 +1,10 @@
-// Reading one account's blueprint originals and dressing them with SDE names.
+// Reading a subject's blueprint originals and dressing them with SDE names.
 //
-// Service-role, explicitly scoped to the registrations resolveBposAccount()
-// found — the /corpses precedent. The caller has already decided the viewer may
-// see them.
+// Two subjects, one shape: an account's characters (character_blueprint, scoped
+// to the registrations resolveBposAccount() found) or a corporation's hangars
+// (corp_blueprint, scoped to the one corporation id). Service-role in both
+// cases — the /corpses precedent — because the caller has already decided the
+// viewer may see them.
 import { getBlueprintsByTypeIDs } from '@/sdeBlueprints'
 import { getSdeTypes } from '@/sdeTypes'
 import { createServiceClient } from '@/utils/supabase/service'
@@ -39,10 +41,39 @@ const readBlueprints = async (
   return rows.length < PAGE_SIZE ? acc : readBlueprints(registrationIds, from + PAGE_SIZE, acc)
 }
 
-export const fetchBpoEntries = async (registrationIds: string[]): Promise<BpoEntry[]> => {
-  if (registrationIds.length === 0) return []
+// The corporation's own hangars. Same columns, same original filter; the corp
+// mirror is refreshed daily (the character one every 6h), which is the only
+// difference a visitor could notice. Ordered by item_id as well as type_id so
+// the range paging has a unique tiebreaker — corp collections are the large
+// ones, and a page boundary landing inside a run of identical type_ids would
+// otherwise be able to repeat or skip a row.
+const readCorpBlueprints = async (
+  corporationId: number,
+  from = 0,
+  acc: BlueprintRow[] = []
+): Promise<BlueprintRow[]> => {
+  const { data, error } = await createServiceClient()
+    .from('corp_blueprint')
+    .select('type_id, material_efficiency, time_efficiency, quantity, runs')
+    .eq('corporation_id', corporationId)
+    .eq('runs', -1)
+    .order('type_id')
+    .order('item_id')
+    .range(from, from + PAGE_SIZE - 1)
+    .returns<BlueprintRow[]>()
+  if (error) {
+    console.error(`[bpos] corp blueprint read failed: ${error.message}`)
+    return acc
+  }
+  const rows = data ?? []
+  rows.forEach((row) => acc.push(row))
+  return rows.length < PAGE_SIZE ? acc : readCorpBlueprints(corporationId, from + PAGE_SIZE, acc)
+}
 
-  const stacks = stackBpos(await readBlueprints(registrationIds))
+// Stack the rows, then resolve the two SDE hops the table renders. Shared by
+// both subjects: the row shape is identical, so only the read above differs.
+const dressStacks = async (rows: BlueprintRow[]): Promise<BpoEntry[]> => {
+  const stacks = stackBpos(rows)
   if (stacks.length === 0) return []
 
   const blueprintTypeIds = stacks.map((s) => s.typeId)
@@ -69,3 +100,9 @@ export const fetchBpoEntries = async (registrationIds: string[]): Promise<BpoEnt
     }
   })
 }
+
+export const fetchBpoEntries = async (registrationIds: string[]): Promise<BpoEntry[]> =>
+  registrationIds.length === 0 ? [] : dressStacks(await readBlueprints(registrationIds))
+
+export const fetchCorpBpoEntries = async (corporationId: number): Promise<BpoEntry[]> =>
+  dressStacks(await readCorpBlueprints(corporationId))

--- a/src/app/bpos/shareActions.ts
+++ b/src/app/bpos/shareActions.ts
@@ -113,3 +113,102 @@ export const revokeBposShare = async (slug: string): Promise<{ error?: string }>
   revalidatePath(`/bpos/${slug}`)
   return {}
 }
+
+// The corporation showcase's writers. Same shape as the account's, over the
+// corporation-keyed row: the manage policy admits any member, so the row a
+// member saves is the corporation's single share, not a personal one.
+const isMember = async (
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  corporationId: number
+): Promise<boolean> => {
+  const { data } = await supabase.from('registration').select('id').eq('corporation_id', corporationId).limit(1)
+  return (data ?? []).length > 0
+}
+
+export const saveCorpBposShare = async (
+  slug: string,
+  corporationId: number,
+  input: SaveShareInput
+): Promise<SaveShareResult> => {
+  const supabase = await createClient()
+
+  const { data: auth, error: userError } = await supabase.auth.getUser()
+  if (userError || !auth?.user) return { error: 'Not signed in' }
+
+  // RLS would refuse the write anyway; failing here says why.
+  if (!(await isMember(supabase, corporationId))) {
+    return { error: 'Only a member of the corporation can share its blueprint library.' }
+  }
+
+  const owned = await ownAudiences(supabase)
+
+  const corporationIds = input.isPublic
+    ? []
+    : [...new Set(input.corporationIds.map(Number))].filter((id) => owned.ownCorpIds.has(id))
+  const allianceIds = input.isPublic
+    ? []
+    : [...new Set(input.allianceIds.map(Number))].filter((id) => owned.ownAllianceIds.has(id))
+  const link = input.isPublic ? false : input.link
+
+  // Signing requires the deployment's salt; fail before writing anything.
+  let salt: string | null = null
+  if (link) {
+    try {
+      salt = tokenSalt()
+    } catch {
+      return { error: 'Share links are unavailable: TOKEN_SALT is not configured.' }
+    }
+  }
+
+  const { data: existing } = await supabase
+    .from('corp_bpo_share')
+    .select('id, secret')
+    .eq('corporation_id', corporationId)
+    .maybeSingle<{ id: string; secret: string | null }>()
+
+  const secret = link ? (input.rotateLink || !existing?.secret ? mintShareSecret() : existing.secret) : null
+
+  const { data: saved, error } = await supabase
+    .from('corp_bpo_share')
+    .upsert(
+      {
+        corporation_id: corporationId,
+        corporation_ids: corporationIds,
+        alliance_ids: allianceIds,
+        secret,
+        // Audit only, and only on first publish — a later editor doesn't
+        // overwrite who created the row.
+        ...(existing ? {} : { created_by: auth.user.id }),
+      },
+      { onConflict: 'corporation_id' }
+    )
+    .select('id')
+    .maybeSingle<{ id: string }>()
+  if (error || !saved) return { error: error?.message ?? 'Save failed' }
+
+  revalidatePath(`/bpos/${slug}`)
+
+  return {
+    share: {
+      corporationIds,
+      allianceIds,
+      hasLink: secret != null,
+      shareParam: secret != null && salt != null ? signShare(saved.id, secret, salt) : null,
+      isPublic: secret == null && corporationIds.length === 0 && allianceIds.length === 0,
+    },
+  }
+}
+
+export const revokeCorpBposShare = async (slug: string, corporationId: number): Promise<{ error?: string }> => {
+  const supabase = await createClient()
+
+  const { data: auth, error: userError } = await supabase.auth.getUser()
+  if (userError || !auth?.user) return { error: 'Not signed in' }
+
+  // RLS scopes the delete to corporations the caller has a character in.
+  const { error } = await supabase.from('corp_bpo_share').delete().eq('corporation_id', corporationId)
+  if (error) return { error: error.message }
+
+  revalidatePath(`/bpos/${slug}`)
+  return {}
+}

--- a/src/app/bpos/shareData.ts
+++ b/src/app/bpos/shareData.ts
@@ -23,3 +23,24 @@ export const fetchBposShareDialogData = async (supabase: SupabaseClient): Promis
 
   return { share: shareRowToState(shareRow), corporations, alliances, hasLegacyToken: false }
 }
+
+// The corporation showcase's dialog. The row is keyed by corporation rather
+// than by the caller, and the manage policy makes it visible to every member —
+// so this reads it through the caller's own cookie client, and the audiences
+// offered are still the caller's own affiliations (you can only aim a share at
+// a corp or alliance you're in).
+export const fetchCorpBposShareDialogData = async (
+  supabase: SupabaseClient,
+  corporationId: number
+): Promise<ShareDialogData> => {
+  const { data: regs } = await supabase.from('registration').select('id, corporation_id')
+  const { corporations, alliances } = await fetchShareAudiences(supabase, (regs ?? []) as OwnRegistration[])
+
+  const { data: shareRow } = await supabase
+    .from('corp_bpo_share')
+    .select('id, corporation_ids, alliance_ids, secret')
+    .eq('corporation_id', corporationId)
+    .maybeSingle<ShareRowLike>()
+
+  return { share: shareRowToState(shareRow), corporations, alliances, hasLegacyToken: false }
+}

--- a/src/app/bpos/slug.ts
+++ b/src/app/bpos/slug.ts
@@ -1,13 +1,15 @@
-// The /bpos/[name] URL is a person's MAIN character name with its spaces
-// turned into dashes — /bpos/sir-cuddles for "Sir Cuddles". Pure helpers, so
-// the round trip (name → slug, slug → the SQL probe that finds it again) is
-// testable without a database.
+// The /bpos/[name] URL is a person's MAIN character name, or a CORPORATION's
+// name, with its spaces turned into dashes — /bpos/sir-cuddles for "Sir
+// Cuddles". Pure helpers, so the round trip (name → slug, slug → the SQL probe
+// that finds it again) is testable without a database.
 import { escapeLike } from '../../utils/escapeLike.ts'
 
-// A character name's canonical slug. Lowercased so the URL is case-insensitive
-// in practice, whitespace collapsed so a double space can't mint a second slug
-// for the same pilot. EVE names carry no other punctuation worth folding —
-// apostrophes and hyphens are legal in a name and survive verbatim.
+// An EVE name's canonical slug. Lowercased so the URL is case-insensitive in
+// practice, whitespace collapsed so a double space can't mint a second slug for
+// the same subject. EVE names carry no other punctuation worth folding —
+// apostrophes and hyphens are legal in both character and corporation names and
+// survive verbatim. Named for characters because they came first; corporation
+// names slug by exactly the same rules.
 export const characterSlug = (name: string): string => name.trim().replace(/\s+/g, '-').toLowerCase()
 
 // The slug isn't reversible on its own — a dash in the URL could have been a
@@ -30,3 +32,25 @@ export const pickMain = <T extends MainCandidate>(registrations: readonly T[]): 
     (a, b) =>
       Number(Boolean(b.is_main)) - Number(Boolean(a.is_main)) || (a.created_at ?? '').localeCompare(b.created_at ?? '')
   )[0] ?? null
+
+// The corporation half of the same narrowing step the account resolver does by
+// hand: the `_`-wildcard probe over-matches by design, so the rows it returns
+// are compared by exact slug here. Rows are deduplicated by id (a probe can
+// return the same corporation twice only if the directory has, but the page
+// must not be at the mercy of that), and an ambiguous slug — two DIFFERENT
+// corporations folding to one — resolves to nothing rather than a coin flip.
+// EVE corporation names are unique, so ambiguity means only that two names
+// differ solely by case or whitespace.
+export type CorporationCandidate = { corporation_id: number | string; name: string | null }
+
+export const pickCorporation = (
+  rows: readonly CorporationCandidate[],
+  slug: string
+): { corporationId: number; name: string } | null => {
+  const matches = new Map<number, { corporationId: number; name: string }>()
+  rows.forEach((row) => {
+    if (row.name == null || characterSlug(row.name) !== slug) return
+    matches.set(Number(row.corporation_id), { corporationId: Number(row.corporation_id), name: row.name })
+  })
+  return matches.size === 1 ? [...matches.values()][0] : null
+}

--- a/supabase/migrations/20260824211340_corp_bpo_share.sql
+++ b/supabase/migrations/20260824211340_corp_bpo_share.sql
@@ -1,0 +1,68 @@
+-- ── corp_bpo_share ────────────────────────────────────────────────────────
+-- The audience for one CORPORATION's blueprint-original showcase, the page at
+-- /bpos/[corporation-name]. Blueprints deposited into a corp hangar belong to
+-- the corporation, so they land in corp_blueprint and never appear on the
+-- account-scoped showcase; this is that collection's share row.
+--
+-- Standard Revision 3 audience shape (corporation_ids / alliance_ids / secret;
+-- fully public = the row that names no one), keyed one row per corporation the
+-- way bpo_share is keyed one row per account.
+--
+-- WHO MAY MANAGE IT. Any account with a character in the corporation — which is
+-- exactly the set that can already read corp_blueprint for it, so nobody can
+-- share data they cannot themselves see. In-game roles are not tracked
+-- anywhere in this deployment (a Director token proves a scope was granted, not
+-- that the holder is a Director), and gating on the token holder would break
+-- the common case of an alt carrying the scope while the main runs the page.
+-- The share dialog says as much: any member can change or revoke it.
+create table if not exists public.corp_bpo_share (
+  id uuid primary key default gen_random_uuid(),
+  corporation_id bigint not null unique,
+  corporation_ids bigint[] not null default '{}',
+  alliance_ids bigint[] not null default '{}',
+  secret text,
+  -- Audit only: who first published it. Never read for authorization — a
+  -- member who leaves must not keep control, and one who joins must not be
+  -- locked out.
+  created_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now()
+);
+
+alter table public.corp_bpo_share enable row level security;
+
+-- Members of the corporation manage its row. The subquery is the same
+-- membership test corp_blueprint_over_time's own read policy uses.
+drop policy if exists "Members manage corp bpo share" on public.corp_bpo_share;
+create policy "Members manage corp bpo share"
+  on public.corp_bpo_share
+  for all
+  to authenticated
+  using (
+    corporation_id in (
+      select corporation_id from public.registration
+      where user_id = (select auth.uid()) and corporation_id is not null
+    )
+  )
+  with check (
+    corporation_id in (
+      select corporation_id from public.registration
+      where user_id = (select auth.uid()) and corporation_id is not null
+    )
+  );
+
+-- Audience discovery, the load-bearing array policy every Revision 3 share
+-- table carries: the page asks this table, as the viewer, whether a share is
+-- aimed at them. Link-only rows match nobody here (RLS cannot see a URL token;
+-- signed links resolve at the app layer), and neither does the fully-public row
+-- for a signed-out visitor -- the page clears that case through the service
+-- role rather than leaning on an anon evaluation of my_corporation_ids().
+drop policy if exists "Audience reads corp bpo shares aimed at them" on public.corp_bpo_share;
+create policy "Audience reads corp bpo shares aimed at them"
+  on public.corp_bpo_share
+  for select
+  to anon, authenticated
+  using (public.share_audience_matches(corporation_ids, alliance_ids, secret));
+
+grant select                         on public.corp_bpo_share to anon;
+grant select, insert, update, delete on public.corp_bpo_share to authenticated;
+grant all                            on public.corp_bpo_share to service_role;

--- a/test/bposSlug.test.ts
+++ b/test/bposSlug.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
-import { characterSlug, pickMain, slugLikePattern } from '../src/app/bpos/slug.ts'
+import { characterSlug, pickCorporation, pickMain, slugLikePattern } from '../src/app/bpos/slug.ts'
 
 describe('characterSlug', () => {
   it('lowercases and turns spaces into dashes', () => {
@@ -42,5 +42,46 @@ describe('pickMain', () => {
 
   it('is null for an account with no characters', () => {
     assert.equal(pickMain([]), null)
+  })
+})
+
+describe('pickCorporation', () => {
+  const rows = [
+    { corporation_id: 98001, name: 'Sudden Buggery' },
+    { corporation_id: 98002, name: 'Dreddit' },
+  ]
+
+  it('finds the corporation whose name slugifies to the URL segment', () => {
+    assert.deepEqual(pickCorporation(rows, 'sudden-buggery'), { corporationId: 98001, name: 'Sudden Buggery' })
+  })
+
+  it('rejects a row the wildcard probe over-matched', () => {
+    // `_` matched the dash in the name, but the slug of "Sudden-Buggery" is
+    // "sudden-buggery" — so an over-match only survives when it agrees exactly.
+    assert.equal(pickCorporation([{ corporation_id: 98003, name: 'Suddenly Buggery' }], 'sudden-buggery'), null)
+  })
+
+  it('refuses an ambiguous slug rather than flipping a coin', () => {
+    const ambiguous = [
+      { corporation_id: 98001, name: 'Sudden Buggery' },
+      { corporation_id: 98009, name: 'sudden buggery' },
+    ]
+    assert.equal(pickCorporation(ambiguous, 'sudden-buggery'), null)
+  })
+
+  it('is unbothered by the same corporation appearing twice', () => {
+    const duplicated = [
+      { corporation_id: 98001, name: 'Sudden Buggery' },
+      { corporation_id: '98001', name: 'Sudden Buggery' },
+    ]
+    assert.deepEqual(pickCorporation(duplicated, 'sudden-buggery'), { corporationId: 98001, name: 'Sudden Buggery' })
+  })
+
+  it('ignores directory rows whose name has not been backfilled', () => {
+    assert.equal(pickCorporation([{ corporation_id: 98004, name: null }], 'sudden-buggery'), null)
+  })
+
+  it('is null when nothing matches', () => {
+    assert.equal(pickCorporation(rows, 'karmafleet'), null)
   })
 })

--- a/test/sql/corp_bpo_share.sql
+++ b/test/sql/corp_bpo_share.sql
@@ -1,0 +1,165 @@
+-- SQL-level coverage for the corp_bpo_share migration
+-- (docs/bpo-showcase-corp.md): the member-manage policy (any account with a
+-- character in the corporation, and NOBODY else), and the audience-read policy
+-- through share_audience_matches().
+--
+-- The membership rule is the load-bearing one: it is what lets a corp-mate
+-- publish the library, and what must stop an outsider from publishing —
+-- or revoking — a corporation's showcase they have no character in.
+--
+-- Run against a THROWAWAY database from the repo root (same harness as
+-- asset_share.sql): DATABASE_URL='postgresql://…/throwaway' pnpm run test:sql
+begin;
+
+do $$ begin create role anon nologin; exception when duplicate_object then null; end $$;
+do $$ begin create role authenticated nologin; exception when duplicate_object then null; end $$;
+do $$ begin create role service_role nologin; exception when duplicate_object then null; end $$;
+
+create schema if not exists auth;
+create or replace function auth.uid() returns uuid
+language sql stable
+as $$ select nullif(current_setting('test.uid', true), '')::uuid $$;
+
+-- Stand-ins for the FK target and the membership helpers' inputs.
+create table if not exists auth.users (
+  id uuid primary key
+);
+create table public.registration (
+  id uuid primary key,
+  user_id uuid,
+  corporation_id bigint
+);
+create table public.corporation (
+  corporation_id bigint primary key,
+  alliance_id bigint
+);
+grant select on public.registration to anon, authenticated;
+grant select on public.corporation to anon, authenticated;
+grant usage on schema auth to anon, authenticated;
+grant usage on schema public to anon, authenticated;
+
+create or replace function public.my_corporation_ids()
+returns setof bigint
+language sql
+stable
+as $$
+  select r.corporation_id
+  from public.registration r
+  where r.user_id = (select auth.uid()) and r.corporation_id is not null;
+$$;
+
+create or replace function public.my_alliance_ids()
+returns setof bigint
+language sql
+stable
+as $$
+  select c.alliance_id
+  from public.registration r
+  join public.corporation c on c.corporation_id = r.corporation_id
+  where r.user_id = (select auth.uid()) and c.alliance_id is not null;
+$$;
+
+create or replace function public.share_audience_matches(
+  corporation_ids bigint[], alliance_ids bigint[], secret text
+)
+returns boolean
+language sql
+stable
+as $$
+  select
+    (secret is null and corporation_ids = '{}' and alliance_ids = '{}')
+    or corporation_ids && array(select public.my_corporation_ids())
+    or alliance_ids && array(select public.my_alliance_ids());
+$$;
+
+\i supabase/migrations/20260824211340_corp_bpo_share.sql
+
+-- Fixtures. Corporation 98001 (alliance 99001) is the one with a showcase;
+-- alice and bob both have characters in it, carol is in an alliance-mate corp
+-- 98002, and dave is unaffiliated.
+insert into auth.users values
+  ('a0000000-0000-0000-0000-000000000000'),
+  ('b0000000-0000-0000-0000-000000000000'),
+  ('c0000000-0000-0000-0000-000000000000'),
+  ('d0000000-0000-0000-0000-000000000000');
+insert into public.corporation values (98001, 99001), (98002, 99001), (98003, null);
+insert into public.registration values
+  ('00000000-0000-0000-0000-0000000000aa', 'a0000000-0000-0000-0000-000000000000', 98001),
+  ('00000000-0000-0000-0000-0000000000bb', 'b0000000-0000-0000-0000-000000000000', 98001),
+  ('00000000-0000-0000-0000-0000000000cc', 'c0000000-0000-0000-0000-000000000000', 98002),
+  ('00000000-0000-0000-0000-0000000000dd', 'd0000000-0000-0000-0000-000000000000', null);
+
+do $$
+declare
+  n int;
+begin
+  -- A member publishes the corporation's showcase, aimed at its own alliance.
+  set local role authenticated;
+  perform set_config('test.uid', 'a0000000-0000-0000-0000-000000000000', true);
+  insert into public.corp_bpo_share (corporation_id, alliance_ids)
+    values (98001, '{99001}');
+
+  -- The OTHER member of the same corp can edit it: the row belongs to the
+  -- corporation, not to whoever created it.
+  perform set_config('test.uid', 'b0000000-0000-0000-0000-000000000000', true);
+  update public.corp_bpo_share set corporation_ids = '{98002}' where corporation_id = 98001;
+  get diagnostics n = row_count;
+  assert n = 1, 'a corp-mate can edit the corporation''s share row';
+
+  -- An outsider cannot create a share for a corporation they are not in.
+  perform set_config('test.uid', 'd0000000-0000-0000-0000-000000000000', true);
+  begin
+    insert into public.corp_bpo_share (corporation_id) values (98003);
+    assert false, 'an outsider must not be able to publish a corporation''s library';
+  exception when insufficient_privilege then null;
+  end;
+
+  -- Nor delete one. RLS makes the row invisible to the delete rather than
+  -- raising: what matters is that it survives.
+  delete from public.corp_bpo_share where corporation_id = 98001;
+  get diagnostics n = row_count;
+  assert n = 0, 'an outsider cannot revoke a corporation''s share';
+
+  -- Audience: the row names alliance 99001 and corp 98002, so carol (in 98002,
+  -- alliance 99001) reads it and dave does not.
+  perform set_config('test.uid', 'c0000000-0000-0000-0000-000000000000', true);
+  select count(*) into n from public.corp_bpo_share;
+  assert n = 1, format('an alliance-mate reads the share aimed at them, got %s', n);
+
+  perform set_config('test.uid', 'd0000000-0000-0000-0000-000000000000', true);
+  select count(*) into n from public.corp_bpo_share;
+  assert n = 0, format('an unaffiliated caller reads nothing, got %s', n);
+
+  -- A link-only row (secret set, audience empty) matches NOBODY under RLS —
+  -- the token is invisible to the database, so the app layer resolves it.
+  perform set_config('test.uid', 'a0000000-0000-0000-0000-000000000000', true);
+  update public.corp_bpo_share
+    set corporation_ids = '{}', alliance_ids = '{}', secret = 'deadbeef'
+    where corporation_id = 98001;
+
+  perform set_config('test.uid', 'c0000000-0000-0000-0000-000000000000', true);
+  select count(*) into n from public.corp_bpo_share;
+  assert n = 0, format('a link-only share matches nobody under RLS, got %s', n);
+
+  reset role;
+  set local role anon;
+  perform set_config('test.uid', '', true);
+  select count(*) into n from public.corp_bpo_share;
+  assert n = 0, format('a link-only share is invisible to anon, got %s', n);
+
+  -- Fully public: the row that names no one, with no secret.
+  reset role;
+  set local role authenticated;
+  perform set_config('test.uid', 'a0000000-0000-0000-0000-000000000000', true);
+  update public.corp_bpo_share set secret = null where corporation_id = 98001;
+
+  reset role;
+  set local role anon;
+  perform set_config('test.uid', '', true);
+  select count(*) into n from public.corp_bpo_share;
+  assert n = 1, format('a fully public share is readable signed-out, got %s', n);
+
+  reset role;
+end $$;
+
+rollback;


### PR DESCRIPTION
## Summary

A player reported the BPO showcase was empty for them because they keep their originals in a corp hangar — those blueprints belong to the corporation, land in `corp_blueprint`, and the account-scoped `/bpos/[name]` read (over `character_blueprint`) never saw them.

`/bpos/[name]` now addresses a corporation as well as a person. Design doc in `docs/bpo-showcase-corp.md`; implementation follows it.

## What changed

**Subject resolution (`access.ts`).** The URL resolves a corporation name first, falling back to an account's main character — corp-first because there are far fewer corporations than registrations, so that probe is the cheap common case. Both use the same `_`-wildcard `ilike` probe narrowed by an exact slug comparison. `BposSubject` is a discriminated union; the page branches on it with `ts-pattern`'s `.exhaustive()`.

**`corp_bpo_share`.** New Revision 3 audience table (`corporation_ids` / `alliance_ids` / `secret`), keyed one row per corporation the way `bpo_share` is keyed one row per account. No row means not shared, so an unshared corp name 404s and confirms nothing.

Any account with a character in the corporation manages the row — exactly the set that can already read `corp_blueprint` under RLS, so nobody can share data they cannot themselves see. In-game roles aren't tracked anywhere in this deployment (a Director token proves a scope was granted, not who holds the role), and gating on the token holder would break the common case of an alt carrying the scope while the main runs the page. `created_by` is recorded for audit only, never read for authorization, so a member who leaves doesn't keep control and one who joins isn't locked out. The share dialog says as much.

**Access ladder.** Members always see the corp page (that's where the dialog lives); everyone else walks the same ladder as the account page — no row → 404, then fully public, signed link, audience. The two subjects share one `shareAccess` helper, so the ladder can't drift between them; `share_audience_matches` and `shareToken.ts` are reused untouched.

**Data read.** `fetchCorpBpoEntries` over `corp_blueprint`, range-paged like the character read and ordered by `item_id` as well as `type_id` so paging has a unique tiebreaker. The stacking and SDE-dressing step is factored into a shared `dressStacks` both fetchers call.

**Non-goals, deliberately.** Corp holdings are not unioned into the account page (one member's personal share must not expose corp property, and two members would double-count it), and there's no per-division filtering.

## Testing

- `pnpm test` — 532 pass, including new `pickCorporation` cases (exact-slug narrowing rejects probe over-matches, ambiguity refused rather than coin-flipped, unbackfilled directory names ignored).
- `pnpm run lint` and `pnpm run build` clean; migration ordering guard reports no problems.
- `test/sql/corp_bpo_share.sql` added for the RLS rules — member manages, corp-mate can edit the same row, outsider can neither publish nor revoke, audience/link-only/public visibility. Not run here (no Postgres server in this environment); `test:branch` exercises the migration in CI since this touches `supabase/migrations/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Eh71M22uC6MZaFErV73tZ