### PR TITLE
Account ids in the chancellor lookup, corp library links on /blueprint

### DIFF
--- a/src/app/account/settings/chancellor/flagForm.tsx
+++ b/src/app/account/settings/chancellor/flagForm.tsx
@@ -65,6 +65,11 @@ const FlagForm = () => {
 
       {account && (
         <form>
+          {/* The account's own id, shown because the Impersonate form below
+              takes a user id and this lookup is the only place to get one. */}
+          <p>
+            User ID: <code>{account.userId}</code>
+          </p>
           <ul>
             {names.map((flag) => (
               <li key={flag}>

--- a/src/app/blueprint/page.tsx
+++ b/src/app/blueprint/page.tsx
@@ -1,9 +1,17 @@
 import Link from 'next/link'
+import { uniq } from 'ramda'
 
 import { createClient } from '@/utils/supabase/server'
+import { createServiceClient } from '@/utils/supabase/service'
 
 import { characterSlug } from '../bpos/slug'
 import { TypeSearch } from './typeSearch'
+
+// ESI hands this scope out only to a character holding the Director role in
+// game, so a token carrying it is our one signal that a character is a
+// director — and it is the same grant that makes the corporation's blueprints
+// readable at all, which is exactly what the corp showcase renders.
+const CORP_BLUEPRINTS_SCOPE = 'esi-corporations.read_blueprints.v1'
 
 // The signed-in user's own showcase lives under their main character's name,
 // derived the same way the header labels them (flagged main first, then their
@@ -26,12 +34,68 @@ const OwnBposLink = async () => {
   )
 }
 
+// A corporation's originals live in its hangars, not any character's, so they
+// get their own showcase — one link per corporation this account has a director
+// in. Read through the service role, explicitly scoped to the caller: `token`
+// is service-role-only (those are live EVE refresh tokens), so a session client
+// cannot ask which scopes it holds.
+const CorpBposLinks = async () => {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user?.id) return null
+
+  const service = createServiceClient()
+
+  const { data: tokens } = await service
+    .from('token')
+    .select('registration_id')
+    .eq('user_id', user.id)
+    .contains('scope', [CORP_BLUEPRINTS_SCOPE])
+    .returns<Array<{ registration_id: string }>>()
+  const registrationIds = uniq((tokens ?? []).map((t) => t.registration_id))
+  if (registrationIds.length === 0) return null
+
+  const { data: regs } = await service
+    .from('registration')
+    .select('corporation_id')
+    .in('id', registrationIds)
+    .not('corporation_id', 'is', null)
+    .returns<Array<{ corporation_id: number | string }>>()
+  const corporationIds = uniq((regs ?? []).map((r) => Number(r.corporation_id)))
+  if (corporationIds.length === 0) return null
+
+  // A corporation whose name the directory hasn't backfilled yet can't be
+  // addressed by slug, so it simply isn't listed rather than linking nowhere.
+  const { data: corps } = await service
+    .from('corporation')
+    .select('corporation_id, name')
+    .in('corporation_id', corporationIds)
+    .not('name', 'is', null)
+    .returns<Array<{ corporation_id: number | string; name: string }>>()
+  const named = (corps ?? []).slice().sort((a, b) => a.name.localeCompare(b.name))
+  if (named.length === 0) return null
+
+  return (
+    <>
+      {named.map((corp) => (
+        <p key={corp.corporation_id}>
+          <Link href={`/bpos/${characterSlug(corp.name)}`}>{corp.name}&rsquo;s blueprint originals</Link> — everything
+          in the corporation&rsquo;s hangars, shareable the same way.
+        </p>
+      ))}
+    </>
+  )
+}
+
 const BlueprintPage = () => (
   <>
     <h1>Blueprint</h1>
     <p>Given a blueprint, this tool will tell you which Upwell rigs give it a bonus.</p>
     <TypeSearch />
     <OwnBposLink />
+    <CorpBposLinks />
   </>
 )
 


### PR DESCRIPTION
Two small follow-ups to the corporation blueprint showcase (#960).

## Account id in the chancellor lookup

The flag lookup on `/account/settings/chancellor` resolves a character name to an account and already carried its `userId` in the returned payload — it just never rendered it. The Impersonate form directly below takes exactly that id, so the one screen that can turn a character name into a user id printed everything except the user id.

It's now shown with the loaded account, as `<code>` so it's easy to copy into the field below.

## Corp library links on /blueprint

`/blueprint` already links a player to their own showcase. Originals kept in a corp hangar belong to the corporation and appear on the corp page instead, so those get links too — one per corporation the account holds a director character in, sorted by name.

Director-ness is read from the `esi-corporations.read_blueprints.v1` scope on the character's token. ESI grants that scope only to a character with the Director role in game, and it's the same grant that makes the corporation's blueprints readable at all — so it's both the best signal available (in-game roles aren't tracked anywhere in this deployment) and precisely the right one: a corp shows up here only if we actually have its blueprints to display.

The lookup goes through the service role, explicitly scoped to the caller's `user_id`, because `token` is service-role-only — those are live EVE refresh tokens, so no session client may read them. A corporation whose name the directory hasn't backfilled yet is skipped rather than linked to an unaddressable slug.

## Testing

`pnpm run lint`, `pnpm test` (532 pass) and `pnpm run build` all clean; `/blueprint` stays dynamically rendered, as it already was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Eh71M22uC6MZaFErV73tZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012Eh71M22uC6MZaFErV73tZ)_