### PR TITLE
fix(shipping): drop the queue explainer from the freight loader

### DIFF
--- a/src/app/asset/shipping/shippingCalculator.tsx
+++ b/src/app/asset/shipping/shippingCalculator.tsx
@@ -41,11 +41,7 @@ const Pending = () => (
     <span className={styles.srOnly} role="status">
       Pricing…
     </span>
-    <p className={styles.pendingLabel}>
-      Appraising and quoting freight…
-      <br />
-      <span className={styles.muted}>Appraisals share one queue site-wide, so this can wait its turn.</span>
-    </p>
+    <p className={styles.pendingLabel}>Appraising and quoting freight…</p>
     <SkeletonLines count={6} />
   </div>
 )


### PR DESCRIPTION
## What

Removes the second line from the `/asset/shipping` loading state:

> Appraisals share one queue site-wide, so this can wait its turn.

The loader now reads just `Appraising and quoting freight…`.

## Why

That sentence describes backend plumbing — how appraisals are throttled through a shared Vercel queue. It isn't something the user can act on while waiting, and it invites the question "whose turn am I behind?" which the page can't answer. The remaining line already says what's happening.

## Notes for the reviewer

- One-file change; `styles.muted` is still used in `page.tsx` and `shippingResults.tsx`, so the CSS class stays.
- The near-identical sentence on `/asset/[locationId]` (`appraisalPanel.tsx:141`) is a `title` tooltip rather than visible copy, and is deliberately left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)