### PR TITLE
Fix cost avoidance to turn on ownership, with a breakdown, plus a ramda refactor

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -4939,10 +4939,11 @@ grant  execute on function public.industry_job_tax_facility(bigint[]) to authent
 --               that payment). A corp job's payment is already the outgoing
 --               entry in that corp's own wallet, so counting the landlord's
 --               receipt too would bill it twice.
---   isk_self_paid  the subset billed at our own rate — the installer's own
---               corporation owns this structure. Only that can be scaled into a
---               saving; a structure bills a corporation it does not contain at
---               whatever rate it likes.
+--   isk_self_paid  the subset billed at our own rate — the job was ours and one
+--               of OUR corporations owns this structure. Not a match between the
+--               installing corporation and the owning one: characters commonly
+--               sit in one corp while the structures belong to another, and the
+--               ISK stays with us either way.
 --   isk_total   every entry once, whichever direction. What the payer
 --               leaderboard ranks; revenue and taxes paid deliberately overlap
 --               (a member billing their own corp is both), so they cannot be
@@ -4967,49 +4968,61 @@ returns table (
 language sql
 stable
 as $$
-  with owner as (
-    select cs.corporation_id
-    from public.corp_structure cs
-    where cs.structure_id = structure_tax_revenue.structure_id
-    limit 1
-  ),
-  tax as (
+  with tax as (
     select w.first_party_id, w.corporation_id, w.date, w.amount, w.context_id
     from public.corp_wallet_journal w
     where w.ref_type = 'industry_job_tax'
       and w.context_id is not null
       and w.date >= since
   ),
+  taxed_jobs as (
+    select distinct t.context_id as job_id from tax t
+  ),
+  -- Do WE own this structure? Any of our corporations owning it is enough; an
+  -- alliance-mate's tile is on the page too, and paying them is rent.
+  owned as (
+    select exists (
+      select 1
+      from public.corp_structure cs
+      where cs.structure_id = structure_tax_revenue.structure_id
+        and cs.corporation_id in (select public.my_corporation_ids())
+    ) as ours
+  ),
   -- One call for the whole window rather than per row; the function dedupes to
   -- at most one location per job.
   located as (
     select f.job_id, f.station_id, f.facility_id
-    from public.industry_job_tax_facility(array(select distinct t.context_id from tax t)) f
+    from public.industry_job_tax_facility(array(select j.job_id from taxed_jobs j)) f
   ),
-  -- Our characters' personal jobs, and the corporation each installer was in.
-  -- Corp jobs are deliberately absent: it is the outgoing entry in the paying
-  -- corp's own wallet that records those, not the receipt.
+  -- Jobs of ours, either way they were installed. Both views are RLS-scoped to
+  -- the caller, so somebody else's job renting our slots is absent.
+  ours as (
+    select cij.job_id from public.character_industry_job cij where cij.job_id in (select job_id from taxed_jobs)
+    union
+    select coj.job_id from public.corp_industry_job coj where coj.job_id in (select job_id from taxed_jobs)
+  ),
+  -- The character-installed subset, which decides only that a charge is billed
+  -- once — never whether it was billed at our own rate.
   personal as (
-    select cij.job_id, r.corporation_id
-    from public.character_industry_job cij
-    join public.registration r on r.id = cij.registration_id
+    select cij.job_id from public.character_industry_job cij where cij.job_id in (select job_id from taxed_jobs)
   ),
   scoped as (
     select
       t.first_party_id,
-      t.corporation_id,
       t.date,
       t.amount,
-      p.corporation_id is not null as is_personal,
-      -- Was this charge billed at our own rate? For an outgoing entry the payer
-      -- IS the installer; for an incoming one the wallet belongs to the
-      -- landlord, so the installer comes from the job instead.
+      p.job_id is not null as is_personal,
       case
-        when t.amount < 0 then t.corporation_id = (select corporation_id from owner)
-        else p.corporation_id is not null and p.corporation_id = (select corporation_id from owner)
+        -- We paid it, so the job was ours; all that remains is whether the
+        -- structure is.
+        when t.amount < 0 then (select ours from owned)
+        -- Somebody paid us. It is an own-rate charge when the job was ours and
+        -- we own the structure it ran in.
+        else o.job_id is not null and (select ours from owned)
       end as own_rate
     from tax t
     join located l on l.job_id = t.context_id
+    left join ours o on o.job_id = t.context_id
     left join personal p on p.job_id = t.context_id
     -- Upwell structures share the id between station_id and facility_id; jobs in
     -- NPC stations carry only station_id. Same coalesce the revenue page uses.

--- a/src/app/blueprint/page.tsx
+++ b/src/app/blueprint/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { uniq } from 'ramda'
+import { map, sort, uniq } from 'ramda'
 
 import { createClient } from '@/utils/supabase/server'
 import { createServiceClient } from '@/utils/supabase/service'
@@ -56,7 +56,7 @@ const CorpBposLinks = async () => {
     .eq('user_id', user.id)
     .contains('scope', [CORP_BLUEPRINTS_SCOPE])
     .returns<Array<{ registration_id: string }>>()
-  const registrationIds = uniq((tokens ?? []).map((t) => t.registration_id))
+  const registrationIds = uniq(map((t: { registration_id: string }) => t.registration_id, tokens ?? []))
   const { data: regs } = registrationIds.length
     ? await service
         .from('registration')
@@ -65,7 +65,7 @@ const CorpBposLinks = async () => {
         .not('corporation_id', 'is', null)
         .returns<Array<{ corporation_id: number | string }>>()
     : { data: [] }
-  const directorCorpIds = uniq((regs ?? []).map((r) => Number(r.corporation_id)))
+  const directorCorpIds = uniq(map((r: { corporation_id: number | string }) => Number(r.corporation_id), regs ?? []))
 
   // Corporations whose showcase is shared with us. Asked as the VIEWER, because
   // corp_bpo_share's own policies already answer exactly this question: a member
@@ -76,7 +76,7 @@ const CorpBposLinks = async () => {
     .from('corp_bpo_share')
     .select('corporation_id')
     .returns<Array<{ corporation_id: number | string }>>()
-  const sharedCorpIds = uniq((shares ?? []).map((r) => Number(r.corporation_id)))
+  const sharedCorpIds = uniq(map((r: { corporation_id: number | string }) => Number(r.corporation_id), shares ?? []))
 
   // Either route means the page has something to show: a director's grant is
   // what fills corp_blueprint in the first place, and a share is somebody
@@ -93,7 +93,7 @@ const CorpBposLinks = async () => {
     .in('corporation_id', corporationIds)
     .not('name', 'is', null)
     .returns<Array<{ corporation_id: number | string; name: string }>>()
-  const named = (corps ?? []).slice().sort((a, b) => a.name.localeCompare(b.name))
+  const named = sort((a: { name: string }, b: { name: string }) => a.name.localeCompare(b.name), corps ?? [])
   if (named.length === 0) return null
 
   return (

--- a/src/app/blueprint/page.tsx
+++ b/src/app/blueprint/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { map, sort, uniq } from 'ramda'
+import { filter, isNil, map, reject, sort, uniq } from 'ramda'
 
 import { createClient } from '@/utils/supabase/server'
 import { createServiceClient } from '@/utils/supabase/service'
@@ -67,22 +67,36 @@ const CorpBposLinks = async () => {
     : { data: [] }
   const directorCorpIds = uniq(map((r: { corporation_id: number | string }) => Number(r.corporation_id), regs ?? []))
 
-  // Corporations whose showcase is shared with us. Asked as the VIEWER, because
-  // corp_bpo_share's own policies already answer exactly this question: a member
-  // sees their corporation's row, and the audience policy adds rows aimed at
-  // their corp or alliance plus any that are fully public. A link-only share
-  // matches nobody here, which is correct — its URL is the only way in.
+  // Corporations whose showcase has been published. Asked as the VIEWER, so
+  // corp_bpo_share's own policies answer it: a member sees their corporation's
+  // row, and the audience policy adds rows aimed at their corp or alliance
+  // plus any that are fully public.
   const { data: shares } = await supabase
     .from('corp_bpo_share')
     .select('corporation_id')
     .returns<Array<{ corporation_id: number | string }>>()
   const sharedCorpIds = uniq(map((r: { corporation_id: number | string }) => Number(r.corporation_id), shares ?? []))
 
-  // Either route means the page has something to show: a director's grant is
+  // Our own corporations — the ones we have a character in, which is also
+  // exactly the set whose showcase we could publish or revoke ourselves.
+  const { data: ownRegistrations } = await supabase.from('registration').select('corporation_id')
+  const ownCorporationIds = new Set(
+    map(
+      Number,
+      reject(
+        isNil,
+        map((r: { corporation_id: number | string | null }) => r.corporation_id, ownRegistrations ?? [])
+      )
+    )
+  )
+
+  // Either route means the page has something to show — a director's grant is
   // what fills corp_blueprint in the first place, and a share is somebody
-  // saying they want it seen. Without one of them the link would open an empty
-  // page, or a 404.
-  const corporationIds = uniq([...directorCorpIds, ...sharedCorpIds])
+  // saying they want it seen — but this is OUR blueprint page, so it lists only
+  // our own corporations. A stranger's corp aiming a share at our alliance, or
+  // publishing one outright, is theirs to link to; it does not belong in a list
+  // of libraries we keep.
+  const corporationIds = filter((id: number) => ownCorporationIds.has(id), uniq([...directorCorpIds, ...sharedCorpIds]))
   if (corporationIds.length === 0) return null
 
   // A corporation whose name the directory hasn't backfilled yet can't be

--- a/src/app/bpos/data.ts
+++ b/src/app/bpos/data.ts
@@ -5,6 +5,8 @@
 // (corp_blueprint, scoped to the one corporation id). Service-role in both
 // cases — the /corpses precedent — because the caller has already decided the
 // viewer may see them.
+import { forEach, map } from 'ramda'
+
 import { getBlueprintsByTypeIDs } from '@/sdeBlueprints'
 import { getSdeTypes } from '@/sdeTypes'
 import { createServiceClient } from '@/utils/supabase/service'
@@ -37,7 +39,7 @@ const readBlueprints = async (
     return acc
   }
   const rows = data ?? []
-  rows.forEach((row) => acc.push(row))
+  forEach((row: BlueprintRow) => acc.push(row), rows)
   return rows.length < PAGE_SIZE ? acc : readBlueprints(registrationIds, from + PAGE_SIZE, acc)
 }
 
@@ -66,7 +68,7 @@ const readCorpBlueprints = async (
     return acc
   }
   const rows = data ?? []
-  rows.forEach((row) => acc.push(row))
+  forEach((row: BlueprintRow) => acc.push(row), rows)
   return rows.length < PAGE_SIZE ? acc : readCorpBlueprints(corporationId, from + PAGE_SIZE, acc)
 }
 
@@ -76,7 +78,7 @@ const dressStacks = async (rows: BlueprintRow[]): Promise<BpoEntry[]> => {
   const stacks = stackBpos(rows)
   if (stacks.length === 0) return []
 
-  const blueprintTypeIds = stacks.map((s) => s.typeId)
+  const blueprintTypeIds = map((s) => s.typeId, stacks)
 
   // Two SDE hops: the blueprint's own name, and — via what it manufactures —
   // the category worth sorting by. A blueprint type's own category is always
@@ -85,9 +87,9 @@ const dressStacks = async (rows: BlueprintRow[]): Promise<BpoEntry[]> => {
     getSdeTypes(blueprintTypeIds),
     getBlueprintsByTypeIDs(blueprintTypeIds),
   ])
-  const productTypes = await getSdeTypes(Object.values(products).map((b) => b.productTypeID))
+  const productTypes = await getSdeTypes(map((b) => b.productTypeID, Object.values(products)))
 
-  return stacks.map((stack) => {
+  return map((stack) => {
     const product = products[stack.typeId]
     const productType = product ? productTypes[product.productTypeID] : undefined
     return {
@@ -98,7 +100,7 @@ const dressStacks = async (rows: BlueprintRow[]): Promise<BpoEntry[]> => {
       // lands in a sensible bucket rather than under "Uncategorized".
       category: productType?.categoryName ?? blueprintTypes[stack.typeId]?.groupName ?? null,
     }
-  })
+  }, stacks)
 }
 
 export const fetchBpoEntries = async (registrationIds: string[]): Promise<BpoEntry[]> =>

--- a/src/app/bpos/shareActions.ts
+++ b/src/app/bpos/shareActions.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
+import { filter, isNil, map, reject, uniq } from 'ramda'
 
 import { mintShareSecret, signShare, tokenSalt } from '@/shareToken'
 import { createClient } from '@/utils/supabase/server'
@@ -12,30 +13,21 @@ import type { SaveShareInput, SaveShareResult } from '../asset/shareActions'
 // over the one user_id-keyed bpo_share row. Cookie-session client, never the
 // service role: the table's own policy pins user_id to the caller.
 
+// Every non-null id in a column, deduped and numeric — the shape both halves of
+// the affiliation walk below need.
+const idsIn = <T>(rows: readonly T[], pick: (row: T) => number | string | null): number[] =>
+  uniq(map(Number, reject(isNil, map(pick, rows))))
+
 // The affiliations a share may be aimed at. Requested ids are filtered against
 // these so a hand-rolled request can't aim a share at a corporation the caller
 // has no character in.
 const ownAudiences = async (supabase: Awaited<ReturnType<typeof createClient>>) => {
   const { data: regs } = await supabase.from('registration').select('id, corporation_id')
-  const corpIds = [
-    ...new Set(
-      ((regs ?? []) as Array<{ corporation_id: number | string | null }>)
-        .map((r) => r.corporation_id)
-        .filter((c): c is number => c != null)
-        .map(Number)
-    ),
-  ]
+  const corpIds = idsIn((regs ?? []) as Array<{ corporation_id: number | string | null }>, (r) => r.corporation_id)
   const { data: corps } = corpIds.length
     ? await supabase.from('corporation').select('corporation_id, alliance_id').in('corporation_id', corpIds)
     : { data: [] }
-  const allianceIds = [
-    ...new Set(
-      ((corps ?? []) as Array<{ alliance_id: number | string | null }>)
-        .map((c) => c.alliance_id)
-        .filter((a): a is number => a != null)
-        .map(Number)
-    ),
-  ]
+  const allianceIds = idsIn((corps ?? []) as Array<{ alliance_id: number | string | null }>, (c) => c.alliance_id)
   return { ownCorpIds: new Set(corpIds), ownAllianceIds: new Set(allianceIds) }
 }
 
@@ -49,10 +41,10 @@ export const saveBposShare = async (slug: string, input: SaveShareInput): Promis
 
   const corporationIds = input.isPublic
     ? []
-    : [...new Set(input.corporationIds.map(Number))].filter((id) => owned.ownCorpIds.has(id))
+    : filter((id: number) => owned.ownCorpIds.has(id), uniq(map(Number, input.corporationIds)))
   const allianceIds = input.isPublic
     ? []
-    : [...new Set(input.allianceIds.map(Number))].filter((id) => owned.ownAllianceIds.has(id))
+    : filter((id: number) => owned.ownAllianceIds.has(id), uniq(map(Number, input.allianceIds)))
   const link = input.isPublic ? false : input.link
 
   // Signing requires the deployment's salt; fail before writing anything.
@@ -144,10 +136,10 @@ export const saveCorpBposShare = async (
 
   const corporationIds = input.isPublic
     ? []
-    : [...new Set(input.corporationIds.map(Number))].filter((id) => owned.ownCorpIds.has(id))
+    : filter((id: number) => owned.ownCorpIds.has(id), uniq(map(Number, input.corporationIds)))
   const allianceIds = input.isPublic
     ? []
-    : [...new Set(input.allianceIds.map(Number))].filter((id) => owned.ownAllianceIds.has(id))
+    : filter((id: number) => owned.ownAllianceIds.has(id), uniq(map(Number, input.allianceIds)))
   const link = input.isPublic ? false : input.link
 
   // Signing requires the deployment's salt; fail before writing anything.

--- a/src/app/bpos/slug.ts
+++ b/src/app/bpos/slug.ts
@@ -2,6 +2,8 @@
 // name, with its spaces turned into dashes — /bpos/sir-cuddles for "Sir
 // Cuddles". Pure helpers, so the round trip (name → slug, slug → the SQL probe
 // that finds it again) is testable without a database.
+import { reduce } from 'ramda'
+
 import { escapeLike } from '../../utils/escapeLike.ts'
 
 // An EVE name's canonical slug. Lowercased so the URL is case-insensitive in
@@ -47,10 +49,13 @@ export const pickCorporation = (
   rows: readonly CorporationCandidate[],
   slug: string
 ): { corporationId: number; name: string } | null => {
-  const matches = new Map<number, { corporationId: number; name: string }>()
-  rows.forEach((row) => {
-    if (row.name == null || characterSlug(row.name) !== slug) return
-    matches.set(Number(row.corporation_id), { corporationId: Number(row.corporation_id), name: row.name })
-  })
+  const matches = reduce(
+    (acc: Map<number, { corporationId: number; name: string }>, row: CorporationCandidate) =>
+      row.name == null || characterSlug(row.name) !== slug
+        ? acc
+        : acc.set(Number(row.corporation_id), { corporationId: Number(row.corporation_id), name: row.name }),
+    new Map<number, { corporationId: number; name: string }>(),
+    rows
+  )
   return matches.size === 1 ? [...matches.values()][0] : null
 }

--- a/src/app/structure/[structureId]/page.tsx
+++ b/src/app/structure/[structureId]/page.tsx
@@ -513,8 +513,8 @@ const StructurePage = async ({ params, searchParams }: StructureParams) => {
                       Billed at our own rate <span className={retro.muted}>({formatRate(taxRates.own)})</span>
                     </span>
                     <span className={structureStyles.payerCorp}>
-                      {selfPaidJobs.toLocaleString()} charge{selfPaidJobs === 1 ? '' : 's'} on jobs whose own
-                      corporation owns this structure
+                      {selfPaidJobs.toLocaleString()} charge{selfPaidJobs === 1 ? '' : 's'} on jobs of ours run in a
+                      structure we own
                     </span>
                   </span>
                 </td>
@@ -559,9 +559,8 @@ const StructurePage = async ({ params, searchParams }: StructureParams) => {
               )}
               {paidAtOtherRate > 0 && (
                 <>
-                  A further {formatIskValue(paidAtOtherRate)} of tax we paid here is excluded: it was billed by a
-                  corporation that does not own this structure, at whatever rate that corporation sets, so there is no
-                  own rate to scale.{' '}
+                  A further {formatIskValue(paidAtOtherRate)} of tax we paid here is excluded — it was not billed at our
+                  own rate, so there is no own rate to scale.{' '}
                 </>
               )}
               <Link href="/settings/tax">Change the rates &raquo;</Link>
@@ -573,9 +572,8 @@ const StructurePage = async ({ params, searchParams }: StructureParams) => {
       {selfPaidIsk === 0 && paidIsk > 0 && (
         <p className={structureStyles.unaccountedNote}>
           <em>
-            No cost avoidance here: none of the {formatIskValue(paidIsk)} we paid was billed at our own rate. That
-            happens when the jobs were installed by characters or corporations that this structure&rsquo;s owner
-            doesn&rsquo;t contain — a landlord bills them at its own rate, so there is no saving to price.
+            No cost avoidance here: none of the {formatIskValue(paidIsk)} we paid was billed at our own rate, because
+            this structure isn&rsquo;t ours. A landlord bills us whatever rate it likes, so there is no saving to price.
           </em>
         </p>
       )}

--- a/src/app/structure/[structureId]/page.tsx
+++ b/src/app/structure/[structureId]/page.tsx
@@ -5,6 +5,8 @@ import { chain, descend, map, reduce, reject, sortWith, sum, uniq } from 'ramda'
 import { createClient } from '@/utils/supabase/server'
 
 import { establishedUser } from '../../account/lib/establishedUser'
+import { fetchTaxRates, formatRate } from '../../settings/tax/rates'
+import { costAvoidance } from '../costAvoidance'
 import { DateTime } from '../../DateTime'
 import { ACTIVITY_NAMES } from '../../industry/jobFields'
 import { formatIskValue } from '../../isk'
@@ -232,6 +234,16 @@ const StructurePage = async ({ params, searchParams }: StructureParams) => {
   const selfPaidIsk = totalOf((r) => r.isk_self_paid)
   const paidIsk = totalOf((r) => r.isk_paid)
   const paidJobs = totalOf((r) => r.paid_jobs)
+  const selfPaidJobs = totalOf((r) => r.self_paid_jobs)
+
+  // The same arithmetic the list page's Cost Avoidance tile runs, over this
+  // structure's own-rate charges alone — reusing costAvoidance() rather than
+  // repeating the formula, so the two can't disagree about what a saving is.
+  const taxRates = await fetchTaxRates(supabase, user.id)
+  const avoidance = costAvoidance([{ structureId: String(s.structure_id), amount: selfPaidIsk }], taxRates)
+  // What we paid that was NOT billed at our own rate: a landlord charges a
+  // corporation it doesn't contain whatever it likes, so none of it is a saving.
+  const paidAtOtherRate = paidIsk - selfPaidIsk
   // A structure whose corp installs everything under corp ownership has only
   // outgoing rows, so the received column would be all zeroes; the extra column
   // earns its width only when there is something in it.
@@ -485,13 +497,85 @@ const StructurePage = async ({ params, searchParams }: StructureParams) => {
             ISK is tax that arrived here; Paid ISK is what we were charged to run our own jobs here, whoever owns the
             structure. One charge can be both — a member billing their own corporation pays it and we receive it — so
             the two columns describe the same events from different sides rather than summing to a balance.
-            {selfPaidIsk > 0 && (
-              <>
-                {' '}
-                Of what we paid, {formatIskValue(selfPaidIsk)} was billed at our own rate, which is the part{' '}
-                <Link href="/structure">cost avoidance</Link> prices against a public structure.
-              </>
-            )}
+          </em>
+        </p>
+      )}
+
+      {selfPaidIsk > 0 && (
+        <>
+          <h2>Cost Avoidance</h2>
+          <table className={retro.retro}>
+            <tbody>
+              <tr>
+                <td>
+                  <span className={structureStyles.payer}>
+                    <span>
+                      Billed at our own rate <span className={retro.muted}>({formatRate(taxRates.own)})</span>
+                    </span>
+                    <span className={structureStyles.payerCorp}>
+                      {selfPaidJobs.toLocaleString()} charge{selfPaidJobs === 1 ? '' : 's'} on jobs whose own
+                      corporation owns this structure
+                    </span>
+                  </span>
+                </td>
+                <td className={retro.num}>{formatIskValue(selfPaidIsk)}</td>
+              </tr>
+              <tr>
+                <td>
+                  <span className={structureStyles.payer}>
+                    <span>
+                      The same jobs in a public structure{' '}
+                      <span className={retro.muted}>({formatRate(taxRates.public)})</span>
+                    </span>
+                    <span className={structureStyles.payerCorp}>
+                      what they would have been billed, and kept none of
+                    </span>
+                  </span>
+                </td>
+                <td className={retro.num}>
+                  {avoidance.counterfactual == null ? '—' : formatIskValue(avoidance.counterfactual)}
+                </td>
+              </tr>
+              <tr>
+                <th>Avoided</th>
+                <th className={retro.num}>{avoidance.total == null ? '—' : formatIskValue(avoidance.total)}</th>
+              </tr>
+            </tbody>
+          </table>
+          <p className={structureStyles.unaccountedNote}>
+            <em>
+              {avoidance.total == null ? (
+                <>
+                  Cost avoidance needs a non-zero rate for your own characters — nothing was billed, so there is no
+                  receipt to price a public structure against.{' '}
+                </>
+              ) : (
+                <>
+                  The tax receipt is {formatRate(taxRates.own)} of the job&rsquo;s Estimated Item Value, so the same
+                  jobs at {formatRate(taxRates.public)} come to {formatRate(taxRates.public)} ÷{' '}
+                  {formatRate(taxRates.own)} times as much, and the difference is the expense never incurred. No ISK
+                  changed hands, so it is not revenue.{' '}
+                </>
+              )}
+              {paidAtOtherRate > 0 && (
+                <>
+                  A further {formatIskValue(paidAtOtherRate)} of tax we paid here is excluded: it was billed by a
+                  corporation that does not own this structure, at whatever rate that corporation sets, so there is no
+                  own rate to scale.{' '}
+                </>
+              )}
+              <Link href="/settings/tax">Change the rates &raquo;</Link>
+            </em>
+          </p>
+        </>
+      )}
+
+      {selfPaidIsk === 0 && paidIsk > 0 && (
+        <p className={structureStyles.unaccountedNote}>
+          <em>
+            No cost avoidance here: none of the {formatIskValue(paidIsk)} we paid was billed at our own rate. That
+            happens when the jobs were installed by characters or corporations that this structure&rsquo;s owner
+            doesn&rsquo;t contain — a landlord bills them at its own rate, so there is no saving to price.
           </em>
         </p>
       )}

--- a/src/app/structure/[structureId]/page.tsx
+++ b/src/app/structure/[structureId]/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
+import { chain, descend, map, reduce, reject, sortWith, sum, uniq } from 'ramda'
 
 import { createClient } from '@/utils/supabase/server'
 
@@ -80,6 +81,14 @@ type TaxRow = {
   total_jobs: number | string
   isk_total: number | string | null
 }
+
+// universe_name rows, and the id -> name map every one of them turns into.
+type IdName = { id: number | string; name: string }
+
+const nameById = (rows: readonly IdName[]): Map<string, string> =>
+  new Map(map((r: IdName) => [String(r.id), r.name] as [string, string], rows))
+
+type AffiliationRow = { character_id: number | string; corporation_id: number | string }
 
 type StructureParams = {
   params: Promise<{
@@ -176,44 +185,53 @@ const StructurePage = async ({ params, searchParams }: StructureParams) => {
   // Payer names and the corp they fly for, same sources as /structure/revenue:
   // universe_name (the universe-names job) and character_affiliation (the
   // character-directory job).
-  const payerIds = [...new Set(taxRows.map((r) => r.payer_id).filter((p) => p != null))].map(Number)
-  const payerNames = new Map<string, string>()
-  const payerCorps = new Map<string, string>()
-  if (payerIds.length > 0) {
-    const [{ data: charNames }, { data: affiliations }] = await Promise.all([
-      supabase.from('universe_name').select('id, name').in('id', payerIds),
-      supabase.from('character_affiliation').select('character_id, corporation_id').in('character_id', payerIds),
-    ])
-    for (const r of (charNames ?? []) as Array<{ id: number | string; name: string }>) {
-      payerNames.set(String(r.id), r.name)
-    }
-    const corpByPayer = new Map<string, string>()
-    const corpIds = new Set<number>()
-    for (const a of (affiliations ?? []) as Array<{ character_id: number | string; corporation_id: number | string }>) {
-      corpByPayer.set(String(a.character_id), String(a.corporation_id))
-      corpIds.add(Number(a.corporation_id))
-    }
-    if (corpIds.size > 0) {
-      const { data: corpNames } = await supabase
-        .from('universe_name')
-        .select('id, name')
-        .in('id', [...corpIds])
-      const corpNameById = new Map<string, string>()
-      for (const r of (corpNames ?? []) as Array<{ id: number | string; name: string }>) {
-        corpNameById.set(String(r.id), r.name)
-      }
-      for (const [payer, corpId] of corpByPayer) {
-        const name = corpNameById.get(corpId)
-        if (name) payerCorps.set(payer, name)
-      }
-    }
-  }
+  const payerIds = uniq(
+    map(
+      Number,
+      reject(
+        (id): id is null => id == null,
+        map((r: TaxRow) => r.payer_id, taxRows)
+      )
+    )
+  )
 
-  const taxTotalIsk = taxRows.reduce((sum, r) => sum + Number(r.isk ?? 0), 0)
-  const taxTotalJobs = taxRows.reduce((sum, r) => sum + Number(r.jobs ?? 0), 0)
-  const selfPaidIsk = taxRows.reduce((sum, r) => sum + Number(r.isk_self_paid ?? 0), 0)
-  const paidIsk = taxRows.reduce((sum, r) => sum + Number(r.isk_paid ?? 0), 0)
-  const paidJobs = taxRows.reduce((sum, r) => sum + Number(r.paid_jobs ?? 0), 0)
+  const [{ data: charNames }, { data: affiliations }] = payerIds.length
+    ? await Promise.all([
+        supabase.from('universe_name').select('id, name').in('id', payerIds),
+        supabase.from('character_affiliation').select('character_id, corporation_id').in('character_id', payerIds),
+      ])
+    : [{ data: [] }, { data: [] }]
+
+  const payerNames = nameById((charNames ?? []) as IdName[])
+
+  const affiliationRows = (affiliations ?? []) as AffiliationRow[]
+  const corpByPayer = map(
+    (a: AffiliationRow) => [String(a.character_id), String(a.corporation_id)] as [string, string],
+    affiliationRows
+  )
+  const corpIds = uniq(map((a: AffiliationRow) => Number(a.corporation_id), affiliationRows))
+
+  const { data: corpNames } = corpIds.length
+    ? await supabase.from('universe_name').select('id, name').in('id', corpIds)
+    : { data: [] }
+  const corpNameById = nameById((corpNames ?? []) as IdName[])
+
+  // A payer whose corporation the directory hasn't named yet simply has no corp
+  // line, rather than one reading as an id.
+  const payerCorps = new Map<string, string>(
+    chain(([payer, corpId]: [string, string]) => {
+      const name = corpNameById.get(corpId)
+      return name ? [[payer, name] as [string, string]] : []
+    }, corpByPayer)
+  )
+
+  const totalOf = (pick: (r: TaxRow) => number | string | null) =>
+    sum(map((r: TaxRow) => Number(pick(r) ?? 0), taxRows))
+  const taxTotalIsk = totalOf((r) => r.isk)
+  const taxTotalJobs = totalOf((r) => r.jobs)
+  const selfPaidIsk = totalOf((r) => r.isk_self_paid)
+  const paidIsk = totalOf((r) => r.isk_paid)
+  const paidJobs = totalOf((r) => r.paid_jobs)
   // A structure whose corp installs everything under corp ownership has only
   // outgoing rows, so the received column would be all zeroes; the extra column
   // earns its width only when there is something in it.
@@ -227,15 +245,19 @@ const StructurePage = async ({ params, searchParams }: StructureParams) => {
   // which is the same question whichever wallet the tax came out of — so it
   // ranks on isk_total, every charge counted once. Adding revenue to taxes paid
   // would count a member's own-corp job twice, since that one charge is both.
-  const byPayer = new Map<string, { payerId: string; isk: number; jobs: number }>()
-  for (const r of taxRows) {
-    const payerId = r.payer_id != null ? String(r.payer_id) : 'unknown'
-    const entry = byPayer.get(payerId) ?? { payerId, isk: 0, jobs: 0 }
-    entry.isk += Number(r.isk_total ?? 0)
-    entry.jobs += Number(r.total_jobs ?? 0)
-    byPayer.set(payerId, entry)
-  }
-  const leaderboard = [...byPayer.values()].sort((a, b) => b.isk - a.isk)
+  type PayerTotal = { payerId: string; isk: number; jobs: number }
+  const byPayer = reduce(
+    (acc: Map<string, PayerTotal>, r: TaxRow) => {
+      const payerId = r.payer_id != null ? String(r.payer_id) : 'unknown'
+      const entry = acc.get(payerId) ?? { payerId, isk: 0, jobs: 0 }
+      entry.isk += Number(r.isk_total ?? 0)
+      entry.jobs += Number(r.total_jobs ?? 0)
+      return acc.set(payerId, entry)
+    },
+    new Map<string, PayerTotal>(),
+    taxRows
+  )
+  const leaderboard = sortWith([descend((p: PayerTotal) => p.isk)], [...byPayer.values()])
 
   const typeNames = await fetchTypeNames([
     Number(s.type_id),

--- a/src/app/structure/page.tsx
+++ b/src/app/structure/page.tsx
@@ -1,6 +1,20 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
-import { chain, concat, filter, forEach, map, splitEvery, uniq } from 'ramda'
+import {
+  chain,
+  concat,
+  descend,
+  filter,
+  forEach,
+  map,
+  reduce,
+  reject,
+  sort,
+  sortWith,
+  splitEvery,
+  sum,
+  uniq,
+} from 'ramda'
 
 import { createClient } from '@/utils/supabase/server'
 
@@ -84,6 +98,14 @@ type JournalRow = {
   first_party_id: number | string | null
   second_party_id: number | string | null
 }
+
+// universe_name rows, and the id -> name map they turn into.
+type IdName = { id: number | string; name: string }
+
+const nameById = (rows: readonly IdName[]): Map<string, string> =>
+  new Map(map((r: IdName) => [String(r.id), r.name] as [string, string], rows))
+
+type AffiliationRow = { character_id: number | string; corporation_id: number | string }
 
 type RigRow = {
   structure_id: number | string
@@ -226,7 +248,9 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
       r.fuel_expires,
     ])
   )
-  for (const s of list) s.fuel_expires = fuelByStructure.get(String(s.structure_id)) ?? null
+  forEach((st: Structure) => {
+    st.fuel_expires = fuelByStructure.get(String(st.structure_id)) ?? null
+  }, list)
 
   // Rigs fitted to each structure (pulled from corp assets by the corp-assets job).
   const { data: rigRows } = structureIds.length
@@ -238,15 +262,21 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
     : { data: [] }
 
   const rigList = (rigRows ?? []) as RigRow[]
-  const rigTypeNames = await fetchTypeNames(rigList.map((r) => Number(r.type_id)))
-  const rigsByStructure = new Map<string, string[]>()
-  for (const r of rigList) {
-    const key = String(r.structure_id)
-    const name = rigTypeNames[Number(r.type_id)] ?? String(r.type_id)
-    const existing = rigsByStructure.get(key)
-    if (existing) existing.push(name)
-    else rigsByStructure.set(key, [name])
-  }
+  const rigTypeNames = await fetchTypeNames(map((r: RigRow) => Number(r.type_id), rigList))
+  // Push-mutated per structure rather than re-spread per rig: the order the
+  // select asked for is the order they render in.
+  const rigsByStructure = reduce(
+    (acc: Map<string, string[]>, r: RigRow) => {
+      const key = String(r.structure_id)
+      const name = rigTypeNames[Number(r.type_id)] ?? String(r.type_id)
+      const existing = acc.get(key)
+      if (existing) existing.push(name)
+      else acc.set(key, [name])
+      return acc
+    },
+    new Map<string, string[]>(),
+    rigList
+  )
 
   const systemNames = await fetchSystemNames(list.map((s) => Number(s.system_id)))
   const structureTypeNames = await fetchTypeNames(list.map((s) => Number(s.type_id)))
@@ -354,7 +384,7 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
 
   const totalByStructure = ledger.revenueByStructure
   const taxesPaidByStructure = ledger.taxesPaidByStructure
-  const taxesPaidTotal = [...taxesPaidByStructure.values()].reduce((sum, v) => sum + v, 0)
+  const taxesPaidTotal = sum([...taxesPaidByStructure.values()])
   const unaccounted = ledger.unaccounted
   const unaccountedByParty = ledger.unaccountedByParty
 
@@ -420,8 +450,11 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
     if (systemId != null) row.systemIds.add(systemId)
     unlistedByCorp.set(key, row)
   }, ledger.unlistedPayments)
-  const unlistedLandlords = [...unlistedByCorp.entries()].sort((a, b) => b[1].amount - a[1].amount)
-  const unlistedTotal = unlistedLandlords.reduce((sum, [, row]) => sum + row.amount, 0)
+  const unlistedLandlords = sortWith(
+    [descend(([, row]: [string, { amount: number }]) => row.amount)],
+    [...unlistedByCorp.entries()]
+  )
+  const unlistedTotal = sum(map(([, row]) => row.amount, unlistedLandlords))
 
   // Landlord names from the world-readable corporation directory, and system
   // names alongside the ones the tiles already resolve.
@@ -444,47 +477,48 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
   )
 
   // Largest payers first.
-  const unaccountedParties = [...unaccountedByParty.entries()].sort((a, b) => b[1] - a[1])
+  const unaccountedParties = sortWith([descend(([, isk]: [string, number]) => isk)], [...unaccountedByParty.entries()])
 
   // Resolve each payer (a character) to their name and the corp they fly for. Names come from the
   // universe_name table (populated by the universe-names job) and corp affiliations from
   // character_affiliation (populated by the character-directory job); ids not yet resolved fall
   // back to showing the raw id.
-  const partyIds = unaccountedParties.map(([party]) => party).filter((p) => p !== 'unknown')
-  const payerNames = new Map<string, string>()
-  const payerCorps = new Map<string, string>()
-  if (partyIds.length > 0) {
-    const partyIdNums = partyIds.map(Number)
-    const { data: charNames } = await supabase.from('universe_name').select('id, name').in('id', partyIdNums)
-    for (const r of (charNames ?? []) as Array<{ id: number | string; name: string }>) {
-      payerNames.set(String(r.id), r.name)
-    }
+  const partyIds = map(
+    Number,
+    reject(
+      (p: string) => p === 'unknown',
+      map(([party]: [string, number]) => party, unaccountedParties)
+    )
+  )
 
-    const { data: affiliations } = await supabase
-      .from('character_affiliation')
-      .select('character_id, corporation_id')
-      .in('character_id', partyIdNums)
-    const corpByParty = new Map<string, string>()
-    const corpIds = new Set<number>()
-    for (const a of (affiliations ?? []) as Array<{ character_id: number | string; corporation_id: number | string }>) {
-      corpByParty.set(String(a.character_id), String(a.corporation_id))
-      corpIds.add(Number(a.corporation_id))
-    }
-    if (corpIds.size > 0) {
-      const { data: corpNames } = await supabase
-        .from('universe_name')
-        .select('id, name')
-        .in('id', [...corpIds])
-      const corpNameById = new Map<string, string>()
-      for (const r of (corpNames ?? []) as Array<{ id: number | string; name: string }>) {
-        corpNameById.set(String(r.id), r.name)
-      }
-      for (const [party, corpId] of corpByParty) {
-        const name = corpNameById.get(corpId)
-        if (name) payerCorps.set(party, name)
-      }
-    }
-  }
+  const { data: charNames } = partyIds.length
+    ? await supabase.from('universe_name').select('id, name').in('id', partyIds)
+    : { data: [] }
+  const payerNames = nameById((charNames ?? []) as IdName[])
+
+  const { data: affiliations } = partyIds.length
+    ? await supabase.from('character_affiliation').select('character_id, corporation_id').in('character_id', partyIds)
+    : { data: [] }
+  const affiliationRows = (affiliations ?? []) as AffiliationRow[]
+  const corpByParty = map(
+    (a: AffiliationRow) => [String(a.character_id), String(a.corporation_id)] as [string, string],
+    affiliationRows
+  )
+  const corpIds = uniq(map((a: AffiliationRow) => Number(a.corporation_id), affiliationRows))
+
+  const { data: corpNames } = corpIds.length
+    ? await supabase.from('universe_name').select('id, name').in('id', corpIds)
+    : { data: [] }
+  const corpNameById = nameById((corpNames ?? []) as IdName[])
+
+  // A party whose corporation the directory hasn't named yet simply has no corp
+  // line, rather than one reading as an id.
+  const payerCorps = new Map<string, string>(
+    chain(([party, corpId]: [string, string]) => {
+      const name = corpNameById.get(corpId)
+      return name ? [[party, name] as [string, string]] : []
+    }, corpByParty)
+  )
 
   // Revenue from structure clone bays (jump clone installation and activation
   // fees), over the same window as the tax revenue above.
@@ -498,7 +532,7 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
       .range(from, to)
   )
 
-  const cloneRevenue = cloneJournal.reduce((sum, entry) => sum + Number(entry.amount ?? 0), 0)
+  const cloneRevenue = sum(map((entry: { amount: number | string | null }) => Number(entry.amount ?? 0), cloneJournal))
 
   // When the Structures background job last finished. Each scheduled run writes a
   // public.heartbeat row stamped with ended_at and a link to the workflow run; we
@@ -722,9 +756,10 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
                   // Systems we could place the jobs in. A structure the cache
                   // has never resolved contributes none, so the ISK still shows
                   // with no system rather than being hidden.
-                  const systems = [...row.systemIds]
-                    .map((id) => unlistedSystemNames[Number(id)] ?? `#${id}`)
-                    .sort((a, b) => a.localeCompare(b))
+                  const systems = sort(
+                    (a: string, b: string) => a.localeCompare(b),
+                    map((id: string) => unlistedSystemNames[Number(id)] ?? `#${id}`, [...row.systemIds])
+                  )
                   return (
                     <span key={`landlord-${corporationId}`} className={styles.breakdownRow}>
                       <span className={styles.payer}>

--- a/src/app/structure/page.tsx
+++ b/src/app/structure/page.tsx
@@ -6,6 +6,7 @@ import {
   descend,
   filter,
   forEach,
+  isNil,
   map,
   reduce,
   reject,
@@ -212,26 +213,29 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
     concat(characterJobs, corpJobs)
   )
 
-  // Our characters' PERSONAL jobs, mapped to the corporation each installer was
-  // in. That corporation is what decides cost avoidance (a job is only billed
-  // our own rate by a structure its own corp owns), and the presence of a job
-  // here is what decides whether an incoming receipt also counts as tax we paid
-  // — see taxLedger.ts. Corp jobs are deliberately excluded: their payment is
-  // readable as the outgoing entry in the paying corp's own wallet.
-  //
-  // registration is RLS-scoped to the caller, so this only ever resolves our
-  // own characters; a job whose registration we can't see contributes nothing.
-  const { data: ownRegistrations } = await supabase.from('registration').select('id, corporation_id')
-  const corpByRegistration = new Map<string, string>(
-    ((ownRegistrations ?? []) as Array<{ id: string; corporation_id: number | string | null }>)
-      .filter((r) => r.corporation_id != null)
-      .map((r) => [r.id, String(r.corporation_id)])
+  // The jobs that are OURS — our characters' and our corporations' alike. A job
+  // of ours run in a structure of ours is billed our own rate whichever way it
+  // was installed, so cost avoidance turns on this set and on who owns the
+  // structure, never on which corporation the installer belonged to.
+  const ownJobIds = new Set(map((j: JobRow) => String(j.job_id), concat(characterJobs, corpJobs)))
+  // The character-installed subset. This decides nothing about avoidance; it is
+  // only how one charge gets billed once — a corp job's payment is the outgoing
+  // entry in that corp's own wallet, while a character's has no entry to read.
+  const personalJobIds = new Set(map((j: JobRow) => String(j.job_id), characterJobs))
+
+  // Our own corporations, from our own registrations (RLS-scoped to the
+  // caller). A structure any of them owns is a structure we own — including one
+  // owned by a corp none of the installing characters are in.
+  const { data: ownRegistrations } = await supabase.from('registration').select('corporation_id')
+  const ownCorporationIds = new Set(
+    map(
+      String,
+      reject(
+        isNil,
+        map((r: { corporation_id: number | string | null }) => r.corporation_id, ownRegistrations ?? [])
+      )
+    )
   )
-  const personalJobCorp = new Map<string, string>()
-  forEach((j: JobRow) => {
-    const corporationId = j.registration_id != null ? corpByRegistration.get(j.registration_id) : undefined
-    if (corporationId != null) personalJobCorp.set(String(j.job_id), corporationId)
-  }, characterJobs)
 
   // The two rates behind the cost-avoidance figures live on /settings/tax.
   const taxRates = await fetchTaxRates(supabase, user.id)
@@ -379,7 +383,7 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
       }),
       (journal ?? []) as JournalRow[]
     ),
-    { structureByJob, personalJobCorp, structureOwner, listedOwners }
+    { structureByJob, ownJobIds, personalJobIds, ownCorporationIds, structureOwner, listedOwners }
   )
 
   const totalByStructure = ledger.revenueByStructure

--- a/src/app/structure/taxLedger.ts
+++ b/src/app/structure/taxLedger.ts
@@ -49,6 +49,8 @@
 // tax paid by the installer, but avoidance for neither: a structure bills a
 // corporation it does not contain at whatever rate it likes, and scaling that
 // receipt as though it were the own rate would invent a saving.
+import { find, forEach, sum } from 'ramda'
+
 import type { OwnTaxReceipt } from './costAvoidance'
 
 export type TaxEntry = {
@@ -126,7 +128,10 @@ export const foldTaxLedger = (entries: readonly TaxEntry[], input: TaxLedgerInpu
   // same charge, not a second one — counting both would double the figure.
   const credited = new Set<string>()
   const paid = new Set<string>()
-  let unaccounted = 0
+
+  // Every per-key total here accumulates the same way. Mutating the map rather
+  // than rebuilding it per entry is the accepted shape for a fold this size.
+  const bump = (into: Map<string, number>, key: string, amount: number) => into.set(key, (into.get(key) ?? 0) + amount)
 
   const credit = (jobId: string, structureId: string, amount: number) => {
     if (credited.has(jobId)) return
@@ -137,19 +142,19 @@ export const foldTaxLedger = (entries: readonly TaxEntry[], input: TaxLedgerInpu
   const payTax = (jobId: string, structureId: string, amount: number) => {
     if (paid.has(jobId)) return
     paid.add(jobId)
-    taxesPaidByStructure.set(structureId, (taxesPaidByStructure.get(structureId) ?? 0) + amount)
+    bump(taxesPaidByStructure, structureId, amount)
   }
 
-  for (const entry of entries) {
+  forEach((entry: TaxEntry) => {
     const { amount } = entry
-    if (!Number.isFinite(amount) || amount === 0) continue
+    if (!Number.isFinite(amount) || amount === 0) return
 
-    const jobId = entry.jobIds.find((token) => structureByJob.has(token))
+    const jobId = find((token: string) => structureByJob.has(token), entry.jobIds)
     const structureId = jobId != null ? structureByJob.get(jobId) : undefined
 
     if (amount > 0) {
       if (structureId != null) {
-        revenueByStructure.set(structureId, (revenueByStructure.get(structureId) ?? 0) + amount)
+        bump(revenueByStructure, structureId, amount)
         // Somebody paid us. If it was one of our own characters, that payment is
         // recorded nowhere else — no character wallet journal is ingested — so
         // this receipt is also the record of tax we paid, and of an own-rate
@@ -162,11 +167,9 @@ export const foldTaxLedger = (entries: readonly TaxEntry[], input: TaxLedgerInpu
       } else {
         // Tax we received but can't tie to one of our structures (e.g. jobs not
         // in our tables, or a structure we've stopped monitoring).
-        unaccounted += amount
-        const party = entry.payerId ?? 'unknown'
-        unaccountedByParty.set(party, (unaccountedByParty.get(party) ?? 0) + amount)
+        bump(unaccountedByParty, entry.payerId ?? 'unknown', amount)
       }
-      continue
+      return
     }
 
     // Outgoing: our corporation paid this, so it is tax we paid whoever owns the
@@ -181,24 +184,25 @@ export const foldTaxLedger = (entries: readonly TaxEntry[], input: TaxLedgerInpu
       if (recipient == null || !listedOwners.has(recipient)) {
         unlistedPayments.push({ corporationId: recipient, jobId: entry.jobIds[0] ?? null, amount: -amount })
       }
-      continue
+      return
     }
     payTax(jobId, structureId, -amount)
 
     // ...but only a charge our corporation levied on ITSELF was billed at our
     // own rate, so only that is avoidance. Paying a landlord — an ally's
     // structure, or a sister corp's — is a real expense and no saving at all.
-    if (entry.corporationId == null) continue
-    if (structureOwner.get(structureId) !== entry.corporationId) continue
+    if (entry.corporationId == null) return
+    if (structureOwner.get(structureId) !== entry.corporationId) return
     credit(jobId, structureId, -amount)
-  }
+  }, entries)
 
   return {
     revenueByStructure,
     taxesPaidByStructure,
     ownReceipts,
     unlistedPayments,
-    unaccounted,
+    // The same figure the breakdown adds up to, so the two can never disagree.
+    unaccounted: sum([...unaccountedByParty.values()]),
     unaccountedByParty,
   }
 }

--- a/src/app/structure/taxLedger.ts
+++ b/src/app/structure/taxLedger.ts
@@ -40,15 +40,21 @@
 //     the outgoing entry in that corp's own wallet, so counting the incoming
 //     side too would bill one charge twice.
 //
-// COST AVOIDANCE is narrower than either: only a job whose OWN corporation owns
-// the structure it ran in, because only then was it billed at our own rate,
-// which is what the counterfactual scales. That test is the installer's
-// corporation against the structure's owner — not the wallet's, which for an
-// incoming entry is the landlord rather than the installer. A job one of our
-// corps ran in a SISTER corp's structure is therefore revenue for the owner and
-// tax paid by the installer, but avoidance for neither: a structure bills a
-// corporation it does not contain at whatever rate it likes, and scaling that
-// receipt as though it were the own rate would invent a saving.
+// COST AVOIDANCE is the one that turns on OWNERSHIP, and it is where the ISK is:
+// a job WE initiated, run in a structure WE own, was billed our own rate, and
+// the gap to a public rate is the expense never incurred. Whether the job was
+// installed by a character or as a corporation does not enter into it — the tax
+// is levied on the job either way, and either way we kept it.
+//
+// So the test is: is the job ours, and does one of our corporations own the
+// structure. NOT whether the installing corporation is the owning one. Those
+// differ exactly when one of our corps runs a job in another of our corps'
+// structure, which is a saving like any other — the ISK stays with us. Reading
+// it as a corporation-identity match dropped that case, and with it the whole
+// figure for anyone whose characters sit in a corp that owns no structures.
+//
+// Paying a landlord we do not own — an ally's structure, or a stranger's — is
+// rent. It is tax paid, and no saving at all.
 import { find, forEach, sum } from 'ramda'
 
 import type { OwnTaxReceipt } from './costAvoidance'
@@ -72,15 +78,22 @@ export type TaxEntry = {
 export type TaxLedgerInput = {
   // job id -> the structure it ran in, for every job we could resolve.
   structureByJob: ReadonlyMap<string, string>
-  // job id -> the corporation of the CHARACTER who installed it, for our
-  // characters' personal jobs only.
-  //
-  // Corp jobs are deliberately absent: their payment is readable as the
-  // outgoing entry in the paying corp's own wallet, and it is that entry, not
-  // the landlord's receipt, that says who installed them. Jobs resolved only
+  // The jobs that are OURS — our characters' and our corporations' alike. Which
+  // of the two it was does not matter to avoidance: a job we initiated in a
+  // structure we own is billed our own rate either way. Jobs resolved only
   // through industry_job_tax_facility() are other players' renting our slots
-  // and are absent for the older reason — they were never ours.
-  personalJobCorp: ReadonlyMap<string, string>
+  // and are deliberately absent.
+  ownJobIds: ReadonlySet<string>
+  // The subset of those installed by a CHARACTER rather than as a corporation.
+  // This decides nothing about avoidance; it exists only so one charge is
+  // billed once. A corp job's payment is readable as the outgoing entry in the
+  // paying corp's own wallet, so counting the landlord's receipt too would
+  // double it — a character's payment has no such entry to read.
+  personalJobIds: ReadonlySet<string>
+  // Our own corporations. A structure one of them owns is a structure we own,
+  // whichever of our corps installed the job — that is what separates a saving
+  // from rent.
+  ownCorporationIds: ReadonlySet<string>
   // structure id -> the corporation that owns it. Covers every structure on
   // the page, which includes alliance-mates' as well as our own.
   structureOwner: ReadonlyMap<string, string>
@@ -116,7 +129,7 @@ export type TaxLedger = {
 }
 
 export const foldTaxLedger = (entries: readonly TaxEntry[], input: TaxLedgerInput): TaxLedger => {
-  const { structureByJob, personalJobCorp, structureOwner, listedOwners } = input
+  const { structureByJob, ownJobIds, personalJobIds, ownCorporationIds, structureOwner, listedOwners } = input
 
   const revenueByStructure = new Map<string, number>()
   const taxesPaidByStructure = new Map<string, number>()
@@ -131,6 +144,10 @@ export const foldTaxLedger = (entries: readonly TaxEntry[], input: TaxLedgerInpu
 
   // Every per-key total here accumulates the same way. Mutating the map rather
   // than rebuilding it per entry is the accepted shape for a fold this size.
+  // Ours if one of our corporations owns it. An alliance-mate's tile is on this
+  // page too, and paying them is rent, not a saving.
+  const weOwn = (structureId: string) => ownCorporationIds.has(structureOwner.get(structureId) ?? '')
+
   const bump = (into: Map<string, number>, key: string, amount: number) => into.set(key, (into.get(key) ?? 0) + amount)
 
   const credit = (jobId: string, structureId: string, amount: number) => {
@@ -157,13 +174,13 @@ export const foldTaxLedger = (entries: readonly TaxEntry[], input: TaxLedgerInpu
         bump(revenueByStructure, structureId, amount)
         // Somebody paid us. If it was one of our own characters, that payment is
         // recorded nowhere else — no character wallet journal is ingested — so
-        // this receipt is also the record of tax we paid, and of an own-rate
-        // charge when their corporation is the one that owns the structure.
-        const installerCorp = jobId != null ? personalJobCorp.get(jobId) : undefined
-        if (jobId != null && installerCorp != null) {
-          payTax(jobId, structureId, amount)
-          if (installerCorp === structureOwner.get(structureId)) credit(jobId, structureId, amount)
-        }
+        // this receipt is the only record of tax we paid.
+        if (jobId != null && personalJobIds.has(jobId)) payTax(jobId, structureId, amount)
+        // And a job of ours run in a structure of ours was billed our own rate,
+        // which is the charge the counterfactual scales. A corp job's receipt
+        // reaches us only when a DIFFERENT corp installed it, so the credit is
+        // gated on the job being ours rather than on which wallet paid.
+        if (jobId != null && ownJobIds.has(jobId) && weOwn(structureId)) credit(jobId, structureId, amount)
       } else {
         // Tax we received but can't tie to one of our structures (e.g. jobs not
         // in our tables, or a structure we've stopped monitoring).
@@ -188,11 +205,11 @@ export const foldTaxLedger = (entries: readonly TaxEntry[], input: TaxLedgerInpu
     }
     payTax(jobId, structureId, -amount)
 
-    // ...but only a charge our corporation levied on ITSELF was billed at our
-    // own rate, so only that is avoidance. Paying a landlord — an ally's
-    // structure, or a sister corp's — is a real expense and no saving at all.
-    if (entry.corporationId == null) return
-    if (structureOwner.get(structureId) !== entry.corporationId) return
+    // ...and it is a saving whenever the structure is ours: we initiated the job
+    // (our wallet paid for it) and kept the tax inside the group. Paying a
+    // landlord we don't own — an ally's structure, or a stranger's — is a real
+    // expense and no saving at all.
+    if (!weOwn(structureId)) return
     credit(jobId, structureId, -amount)
   }, entries)
 

--- a/supabase/migrations/20260825015233_structure_tax_own_rate_by_ownership.sql
+++ b/supabase/migrations/20260825015233_structure_tax_own_rate_by_ownership.sql
@@ -1,0 +1,122 @@
+-- structure_tax_revenue(): decide the own-rate subset by OWNERSHIP, not by
+-- matching the installing corporation against the owning one.
+--
+-- The previous reading asked whether the corporation that installed a job was
+-- the same corporation that owns the structure. That is the wrong question, and
+-- it silently zeroed the figure it exists to report.
+--
+-- Facility tax is levied on the JOB. A job we initiated, run in a structure we
+-- own, is billed at our own rate and the ISK never leaves the group — it makes
+-- no difference whether a character installed it or a corporation did, nor
+-- which of our corporations owns the structure it ran in. Characters commonly
+-- sit in one corporation while the structures belong to another; under the old
+-- test every one of those jobs was reported as though a stranger had billed us,
+-- and the whole saving vanished.
+--
+-- So the test is now: is the job ours, and does one of OUR corporations own the
+-- structure. `my_corporation_ids()` answers the second half — the corporations
+-- the caller has a character in — and the two job views answer the first, both
+-- being RLS-scoped so a job counts as ours only when we can see it. An outgoing
+-- entry needs no job lookup at all: our wallet paid it, so the job was ours.
+--
+-- Paying a landlord we do not own — an alliance-mate's structure, or a
+-- stranger's — remains tax paid and no saving whatever.
+--
+-- `isk_paid` is unchanged, and still counts a character's job from the incoming
+-- receipt (no character wallet journal exists to read their side from) while
+-- taking a corporation's from the outgoing entry in its own wallet, so one
+-- charge is billed exactly once.
+drop function if exists public.structure_tax_revenue(bigint, timestamptz);
+
+create function public.structure_tax_revenue(structure_id bigint, since timestamptz)
+returns table (
+  payer_id bigint,
+  day date,
+  jobs bigint,
+  isk numeric,
+  self_paid_jobs bigint,
+  isk_self_paid numeric,
+  paid_jobs bigint,
+  isk_paid numeric,
+  total_jobs bigint,
+  isk_total numeric
+)
+language sql
+stable
+as $$
+  with tax as (
+    select w.first_party_id, w.corporation_id, w.date, w.amount, w.context_id
+    from public.corp_wallet_journal w
+    where w.ref_type = 'industry_job_tax'
+      and w.context_id is not null
+      and w.date >= since
+  ),
+  taxed_jobs as (
+    select distinct t.context_id as job_id from tax t
+  ),
+  -- Do WE own this structure? Any of our corporations owning it is enough; an
+  -- alliance-mate's tile is on the page too, and paying them is rent.
+  owned as (
+    select exists (
+      select 1
+      from public.corp_structure cs
+      where cs.structure_id = structure_tax_revenue.structure_id
+        and cs.corporation_id in (select public.my_corporation_ids())
+    ) as ours
+  ),
+  -- One call for the whole window rather than per row; the function dedupes to
+  -- at most one location per job.
+  located as (
+    select f.job_id, f.station_id, f.facility_id
+    from public.industry_job_tax_facility(array(select j.job_id from taxed_jobs j)) f
+  ),
+  -- Jobs of ours, either way they were installed. Both views are RLS-scoped to
+  -- the caller, so somebody else's job renting our slots is absent.
+  ours as (
+    select cij.job_id from public.character_industry_job cij where cij.job_id in (select job_id from taxed_jobs)
+    union
+    select coj.job_id from public.corp_industry_job coj where coj.job_id in (select job_id from taxed_jobs)
+  ),
+  -- The character-installed subset, which decides only that a charge is billed
+  -- once — never whether it was billed at our own rate.
+  personal as (
+    select cij.job_id from public.character_industry_job cij where cij.job_id in (select job_id from taxed_jobs)
+  ),
+  scoped as (
+    select
+      t.first_party_id,
+      t.date,
+      t.amount,
+      p.job_id is not null as is_personal,
+      case
+        -- We paid it, so the job was ours; all that remains is whether the
+        -- structure is.
+        when t.amount < 0 then (select ours from owned)
+        -- Somebody paid us. It is an own-rate charge when the job was ours and
+        -- we own the structure it ran in.
+        else o.job_id is not null and (select ours from owned)
+      end as own_rate
+    from tax t
+    join located l on l.job_id = t.context_id
+    left join ours o on o.job_id = t.context_id
+    left join personal p on p.job_id = t.context_id
+    -- Upwell structures share the id between station_id and facility_id; jobs in
+    -- NPC stations carry only station_id. Same coalesce the revenue page uses.
+    where coalesce(l.station_id, l.facility_id) = structure_tax_revenue.structure_id
+  )
+  select
+    s.first_party_id                                                as payer_id,
+    (s.date at time zone 'UTC')::date                               as day,
+    count(*) filter (where s.amount > 0)                            as jobs,
+    coalesce(sum(s.amount) filter (where s.amount > 0), 0)          as isk,
+    count(*) filter (where s.own_rate)                              as self_paid_jobs,
+    coalesce(sum(abs(s.amount)) filter (where s.own_rate), 0)       as isk_self_paid,
+    count(*) filter (where s.amount < 0 or s.is_personal)           as paid_jobs,
+    coalesce(sum(abs(s.amount)) filter (where s.amount < 0 or s.is_personal), 0) as isk_paid,
+    count(*)                                                        as total_jobs,
+    coalesce(sum(abs(s.amount)), 0)                                 as isk_total
+  from scoped s
+  -- Positional, so the output column names can't shadow anything in `scoped`.
+  group by 1, 2
+  order by 2 desc, 4 desc;
+$$;

--- a/test/sql/structure_tax_revenue.sql
+++ b/test/sql/structure_tax_revenue.sql
@@ -11,11 +11,14 @@
 -- revenue).
 --
 -- It also pins the measures apart. `isk_self_paid` is the subset billed at OUR
--- OWN RATE — the installer's own corporation owns the structure — so rent paid
--- into somebody else's must never land in it, which is what the earlier
--- every-outgoing-entry reading got wrong. `isk_paid` is the wider figure: every
--- charge we paid, including a member's personal job, whose only record is the
--- incoming receipt because no character wallet journal exists.
+-- OWN RATE, and that turns on OWNERSHIP: the job was ours and one of our
+-- corporations owns the structure. It is NOT a match between the installing
+-- corporation and the owning one — characters commonly sit in one corp while
+-- the structures belong to another, and reading it that way zeroed the figure
+-- for exactly those accounts. Rent paid into a structure we do not own must
+-- still never land in it. `isk_paid` is the wider figure: every charge we paid,
+-- including a member's personal job, whose only record is the incoming receipt
+-- because no character wallet journal exists.
 --
 -- Run against a THROWAWAY database from the repo root (same harness as
 -- asset_share.sql): DATABASE_URL='postgresql://…/throwaway' pnpm run test:sql
@@ -29,6 +32,8 @@ create schema if not exists auth;
 create or replace function auth.uid() returns uuid
 language sql stable
 as $$ select nullif(current_setting('test.uid', true), '')::uuid $$;
+
+do $$ begin create schema if not exists public; end $$;
 
 create table public.registration (
   id uuid primary key,
@@ -52,8 +57,27 @@ create table public.corp_wallet_journal (
 );
 
 insert into public.registration (id, user_id, corporation_id) values
-  ('11111111-1111-1111-1111-111111111111', '99999999-0000-0000-0000-000000000001', 1000);
-insert into public.corp_structure values (60000001, 1000), (60000003, 2000);
+  ('11111111-1111-1111-1111-111111111111', '99999999-0000-0000-0000-000000000001', 1000),
+  -- A second character of ours, in a different corporation of ours.
+  ('22222222-2222-2222-2222-222222222222', '99999999-0000-0000-0000-000000000001', 1500);
+insert into public.corp_structure values (60000001, 1000), (60000003, 2000), (60000004, 1500);
+
+-- Ownership is decided by my_corporation_ids(), the corporations the caller has
+-- a character in — corp 1000 here, via the registration above.
+create or replace function public.my_corporation_ids()
+returns setof bigint
+language sql
+stable
+as $$
+  select r.corporation_id
+  from public.registration r
+  where r.user_id = (select auth.uid()) and r.corporation_id is not null;
+$$;
+
+-- The corp-jobs live view the ownership test reads alongside the character one.
+create view public.corp_industry_job as
+  select * from public.corp_industry_job_over_time
+  where is_current and corporation_id in (select public.my_corporation_ids());
 
 -- The live-rows view the aggregation reads to tell a personal job from a corp
 -- one; the real schema defines it the same way.
@@ -67,7 +91,10 @@ insert into public.character_industry_job_over_time values
   (2, '11111111-1111-1111-1111-111111111111', 60000001, 60000001, true),
   (3, '11111111-1111-1111-1111-111111111111', 60000001, 60000001, true),
   (4, '11111111-1111-1111-1111-111111111111', 60000002, 60000002, true),
-  (6, '11111111-1111-1111-1111-111111111111', 60000001, null,     true);
+  (6, '11111111-1111-1111-1111-111111111111', 60000001, null,     true),
+  -- Installed by the character in corp 1000, but run in 60000004, which corp
+  -- 1500 owns. Both corporations are ours.
+  (8, '11111111-1111-1111-1111-111111111111', 60000004, 60000004, true);
 insert into public.corp_industry_job_over_time values
   (5, 3000, null, 60000001, true),
   -- Our own corporation's job, run in a structure somebody else owns.
@@ -89,12 +116,15 @@ insert into public.corp_wallet_journal values
   -- any of the row/day counts asserted below.
   (1000, 1, 8, '2026-08-08T02:00:00Z', 'industry_job_tax', 3, -300.00, 7001),
   -- Rent: our corporation paying tax into a structure it does not own.
-  (1000, 1, 9, '2026-08-08T03:00:00Z', 'industry_job_tax', 7, -450.00, 7001);
+  (1000, 1, 9, '2026-08-08T03:00:00Z', 'industry_job_tax', 7, -450.00, 7001),
+  -- Our character's job in a structure another of OUR corporations owns.
+  (1500, 1, 10, '2026-08-08T04:00:00Z', 'industry_job_tax', 8, 600.00, 7001);
 
 \i supabase/migrations/20260809000000_industry_job_tax_facility.sql
 \i supabase/migrations/20260809080000_structure_tax_revenue.sql
 \i supabase/migrations/20260822120000_structure_tax_revenue_split_signs.sql
 \i supabase/migrations/20260824234011_structure_tax_paid.sql
+\i supabase/migrations/20260825015233_structure_tax_own_rate_by_ownership.sql
 
 set local test.uid = '99999999-0000-0000-0000-000000000001';
 
@@ -220,6 +250,22 @@ begin
   assert got.isk_paid = 450.00, 'expected 450 paid as rent, got ' || got.isk_paid;
   assert got.isk_self_paid = 0, 'rent is not billed at our own rate, got ' || got.isk_self_paid;
   assert got.self_paid_jobs = 0, 'expected 0 own-rate charges, got ' || got.self_paid_jobs;
+end $$;
+
+-- The case a corporation-identity test drops: the character who installed job 8
+-- is in corp 1000, while 60000004 belongs to corp 1500. Both are ours, so the
+-- tax never left the group and the whole 600 is an own-rate charge.
+do $$
+declare got record;
+begin
+  select * into got
+  from public.structure_tax_revenue(60000004, '2026-08-01T00:00:00Z')
+  where payer_id = 7001 and day = date '2026-08-08';
+  assert got.isk = 600.00, 'expected 600 revenue, got ' || got.isk;
+  assert got.isk_self_paid = 600.00,
+    'a job of ours in a structure of ours is own-rate however the corps line up, got ' || got.isk_self_paid;
+  assert got.self_paid_jobs = 1, 'expected 1 own-rate charge, got ' || got.self_paid_jobs;
+  assert got.isk_paid = 600.00, 'the character paid it, so it is tax we paid, got ' || got.isk_paid;
 end $$;
 
 -- A caller with no journal entries of their own gets nothing, since the

--- a/test/taxLedger.test.ts
+++ b/test/taxLedger.test.ts
@@ -8,9 +8,9 @@
 //
 // What the three measures must not do is collapse into each other. One charge
 // can be revenue AND tax we paid (a member billing their own corp), or tax we
-// paid and no revenue at all (the corp billing itself), and it is avoidance
-// only when the installer's own corporation owns the structure — never merely
-// because the job was ours.
+// paid and no revenue at all (the corp billing itself). Avoidance is the one
+// that turns on OWNERSHIP: a job of ours in a structure of ours, whichever of
+// our corporations owns it and whichever installed the job.
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
@@ -20,14 +20,12 @@ import type { TaxEntry } from '../src/app/structure/taxLedger.ts'
 const OURS = 'corp-1'
 const ALLY = 'corp-2'
 // An alt corp of ours: we hold a director in it, so its wallet is readable and
-// its jobs are ours — but it is still a different corporation from the one that
-// owns S1, which is what cost avoidance turns on.
+// both it and its structures are ours.
 const SISTER = 'corp-3'
 
 // J1 and J3 ran in our structure S1, J2 in an alliance-mate's S2, J4 in the
-// sister corp's own S3. J1 and J4 are personal jobs of our characters; J2 is a
-// personal job of a character in the sister corp; J3 belongs to somebody else
-// entirely (it resolves to a structure but to no character of ours).
+// sister corp's own S3. J3 is somebody else's job renting our slots; the rest
+// are ours.
 const input = {
   structureByJob: new Map([
     ['J1', 'S1'],
@@ -35,11 +33,12 @@ const input = {
     ['J3', 'S1'],
     ['J4', 'S3'],
   ]),
-  personalJobCorp: new Map([
-    ['J1', OURS],
-    ['J2', SISTER],
-    ['J4', SISTER],
-  ]),
+  // J1, J2 and J4 are ours; J3 is somebody else's, renting our slots.
+  ownJobIds: new Set(['J1', 'J2', 'J4']),
+  // Of ours, the character-installed ones. J4 stands in for a corp job.
+  personalJobIds: new Set(['J1', 'J2']),
+  // OURS and SISTER are both our corporations; ALLY is not.
+  ownCorporationIds: new Set([OURS, SISTER]),
   structureOwner: new Map([
     ['S1', OURS],
     ['S2', ALLY],
@@ -70,26 +69,35 @@ test('an incoming payment for our own job is revenue, tax we paid, and an own-ra
   assert.deepEqual(ledger.ownReceipts, [{ structureId: 'S1', amount: 5_000 }])
 })
 
-test("a sister corp's character paying into our structure is revenue and tax paid, never avoidance", () => {
-  // J4's installer is in SISTER, which owns S3 — so in its own corp's structure
-  // it does avoid. The point of the pair below is the corp/owner comparison,
-  // not who we are.
-  const own = foldTaxLedger([entry({ amount: 4_000, corporationId: SISTER, jobIds: ['J4'] })], input)
-  assert.deepEqual(own.ownReceipts, [{ structureId: 'S3', amount: 4_000 }])
+test("a job of ours in a SISTER corp's structure still avoids — the ISK stays with us", () => {
+  // The installer's corporation is not the owner here, and that is precisely
+  // the case a corporation-identity test dropped. Both corps are ours, so the
+  // tax never left the group and the saving is real.
+  const ledger = foldTaxLedger([entry({ amount: 4_000, corporationId: SISTER, jobIds: ['J4'] })], input)
+  assert.deepEqual(ledger.ownReceipts, [{ structureId: 'S3', amount: 4_000 }])
+})
 
-  // J2's installer is in SISTER but S2 belongs to an ally: billed at whatever
-  // rate a stranger gets, so there is no own-rate receipt to scale.
+test("tax into an ALLY's structure is paid, never avoided — we do not own it", () => {
   const rented = foldTaxLedger([entry({ amount: 4_000, jobIds: ['J2'] })], input)
   assert.deepEqual([...rented.revenueByStructure], [['S2', 4_000]])
   assert.deepEqual([...rented.taxesPaidByStructure], [['S2', 4_000]])
   assert.deepEqual(rented.ownReceipts, [])
 })
 
-test('an incoming payment for a CORP job is revenue only — its own wallet records the payment', () => {
-  // J3 is in no personalJobCorp entry, so nothing here bills it a second time.
+test('a CORP job of ours in our own structure avoids, though no character installed it', () => {
+  // J4 is a corp job (absent from personalJobIds) run in SISTER's own S3.
+  // Avoidance must not be gated on the character/corp distinction.
+  const ledger = foldTaxLedger([entry({ amount: -4_000, corporationId: SISTER, jobIds: ['J4'] })], input)
+  assert.deepEqual(ledger.ownReceipts, [{ structureId: 'S3', amount: 4_000 }])
+  assert.deepEqual([...ledger.taxesPaidByStructure], [['S3', 4_000]])
+})
+
+test("an incoming payment for somebody else's job is revenue only", () => {
+  // J3 is neither ours nor personal, so it bills us nothing and avoids nothing.
   const ledger = foldTaxLedger([entry({ amount: 7_000, jobIds: ['J3'] })], input)
   assert.deepEqual([...ledger.revenueByStructure], [['S1', 7_000]])
   assert.equal(ledger.taxesPaidByStructure.size, 0)
+  assert.deepEqual(ledger.ownReceipts, [])
 })
 
 test("tax paid into an ally's structure is counted as paid, on their tile", () => {
@@ -189,8 +197,8 @@ test('both sides of one charge credit the job once, not twice', () => {
   assert.deepEqual([...ledger.taxesPaidByStructure], [['S1', 5_000]])
 })
 
-test('an outgoing entry from a corporation that does not own the structure is dropped', () => {
-  const ledger = foldTaxLedger([entry({ amount: -9_007, corporationId: ALLY, jobIds: ['J1'] })], input)
+test('an outgoing entry for a structure we do not own credits no saving', () => {
+  const ledger = foldTaxLedger([entry({ amount: -9_007, jobIds: ['J2'] })], input)
   assert.deepEqual(ledger.ownReceipts, [])
 })
 


### PR DESCRIPTION
# 1. Cost avoidance was scoring by corporation identity, and reading zero

**This is the correctness fix; the rest is supporting work.**

Facility tax is levied on the **job**. A job we initiated, run in a structure we own, is billed our own rate and the ISK never leaves the group — it makes no difference whether a character or a corporation installed it, nor which of our corporations owns the structure.

The previous test asked whether the corporation that **installed** a job was the same one that **owns** the structure. Characters commonly sit in one corp while the structures belong to another, and for those accounts every job scored as though a stranger had billed us: the entire saving read as **zero** while the tax behind it still showed up as revenue and taxes paid.

Both `taxLedger.ts` and `structure_tax_revenue()` now ask:

> Is the job ours, and does **one of our corporations** own the structure?

- Our job + our structure → **cost avoidance**
- Our job + someone else's structure → **taxes paid** only
- Someone else's job + our structure → **revenue**

An outgoing entry needs no job lookup for the first half — our wallet paid it, so the job was ours. The character/corp distinction survives in exactly one place, which is where it was always the point: keeping one charge from being billed twice. A corp job's payment is the outgoing entry in its own wallet; a character's payment has no entry at all, so the receipt is the only record.

Paying a landlord we don't own stays tax paid and no saving.

# 2. A breakdown behind the number

Cost avoidance was one figure with nothing behind it, so a result that looks wrong couldn't be checked. The detail page now shows the arithmetic:

| | |
|---|---|
| Billed at our own rate (0.1%) — N charges on jobs of ours run in a structure we own | X ISK |
| The same jobs in a public structure (1%) | 10X ISK |
| **Avoided** | **9X ISK** |

Both rates are named, because a public rate set equal to the own rate makes the saving zero and nothing on screen said so. It also accounts for what is *not* in the figure: tax billed by a landlord is excluded with its amount, and a structure with tax paid but no own-rate basis gets a line saying why rather than the section silently not rendering.

The arithmetic reuses `costAvoidance()` rather than repeating the formula, so the detail page and the tile can't disagree about what a saving is.

# 3. Ramda refactor of the recently-touched pages

Every `for`/`while` loop in the pages touched by #960–#963 is now ramda `forEach`/`reduce`, and the native `map`/`filter`/`reduce`/`sort` chains are ramda equivalents — 12 loops to 0 across `structure/taxLedger.ts`, both structure pages, `blueprint/page.tsx` and `bpos/{slug,data,shareActions}.ts`.

Beyond straight substitution: **`unaccounted` is no longer tracked twice** (it kept a running `let` *and* the per-payer breakdown it is exactly the sum of, so the headline and the list under it could drift), and the repeated `map.set(k, (map.get(k) ?? 0) + n)` is a named `bump` helper.

**One deliberate non-conversion:** sorts whose comparator was `localeCompare` stay ramda `sort` with the collator, not `ascend` — ramda's `ascend` compares with `<`/`>`, which sorts `"Banana"` before `"apple"`.

## Testing

`pnpm run lint`, `pnpm test` (542) and `pnpm run build` clean; migration guard passes.

**The SQL was executed, not just reviewed** — `test/sql/structure_tax_revenue.sql` runs against a throwaway Postgres 16 cluster, extended with the case this PR fixes: a character in corp 1000 running a job in a structure corp 1500 owns, both ours, now scoring the full charge as own-rate. Every prior assertion still holds, including rent into a structure we don't own staying paid-but-not-avoided.

Note this changes the function's return signature again, so there's a new migration; `branch` CI applied it against a Supabase preview clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Eh71M22uC6MZaFErV73tZ