### PR TITLE
Taxes Paid on /structure, cost avoidance narrowed, and shared corp BPO links

### DIFF
--- a/src/app/blueprint/page.tsx
+++ b/src/app/blueprint/page.tsx
@@ -48,6 +48,8 @@ const CorpBposLinks = async () => {
 
   const service = createServiceClient()
 
+  // Corporations we hold a director in. `token` is service-role-only (those are
+  // live EVE refresh tokens), so the read is explicitly scoped to the caller.
   const { data: tokens } = await service
     .from('token')
     .select('registration_id')
@@ -55,15 +57,32 @@ const CorpBposLinks = async () => {
     .contains('scope', [CORP_BLUEPRINTS_SCOPE])
     .returns<Array<{ registration_id: string }>>()
   const registrationIds = uniq((tokens ?? []).map((t) => t.registration_id))
-  if (registrationIds.length === 0) return null
+  const { data: regs } = registrationIds.length
+    ? await service
+        .from('registration')
+        .select('corporation_id')
+        .in('id', registrationIds)
+        .not('corporation_id', 'is', null)
+        .returns<Array<{ corporation_id: number | string }>>()
+    : { data: [] }
+  const directorCorpIds = uniq((regs ?? []).map((r) => Number(r.corporation_id)))
 
-  const { data: regs } = await service
-    .from('registration')
+  // Corporations whose showcase is shared with us. Asked as the VIEWER, because
+  // corp_bpo_share's own policies already answer exactly this question: a member
+  // sees their corporation's row, and the audience policy adds rows aimed at
+  // their corp or alliance plus any that are fully public. A link-only share
+  // matches nobody here, which is correct — its URL is the only way in.
+  const { data: shares } = await supabase
+    .from('corp_bpo_share')
     .select('corporation_id')
-    .in('id', registrationIds)
-    .not('corporation_id', 'is', null)
     .returns<Array<{ corporation_id: number | string }>>()
-  const corporationIds = uniq((regs ?? []).map((r) => Number(r.corporation_id)))
+  const sharedCorpIds = uniq((shares ?? []).map((r) => Number(r.corporation_id)))
+
+  // Either route means the page has something to show: a director's grant is
+  // what fills corp_blueprint in the first place, and a share is somebody
+  // saying they want it seen. Without one of them the link would open an empty
+  // page, or a 404.
+  const corporationIds = uniq([...directorCorpIds, ...sharedCorpIds])
   if (corporationIds.length === 0) return null
 
   // A corporation whose name the directory hasn't backfilled yet can't be
@@ -81,8 +100,8 @@ const CorpBposLinks = async () => {
     <>
       {named.map((corp) => (
         <p key={corp.corporation_id}>
-          <Link href={`/bpos/${characterSlug(corp.name)}`}>{corp.name}&rsquo;s blueprint originals</Link> — everything
-          in the corporation&rsquo;s hangars, shareable the same way.
+          <Link href={`/bpos/${characterSlug(corp.name)}`}>{corp.name}&rsquo;s blueprint originals</Link> — every
+          original in the corporation&rsquo;s hangars.
         </p>
       ))}
     </>

--- a/src/app/structure/page.tsx
+++ b/src/app/structure/page.tsx
@@ -82,6 +82,7 @@ type JournalRow = {
   context_id: number | string | null
   description: string | null
   first_party_id: number | string | null
+  second_party_id: number | string | null
 }
 
 type RigRow = {
@@ -275,7 +276,7 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
   const journal = await fetchAllRows<JournalRow>((from, to) =>
     supabase
       .from('corp_wallet_journal')
-      .select('amount, corporation_id, context_id, description, first_party_id')
+      .select('amount, corporation_id, context_id, description, first_party_id, second_party_id')
       .eq('ref_type', 'industry_job_tax')
       .gte('date', windowStart)
       .order('date', { ascending: false })
@@ -328,6 +329,9 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
   // expense, not an expense avoided. Comparing this against the paying corporation is what tells
   // the two apart.
   const structureOwner = new Map<string, string>(list.map((st) => [String(st.structure_id), String(st.corporation_id)]))
+  // Every corporation with a tile here. Tax paid to anyone else went to a
+  // landlord this page doesn't list, and is totalled separately below.
+  const listedOwners = new Set<string>(structureOwner.values())
 
   const ledger = foldTaxLedger(
     map(
@@ -341,10 +345,11 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
           ...(entry.description?.match(/\d+/g) ?? []),
         ],
         payerId: entry.first_party_id != null ? String(entry.first_party_id) : null,
+        recipientId: entry.second_party_id != null ? String(entry.second_party_id) : null,
       }),
       (journal ?? []) as JournalRow[]
     ),
-    { structureByJob, personalJobCorp, structureOwner }
+    { structureByJob, personalJobCorp, structureOwner, listedOwners }
   )
 
   const totalByStructure = ledger.revenueByStructure
@@ -358,6 +363,85 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
   // whose RLS is own-corps only — so, exactly like the Revenue beside it, a
   // structure shows a figure only to callers who can read that corp's ledger.
   const avoidedByStructure = new Map(avoidance.byStructure)
+
+  // Tax that left for a landlord with no tile here. The recipient corporation
+  // comes straight off the journal entry, so the total is known even when the
+  // job doesn't resolve; the SYSTEM needs the job, which was never fetched above
+  // (that select is filtered to structures on the page), so the handful of job
+  // ids involved are looked up directly. Only corp jobs can appear here — a
+  // character's personal job pays from a wallet we have no journal for.
+  const unlistedJobIds = uniq(
+    ledger.unlistedPayments.map((p) => p.jobId).filter((id): id is string => id != null && !structureByJob.has(id))
+  )
+  const unlistedJobStructure = new Map<string, string>()
+  if (unlistedJobIds.length > 0) {
+    const batches = await Promise.all(
+      map(
+        (batch: string[]) =>
+          supabase.from('corp_industry_job').select('job_id, station_id, facility_id').in('job_id', batch.map(Number)),
+        splitEvery(RPC_BATCH, unlistedJobIds)
+      )
+    )
+    forEach(
+      (j: JobRow) => {
+        const structureId = j.station_id ?? j.facility_id
+        if (structureId != null) unlistedJobStructure.set(String(j.job_id), String(structureId))
+      },
+      chain(({ data }) => (data ?? []) as JobRow[], batches)
+    )
+  }
+
+  // Those structures' systems, from the universe_structure cache the
+  // universe-structures job maintains. A structure we've never been able to
+  // resolve simply contributes no system rather than blocking the ISK figure.
+  const unlistedSystemByStructure = new Map<string, string>()
+  const unlistedStructureIds = uniq([...unlistedJobStructure.values()])
+  if (unlistedStructureIds.length > 0) {
+    const { data: known } = await supabase
+      .from('universe_structure')
+      .select('structure_id, system_id')
+      .in('structure_id', unlistedStructureIds.map(Number))
+    forEach(
+      (r: { structure_id: number | string; system_id: number | string | null }) => {
+        if (r.system_id != null) unlistedSystemByStructure.set(String(r.structure_id), String(r.system_id))
+      },
+      (known ?? []) as Array<{ structure_id: number | string; system_id: number | string | null }>
+    )
+  }
+
+  // One row per landlord: what they took, and where. Largest first.
+  const unlistedByCorp = new Map<string, { amount: number; systemIds: Set<string> }>()
+  forEach((payment: (typeof ledger.unlistedPayments)[number]) => {
+    const key = payment.corporationId ?? 'unknown'
+    const row = unlistedByCorp.get(key) ?? { amount: 0, systemIds: new Set<string>() }
+    row.amount += payment.amount
+    const structureId = payment.jobId != null ? unlistedJobStructure.get(payment.jobId) : undefined
+    const systemId = structureId != null ? unlistedSystemByStructure.get(structureId) : undefined
+    if (systemId != null) row.systemIds.add(systemId)
+    unlistedByCorp.set(key, row)
+  }, ledger.unlistedPayments)
+  const unlistedLandlords = [...unlistedByCorp.entries()].sort((a, b) => b[1].amount - a[1].amount)
+  const unlistedTotal = unlistedLandlords.reduce((sum, [, row]) => sum + row.amount, 0)
+
+  // Landlord names from the world-readable corporation directory, and system
+  // names alongside the ones the tiles already resolve.
+  const landlordNames = new Map<string, string>()
+  const landlordIds = unlistedLandlords.map(([id]) => id).filter((id) => id !== 'unknown')
+  if (landlordIds.length > 0) {
+    const { data: corps } = await supabase
+      .from('corporation')
+      .select('corporation_id, name')
+      .in('corporation_id', landlordIds.map(Number))
+    forEach(
+      (c: { corporation_id: number | string; name: string | null }) => {
+        if (c.name != null) landlordNames.set(String(c.corporation_id), c.name)
+      },
+      (corps ?? []) as Array<{ corporation_id: number | string; name: string | null }>
+    )
+  }
+  const unlistedSystemNames = await fetchSystemNames(
+    uniq(unlistedLandlords.flatMap(([, row]) => [...row.systemIds])).map(Number)
+  )
 
   // Largest payers first.
   const unaccountedParties = [...unaccountedByParty.entries()].sort((a, b) => b[1] - a[1])
@@ -578,6 +662,12 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
                 <span className={styles.footerValue}>{formatIsk(taxesPaidTotal)}</span>
               </>
             )}
+            {unlistedTotal > 0 && (
+              <>
+                <span>Taxes paid elsewhere:</span>
+                <span className={styles.footerValue}>{formatIsk(unlistedTotal)}</span>
+              </>
+            )}
             <span>Clone revenue:</span>
             <span className={styles.footerValue}>{formatKisk(cloneRevenue)}</span>
             <span>Cost avoidance:</span>
@@ -606,9 +696,9 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
             <p className={styles.unaccountedNote}>
               <em>
                 Taxes paid is facility tax we were actually charged, for jobs run in the structures listed above —
-                including the {formatRate(taxRates.own)} our own structures bill us. Tax paid for a job in a structure
-                that isn&rsquo;t listed here has no tile to belong to and is left out, as is anything a character paid
-                to a corporation that isn&rsquo;t ours, which never appears in a wallet we can read.
+                including the {formatRate(taxRates.own)} our own structures bill us. Tax paid to a corporation with no
+                structure here is counted separately, since it has no tile to belong to. Neither figure can see what a
+                character paid to a corporation that isn&rsquo;t ours: that leaves a wallet we have no journal for.
               </em>
             </p>
           )}
@@ -619,6 +709,34 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
                 tie the tax back to one of our structures.
               </em>
             </p>
+          )}
+          {unlistedLandlords.length > 0 && (
+            <details className={styles.breakdown}>
+              <summary>Taxes paid elsewhere, by corporation ({unlistedLandlords.length})</summary>
+              <div className={styles.breakdownGrid}>
+                {unlistedLandlords.map(([corporationId, row]) => {
+                  const name =
+                    corporationId === 'unknown'
+                      ? 'Unknown corporation'
+                      : (landlordNames.get(corporationId) ?? `#${corporationId}`)
+                  // Systems we could place the jobs in. A structure the cache
+                  // has never resolved contributes none, so the ISK still shows
+                  // with no system rather than being hidden.
+                  const systems = [...row.systemIds]
+                    .map((id) => unlistedSystemNames[Number(id)] ?? `#${id}`)
+                    .sort((a, b) => a.localeCompare(b))
+                  return (
+                    <span key={`landlord-${corporationId}`} className={styles.breakdownRow}>
+                      <span className={styles.payer}>
+                        <span>{name}</span>
+                        {systems.length > 0 && <span className={styles.payerCorp}>{systems.join(', ')}</span>}
+                      </span>
+                      <span className={styles.footerValue}>{formatIsk(row.amount)}</span>
+                    </span>
+                  )
+                })}
+              </div>
+            </details>
           )}
           {unaccountedParties.length > 0 && (
             <details className={styles.breakdown}>

--- a/src/app/structure/page.tsx
+++ b/src/app/structure/page.tsx
@@ -68,6 +68,12 @@ type JobRow = {
   job_id: number | string
   station_id: number | string | null
   facility_id: number | string | null
+  // Who installed it, and so who was billed. corp_industry_job names the
+  // corporation directly; character_industry_job names the registration, whose
+  // corporation is looked up below. Absent on rows from
+  // industry_job_tax_facility(), which discloses only a location.
+  corporation_id?: number | string | null
+  registration_id?: string | null
 }
 
 type JournalRow = {
@@ -161,7 +167,11 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
     fetchAllRows<JobRow>((from, to) =>
       supabase
         .from(table)
-        .select('job_id, station_id, facility_id')
+        .select(
+          table === 'corp_industry_job'
+            ? 'job_id, station_id, facility_id, corporation_id'
+            : 'job_id, station_id, facility_id, registration_id'
+        )
         .or(jobStructureFilter)
         .order('job_id', { ascending: true })
         .range(from, to)
@@ -179,12 +189,26 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
     concat(characterJobs, corpJobs)
   )
 
-  // Which of those jobs are OURS, for the cost-avoidance figure below. Only the
-  // two selects above qualify — our characters' jobs and our corporations' —
-  // never the industry_job_tax_facility rows merged in further down, which are
-  // other players' jobs renting our slots. Their tax is revenue; ours is a bill
-  // we paid to ourselves, and it is that bill the counterfactual scales.
-  const ownJobIds = new Set(map((j: JobRow) => String(j.job_id), concat(characterJobs, corpJobs)))
+  // Our characters' PERSONAL jobs, mapped to the corporation each installer was
+  // in. That corporation is what decides cost avoidance (a job is only billed
+  // our own rate by a structure its own corp owns), and the presence of a job
+  // here is what decides whether an incoming receipt also counts as tax we paid
+  // — see taxLedger.ts. Corp jobs are deliberately excluded: their payment is
+  // readable as the outgoing entry in the paying corp's own wallet.
+  //
+  // registration is RLS-scoped to the caller, so this only ever resolves our
+  // own characters; a job whose registration we can't see contributes nothing.
+  const { data: ownRegistrations } = await supabase.from('registration').select('id, corporation_id')
+  const corpByRegistration = new Map<string, string>(
+    ((ownRegistrations ?? []) as Array<{ id: string; corporation_id: number | string | null }>)
+      .filter((r) => r.corporation_id != null)
+      .map((r) => [r.id, String(r.corporation_id)])
+  )
+  const personalJobCorp = new Map<string, string>()
+  forEach((j: JobRow) => {
+    const corporationId = j.registration_id != null ? corpByRegistration.get(j.registration_id) : undefined
+    if (corporationId != null) personalJobCorp.set(String(j.job_id), corporationId)
+  }, characterJobs)
 
   // The two rates behind the cost-avoidance figures live on /settings/tax.
   const taxRates = await fetchTaxRates(supabase, user.id)
@@ -320,10 +344,12 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
       }),
       (journal ?? []) as JournalRow[]
     ),
-    { structureByJob, ownJobIds, structureOwner }
+    { structureByJob, personalJobCorp, structureOwner }
   )
 
   const totalByStructure = ledger.revenueByStructure
+  const taxesPaidByStructure = ledger.taxesPaidByStructure
+  const taxesPaidTotal = [...taxesPaidByStructure.values()].reduce((sum, v) => sum + v, 0)
   const unaccounted = ledger.unaccounted
   const unaccountedByParty = ledger.unaccountedByParty
 
@@ -448,6 +474,14 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
                         </span>
                       </>
                     )}
+                    {taxesPaidByStructure.get(String(s.structure_id)) && (
+                      <>
+                        <span className={styles.label}>Taxes Paid</span>
+                        <span className={`${styles.value} ${styles.num}`}>
+                          {formatIsk(taxesPaidByStructure.get(String(s.structure_id)) ?? 0)}
+                        </span>
+                      </>
+                    )}
                     {avoidedByStructure.has(String(s.structure_id)) && (
                       <>
                         <span className={styles.label}>Cost Avoidance</span>
@@ -538,6 +572,12 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
                 <span className={styles.footerValue}>{formatIsk(unaccounted)}</span>
               </>
             )}
+            {taxesPaidTotal > 0 && (
+              <>
+                <span>Taxes paid:</span>
+                <span className={styles.footerValue}>{formatIsk(taxesPaidTotal)}</span>
+              </>
+            )}
             <span>Clone revenue:</span>
             <span className={styles.footerValue}>{formatKisk(cloneRevenue)}</span>
             <span>Cost avoidance:</span>
@@ -562,6 +602,16 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
               <Link href="/settings/tax">Change the rates &raquo;</Link>
             </em>
           </p>
+          {taxesPaidTotal > 0 && (
+            <p className={styles.unaccountedNote}>
+              <em>
+                Taxes paid is facility tax we were actually charged, for jobs run in the structures listed above —
+                including the {formatRate(taxRates.own)} our own structures bill us. Tax paid for a job in a structure
+                that isn&rsquo;t listed here has no tile to belong to and is left out, as is anything a character paid
+                to a corporation that isn&rsquo;t ours, which never appears in a wallet we can read.
+              </em>
+            </p>
+          )}
           {unaccountedParties.length > 0 && (
             <p className={styles.unaccountedNote}>
               <em>

--- a/src/app/structure/taxLedger.ts
+++ b/src/app/structure/taxLedger.ts
@@ -1,5 +1,5 @@
-// Which industry_job_tax journal entries are revenue, which are the basis for
-// cost avoidance, and which are neither.
+// Which industry_job_tax journal entries are revenue, which are tax we paid,
+// which are the basis for cost avoidance, and which are none of those.
 //
 // An `industry_job_tax` entry in one of our corporations' wallets cuts both
 // ways, and the sign is not the whole story:
@@ -24,6 +24,31 @@
 // whose wallet the entry sits in. Two of our own corporations trading tax
 // between themselves fails that test on purpose: ISK moved, and the receiving
 // corp's journal carries the positive side, which is where it gets counted.
+//
+// TAXES PAID is the third measure, and it is not the negation of revenue: it is
+// every charge OUR side actually paid, on our structures and other people's
+// alike. An alt corp is ours (we hold a director in it, which is the only
+// reason its wallet is readable at all), so it is classified exactly like one
+// of our characters.
+//
+// Each charge counts once, which decides which side of a pair to read it from:
+//
+//   - An OUTGOING entry is always tax we paid, so it is counted there.
+//   - An INCOMING entry counts only when a CHARACTER of ours installed the job.
+//     Their wallet paid it and we have no character journal to read, so the
+//     receipt is the only record. A corp job's payment is already visible as
+//     the outgoing entry in that corp's own wallet, so counting the incoming
+//     side too would bill one charge twice.
+//
+// COST AVOIDANCE is narrower than either: only a job whose OWN corporation owns
+// the structure it ran in, because only then was it billed at our own rate,
+// which is what the counterfactual scales. That test is the installer's
+// corporation against the structure's owner — not the wallet's, which for an
+// incoming entry is the landlord rather than the installer. A job one of our
+// corps ran in a SISTER corp's structure is therefore revenue for the owner and
+// tax paid by the installer, but avoidance for neither: a structure bills a
+// corporation it does not contain at whatever rate it likes, and scaling that
+// receipt as though it were the own rate would invent a saving.
 import type { OwnTaxReceipt } from './costAvoidance'
 
 export type TaxEntry = {
@@ -41,10 +66,15 @@ export type TaxEntry = {
 export type TaxLedgerInput = {
   // job id -> the structure it ran in, for every job we could resolve.
   structureByJob: ReadonlyMap<string, string>
-  // The jobs that are OURS — our characters' and our corporations'. Jobs
-  // resolved only through industry_job_tax_facility() are other players'
-  // renting our slots and are deliberately absent.
-  ownJobIds: ReadonlySet<string>
+  // job id -> the corporation of the CHARACTER who installed it, for our
+  // characters' personal jobs only.
+  //
+  // Corp jobs are deliberately absent: their payment is readable as the
+  // outgoing entry in the paying corp's own wallet, and it is that entry, not
+  // the landlord's receipt, that says who installed them. Jobs resolved only
+  // through industry_job_tax_facility() are other players' renting our slots
+  // and are absent for the older reason — they were never ours.
+  personalJobCorp: ReadonlyMap<string, string>
   // structure id -> the corporation that owns it. Covers every structure on
   // the page, which includes alliance-mates' as well as our own.
   structureOwner: ReadonlyMap<string, string>
@@ -52,6 +82,10 @@ export type TaxLedgerInput = {
 
 export type TaxLedger = {
   revenueByStructure: Map<string, number>
+  // Tax we actually paid, positive, keyed by the structure it was paid for —
+  // ours or somebody else's. Overlaps revenueByStructure on purpose where a
+  // member paid their own corp: one charge, two true statements about it.
+  taxesPaidByStructure: Map<string, number>
   ownReceipts: OwnTaxReceipt[]
   // Revenue we received but couldn't tie to a structure on the page.
   unaccounted: number
@@ -59,21 +93,29 @@ export type TaxLedger = {
 }
 
 export const foldTaxLedger = (entries: readonly TaxEntry[], input: TaxLedgerInput): TaxLedger => {
-  const { structureByJob, ownJobIds, structureOwner } = input
+  const { structureByJob, personalJobCorp, structureOwner } = input
 
   const revenueByStructure = new Map<string, number>()
+  const taxesPaidByStructure = new Map<string, number>()
   const unaccountedByParty = new Map<string, number>()
   const ownReceipts: OwnTaxReceipt[] = []
-  // One receipt per job. A job can only be charged its facility tax once, so a
-  // second entry naming it is the other side of the same charge, not a second
-  // one — counting both would double the avoidance.
+  // One receipt per job, and one payment per job. A job can only be charged its
+  // facility tax once, so a second entry naming it is the other side of the
+  // same charge, not a second one — counting both would double the figure.
   const credited = new Set<string>()
+  const paid = new Set<string>()
   let unaccounted = 0
 
   const credit = (jobId: string, structureId: string, amount: number) => {
     if (credited.has(jobId)) return
     credited.add(jobId)
     ownReceipts.push({ structureId, amount })
+  }
+
+  const payTax = (jobId: string, structureId: string, amount: number) => {
+    if (paid.has(jobId)) return
+    paid.add(jobId)
+    taxesPaidByStructure.set(structureId, (taxesPaidByStructure.get(structureId) ?? 0) + amount)
   }
 
   for (const entry of entries) {
@@ -86,7 +128,15 @@ export const foldTaxLedger = (entries: readonly TaxEntry[], input: TaxLedgerInpu
     if (amount > 0) {
       if (structureId != null) {
         revenueByStructure.set(structureId, (revenueByStructure.get(structureId) ?? 0) + amount)
-        if (jobId != null && ownJobIds.has(jobId)) credit(jobId, structureId, amount)
+        // Somebody paid us. If it was one of our own characters, that payment is
+        // recorded nowhere else — no character wallet journal is ingested — so
+        // this receipt is also the record of tax we paid, and of an own-rate
+        // charge when their corporation is the one that owns the structure.
+        const installerCorp = jobId != null ? personalJobCorp.get(jobId) : undefined
+        if (jobId != null && installerCorp != null) {
+          payTax(jobId, structureId, amount)
+          if (installerCorp === structureOwner.get(structureId)) credit(jobId, structureId, amount)
+        }
       } else {
         // Tax we received but can't tie to one of our structures (e.g. jobs not
         // in our tables, or a structure we've stopped monitoring).
@@ -97,15 +147,20 @@ export const foldTaxLedger = (entries: readonly TaxEntry[], input: TaxLedgerInpu
       continue
     }
 
-    // Outgoing. Only a charge our corporation levied on itself is avoidance;
-    // one paid to another owner is a real expense and belongs to neither
-    // figure, so it is dropped rather than falling into "unaccounted" (which
-    // is a revenue bucket).
+    // Outgoing: our corporation paid this, so it is tax we paid whoever owns the
+    // structure. A charge we can't place on this page is dropped rather than
+    // falling into "unaccounted" (which is a revenue bucket) — there is no tile
+    // to attribute it to.
     if (jobId == null || structureId == null) continue
+    payTax(jobId, structureId, -amount)
+
+    // ...but only a charge our corporation levied on ITSELF was billed at our
+    // own rate, so only that is avoidance. Paying a landlord — an ally's
+    // structure, or a sister corp's — is a real expense and no saving at all.
     if (entry.corporationId == null) continue
     if (structureOwner.get(structureId) !== entry.corporationId) continue
     credit(jobId, structureId, -amount)
   }
 
-  return { revenueByStructure, ownReceipts, unaccounted, unaccountedByParty }
+  return { revenueByStructure, taxesPaidByStructure, ownReceipts, unaccounted, unaccountedByParty }
 }

--- a/src/app/structure/taxLedger.ts
+++ b/src/app/structure/taxLedger.ts
@@ -61,6 +61,10 @@ export type TaxEntry = {
   jobIds: readonly string[]
   // The party that paid, for the unaccounted breakdown.
   payerId: string | null
+  // The party that was paid. On an outgoing entry that is the landlord, which
+  // is how tax leaving for a structure this page doesn't list is attributed to
+  // a corporation without resolving the structure at all.
+  recipientId: string | null
 }
 
 export type TaxLedgerInput = {
@@ -78,6 +82,18 @@ export type TaxLedgerInput = {
   // structure id -> the corporation that owns it. Covers every structure on
   // the page, which includes alliance-mates' as well as our own.
   structureOwner: ReadonlyMap<string, string>
+  // The corporations owning a structure on the page. A charge paid to anyone
+  // else went to a landlord this page doesn't list, which is the whole test for
+  // the unlisted bucket — the job needn't resolve for that to be known.
+  listedOwners: ReadonlySet<string>
+}
+
+// One outgoing charge to a landlord with no tile here. `jobId` is kept so the
+// caller can resolve where it ran; the corporation is already known.
+export type UnlistedTaxPayment = {
+  corporationId: string | null
+  jobId: string | null
+  amount: number
 }
 
 export type TaxLedger = {
@@ -87,18 +103,24 @@ export type TaxLedger = {
   // member paid their own corp: one charge, two true statements about it.
   taxesPaidByStructure: Map<string, number>
   ownReceipts: OwnTaxReceipt[]
+  // Tax paid to corporations owning no structure on this page. Kept apart from
+  // taxesPaidByStructure rather than dropped: it is real ISK that left, and
+  // folding it into a per-structure figure would attribute it to a tile that
+  // doesn't exist.
+  unlistedPayments: UnlistedTaxPayment[]
   // Revenue we received but couldn't tie to a structure on the page.
   unaccounted: number
   unaccountedByParty: Map<string, number>
 }
 
 export const foldTaxLedger = (entries: readonly TaxEntry[], input: TaxLedgerInput): TaxLedger => {
-  const { structureByJob, personalJobCorp, structureOwner } = input
+  const { structureByJob, personalJobCorp, structureOwner, listedOwners } = input
 
   const revenueByStructure = new Map<string, number>()
   const taxesPaidByStructure = new Map<string, number>()
   const unaccountedByParty = new Map<string, number>()
   const ownReceipts: OwnTaxReceipt[] = []
+  const unlistedPayments: UnlistedTaxPayment[] = []
   // One receipt per job, and one payment per job. A job can only be charged its
   // facility tax once, so a second entry naming it is the other side of the
   // same charge, not a second one — counting both would double the figure.
@@ -148,10 +170,19 @@ export const foldTaxLedger = (entries: readonly TaxEntry[], input: TaxLedgerInpu
     }
 
     // Outgoing: our corporation paid this, so it is tax we paid whoever owns the
-    // structure. A charge we can't place on this page is dropped rather than
-    // falling into "unaccounted" (which is a revenue bucket) — there is no tile
-    // to attribute it to.
-    if (jobId == null || structureId == null) continue
+    // structure.
+    if (jobId == null || structureId == null) {
+      // No tile to attribute it to. If the landlord owns nothing on this page,
+      // that is because they are somebody else entirely, and the charge belongs
+      // in the unlisted bucket. If they DO own a tile here, the job simply
+      // didn't resolve — attributing it to a structure we cannot name would be
+      // a guess, so it is dropped as before.
+      const recipient = entry.recipientId
+      if (recipient == null || !listedOwners.has(recipient)) {
+        unlistedPayments.push({ corporationId: recipient, jobId: entry.jobIds[0] ?? null, amount: -amount })
+      }
+      continue
+    }
     payTax(jobId, structureId, -amount)
 
     // ...but only a charge our corporation levied on ITSELF was billed at our
@@ -162,5 +193,12 @@ export const foldTaxLedger = (entries: readonly TaxEntry[], input: TaxLedgerInpu
     credit(jobId, structureId, -amount)
   }
 
-  return { revenueByStructure, taxesPaidByStructure, ownReceipts, unaccounted, unaccountedByParty }
+  return {
+    revenueByStructure,
+    taxesPaidByStructure,
+    ownReceipts,
+    unlistedPayments,
+    unaccounted,
+    unaccountedByParty,
+  }
 }

--- a/test/taxLedger.test.ts
+++ b/test/taxLedger.test.ts
@@ -45,13 +45,19 @@ const input = {
     ['S2', ALLY],
     ['S3', SISTER],
   ]),
+  listedOwners: new Set([OURS, ALLY, SISTER]),
 }
+
+// A corporation with no structure on this page — a public station somewhere we
+// rent slots in.
+const LANDLORD = 'corp-9'
 
 const entry = (over: Partial<TaxEntry>): TaxEntry => ({
   amount: 0,
   corporationId: OURS,
   jobIds: [],
   payerId: null,
+  recipientId: null,
   ...over,
 })
 
@@ -93,10 +99,46 @@ test("tax paid into an ally's structure is counted as paid, on their tile", () =
   assert.deepEqual(ledger.ownReceipts, [])
 })
 
-test('a job we cannot place on the page is not tax paid anywhere', () => {
-  const ledger = foldTaxLedger([entry({ amount: -3_500, jobIds: ['off-page'] })], input)
+test('a job we cannot place on the page is never billed to a structure', () => {
+  const ledger = foldTaxLedger([entry({ amount: -3_500, jobIds: ['off-page'], recipientId: LANDLORD })], input)
   assert.equal(ledger.taxesPaidByStructure.size, 0)
   assert.equal(ledger.unaccounted, 0)
+})
+
+test('tax paid to a corporation with no tile here is totalled separately, by landlord', () => {
+  const ledger = foldTaxLedger(
+    [
+      entry({ amount: -3_500, jobIds: ['J9'], recipientId: LANDLORD }),
+      entry({ amount: -1_500, jobIds: ['J10'], recipientId: LANDLORD }),
+    ],
+    input
+  )
+  assert.deepEqual(ledger.unlistedPayments, [
+    { corporationId: LANDLORD, jobId: 'J9', amount: 3_500 },
+    { corporationId: LANDLORD, jobId: 'J10', amount: 1_500 },
+  ])
+  // Never double-billed: it is not on a tile, and not in the revenue bucket.
+  assert.equal(ledger.taxesPaidByStructure.size, 0)
+  assert.equal(ledger.unaccounted, 0)
+})
+
+test('the recipient is known even when the job is not, so the total stays honest', () => {
+  const ledger = foldTaxLedger([entry({ amount: -900, jobIds: [], recipientId: LANDLORD })], input)
+  assert.deepEqual(ledger.unlistedPayments, [{ corporationId: LANDLORD, jobId: null, amount: 900 }])
+})
+
+test('an unresolved charge to a corporation that DOES own a tile is dropped, not called elsewhere', () => {
+  // Its landlord is listed, so the ISK belongs to some tile here — we just
+  // can't say which. Reporting it as paid elsewhere would name the wrong corp.
+  const ledger = foldTaxLedger([entry({ amount: -900, jobIds: ['off-page'], recipientId: ALLY })], input)
+  assert.deepEqual(ledger.unlistedPayments, [])
+  assert.equal(ledger.taxesPaidByStructure.size, 0)
+})
+
+test('a charge we can place on a tile never also counts as paid elsewhere', () => {
+  const ledger = foldTaxLedger([entry({ amount: -9_007, jobIds: ['J2'], recipientId: LANDLORD })], input)
+  assert.deepEqual([...ledger.taxesPaidByStructure], [['S2', 9_007]])
+  assert.deepEqual(ledger.unlistedPayments, [])
 })
 
 test("a renter's payment is revenue but not ours to have avoided", () => {

--- a/test/taxLedger.test.ts
+++ b/test/taxLedger.test.ts
@@ -1,9 +1,16 @@
-// Sorting industry_job_tax journal entries into revenue, cost-avoidance basis,
-// and neither. The case that drove this: a corporation that installs every job
-// AS THE CORPORATION into its own structure pays the facility tax out of the
-// corp wallet and receives it into the same wallet, so CCP writes only the
-// outgoing side. Every entry is negative, no receipt exists to scale, and the
-// page reported zero cost avoidance for a corp that was avoiding it constantly.
+// Sorting industry_job_tax journal entries into revenue, tax we paid,
+// cost-avoidance basis, and none of those. The case that drove the fold: a
+// corporation that installs every job AS THE CORPORATION into its own structure
+// pays the facility tax out of the corp wallet and receives it into the same
+// wallet, so CCP writes only the outgoing side. Every entry is negative, no
+// receipt exists to scale, and the page reported zero cost avoidance for a corp
+// that was avoiding it constantly.
+//
+// What the three measures must not do is collapse into each other. One charge
+// can be revenue AND tax we paid (a member billing their own corp), or tax we
+// paid and no revenue at all (the corp billing itself), and it is avoidance
+// only when the installer's own corporation owns the structure — never merely
+// because the job was ours.
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
@@ -12,18 +19,31 @@ import type { TaxEntry } from '../src/app/structure/taxLedger.ts'
 
 const OURS = 'corp-1'
 const ALLY = 'corp-2'
+// An alt corp of ours: we hold a director in it, so its wallet is readable and
+// its jobs are ours — but it is still a different corporation from the one that
+// owns S1, which is what cost avoidance turns on.
+const SISTER = 'corp-3'
 
-// Job J1 ran in our structure S1; job J2 in an alliance-mate's structure S2.
+// J1 and J3 ran in our structure S1, J2 in an alliance-mate's S2, J4 in the
+// sister corp's own S3. J1 and J4 are personal jobs of our characters; J2 is a
+// personal job of a character in the sister corp; J3 belongs to somebody else
+// entirely (it resolves to a structure but to no character of ours).
 const input = {
   structureByJob: new Map([
     ['J1', 'S1'],
     ['J2', 'S2'],
     ['J3', 'S1'],
+    ['J4', 'S3'],
   ]),
-  ownJobIds: new Set(['J1', 'J2']),
+  personalJobCorp: new Map([
+    ['J1', OURS],
+    ['J2', SISTER],
+    ['J4', SISTER],
+  ]),
   structureOwner: new Map([
     ['S1', OURS],
     ['S2', ALLY],
+    ['S3', SISTER],
   ]),
 }
 
@@ -35,10 +55,48 @@ const entry = (over: Partial<TaxEntry>): TaxEntry => ({
   ...over,
 })
 
-test('an incoming payment for our own job is both revenue and an own-rate receipt', () => {
+test('an incoming payment for our own job is revenue, tax we paid, and an own-rate receipt', () => {
   const ledger = foldTaxLedger([entry({ amount: 5_000, jobIds: ['J1'] })], input)
   assert.deepEqual([...ledger.revenueByStructure], [['S1', 5_000]])
+  // The member's wallet paid it and no character journal exists to read, so
+  // this receipt is the only record of the charge.
+  assert.deepEqual([...ledger.taxesPaidByStructure], [['S1', 5_000]])
   assert.deepEqual(ledger.ownReceipts, [{ structureId: 'S1', amount: 5_000 }])
+})
+
+test("a sister corp's character paying into our structure is revenue and tax paid, never avoidance", () => {
+  // J4's installer is in SISTER, which owns S3 — so in its own corp's structure
+  // it does avoid. The point of the pair below is the corp/owner comparison,
+  // not who we are.
+  const own = foldTaxLedger([entry({ amount: 4_000, corporationId: SISTER, jobIds: ['J4'] })], input)
+  assert.deepEqual(own.ownReceipts, [{ structureId: 'S3', amount: 4_000 }])
+
+  // J2's installer is in SISTER but S2 belongs to an ally: billed at whatever
+  // rate a stranger gets, so there is no own-rate receipt to scale.
+  const rented = foldTaxLedger([entry({ amount: 4_000, jobIds: ['J2'] })], input)
+  assert.deepEqual([...rented.revenueByStructure], [['S2', 4_000]])
+  assert.deepEqual([...rented.taxesPaidByStructure], [['S2', 4_000]])
+  assert.deepEqual(rented.ownReceipts, [])
+})
+
+test('an incoming payment for a CORP job is revenue only — its own wallet records the payment', () => {
+  // J3 is in no personalJobCorp entry, so nothing here bills it a second time.
+  const ledger = foldTaxLedger([entry({ amount: 7_000, jobIds: ['J3'] })], input)
+  assert.deepEqual([...ledger.revenueByStructure], [['S1', 7_000]])
+  assert.equal(ledger.taxesPaidByStructure.size, 0)
+})
+
+test("tax paid into an ally's structure is counted as paid, on their tile", () => {
+  const ledger = foldTaxLedger([entry({ amount: -3_500, jobIds: ['J2'] })], input)
+  assert.deepEqual([...ledger.taxesPaidByStructure], [['S2', 3_500]])
+  assert.equal(ledger.revenueByStructure.size, 0)
+  assert.deepEqual(ledger.ownReceipts, [])
+})
+
+test('a job we cannot place on the page is not tax paid anywhere', () => {
+  const ledger = foldTaxLedger([entry({ amount: -3_500, jobIds: ['off-page'] })], input)
+  assert.equal(ledger.taxesPaidByStructure.size, 0)
+  assert.equal(ledger.unaccounted, 0)
 })
 
 test("a renter's payment is revenue but not ours to have avoided", () => {
@@ -47,14 +105,15 @@ test("a renter's payment is revenue but not ours to have avoided", () => {
   assert.deepEqual(ledger.ownReceipts, [])
 })
 
-test('tax our corp paid itself is an own-rate receipt, and is never revenue', () => {
+test('tax our corp paid itself is an own-rate receipt and tax paid, and is never revenue', () => {
   const ledger = foldTaxLedger([entry({ amount: -9_007, jobIds: ['J1'] })], input)
   assert.deepEqual(ledger.ownReceipts, [{ structureId: 'S1', amount: 9_007 }])
+  assert.deepEqual([...ledger.taxesPaidByStructure], [['S1', 9_007]])
   assert.equal(ledger.revenueByStructure.size, 0)
   assert.equal(ledger.unaccounted, 0)
 })
 
-test("tax paid into somebody else's structure is a real expense — neither figure", () => {
+test("tax paid into somebody else's structure is an expense, not revenue and not avoided", () => {
   const ledger = foldTaxLedger([entry({ amount: -9_007, jobIds: ['J2'] })], input)
   assert.deepEqual(ledger.ownReceipts, [])
   assert.equal(ledger.revenueByStructure.size, 0)
@@ -84,6 +143,8 @@ test('both sides of one charge credit the job once, not twice', () => {
     input
   )
   assert.deepEqual(ledger.ownReceipts, [{ structureId: 'S1', amount: 5_000 }])
+  // A job is charged its facility tax once, so it is billed to Taxes Paid once.
+  assert.deepEqual([...ledger.taxesPaidByStructure], [['S1', 5_000]])
 })
 
 test('an outgoing entry from a corporation that does not own the structure is dropped', () => {
@@ -105,7 +166,7 @@ test('zero and non-numeric amounts are ignored rather than crediting a phantom j
   assert.equal(ledger.revenueByStructure.size, 0)
 })
 
-test('receipts accumulate per structure across many entries', () => {
+test('receipts and payments accumulate per structure across many entries', () => {
   const ledger = foldTaxLedger(
     [
       entry({ amount: -9_007, jobIds: ['J1'] }),
@@ -118,4 +179,12 @@ test('receipts accumulate per structure across many entries', () => {
     { structureId: 'S1', amount: 9_007 },
     { structureId: 'S1', amount: 82_249 },
   ])
+  // Every outgoing charge is tax we paid, including the one to the ally.
+  assert.deepEqual(
+    [...ledger.taxesPaidByStructure],
+    [
+      ['S1', 91_256],
+      ['S2', 3_487],
+    ]
+  )
 })


### PR DESCRIPTION
Two changes, both landing on the same branch.

---

# 1. Taxes Paid on /structure

Revenue only ever answered *what others paid us*, so two real things were invisible: the 0.1% our own structures bill us, and tax paid into an alliance-mate's structure, which was dropped outright. Both are now a third measure, **Taxes Paid**, shown per structure and in the footer — plus a separate **Taxes paid elsewhere** total for landlords with no tile here.

## How a charge is classified

An alt corp is ours — we hold a director in it, which is the only reason its wallet is readable — so its jobs are classified exactly like one of our characters'.

| Case | Revenue | Taxes paid | Avoidance |
|---|---|---|---|
| Outsider's job in our structure | ✓ | — | — |
| Our member's personal job in their own corp's structure | ✓ | ✓ | ✓ |
| Our corp's job in its own structure (outgoing only) | — | ✓ | ✓ |
| Sister corp A → corp B's structure | ✓ (at B) | ✓ (at A) | — |
| Our corp → ally's structure | — | ✓ | — |
| Our corp → a corp with no tile here | — | *paid elsewhere* | — |
| Incoming, resolves to no listed structure | unaccounted | — | — |

**Each charge is billed once, which decides which side of a pair to read it from.** An outgoing entry is always tax we paid. An incoming one counts only when a *character* of ours installed the job: their wallet paid it and no character wallet journal is ingested, so the receipt is the only record that exists. A corp job's payment is already visible as the outgoing entry in that corp's own wallet, so counting the landlord's receipt too would bill one charge twice. Both `credit` and the new `payTax` dedupe per job.

## Bug fixed along the way

Cost avoidance compared the structure's owner against **the wallet the entry sat in**. That's the installer for an outgoing entry, but the *landlord* for an incoming one — so a sister corp's job into our structure credited a saving. It was never charged at our own rate (a structure bills a corporation it doesn't contain at whatever rate it likes), and scaling that receipt by `public/own` invents ISK.

The test is now uniform: **a job avoids only when its installer's own corporation owns the structure**. The installer's corp comes from the job row — `corporation_id` for corp jobs, `registration → corporation_id` for a character's. `ownJobIds` is replaced by `personalJobCorp`, which answers both the avoidance test and the count-once rule.

## Taxes paid elsewhere

Attribution still lands only on listed structures, so an outside landlord's tax has no tile — but dropping it made the footer understate what industry costs. It gets its own line, expandable to which corporation took it and in which systems.

The landlord comes from the entry's `second_party_id`, not from resolving the structure, so the total is correct even for a job that never resolves. Whether the recipient owns a tile here is the discriminator: an unresolved charge *to a listed corp* is still dropped rather than misattributed to someone else. Only the system needs the job, and those jobs were never fetched (that select is filtered to on-page structures), so the few ids involved are looked up directly and placed via the `universe_structure` cache; a structure the cache has never resolved contributes no system rather than hiding the ISK.

The remaining blind spot is stated in the caption and is unfixable here: tax a character pays to a corporation that isn't ours leaves a wallet we have no journal for.

`/structure/[structureId]` and `structure_tax_revenue()` are unchanged — extending them needs a migration, so that's a follow-up.

---

# 2. Corp BPO showcase links on /blueprint

The link introduced in #961 required a director's token — the grant that fills `corp_blueprint` in the first place, so without one the link opened an empty page. That gate stays, but it missed the other case where the page genuinely has something to show: **a corporation that published its showcase to us**.

Visibility is asked as the *viewer*, because `corp_bpo_share`'s own policies already answer the question exactly — a member sees their corporation's row, the audience policy adds rows aimed at their corp or alliance plus any that are fully public, and a link-only share matches nobody, which is right because its URL is the only way in.

---

## Testing

`pnpm run lint`, `pnpm test` (540 pass, up from 532) and `pnpm run build` all clean. New ledger cases cover the sister-corp split, corp-job receipts not double-billing, tax on an ally's tile, the unlisted bucket grouping by landlord, a known recipient with an unknown job, and an unresolved charge to a listed corp staying dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Eh71M22uC6MZaFErV73tZ