### PR TITLE
Search the blueprint libraries shared with us

### DIFF
--- a/src/app/blueprint/actions.ts
+++ b/src/app/blueprint/actions.ts
@@ -1,6 +1,12 @@
 'use server'
 
 import { searchBlueprints } from './api'
+import { type SharedSearchResult } from './searchHits'
+import { searchSharedBlueprints } from './sharedSearch'
 
 export const searchType = async (typeNameSubstring: string): Promise<[string, string][]> =>
   searchBlueprints(typeNameSubstring)
+
+// The shared-library search. Everything it may read is decided server-side from
+// the caller's own session, so the substring is the only input.
+export const searchShared = async (substring: string): Promise<SharedSearchResult> => searchSharedBlueprints(substring)

--- a/src/app/blueprint/libraries.ts
+++ b/src/app/blueprint/libraries.ts
@@ -1,0 +1,245 @@
+// Which blueprint libraries this account can open, resolved once and used
+// twice: the two lists /blueprint renders, and the set the shared-library
+// search reads through.
+//
+// A library is either a CORPORATION's hangars (corp_blueprint, keyed on the
+// corporation id) or an ACCOUNT's pooled originals (character_blueprint, keyed
+// on the user id) — the same two subjects /bpos/[name] addresses, which is why
+// each one carries the slug href that opens it there.
+import { chain, filter, groupBy, isNil, map, reject, sort, uniq } from 'ramda'
+
+import { createClient } from '@/utils/supabase/server'
+import { createServiceClient } from '@/utils/supabase/service'
+
+import { characterSlug, pickMain } from '../bpos/slug'
+
+// ESI hands this scope out only to a character holding the Director role in
+// game, so a token carrying it is our one signal that a character is a
+// director — and it is the same grant that makes the corporation's blueprints
+// readable at all, which is exactly what the corp showcase renders.
+const CORP_BLUEPRINTS_SCOPE = 'esi-corporations.read_blueprints.v1'
+
+// Which of the two tables the library's blueprints live in, and the id that
+// scopes the read. Discriminated so the search branches exhaustively rather
+// than on the presence of a field.
+export type LibrarySubject = { kind: 'corporation'; corporationId: number } | { kind: 'account'; userId: string }
+
+// One row in either list: where it goes, how it reads, and — for a corporation
+// somebody published to us — who published it.
+export type Library = {
+  key: string
+  href: string
+  label: string
+  note: string
+  subject: LibrarySubject
+  sharedBy: string | null
+}
+
+const libraryOf = (
+  name: string,
+  note: string,
+  key: string,
+  subject: LibrarySubject,
+  sharedBy: string | null
+): Library => ({
+  key,
+  href: `/bpos/${characterSlug(name)}`,
+  label: name,
+  note,
+  subject,
+  sharedBy,
+})
+
+const byLabel = (a: Library, b: Library) => a.label.localeCompare(b.label)
+
+export type Libraries = { mine: Library[]; shared: Library[] }
+
+const EMPTY: Libraries = { mine: [], shared: [] }
+
+// The ones that are OURS — our own originals pooled across characters, and the
+// corporations we hold a director in — and the ones somebody else published to
+// us. A corporation we are merely a member of sits in the second list: the
+// library is the corporation's, not ours to keep, but membership is why we can
+// see it, so it leads that list.
+export const resolveLibraries = async (): Promise<Libraries> => {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user?.id) return EMPTY
+
+  const service = createServiceClient()
+
+  // Our characters: the main names our own showcase, and their corporations are
+  // the ones we have a character in.
+  const { data: ownRegistrations } = await supabase
+    .from('registration')
+    .select('name, is_main, created_at, corporation_id')
+  type OwnReg = {
+    name: string
+    is_main: boolean | null
+    created_at: string | null
+    corporation_id: number | string | null
+  }
+  const ownRegs = (ownRegistrations ?? []) as OwnReg[]
+  const main = pickMain(ownRegs)
+  const memberCorpIds = new Set(
+    map(
+      Number,
+      reject(
+        isNil,
+        map((r: OwnReg) => r.corporation_id, ownRegs)
+      )
+    )
+  )
+
+  // Corporations we hold a DIRECTOR in. `token` is service-role-only (those are
+  // live EVE refresh tokens), so the read is explicitly scoped to the caller.
+  // The scope is our only signal, and it is the grant that fills corp_blueprint
+  // in the first place.
+  const { data: tokens } = await service
+    .from('token')
+    .select('registration_id')
+    .eq('user_id', user.id)
+    .contains('scope', [CORP_BLUEPRINTS_SCOPE])
+    .returns<Array<{ registration_id: string }>>()
+  const registrationIds = uniq(map((t: { registration_id: string }) => t.registration_id, tokens ?? []))
+  const { data: directorRegs } = registrationIds.length
+    ? await service
+        .from('registration')
+        .select('corporation_id')
+        .in('id', registrationIds)
+        .not('corporation_id', 'is', null)
+        .returns<Array<{ corporation_id: number | string }>>()
+    : { data: [] }
+  const directorCorpIds = new Set(
+    map((r: { corporation_id: number | string }) => Number(r.corporation_id), directorRegs ?? [])
+  )
+
+  // Published corporation libraries. Asked as the VIEWER, so corp_bpo_share's
+  // own policies answer it: a member sees their corporation's row, and the
+  // audience policy adds rows aimed at their corp or alliance plus any that are
+  // fully public. A link-only share matches nobody, which is right — its URL is
+  // the only way in.
+  type CorpShare = { corporation_id: number | string; created_by: string | null }
+  const { data: corpShares } = await supabase
+    .from('corp_bpo_share')
+    .select('corporation_id, created_by')
+    .returns<CorpShare[]>()
+  const sharedCorpIds = uniq(map((r: CorpShare) => Number(r.corporation_id), corpShares ?? []))
+  const publisherByCorp = new Map(
+    chain(
+      (r: CorpShare) => (r.created_by == null ? [] : [[Number(r.corporation_id), r.created_by] as [number, string]]),
+      corpShares ?? []
+    )
+  )
+
+  // Other players' account libraries, published to us the same way. Our own row
+  // is visible here too and is dropped: that library is already the first entry
+  // of the list above.
+  const { data: accountShares } = await supabase
+    .from('bpo_share')
+    .select('user_id')
+    .returns<Array<{ user_id: string }>>()
+  const sharedUserIds = reject(
+    (id: string) => id === user.id,
+    uniq(map((r: { user_id: string }) => r.user_id, accountShares ?? []))
+  )
+
+  // Names. A corporation the directory hasn't backfilled can't be addressed by
+  // slug, so it is left out rather than linking nowhere; an account is
+  // addressed by its main, resolved the same way our own is.
+  const corpIds = uniq([...directorCorpIds, ...sharedCorpIds])
+  const { data: corps } = corpIds.length
+    ? await service
+        .from('corporation')
+        .select('corporation_id, name')
+        .in('corporation_id', corpIds)
+        .not('name', 'is', null)
+        .returns<Array<{ corporation_id: number | string; name: string }>>()
+    : { data: [] }
+  const corpName = new Map(
+    map(
+      (c: { corporation_id: number | string; name: string }) => [Number(c.corporation_id), c.name] as [number, string],
+      corps ?? []
+    )
+  )
+
+  // One registration read covers both the accounts that shared a library with
+  // us and the people who published a corporation's — each is named by their
+  // own main, the same way ours is.
+  const namedUserIds = uniq([...sharedUserIds, ...publisherByCorp.values()])
+  const { data: sharerRegs } = namedUserIds.length
+    ? await service
+        .from('registration')
+        .select('user_id, name, is_main, created_at')
+        .in('user_id', namedUserIds)
+        .returns<Array<{ user_id: string; name: string; is_main: boolean | null; created_at: string | null }>>()
+    : { data: [] }
+  const mainByUser = new Map(
+    chain(
+      ([userId, regs = []]) => {
+        const sharerMain = pickMain(regs)
+        return sharerMain ? [[userId, sharerMain.name] as [string, string]] : []
+      },
+      Object.entries(groupBy((r: { user_id: string }) => r.user_id, sharerRegs ?? []))
+    )
+  )
+
+  const publisherOf = (corporationId: number): string | null => {
+    const userId = publisherByCorp.get(corporationId)
+    return userId == null ? null : (mainByUser.get(userId) ?? null)
+  }
+
+  const corpLibrary = (id: number, note: string, sharedBy: string | null): Library[] => {
+    const name = corpName.get(id)
+    return name ? [libraryOf(name, note, `corp-${id}`, { kind: 'corporation', corporationId: id }, sharedBy)] : []
+  }
+
+  const mine: Library[] = [
+    ...(main
+      ? [
+          libraryOf(
+            main.name,
+            'every original across your characters',
+            'own',
+            { kind: 'account', userId: user.id },
+            null
+          ),
+        ]
+      : []),
+    ...sort(
+      byLabel,
+      chain((id: number) => corpLibrary(id, 'every original in the corporation’s hangars', null), [...directorCorpIds])
+    ),
+  ]
+
+  // Membership first, since that is the closest of these to being ours.
+  const shared: Library[] = [
+    ...sort(
+      byLabel,
+      chain(
+        (id: number) => corpLibrary(id, 'your corporation’s hangars', publisherOf(id)),
+        filter((id: number) => memberCorpIds.has(id) && !directorCorpIds.has(id), sharedCorpIds)
+      )
+    ),
+    ...sort(
+      byLabel,
+      chain(
+        (id: number) => corpLibrary(id, 'another corporation’s hangars', publisherOf(id)),
+        filter((id: number) => !memberCorpIds.has(id), sharedCorpIds)
+      )
+    ),
+    ...sort(
+      byLabel,
+      chain((id: string) => {
+        const name = mainByUser.get(id)
+        return name
+          ? [libraryOf(name, 'another player’s originals', `user-${id}`, { kind: 'account', userId: id }, name)]
+          : []
+      }, sharedUserIds)
+    ),
+  ]
+
+  return { mine, shared }
+}

--- a/src/app/blueprint/page.tsx
+++ b/src/app/blueprint/page.tsx
@@ -1,209 +1,40 @@
 import Link from 'next/link'
-import { chain, filter, groupBy, isNil, map, reject, sort, uniq } from 'ramda'
 
-import { createClient } from '@/utils/supabase/server'
-import { createServiceClient } from '@/utils/supabase/service'
-
-import { characterSlug, pickMain } from '../bpos/slug'
+import { resolveLibraries, type Library } from './libraries'
+import { SharedSearchBox } from './sharedSearchBox'
 import { TypeSearch } from './typeSearch'
 
-// ESI hands this scope out only to a character holding the Director role in
-// game, so a token carrying it is our one signal that a character is a
-// director — and it is the same grant that makes the corporation's blueprints
-// readable at all, which is exactly what the corp showcase renders.
-const CORP_BLUEPRINTS_SCOPE = 'esi-corporations.read_blueprints.v1'
+const List = ({ heading, libraries }: { heading: string; libraries: Library[] }) => (
+  <>
+    <h2>{heading}</h2>
+    <ul>
+      {libraries.map((library) => (
+        <li key={library.key}>
+          <Link href={library.href}>{library.label}</Link> — {library.note}
+        </li>
+      ))}
+    </ul>
+  </>
+)
 
-// One row in either list: where it goes and how it reads.
-type Library = { key: string; href: string; label: string; note: string }
-
-const libraryOf = (name: string, note: string, key: string): Library => ({
-  key,
-  href: `/bpos/${characterSlug(name)}`,
-  label: name,
-  note,
-})
-
-const byLabel = (a: Library, b: Library) => a.label.localeCompare(b.label)
-
-// The blueprint libraries this account can open, in two lists: the ones that
-// are OURS — our own originals pooled across characters, and the corporations
-// we hold a director in — and below them the ones somebody else published to
-// us. A corporation we are merely a member of sits in the second list: the
-// library is the corporation's, not ours to keep, but membership is why we can
-// see it, so it leads that list.
+// The blueprint libraries this account can open, in two lists (see
+// ./libraries), with a search across the shared ones sitting between them: the
+// list answers "whose libraries can I open", and the box answers "which of them
+// has the thing I want".
 const BposLibraries = async () => {
-  const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-  if (!user?.id) return null
-
-  const service = createServiceClient()
-
-  // Our characters: the main names our own showcase, and their corporations are
-  // the ones we have a character in.
-  const { data: ownRegistrations } = await supabase
-    .from('registration')
-    .select('name, is_main, created_at, corporation_id')
-  type OwnReg = {
-    name: string
-    is_main: boolean | null
-    created_at: string | null
-    corporation_id: number | string | null
-  }
-  const ownRegs = (ownRegistrations ?? []) as OwnReg[]
-  const main = pickMain(ownRegs)
-  const memberCorpIds = new Set(
-    map(
-      Number,
-      reject(
-        isNil,
-        map((r: OwnReg) => r.corporation_id, ownRegs)
-      )
-    )
-  )
-
-  // Corporations we hold a DIRECTOR in. `token` is service-role-only (those are
-  // live EVE refresh tokens), so the read is explicitly scoped to the caller.
-  // The scope is our only signal, and it is the grant that fills corp_blueprint
-  // in the first place.
-  const { data: tokens } = await service
-    .from('token')
-    .select('registration_id')
-    .eq('user_id', user.id)
-    .contains('scope', [CORP_BLUEPRINTS_SCOPE])
-    .returns<Array<{ registration_id: string }>>()
-  const registrationIds = uniq(map((t: { registration_id: string }) => t.registration_id, tokens ?? []))
-  const { data: directorRegs } = registrationIds.length
-    ? await service
-        .from('registration')
-        .select('corporation_id')
-        .in('id', registrationIds)
-        .not('corporation_id', 'is', null)
-        .returns<Array<{ corporation_id: number | string }>>()
-    : { data: [] }
-  const directorCorpIds = new Set(
-    map((r: { corporation_id: number | string }) => Number(r.corporation_id), directorRegs ?? [])
-  )
-
-  // Published corporation libraries. Asked as the VIEWER, so corp_bpo_share's
-  // own policies answer it: a member sees their corporation's row, and the
-  // audience policy adds rows aimed at their corp or alliance plus any that are
-  // fully public. A link-only share matches nobody, which is right — its URL is
-  // the only way in.
-  const { data: corpShares } = await supabase
-    .from('corp_bpo_share')
-    .select('corporation_id')
-    .returns<Array<{ corporation_id: number | string }>>()
-  const sharedCorpIds = uniq(
-    map((r: { corporation_id: number | string }) => Number(r.corporation_id), corpShares ?? [])
-  )
-
-  // Other players' account libraries, published to us the same way. Our own row
-  // is visible here too and is dropped: that library is already the first entry
-  // of the list above.
-  const { data: accountShares } = await supabase
-    .from('bpo_share')
-    .select('user_id')
-    .returns<Array<{ user_id: string }>>()
-  const sharedUserIds = reject(
-    (id: string) => id === user.id,
-    uniq(map((r: { user_id: string }) => r.user_id, accountShares ?? []))
-  )
-
-  // Names. A corporation the directory hasn't backfilled can't be addressed by
-  // slug, so it is left out rather than linking nowhere; an account is
-  // addressed by its main, resolved the same way our own is.
-  const corpIds = uniq([...directorCorpIds, ...sharedCorpIds])
-  const { data: corps } = corpIds.length
-    ? await service
-        .from('corporation')
-        .select('corporation_id, name')
-        .in('corporation_id', corpIds)
-        .not('name', 'is', null)
-        .returns<Array<{ corporation_id: number | string; name: string }>>()
-    : { data: [] }
-  const corpName = new Map(
-    map(
-      (c: { corporation_id: number | string; name: string }) => [Number(c.corporation_id), c.name] as [number, string],
-      corps ?? []
-    )
-  )
-
-  const { data: sharerRegs } = sharedUserIds.length
-    ? await service
-        .from('registration')
-        .select('user_id, name, is_main, created_at')
-        .in('user_id', sharedUserIds)
-        .returns<Array<{ user_id: string; name: string; is_main: boolean | null; created_at: string | null }>>()
-    : { data: [] }
-  const mainByUser = new Map(
-    chain(
-      ([userId, regs = []]) => {
-        const sharerMain = pickMain(regs)
-        return sharerMain ? [[userId, sharerMain.name] as [string, string]] : []
-      },
-      Object.entries(groupBy((r: { user_id: string }) => r.user_id, sharerRegs ?? []))
-    )
-  )
-
-  const corpLibrary = (id: number, note: string): Library[] => {
-    const name = corpName.get(id)
-    return name ? [libraryOf(name, note, `corp-${id}`)] : []
-  }
-
-  const mine: Library[] = [
-    ...(main ? [libraryOf(main.name, 'every original across your characters', 'own')] : []),
-    ...sort(
-      byLabel,
-      chain((id: number) => corpLibrary(id, 'every original in the corporation’s hangars'), [...directorCorpIds])
-    ),
-  ]
-
-  // Membership first, since that is the closest of these to being ours.
-  const shared: Library[] = [
-    ...sort(
-      byLabel,
-      chain(
-        (id: number) => corpLibrary(id, 'your corporation’s hangars'),
-        filter((id: number) => memberCorpIds.has(id) && !directorCorpIds.has(id), sharedCorpIds)
-      )
-    ),
-    ...sort(
-      byLabel,
-      chain(
-        (id: number) => corpLibrary(id, 'another corporation’s hangars'),
-        filter((id: number) => !memberCorpIds.has(id), sharedCorpIds)
-      )
-    ),
-    ...sort(
-      byLabel,
-      chain((id: string) => {
-        const name = mainByUser.get(id)
-        return name ? [libraryOf(name, 'another player’s originals', `user-${id}`)] : []
-      }, sharedUserIds)
-    ),
-  ]
-
+  const { mine, shared } = await resolveLibraries()
   if (mine.length === 0 && shared.length === 0) return null
-
-  const List = ({ heading, libraries }: { heading: string; libraries: Library[] }) => (
-    <>
-      <h2>{heading}</h2>
-      <ul>
-        {libraries.map((library) => (
-          <li key={library.key}>
-            <Link href={library.href}>{library.label}</Link> — {library.note}
-          </li>
-        ))}
-      </ul>
-    </>
-  )
 
   return (
     <>
       {mine.length > 0 && <List heading="Your blueprint libraries" libraries={mine} />}
-      {shared.length > 0 && <List heading="Shared with you" libraries={shared} />}
+      {shared.length > 0 && (
+        <>
+          <h2>Search shared libraries</h2>
+          <SharedSearchBox />
+          <List heading="Shared with you" libraries={shared} />
+        </>
+      )}
     </>
   )
 }

--- a/src/app/blueprint/searchHits.ts
+++ b/src/app/blueprint/searchHits.ts
@@ -1,0 +1,82 @@
+// The pure half of the shared-library blueprint search: which of the SDE's
+// name matches are blueprints worth querying for, and how the rows that come
+// back collapse into the lines a visitor reads. No I/O, so the rules are
+// testable on their own.
+import { reduce, sort } from 'ramda'
+
+import { BLUEPRINT_CATEGORY_ID } from '../../utils/sdeCategories.ts'
+
+import { isOriginal, rowQuantity, type BlueprintRow } from '../bpos/stack.ts'
+
+// The shape src/sdeTypes.ts's search returns, restated structurally so this
+// module pulls in no database client.
+export type TypeMatch = { typeID: number; name: string; categoryID: number | null }
+
+// A substring search over type names matches the product as readily as the
+// blueprint ("Rifter" finds both), and only the blueprint can be in a library.
+// The names ride along so the hits below can be labelled without a second
+// lookup.
+export const blueprintMatches = (results: readonly TypeMatch[]): Map<number, string> =>
+  reduce(
+    (acc: Map<number, string>, r: TypeMatch) =>
+      r.categoryID === BLUEPRINT_CATEGORY_ID ? acc.set(r.typeID, r.name) : acc,
+    new Map<number, string>(),
+    results
+  )
+
+// One line of a library's answer: a blueprint it holds, and how many.
+export type BlueprintHit = { typeId: number; name: string; quantity: number }
+
+// Rows from one library, collapsed per type. Unlike the showcase's stacking
+// this does NOT split on ME/TE — the question here is only whether a library
+// has the thing at all, so eight copies at four research levels read as "×8".
+// Copies are dropped (the showcase's own rule, re-checked here so a caller
+// that forgets the SQL filter still can't leak one), as is any type the name
+// map doesn't cover — a library row for something the search didn't ask about
+// has no business in the answer.
+export const foldHits = (rows: readonly BlueprintRow[], names: ReadonlyMap<number, string>): BlueprintHit[] => {
+  const byType = reduce(
+    (acc: Map<number, BlueprintHit>, row: BlueprintRow) => {
+      if (!isOriginal(row)) return acc
+      const typeId = Number(row.type_id)
+      const name = names.get(typeId)
+      if (name === undefined) return acc
+      const seen = acc.get(typeId)
+      if (seen) seen.quantity += rowQuantity(row)
+      else acc.set(typeId, { typeId, name, quantity: rowQuantity(row) })
+      return acc
+    },
+    new Map<number, BlueprintHit>(),
+    rows
+  )
+  return sort(
+    (a: BlueprintHit, b: BlueprintHit) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }) || a.typeId - b.typeId,
+    [...byType.values()]
+  )
+}
+
+// A one- or two-letter substring matches thousands of types and would fan out
+// into a query per chunk per library for an answer nobody could read. Three is
+// the shortest term that means anything ("orc", "web").
+export const MIN_QUERY_LENGTH = 3
+
+// One shared library's answer: where it is, who to ask, and what it holds.
+export type SharedSearchHit = {
+  key: string
+  href: string
+  label: string
+  kind: 'corporation' | 'account'
+  // Who published it: for a corporation, the member who did; for an account,
+  // the owner themselves.
+  sharedBy: string | null
+  hits: BlueprintHit[]
+}
+
+export type SharedSearchResult = {
+  // Echoed back so a stale response can be recognised by the caller.
+  query: string
+  // No shared libraries at all — a different answer from "nobody has one".
+  libraries: number
+  results: SharedSearchHit[]
+}

--- a/src/app/blueprint/sharedSearch.ts
+++ b/src/app/blueprint/sharedSearch.ts
@@ -1,0 +1,145 @@
+// "Does anyone who shares a library with me have one of these?"
+//
+// The search on /blueprint, over the libraries somebody else published to us —
+// never our own, which the showcase above it already opens. Reads through the
+// service role, like /bpos does: the caller's access was settled by
+// resolveLibraries() asking corp_bpo_share and bpo_share AS the viewer, so RLS
+// has already had its say and the reads below are explicitly scoped to exactly
+// the libraries it returned.
+import { chain, groupBy, map, splitEvery, uniq } from 'ramda'
+
+import { searchSdeTypesAll } from '@/sdeTypes'
+import { createServiceClient } from '@/utils/supabase/service'
+
+import type { BlueprintRow } from '../bpos/stack'
+import { resolveLibraries, type Library } from './libraries'
+import {
+  blueprintMatches,
+  foldHits,
+  MIN_QUERY_LENGTH,
+  type SharedSearchHit,
+  type SharedSearchResult,
+} from './searchHits'
+
+// PostgREST takes the type-id filter in the URL, so the list is chunked rather
+// than sent whole — `sde_search_type` caps at 1000 ids, which would overrun it.
+const CHUNK = 200
+
+const BLUEPRINT_COLUMNS = 'type_id, material_efficiency, time_efficiency, quantity, runs'
+
+const empty = (query: string): SharedSearchResult => ({ query, libraries: 0, results: [] })
+
+// Every original of the given types in one corporation's hangars. Chunked, and
+// the chunks run together — each is an independent read of an indexed column.
+const readCorp = async (corporationId: number, typeIds: number[]): Promise<BlueprintRow[]> => {
+  const pages = await Promise.all(
+    map(
+      async (ids: number[]) => {
+        const { data, error } = await createServiceClient()
+          .from('corp_blueprint')
+          .select(BLUEPRINT_COLUMNS)
+          .eq('corporation_id', corporationId)
+          .eq('runs', -1)
+          .in('type_id', ids)
+          .returns<BlueprintRow[]>()
+        if (error) {
+          console.error(`[blueprint] shared corp search failed: ${error.message}`)
+          return []
+        }
+        return data ?? []
+      },
+      splitEvery(CHUNK, typeIds)
+    )
+  )
+  return chain((rows: BlueprintRow[]) => rows, pages)
+}
+
+// The same, pooled across every character on an account.
+const readAccount = async (registrationIds: string[], typeIds: number[]): Promise<BlueprintRow[]> => {
+  if (registrationIds.length === 0) return []
+  const pages = await Promise.all(
+    map(
+      async (ids: number[]) => {
+        const { data, error } = await createServiceClient()
+          .from('character_blueprint')
+          .select(BLUEPRINT_COLUMNS)
+          .in('registration_id', registrationIds)
+          .eq('runs', -1)
+          .in('type_id', ids)
+          .returns<BlueprintRow[]>()
+        if (error) {
+          console.error(`[blueprint] shared account search failed: ${error.message}`)
+          return []
+        }
+        return data ?? []
+      },
+      splitEvery(CHUNK, typeIds)
+    )
+  )
+  return chain((rows: BlueprintRow[]) => rows, pages)
+}
+
+// user_id → its registrations, for every account library in one read.
+const registrationsByUser = async (userIds: string[]): Promise<Map<string, string[]>> => {
+  if (userIds.length === 0) return new Map()
+  const { data, error } = await createServiceClient()
+    .from('registration')
+    .select('id, user_id')
+    .in('user_id', userIds)
+    .returns<Array<{ id: string; user_id: string }>>()
+  if (error) {
+    console.error(`[blueprint] shared account registrations failed: ${error.message}`)
+    return new Map()
+  }
+  return new Map(
+    map(
+      ([userId, regs = []]) => [userId, map((r: { id: string }) => r.id, regs)] as [string, string[]],
+      Object.entries(groupBy((r: { user_id: string }) => r.user_id, data ?? []))
+    )
+  )
+}
+
+export const searchSharedBlueprints = async (query: string): Promise<SharedSearchResult> => {
+  const trimmed = query.trim()
+  if (trimmed.length < MIN_QUERY_LENGTH) return empty(trimmed)
+
+  const { shared } = await resolveLibraries()
+  if (shared.length === 0) return empty(trimmed)
+
+  // Narrow to blueprint type ids FIRST, so each library is asked an indexed
+  // `type_id in (…)` rather than scanned whole.
+  const names = blueprintMatches(await searchSdeTypesAll(trimmed))
+  const typeIds = [...names.keys()]
+  if (typeIds.length === 0) return { query: trimmed, libraries: shared.length, results: [] }
+
+  const userIds = uniq(chain((l: Library) => (l.subject.kind === 'account' ? [l.subject.userId] : []), shared))
+  const regsByUser = await registrationsByUser(userIds)
+
+  const answered = await Promise.all(
+    map(async (library: Library): Promise<SharedSearchHit[]> => {
+      const rows =
+        library.subject.kind === 'corporation'
+          ? await readCorp(library.subject.corporationId, typeIds)
+          : await readAccount(regsByUser.get(library.subject.userId) ?? [], typeIds)
+      const hits = foldHits(rows, names)
+      return hits.length === 0
+        ? []
+        : [
+            {
+              key: library.key,
+              href: library.href,
+              label: library.label,
+              kind: library.subject.kind,
+              sharedBy: library.sharedBy,
+              hits,
+            },
+          ]
+    }, shared)
+  )
+
+  return {
+    query: trimmed,
+    libraries: shared.length,
+    results: chain((hit: SharedSearchHit[]) => hit, answered),
+  }
+}

--- a/src/app/blueprint/sharedSearchBox.tsx
+++ b/src/app/blueprint/sharedSearchBox.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useRef, useState } from 'react'
+
+import { searchShared } from './actions'
+import { MIN_QUERY_LENGTH, type SharedSearchResult } from './searchHits'
+
+const DEBOUNCE_MS = 500
+
+// "Has anyone shared one of these with me?" — a substring typed here is matched
+// case-insensitively against every blueprint in the libraries listed below, and
+// each answer names who to ask for it.
+export const SharedSearchBox = () => {
+  const [query, setQuery] = useState('')
+  const [result, setResult] = useState<SharedSearchResult | null>(null)
+  const [searching, setSearching] = useState(false)
+  const timeoutRef = useRef<number | undefined>(undefined)
+  // Tracks the latest issued query so a slow response can't clobber a newer one.
+  const latestRef = useRef('')
+
+  const runSearch = (term: string) => {
+    const trimmed = term.trim()
+    latestRef.current = trimmed
+    if (trimmed.length < MIN_QUERY_LENGTH) {
+      setResult(null)
+      setSearching(false)
+      return
+    }
+    setSearching(true)
+    searchShared(trimmed).then((found) => {
+      if (latestRef.current !== trimmed) return
+      setResult(found)
+      setSearching(false)
+    })
+  }
+
+  // Debounced: fires on its own a short while after typing stops.
+  useEffect(() => {
+    if (timeoutRef.current) window.clearTimeout(timeoutRef.current)
+    if (query.trim().length < MIN_QUERY_LENGTH) {
+      runSearch('')
+      return
+    }
+    timeoutRef.current = window.setTimeout(() => runSearch(query), DEBOUNCE_MS)
+    return () => window.clearTimeout(timeoutRef.current)
+  }, [query])
+
+  const onManualSearch = () => {
+    if (timeoutRef.current) window.clearTimeout(timeoutRef.current)
+    runSearch(query)
+  }
+
+  return (
+    <>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          onManualSearch()
+        }}
+      >
+        <input
+          type="text"
+          value={query}
+          placeholder="Search shared libraries…"
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <button type="submit" disabled={query.trim().length < MIN_QUERY_LENGTH || searching}>
+          {searching ? 'Searching…' : 'Search'}
+        </button>
+      </form>
+      {result != null && !searching && result.results.length === 0 && (
+        <p>No shared library holds a blueprint matching “{result.query}”.</p>
+      )}
+      {result != null &&
+        result.results.map((library) => (
+          <div key={library.key}>
+            <p>
+              <Link href={library.href}>{library.label}</Link>
+              {library.kind === 'corporation'
+                ? library.sharedBy
+                  ? ` — shared by ${library.sharedBy}`
+                  : ' — a corporation library'
+                : ''}
+            </p>
+            <ul>
+              {library.hits.map((hit) => (
+                <li key={hit.typeId}>
+                  <Link href={`/blueprint/${hit.typeId}`}>{hit.name}</Link>
+                  {hit.quantity > 1 ? ` ×${hit.quantity}` : ''}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+    </>
+  )
+}

--- a/test/blueprintSearchHits.test.ts
+++ b/test/blueprintSearchHits.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { blueprintMatches, foldHits, MIN_QUERY_LENGTH, type TypeMatch } from '../src/app/blueprint/searchHits.ts'
+import type { BlueprintRow } from '../src/app/bpos/stack.ts'
+
+const match = (over: Partial<TypeMatch> = {}): TypeMatch => ({
+  typeID: 681,
+  name: 'Rifter Blueprint',
+  categoryID: 9,
+  ...over,
+})
+
+const row = (over: Partial<BlueprintRow> = {}): BlueprintRow => ({
+  type_id: 681,
+  material_efficiency: 0,
+  time_efficiency: 0,
+  quantity: -1,
+  runs: -1,
+  ...over,
+})
+
+describe('blueprintMatches', () => {
+  it('keeps only the blueprint category', () => {
+    const names = blueprintMatches([match(), match({ typeID: 587, name: 'Rifter', categoryID: 6 })])
+    assert.deepEqual([...names], [[681, 'Rifter Blueprint']])
+  })
+
+  it('drops a type the mirror gives no category', () => {
+    assert.equal(blueprintMatches([match({ categoryID: null })]).size, 0)
+  })
+
+  it('is empty for no results', () => {
+    assert.equal(blueprintMatches([]).size, 0)
+  })
+})
+
+describe('foldHits', () => {
+  const names = new Map([
+    [681, 'Rifter Blueprint'],
+    [645, 'Dominix Blueprint'],
+  ])
+
+  it('collapses the same blueprint across research levels into one line', () => {
+    const hits = foldHits([row(), row({ material_efficiency: 10, time_efficiency: 20 }), row({ quantity: 6 })], names)
+    assert.deepEqual(hits, [{ typeId: 681, name: 'Rifter Blueprint', quantity: 8 }])
+  })
+
+  it('counts an unresearched stack by its quantity and a singleton as one', () => {
+    assert.equal(foldHits([row({ quantity: 8 })], names)[0].quantity, 8)
+    assert.equal(foldHits([row({ quantity: -1 })], names)[0].quantity, 1)
+  })
+
+  it('drops copies even when SQL forgot to', () => {
+    assert.deepEqual(foldHits([row({ runs: 10, quantity: -2 })], names), [])
+  })
+
+  it('drops a row the search never asked about', () => {
+    assert.deepEqual(foldHits([row({ type_id: 999 })], names), [])
+  })
+
+  it('orders by name, case-insensitively', () => {
+    const hits = foldHits([row(), row({ type_id: 645 })], names)
+    assert.deepEqual(
+      hits.map((h) => h.name),
+      ['Dominix Blueprint', 'Rifter Blueprint']
+    )
+  })
+
+  it('normalizes ids arriving from PostgREST as strings', () => {
+    assert.deepEqual(foldHits([row({ type_id: '681', quantity: '3', runs: '-1' })], names), [
+      { typeId: 681, name: 'Rifter Blueprint', quantity: 3 },
+    ])
+  })
+})
+
+describe('MIN_QUERY_LENGTH', () => {
+  it('is short enough for a real term but long enough to narrow', () => {
+    assert.equal(MIN_QUERY_LENGTH, 3)
+  })
+})


### PR DESCRIPTION
The list on `/blueprint` answers "whose libraries can I open". It does not answer the question anyone actually arrives with, which is "does one of them have the thing I need" — a visitor had to open each showcase in turn and search it by eye.

So a box now sits between the two lists: type a substring, and every library somebody published to us is searched case-insensitively for a blueprint whose name contains it. Each answer names where to go for it — the player whose originals those are, or the corporation plus the member who published its library — and links both the showcase and each blueprint.

### How it reads

The type names are resolved from the SDE first (`sde_search_type`, which is already a case-insensitive substring match) and narrowed to the blueprint category; the libraries are then asked an indexed `type_id in (…)`, rather than every library being read whole and filtered in JS. The id list is chunked at 200 because PostgREST carries it in the URL and the RPC can return up to 1000.

Three characters minimum: a one- or two-letter substring matches thousands of types and fans out into a query per chunk per library for an answer nobody could read.

### Access

Reads go through the service role exactly as `/bpos` does, scoped to the libraries the viewer's own session already proved they may open — `corp_bpo_share` and `bpo_share` are still asked as the viewer, so RLS decides access and this code only spends it. Our own libraries are deliberately not searched: the list above the box already opens them.

### Shape

- `src/app/blueprint/libraries.ts` — the library resolution, moved out of the page since the search needs the same set. It now carries the subject (which table, which id) and, for a corporation, who published it (`corp_bpo_share.created_by` → that account's main).
- `src/app/blueprint/searchHits.ts` — the pure half: the blueprint-category filter and the fold that collapses rows into lines. Unlike the showcase's stacking this does not split on ME/TE — the question is only whether a library has the thing at all. Tested.
- `src/app/blueprint/sharedSearch.ts` — the reads.
- `src/app/blueprint/sharedSearchBox.tsx` — the debounced box, same shape as the existing `TypeSearch`.

### Verification

`pnpm run lint`, `pnpm test` (552 pass, 9 new), `pnpm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Eh71M22uC6MZaFErV73tZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012Eh71M22uC6MZaFErV73tZ)_