### PR TITLE
Structure detail tax measures, and full-width structure tiles on phones

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -4921,22 +4921,60 @@ grant  execute on function public.industry_job_tax_facility(bigint[]) to authent
 -- Payer identity crosses no new boundary: first_party_id is already on the
 -- journal row the caller can read, and /structure/revenue already displays it.
 --
--- Two measures, never netted. industry_job_tax cuts both ways in a corp wallet:
--- a positive entry is money that arrived, a negative one is tax the corporation
--- paid — and for a job installed AS THE CORPORATION into its own structure that
--- is money that never left the entity (CCP writes only the outgoing side), so a
--- corp running everything under corp ownership generates nothing but negative
--- entries. Summing the two reported such structures as earning large negative
--- revenue. `isk_self_paid` is the own-rate charge behind the cost-avoidance
--- figure on /structure; see docs/cost-avoidance.md and
--- src/app/structure/taxLedger.ts.
+-- Measures that overlap and are never netted. industry_job_tax cuts both ways in
+-- a corp wallet: a positive entry is money that arrived, a negative one is tax
+-- the corporation paid — and for a job installed AS THE CORPORATION into its own
+-- structure that is money that never left the entity (CCP writes only the
+-- outgoing side), so a corp running everything under corp ownership generates
+-- nothing but negative entries. Summing the two reported such structures as
+-- earning large negative revenue.
+--
+-- The rules below mirror src/app/structure/taxLedger.ts, which is the canonical
+-- statement of them; see also docs/cost-avoidance.md:
+--
+--   isk         incoming. Somebody paid to run a job here.
+--   isk_paid    every charge our side paid: all outgoing entries, plus incoming
+--               ones whose job one of OUR CHARACTERS installed (no character
+--               wallet journal exists, so the receipt is the only record of
+--               that payment). A corp job's payment is already the outgoing
+--               entry in that corp's own wallet, so counting the landlord's
+--               receipt too would bill it twice.
+--   isk_self_paid  the subset billed at our own rate — the installer's own
+--               corporation owns this structure. Only that can be scaled into a
+--               saving; a structure bills a corporation it does not contain at
+--               whatever rate it likes.
+--   isk_total   every entry once, whichever direction. What the payer
+--               leaderboard ranks; revenue and taxes paid deliberately overlap
+--               (a member billing their own corp is both), so they cannot be
+--               added for that purpose.
+--
+-- SECURITY INVOKER throughout: corp_structure, character_industry_job and
+-- registration are all RLS-scoped to the caller, so a job is only ever "ours"
+-- when we can actually see it.
 create or replace function public.structure_tax_revenue(structure_id bigint, since timestamptz)
-returns table (payer_id bigint, day date, jobs bigint, isk numeric, self_paid_jobs bigint, isk_self_paid numeric)
+returns table (
+  payer_id bigint,
+  day date,
+  jobs bigint,
+  isk numeric,
+  self_paid_jobs bigint,
+  isk_self_paid numeric,
+  paid_jobs bigint,
+  isk_paid numeric,
+  total_jobs bigint,
+  isk_total numeric
+)
 language sql
 stable
 as $$
-  with tax as (
-    select w.first_party_id, w.date, w.amount, w.context_id
+  with owner as (
+    select cs.corporation_id
+    from public.corp_structure cs
+    where cs.structure_id = structure_tax_revenue.structure_id
+    limit 1
+  ),
+  tax as (
+    select w.first_party_id, w.corporation_id, w.date, w.amount, w.context_id
     from public.corp_wallet_journal w
     where w.ref_type = 'industry_job_tax'
       and w.context_id is not null
@@ -4947,20 +4985,49 @@ as $$
   located as (
     select f.job_id, f.station_id, f.facility_id
     from public.industry_job_tax_facility(array(select distinct t.context_id from tax t)) f
+  ),
+  -- Our characters' personal jobs, and the corporation each installer was in.
+  -- Corp jobs are deliberately absent: it is the outgoing entry in the paying
+  -- corp's own wallet that records those, not the receipt.
+  personal as (
+    select cij.job_id, r.corporation_id
+    from public.character_industry_job cij
+    join public.registration r on r.id = cij.registration_id
+  ),
+  scoped as (
+    select
+      t.first_party_id,
+      t.corporation_id,
+      t.date,
+      t.amount,
+      p.corporation_id is not null as is_personal,
+      -- Was this charge billed at our own rate? For an outgoing entry the payer
+      -- IS the installer; for an incoming one the wallet belongs to the
+      -- landlord, so the installer comes from the job instead.
+      case
+        when t.amount < 0 then t.corporation_id = (select corporation_id from owner)
+        else p.corporation_id is not null and p.corporation_id = (select corporation_id from owner)
+      end as own_rate
+    from tax t
+    join located l on l.job_id = t.context_id
+    left join personal p on p.job_id = t.context_id
+    -- Upwell structures share the id between station_id and facility_id; jobs in
+    -- NPC stations carry only station_id. Same coalesce the revenue page uses.
+    where coalesce(l.station_id, l.facility_id) = structure_tax_revenue.structure_id
   )
   select
-    t.first_party_id                                            as payer_id,
-    (t.date at time zone 'UTC')::date                           as day,
-    count(*) filter (where t.amount > 0)                        as jobs,
-    coalesce(sum(t.amount) filter (where t.amount > 0), 0)      as isk,
-    count(*) filter (where t.amount < 0)                        as self_paid_jobs,
-    coalesce(-sum(t.amount) filter (where t.amount < 0), 0)     as isk_self_paid
-  from tax t
-  join located l on l.job_id = t.context_id
-  -- Upwell structures share the id between station_id and facility_id; jobs in
-  -- NPC stations carry only station_id. Same coalesce the revenue page uses.
-  where coalesce(l.station_id, l.facility_id) = structure_tax_revenue.structure_id
-  -- Positional, so the output column names can't shadow anything in `tax`.
+    s.first_party_id                                                as payer_id,
+    (s.date at time zone 'UTC')::date                               as day,
+    count(*) filter (where s.amount > 0)                            as jobs,
+    coalesce(sum(s.amount) filter (where s.amount > 0), 0)          as isk,
+    count(*) filter (where s.own_rate)                              as self_paid_jobs,
+    coalesce(sum(abs(s.amount)) filter (where s.own_rate), 0)       as isk_self_paid,
+    count(*) filter (where s.amount < 0 or s.is_personal)           as paid_jobs,
+    coalesce(sum(abs(s.amount)) filter (where s.amount < 0 or s.is_personal), 0) as isk_paid,
+    count(*)                                                        as total_jobs,
+    coalesce(sum(abs(s.amount)), 0)                                 as isk_total
+  from scoped s
+  -- Positional, so the output column names can't shadow anything in `scoped`.
   group by 1, 2
   order by 2 desc, 4 desc;
 $$;

--- a/src/app/structure/[structureId]/page.tsx
+++ b/src/app/structure/[structureId]/page.tsx
@@ -60,11 +60,14 @@ type Rig = {
   type_id: number | string
 }
 
-// One row per (payer, UTC day) from structure_tax_revenue(). The two measures
-// are separate and never netted: `isk` is tax that ARRIVED, `isk_self_paid` is
-// tax the caller's own corporation paid for a job it installed as itself into
-// this structure — money that never left the entity, and the basis of the cost
-// avoidance on /structure rather than revenue. Both come back positive.
+// One row per (payer, UTC day) from structure_tax_revenue(), carrying the same
+// measures /structure shows per tile. They OVERLAP and are never netted: `isk`
+// is tax that arrived, `isk_paid` is tax our side paid whoever owns this
+// structure, and a member billing their own corporation is both at once.
+// `isk_self_paid` is the subset of what we paid that was billed at our own rate
+// — the basis of the cost-avoidance figure rather than revenue — and `isk_total`
+// counts every entry once, which is what the leaderboard can rank without
+// double-counting the overlap. All come back positive.
 type TaxRow = {
   payer_id: number | string | null
   day: string
@@ -72,6 +75,10 @@ type TaxRow = {
   isk: number | string | null
   self_paid_jobs: number | string
   isk_self_paid: number | string | null
+  paid_jobs: number | string
+  isk_paid: number | string | null
+  total_jobs: number | string
+  isk_total: number | string | null
 }
 
 type StructureParams = {
@@ -205,25 +212,27 @@ const StructurePage = async ({ params, searchParams }: StructureParams) => {
   const taxTotalIsk = taxRows.reduce((sum, r) => sum + Number(r.isk ?? 0), 0)
   const taxTotalJobs = taxRows.reduce((sum, r) => sum + Number(r.jobs ?? 0), 0)
   const selfPaidIsk = taxRows.reduce((sum, r) => sum + Number(r.isk_self_paid ?? 0), 0)
-  const selfPaidJobs = taxRows.reduce((sum, r) => sum + Number(r.self_paid_jobs ?? 0), 0)
+  const paidIsk = taxRows.reduce((sum, r) => sum + Number(r.isk_paid ?? 0), 0)
+  const paidJobs = taxRows.reduce((sum, r) => sum + Number(r.paid_jobs ?? 0), 0)
   // A structure whose corp installs everything under corp ownership has only
-  // self-paid rows, so the received column would be all zeroes; the extra
-  // column earns its width only when there is something in it.
-  const showSelfPaid = selfPaidJobs > 0
+  // outgoing rows, so the received column would be all zeroes; the extra column
+  // earns its width only when there is something in it.
+  const showPaid = paidJobs > 0
 
   // The payer leaderboard above the table: the same rows folded from
   // (payer, day) down to (payer), ranked by ISK. No extra query — the window's
   // rows are already in hand, and re-aggregating here keeps the two views
   // guaranteed consistent with each other.
-  // Both measures fold together here: the leaderboard ranks who put the most
-  // industry through this structure, which is the same question whichever
-  // wallet the tax came out of.
+  // The leaderboard ranks who put the most industry through this structure,
+  // which is the same question whichever wallet the tax came out of — so it
+  // ranks on isk_total, every charge counted once. Adding revenue to taxes paid
+  // would count a member's own-corp job twice, since that one charge is both.
   const byPayer = new Map<string, { payerId: string; isk: number; jobs: number }>()
   for (const r of taxRows) {
     const payerId = r.payer_id != null ? String(r.payer_id) : 'unknown'
     const entry = byPayer.get(payerId) ?? { payerId, isk: 0, jobs: 0 }
-    entry.isk += Number(r.isk ?? 0) + Number(r.isk_self_paid ?? 0)
-    entry.jobs += Number(r.jobs ?? 0) + Number(r.self_paid_jobs ?? 0)
+    entry.isk += Number(r.isk_total ?? 0)
+    entry.jobs += Number(r.total_jobs ?? 0)
     byPayer.set(payerId, entry)
   }
   const leaderboard = [...byPayer.values()].sort((a, b) => b.isk - a.isk)
@@ -396,10 +405,10 @@ const StructurePage = async ({ params, searchParams }: StructureParams) => {
               <th>Day</th>
               <th className={retro.num}>Jobs</th>
               <th className={retro.num}>ISK</th>
-              {showSelfPaid && (
+              {showPaid && (
                 <>
-                  <th className={retro.num}>Self Jobs</th>
-                  <th className={retro.num}>Self ISK</th>
+                  <th className={retro.num}>Paid Jobs</th>
+                  <th className={retro.num}>Paid ISK</th>
                 </>
               )}
             </tr>
@@ -420,10 +429,10 @@ const StructurePage = async ({ params, searchParams }: StructureParams) => {
                   <td className="serif">{r.day}</td>
                   <td className={retro.num}>{Number(r.jobs)}</td>
                   <td className={retro.num}>{formatIskValue(r.isk)}</td>
-                  {showSelfPaid && (
+                  {showPaid && (
                     <>
-                      <td className={retro.num}>{Number(r.self_paid_jobs)}</td>
-                      <td className={retro.num}>{formatIskValue(r.isk_self_paid)}</td>
+                      <td className={retro.num}>{Number(r.paid_jobs)}</td>
+                      <td className={retro.num}>{formatIskValue(r.isk_paid)}</td>
                     </>
                   )}
                 </tr>
@@ -436,10 +445,10 @@ const StructurePage = async ({ params, searchParams }: StructureParams) => {
               <th />
               <th className={retro.num}>{taxTotalJobs}</th>
               <th className={retro.num}>{formatIskValue(taxTotalIsk)}</th>
-              {showSelfPaid && (
+              {showPaid && (
                 <>
-                  <th className={retro.num}>{selfPaidJobs}</th>
-                  <th className={retro.num}>{formatIskValue(selfPaidIsk)}</th>
+                  <th className={retro.num}>{paidJobs}</th>
+                  <th className={retro.num}>{formatIskValue(paidIsk)}</th>
                 </>
               )}
             </tr>
@@ -447,6 +456,22 @@ const StructurePage = async ({ params, searchParams }: StructureParams) => {
         </table>
       ) : (
         <p>No industry tax from this structure in the last {windowDays} days.</p>
+      )}
+      {showPaid && (
+        <p className={structureStyles.unaccountedNote}>
+          <em>
+            ISK is tax that arrived here; Paid ISK is what we were charged to run our own jobs here, whoever owns the
+            structure. One charge can be both — a member billing their own corporation pays it and we receive it — so
+            the two columns describe the same events from different sides rather than summing to a balance.
+            {selfPaidIsk > 0 && (
+              <>
+                {' '}
+                Of what we paid, {formatIskValue(selfPaidIsk)} was billed at our own rate, which is the part{' '}
+                <Link href="/structure">cost avoidance</Link> prices against a public structure.
+              </>
+            )}
+          </em>
+        </p>
       )}
 
       <h2>Industry Jobs</h2>

--- a/src/app/structure/structures.module.css
+++ b/src/app/structure/structures.module.css
@@ -1,11 +1,13 @@
 /*
- * Structures as a responsive tile grid — two per row on phones, packing in
- * more columns as the viewport grows (SwiftUI LazyVGrid feel).
+ * Structures as a responsive tile grid — one full-width tile per row on phones,
+ * packing in more columns as the viewport grows (SwiftUI LazyVGrid feel). A
+ * tile carries a name, several labelled figures and a services list, none of
+ * which survive being squeezed into half a phone's width.
  */
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: 1fr;
   gap: 12px;
   list-style: none;
   padding: 0;
@@ -230,9 +232,10 @@
   overflow: visible;
 }
 
-/* On narrow phones the tiles are half-screen wide, so the 3-column label /
- * sparkline / value layout overflows. Instead, stack label+value on the first
- * row and let the sparkline take the full width on the second row. */
+/* Phones get one tile per row, but the 3-column label / sparkline / value
+ * layout still leaves the sparkline a sliver between two text columns at that
+ * width. Stack label+value on the first row instead and give the sparkline the
+ * full width on the second, where the trend is actually readable. */
 @media (max-width: 639px) {
   .indexes {
     display: flex;

--- a/supabase/migrations/20260824234011_structure_tax_paid.sql
+++ b/supabase/migrations/20260824234011_structure_tax_paid.sql
@@ -1,0 +1,117 @@
+-- structure_tax_revenue(): report the same three measures /structure does.
+--
+-- The list page now separates what others paid US (revenue), what WE paid
+-- whoever owns a structure (taxes paid), and the subset of that billed at our
+-- own rate (the cost-avoidance basis). This function knew only the first two,
+-- and its second one was wrong in the same way the list page's was:
+-- `isk_self_paid` summed EVERY outgoing entry with no owner test, so tax paid
+-- as rent into an alliance-mate's structure was reported as tax we had billed
+-- ourselves. It also missed a member's personal job entirely — that charge
+-- arrives as an incoming entry, and no character wallet journal exists to read
+-- the paying side from, so it was only ever counted as revenue.
+--
+-- The rules below mirror src/app/structure/taxLedger.ts, which is the canonical
+-- statement of them:
+--
+--   isk         incoming. Somebody paid to run a job here.
+--   isk_paid    every charge our side paid: all outgoing entries, plus incoming
+--               ones whose job one of OUR CHARACTERS installed. A corp job's
+--               payment is already the outgoing entry in that corp's own
+--               wallet, so counting the landlord's receipt too would bill it
+--               twice.
+--   isk_self_paid  the subset billed at our own rate — the installer's own
+--               corporation owns this structure. Only that can be scaled by
+--               public/own into a saving; a structure bills a corporation it
+--               does not contain at whatever rate it likes.
+--   isk_total   every entry once, whichever direction. What the payer
+--               leaderboard ranks, since "who put industry through here" is the
+--               same question whichever wallet the tax came out of. Revenue and
+--               taxes paid deliberately overlap (a member billing their own
+--               corp is both), so they cannot be added for that purpose.
+--
+-- The return type changes, so the function is dropped rather than replaced —
+-- CREATE OR REPLACE cannot alter OUT parameters. SECURITY INVOKER throughout:
+-- corp_structure, character_industry_job and registration are all RLS-scoped to
+-- the caller, so a job is only ever "ours" when we can actually see it.
+drop function if exists public.structure_tax_revenue(bigint, timestamptz);
+
+create function public.structure_tax_revenue(structure_id bigint, since timestamptz)
+returns table (
+  payer_id bigint,
+  day date,
+  jobs bigint,
+  isk numeric,
+  self_paid_jobs bigint,
+  isk_self_paid numeric,
+  paid_jobs bigint,
+  isk_paid numeric,
+  total_jobs bigint,
+  isk_total numeric
+)
+language sql
+stable
+as $$
+  with owner as (
+    select cs.corporation_id
+    from public.corp_structure cs
+    where cs.structure_id = structure_tax_revenue.structure_id
+    limit 1
+  ),
+  tax as (
+    select w.first_party_id, w.corporation_id, w.date, w.amount, w.context_id
+    from public.corp_wallet_journal w
+    where w.ref_type = 'industry_job_tax'
+      and w.context_id is not null
+      and w.date >= since
+  ),
+  -- One call for the whole window rather than per row; the function dedupes to
+  -- at most one location per job.
+  located as (
+    select f.job_id, f.station_id, f.facility_id
+    from public.industry_job_tax_facility(array(select distinct t.context_id from tax t)) f
+  ),
+  -- Our characters' personal jobs, and the corporation each installer was in.
+  -- Corp jobs are deliberately absent: it is the outgoing entry in the paying
+  -- corp's own wallet that records those, not the receipt.
+  personal as (
+    select cij.job_id, r.corporation_id
+    from public.character_industry_job cij
+    join public.registration r on r.id = cij.registration_id
+  ),
+  scoped as (
+    select
+      t.first_party_id,
+      t.corporation_id,
+      t.date,
+      t.amount,
+      p.corporation_id is not null as is_personal,
+      -- Was this charge billed at our own rate? For an outgoing entry the payer
+      -- IS the installer; for an incoming one the wallet belongs to the
+      -- landlord, so the installer comes from the job instead.
+      case
+        when t.amount < 0 then t.corporation_id = (select corporation_id from owner)
+        else p.corporation_id is not null and p.corporation_id = (select corporation_id from owner)
+      end as own_rate
+    from tax t
+    join located l on l.job_id = t.context_id
+    left join personal p on p.job_id = t.context_id
+    -- Upwell structures share the id between station_id and facility_id; jobs in
+    -- NPC stations carry only station_id. Same coalesce the revenue page uses.
+    where coalesce(l.station_id, l.facility_id) = structure_tax_revenue.structure_id
+  )
+  select
+    s.first_party_id                                                as payer_id,
+    (s.date at time zone 'UTC')::date                               as day,
+    count(*) filter (where s.amount > 0)                            as jobs,
+    coalesce(sum(s.amount) filter (where s.amount > 0), 0)          as isk,
+    count(*) filter (where s.own_rate)                              as self_paid_jobs,
+    coalesce(sum(abs(s.amount)) filter (where s.own_rate), 0)       as isk_self_paid,
+    count(*) filter (where s.amount < 0 or s.is_personal)           as paid_jobs,
+    coalesce(sum(abs(s.amount)) filter (where s.amount < 0 or s.is_personal), 0) as isk_paid,
+    count(*)                                                        as total_jobs,
+    coalesce(sum(abs(s.amount)), 0)                                 as isk_total
+  from scoped s
+  -- Positional, so the output column names can't shadow anything in `scoped`.
+  group by 1, 2
+  order by 2 desc, 4 desc;
+$$;

--- a/test/sql/structure_tax_revenue.sql
+++ b/test/sql/structure_tax_revenue.sql
@@ -10,6 +10,13 @@
 -- outgoing side, so netting reported such a structure as earning negative
 -- revenue).
 --
+-- It also pins the measures apart. `isk_self_paid` is the subset billed at OUR
+-- OWN RATE — the installer's own corporation owns the structure — so rent paid
+-- into somebody else's must never land in it, which is what the earlier
+-- every-outgoing-entry reading got wrong. `isk_paid` is the wider figure: every
+-- charge we paid, including a member's personal job, whose only record is the
+-- incoming receipt because no character wallet journal exists.
+--
 -- Run against a THROWAWAY database from the repo root (same harness as
 -- asset_share.sql): DATABASE_URL='postgresql://…/throwaway' pnpm run test:sql
 begin;
@@ -34,6 +41,11 @@ create table public.character_industry_job_over_time (
 create table public.corp_industry_job_over_time (
   job_id bigint, corporation_id bigint, station_id bigint, facility_id bigint, is_current boolean
 );
+-- Who owns what. 60000001 is ours (corp 1000); 60000003 belongs to somebody
+-- else, so tax paid into it is rent rather than a charge we billed ourselves.
+create table public.corp_structure (
+  structure_id bigint primary key, corporation_id bigint
+);
 create table public.corp_wallet_journal (
   corporation_id bigint, division smallint, entry_id bigint,
   date timestamptz, ref_type text, context_id bigint, amount numeric(20, 2), first_party_id bigint
@@ -41,6 +53,12 @@ create table public.corp_wallet_journal (
 
 insert into public.registration (id, user_id, corporation_id) values
   ('11111111-1111-1111-1111-111111111111', '99999999-0000-0000-0000-000000000001', 1000);
+insert into public.corp_structure values (60000001, 1000), (60000003, 2000);
+
+-- The live-rows view the aggregation reads to tell a personal job from a corp
+-- one; the real schema defines it the same way.
+create view public.character_industry_job as
+  select * from public.character_industry_job_over_time where is_current;
 
 -- Jobs 1-3 in structure 60000001 (the one under test), job 4 in 60000002, and
 -- job 6 carrying only station_id to exercise the coalesce fallback.
@@ -51,7 +69,9 @@ insert into public.character_industry_job_over_time values
   (4, '11111111-1111-1111-1111-111111111111', 60000002, 60000002, true),
   (6, '11111111-1111-1111-1111-111111111111', 60000001, null,     true);
 insert into public.corp_industry_job_over_time values
-  (5, 3000, null, 60000001, true);
+  (5, 3000, null, 60000001, true),
+  -- Our own corporation's job, run in a structure somebody else owns.
+  (7, 1000, null, 60000003, true);
 
 -- Payer 7001 pays twice on 2026-08-08 and once on 2026-08-07; payer 7002 pays
 -- once on 2026-08-07. Job 4's tax belongs to a different structure, and the
@@ -67,11 +87,14 @@ insert into public.corp_wallet_journal values
   -- Tax our own corporation PAID for job 3, on a (payer, day) that already has
   -- an incoming row — so the split shows up in the measures without perturbing
   -- any of the row/day counts asserted below.
-  (1000, 1, 8, '2026-08-08T02:00:00Z', 'industry_job_tax', 3, -300.00, 7001);
+  (1000, 1, 8, '2026-08-08T02:00:00Z', 'industry_job_tax', 3, -300.00, 7001),
+  -- Rent: our corporation paying tax into a structure it does not own.
+  (1000, 1, 9, '2026-08-08T03:00:00Z', 'industry_job_tax', 7, -450.00, 7001);
 
 \i supabase/migrations/20260809000000_industry_job_tax_facility.sql
 \i supabase/migrations/20260809080000_structure_tax_revenue.sql
 \i supabase/migrations/20260822120000_structure_tax_revenue_split_signs.sql
+\i supabase/migrations/20260824234011_structure_tax_paid.sql
 
 set local test.uid = '99999999-0000-0000-0000-000000000001';
 
@@ -142,7 +165,13 @@ end $$;
 -- The two directions stay apart. An outgoing entry must not net against the
 -- incoming ones (which would drop 7001's 08-08 total from 1500 to 1200), nor
 -- inflate the received job count; it lands in its own measures, sign flipped so
--- both columns read positive.
+-- every column reads positive.
+--
+-- 7001 on 08-08 is three charges in our own structure: jobs 1 and 2 arriving
+-- from a member's personal jobs (1000 + 500) and job 3's 300 going out as the
+-- corporation billed itself. All three were billed at our own rate, and all
+-- three are tax our side paid — the receipts because no character journal
+-- records the member's side, the outgoing one directly.
 do $$
 declare got record;
 begin
@@ -151,20 +180,46 @@ begin
   where payer_id = 7001 and day = date '2026-08-08';
   assert got.isk = 1500.00, 'received ISK must not be netted against tax paid, got ' || got.isk;
   assert got.jobs = 2, 'the outgoing entry must not count as a received job, got ' || got.jobs;
-  assert got.isk_self_paid = 300.00, 'expected 300 self-paid ISK (positive), got ' || got.isk_self_paid;
-  assert got.self_paid_jobs = 1, 'expected 1 self-paid job, got ' || got.self_paid_jobs;
+  assert got.isk_self_paid = 1800.00, 'expected 1800 own-rate ISK, got ' || got.isk_self_paid;
+  assert got.self_paid_jobs = 3, 'expected 3 own-rate charges, got ' || got.self_paid_jobs;
+  assert got.isk_paid = 1800.00, 'expected 1800 paid ISK, got ' || got.isk_paid;
+  assert got.paid_jobs = 3, 'expected 3 paid charges, got ' || got.paid_jobs;
+  -- Every entry once: what the leaderboard ranks. Revenue and taxes paid
+  -- overlap here, so adding them would count 1500 twice.
+  assert got.isk_total = 1800.00, 'expected 1800 total ISK, got ' || got.isk_total;
+  assert got.total_jobs = 3, 'expected 3 entries, got ' || got.total_jobs;
 end $$;
 
--- A (payer, day) with nothing outgoing reports zero rather than null, so the
--- page can sum the column without coalescing every row.
+-- A CORP job somebody else installed here is revenue and nothing else: we did
+-- not pay it, and its payer's own wallet is where their side would live.
 do $$
 declare got record;
 begin
   select * into got
   from public.structure_tax_revenue(60000001, '2026-08-01T00:00:00Z')
   where payer_id = 7002 and day = date '2026-08-07';
+  assert got.isk = 700.00, 'expected 700 revenue, got ' || got.isk;
+  assert got.isk_paid = 0, 'a corp job of theirs is not tax we paid, got ' || got.isk_paid;
+  assert got.paid_jobs = 0, 'expected 0 paid charges, got ' || got.paid_jobs;
+  -- Zero rather than null, so the page can sum the column without coalescing.
   assert got.isk_self_paid = 0, 'expected 0, got ' || coalesce(got.isk_self_paid::text, 'null');
   assert got.self_paid_jobs = 0, 'expected 0, got ' || coalesce(got.self_paid_jobs::text, 'null');
+end $$;
+
+-- Rent is tax we paid, but never tax we billed ourselves. Structure 60000003
+-- belongs to corp 2000, so our corporation's 450 is paid but NOT own-rate —
+-- the distinction the every-outgoing-entry reading collapsed, which reported a
+-- saving on ISK that was charged at somebody else's rate.
+do $$
+declare got record;
+begin
+  select * into got
+  from public.structure_tax_revenue(60000003, '2026-08-01T00:00:00Z')
+  where payer_id = 7001 and day = date '2026-08-08';
+  assert got.isk = 0, 'rent brings in no revenue, got ' || got.isk;
+  assert got.isk_paid = 450.00, 'expected 450 paid as rent, got ' || got.isk_paid;
+  assert got.isk_self_paid = 0, 'rent is not billed at our own rate, got ' || got.isk_self_paid;
+  assert got.self_paid_jobs = 0, 'expected 0 own-rate charges, got ' || got.self_paid_jobs;
 end $$;
 
 -- A caller with no journal entries of their own gets nothing, since the


### PR DESCRIPTION
Two changes on the same branch.

---

# 1. All three tax measures on the structure detail page

The follow-up to #962. `/structure` gained Taxes Paid and narrowed cost avoidance to jobs whose installer's own corporation owns the structure; `structure_tax_revenue()` still knew only two measures, so the detail page disagreed with the list beside it.

## The two things it got wrong

**`isk_self_paid` summed every outgoing entry with no owner test** — the same bug the list page had. Tax paid as rent into an alliance-mate's structure was reported as tax we had billed ourselves, which is a saving claimed on ISK that was charged at somebody else's rate.

**It missed a member's personal job entirely.** That charge arrives as an *incoming* entry, and with no character wallet journal to read the paying side from, the receipt is the only record it exists at all — so it was only ever counted as revenue, never as tax we paid or as an own-rate charge.

## What the function returns now

| column | meaning |
|---|---|
| `isk` | incoming — somebody paid to run a job here |
| `isk_paid` | every charge our side paid: all outgoing entries, plus incoming ones whose job one of our characters installed |
| `isk_self_paid` | the subset billed at our own rate — the installer's own corporation owns this structure |
| `isk_total` | every entry once, whichever direction |

The rules mirror `src/app/structure/taxLedger.ts`, which stays the canonical statement of them.

`isk_total` exists because the payer leaderboard can no longer add revenue to taxes paid: those overlap on a member billing their own corporation, so summing them counted that charge twice. Ranking "who put industry through here" wants every charge once, which is what the new column is.

The return type changes, so the function is dropped and recreated — `CREATE OR REPLACE` cannot alter OUT parameters. `SECURITY INVOKER` throughout, and the new joins (`corp_structure`, `character_industry_job`, `registration`) are all RLS-scoped to the caller, so a job counts as "ours" only when we can actually see it.

The table's second column pair is relabelled Self → **Paid**, since taxes paid is the more general figure and subsumes the old one for our own structures; the own-rate total moves into a note under the table that names it as what cost avoidance prices against.

---

# 2. Full-width structure tiles on phones

The tile grid was two per row below 640px, leaving each tile about half a phone wide to carry a name, several labelled figures and a services list. It's one per row now; the auto-fill columns above 640px are unchanged.

The index-sparkline stacking sitting behind the same breakpoint stays as it was. Its stated reason (tiles are half-screen wide) no longer holds, but at a phone's full width the three-column label/sparkline/value layout still leaves the sparkline a sliver between two text columns — so the behaviour is right and only the comment needed correcting.

---

## Testing

`pnpm run lint`, `pnpm test` (540) and `pnpm run build` clean; migration ordering guard reports no problems.

**`test/sql/structure_tax_revenue.sql` was actually executed this time**, against a throwaway Postgres 16 cluster — the SQL suite isn't part of PR CI, and this change is mostly SQL. It's extended with fixtures for structure ownership and a rent case, and now pins: the own-rate subset covering a member's personal job in their own corp's structure, a corp job somebody else installed being revenue and nothing else, and rent into another corp's structure being paid-but-not-own-rate — the exact case the old reading collapsed.

Two other files in that suite fail on a bare cluster for reasons that predate this change and are untouched by it: `blueprint_search.sql` doesn't create the `anon`/`authenticated`/`service_role` roles it assumes (passes once they exist), and `link.sql` does `\i` on `20260806130000_link.sql`, which doesn't exist — the migration kept its `_lens` filename through the rename. Happy to fix that second one separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Eh71M22uC6MZaFErV73tZ