### PR TITLE
Add a click-to-copy EFT export to the fitting page

### DIFF
--- a/src/app/fitting/[characterId]/[fittingId]/page.tsx
+++ b/src/app/fitting/[characterId]/[fittingId]/page.tsx
@@ -7,11 +7,13 @@ import { establishedUser } from '../../../account/lib/establishedUser'
 import { createServiceClient } from '@/utils/supabase/service'
 import { ShipFitViewDynamic } from '../../../ship/[itemId]/shipFitViewDynamic'
 import { Name } from '../../../names'
-import { fetchTypeNames } from '../../../typeNames'
+import { getSdeTypes } from '@/sdeTypes'
 import { ShareDialog } from '../../../asset/shareDialog'
 import { ShareUrlCleanup } from '../../../shareUrlCleanup'
 import { verifySignedFittingShare } from '../../access'
 import { saveFittingShare, revokeFittingShare } from '../../actions'
+import { EftExport } from '../../eftExport'
+import { toEft, type EftType } from '../../eft'
 import { toEsiFit, type FittingItem, type FittingRow } from '../../fit'
 import { resolveFittingOwner } from '../../resolveCharacter'
 import { fetchFittingShareDialogData } from '../../shareData'
@@ -76,7 +78,15 @@ const FittingDetailPage = async ({
   if (!fit) notFound()
 
   const items: FittingItem[] = fit.items ?? []
-  const typeNames = await fetchTypeNames([Number(fit.ship_type_id), ...items.map((i) => Number(i.type_id))])
+  // Categories ride along with the names because the EFT export needs them:
+  // a charge shares its module's slot flag in an ESI fitting, and only the
+  // category tells the two apart (src/app/fitting/eft.ts).
+  const sdeTypes = await getSdeTypes([Number(fit.ship_type_id), ...items.map((i) => Number(i.type_id))])
+  const entries = Object.values(sdeTypes)
+  const types: Record<number, EftType> = Object.fromEntries(
+    entries.map((t) => [t.typeID, { name: t.name, categoryID: t.categoryID }])
+  )
+  const typeNames: Record<number, string> = Object.fromEntries(entries.map((t) => [t.typeID, t.name]))
   const hull = typeNames[Number(fit.ship_type_id)] ?? `#${fit.ship_type_id}`
 
   // resolveFittingOwner set this from `registration`, which RLS scopes to the
@@ -131,6 +141,8 @@ const FittingDetailPage = async ({
       <ShipFitViewDynamic esiFit={toEsiFit(fit)} />
 
       <SlotGroups items={items} typeNames={typeNames} />
+
+      <EftExport eft={toEft(fit, types)} />
     </div>
   )
 }

--- a/src/app/fitting/eft.ts
+++ b/src/app/fitting/eft.ts
@@ -1,0 +1,120 @@
+import { ascend, sortWith } from 'ramda'
+
+import type { FittingItem } from './fit'
+
+// EFT format — the plain-text fitting notation the in-game fitting window
+// reads from the clipboard ("Import from clipboard"), and what every third
+// party (Pyfa, zkillboard, forum posts) speaks:
+//
+//   [Rifter, Shield Rifter]
+//
+//   Nanofiber Internal Structure II
+//   [Empty Low slot]
+//
+//   5MN Y-T8 Compact Microwarpdrive
+//
+//   200mm AutoCannon II, Republic Fleet EMP S
+//
+//   Small Projectile Burst Aerator II
+//
+//
+//   Warrior II x2
+//
+//   Nanite Repair Paste x50
+//
+// Blocks run low → mid → high → rig → subsystem → service, then the bays and
+// cargo, separated by blank lines. The block order is the importer's contract:
+// it has no slot labels to go on, so it counts blank lines.
+
+// The SDE categories this needs to tell apart. A charge shares its module's
+// slot flag in an ESI fitting (that's how ESI says "loaded into"), so the two
+// are only separable by category — and EFT wants them on one line, joined by
+// a comma, rather than as two entries.
+const CHARGE_CATEGORY_ID = 8
+
+export type EftType = { name: string; categoryID: number | null }
+
+// The fitted-slot blocks, in EFT's order. `empty` is the placeholder line the
+// game itself writes for a slot the hull has but the fit leaves open.
+const SLOT_BLOCKS: Array<{ prefix: string; empty: string }> = [
+  { prefix: 'LoSlot', empty: '[Empty Low slot]' },
+  { prefix: 'MedSlot', empty: '[Empty Med slot]' },
+  { prefix: 'HiSlot', empty: '[Empty High slot]' },
+  { prefix: 'RigSlot', empty: '[Empty Rig slot]' },
+  { prefix: 'SubSystemSlot', empty: '[Empty Subsystem slot]' },
+  { prefix: 'ServiceSlot', empty: '[Empty Service slot]' },
+]
+
+// The trailing quantity blocks, in EFT's order. Everything here is written
+// "Name xN" rather than one line per unit.
+const BAY_BLOCKS: Array<{ prefix: string }> = [{ prefix: 'DroneBay' }, { prefix: 'FighterBay' }, { prefix: 'Cargo' }]
+
+const nameOf = (types: Record<number, EftType>, typeID: number): string =>
+  types[typeID]?.name ?? `[Unknown type ${typeID}]`
+
+const isCharge = (types: Record<number, EftType>, typeID: number): boolean =>
+  types[typeID]?.categoryID === CHARGE_CATEGORY_ID
+
+// The numeric suffix on a slot flag (HiSlot3 → 3). Anything unparseable sorts
+// to the front rather than throwing off the whole block.
+const slotIndex = (flag: string, prefix: string): number => {
+  const n = Number.parseInt(flag.slice(prefix.length), 10)
+  return Number.isFinite(n) ? n : 0
+}
+
+// One fitted-slot block. Empty indices *below* the highest occupied one are
+// real holes in the fit and get a placeholder; anything above it is unknowable
+// from the fitting alone (ESI never says how many slots the hull has), so the
+// block simply ends. The importer is happy either way — it fills the rest.
+const slotBlock = (items: FittingItem[], types: Record<number, EftType>, prefix: string, empty: string): string[] => {
+  const inBlock = items.filter((item) => item.flag.startsWith(prefix))
+  if (inBlock.length === 0) return []
+
+  const highest = inBlock.reduce((max, item) => Math.max(max, slotIndex(item.flag, prefix)), 0)
+
+  return Array.from({ length: highest + 1 }, (_unused, index) => {
+    const atIndex = inBlock.filter((item) => slotIndex(item.flag, prefix) === index)
+    const module = atIndex.find((item) => !isCharge(types, Number(item.type_id)))
+    const charge = atIndex.find((item) => isCharge(types, Number(item.type_id)))
+    if (!module) return empty
+    const moduleName = nameOf(types, Number(module.type_id))
+    return charge ? `${moduleName}, ${nameOf(types, Number(charge.type_id))}` : moduleName
+  })
+}
+
+// One bay/cargo block. Identical stacks are folded together so a drone bay
+// holding five Warrior IIs across two rows reads as one "Warrior II x5" line,
+// the way the game writes it.
+const bayBlock = (items: FittingItem[], types: Record<number, EftType>, prefix: string): string[] => {
+  const inBlock = items.filter((item) => item.flag.startsWith(prefix))
+  if (inBlock.length === 0) return []
+
+  const stacked = inBlock.reduce<Map<number, number>>((acc, item) => {
+    const typeID = Number(item.type_id)
+    acc.set(typeID, (acc.get(typeID) ?? 0) + Number(item.quantity ?? 1))
+    return acc
+  }, new Map())
+
+  const rows = Array.from(stacked, ([typeID, quantity]) => ({ name: nameOf(types, typeID), quantity }))
+  return sortWith([ascend((row: { name: string }) => row.name)], rows).map(
+    ({ name, quantity }) => `${name} x${quantity}`
+  )
+}
+
+// The whole fit as EFT text. Pure — the caller resolves the type names and
+// categories (SDE) and hands them in.
+export const toEft = (
+  fit: { name: string | null; ship_type_id: number | string; items: FittingItem[] | null },
+  types: Record<number, EftType>
+): string => {
+  const items = fit.items ?? []
+  const hull = nameOf(types, Number(fit.ship_type_id))
+  const title = fit.name?.trim() || hull
+
+  const blocks = [
+    ...SLOT_BLOCKS.map(({ prefix, empty }) => slotBlock(items, types, prefix, empty)),
+    ...BAY_BLOCKS.map(({ prefix }) => bayBlock(items, types, prefix)),
+  ].filter((block) => block.length > 0)
+
+  return [`[${hull}, ${title}]`, ...blocks.map((block) => block.join('\n'))].join('\n\n')
+}

--- a/src/app/fitting/eftExport.tsx
+++ b/src/app/fitting/eftExport.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { useRef, useState } from 'react'
+
+import styles from './fittings.module.css'
+
+// The EFT block at the foot of a fitting page. Click it and the whole export
+// lands on the clipboard, ready for the in-game fitting window's "Import from
+// clipboard" — the textarea is read-only and selects itself so a click is the
+// whole interaction, and a manual ⌘A/⌘C still works if the clipboard API is
+// denied (insecure context, permission refused).
+export const EftExport = ({ eft }: { eft: string }) => {
+  const [copied, setCopied] = useState(false)
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const flash = () => {
+    setCopied(true)
+    if (resetTimer.current) clearTimeout(resetTimer.current)
+    resetTimer.current = setTimeout(() => setCopied(false), 2000)
+  }
+
+  const onClick = async (event: React.MouseEvent<HTMLTextAreaElement>) => {
+    event.currentTarget.select()
+    try {
+      await navigator.clipboard.writeText(eft)
+      flash()
+    } catch {
+      // Selection is already made, so the fallback is a manual copy — nothing
+      // to alert about.
+    }
+  }
+
+  return (
+    <div className={styles.eftExport}>
+      <div className={styles.eftHeader}>
+        <span className={styles.slotLabel}>EFT export</span>
+        <span className={styles.eftHint} aria-live="polite">
+          {copied ? 'Copied' : 'Click to copy'}
+        </span>
+      </div>
+      <textarea
+        className={styles.eftText}
+        value={eft}
+        readOnly
+        spellCheck={false}
+        rows={Math.min(eft.split('\n').length + 1, 30)}
+        onClick={onClick}
+        onFocus={(event) => event.currentTarget.select()}
+        aria-label="Fitting in EFT format — click to copy"
+      />
+    </div>
+  )
+}

--- a/src/app/fitting/fittings.module.css
+++ b/src/app/fitting/fittings.module.css
@@ -240,3 +240,41 @@
   color: var(--ink-faint);
   white-space: nowrap;
 }
+
+/* The EFT export block at the foot of a fitting page: the whole fit as the
+ * plain text the in-game fitting window imports. Read-only and click-to-copy. */
+.eftExport {
+  margin: 24px 0;
+}
+
+.eftHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.eftHint {
+  font-size: 11px;
+  color: var(--ink-faint);
+}
+
+.eftText {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--paper-raised);
+  color: var(--ink-soft);
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre;
+  overflow-wrap: normal;
+  overflow-x: auto;
+  cursor: pointer;
+}

--- a/test/fittingEft.test.ts
+++ b/test/fittingEft.test.ts
@@ -1,0 +1,109 @@
+// The EFT export at the foot of a fitting page (src/app/fitting/eft.ts). The
+// text is the interoperability contract — the in-game fitting window imports
+// it by counting blank-line-separated blocks, with no labels to go on — so the
+// exact shape is worth pinning.
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { toEft, type EftType } from '../src/app/fitting/eft.ts'
+
+const types: Record<number, EftType> = {
+  587: { name: 'Rifter', categoryID: 6 },
+  2873: { name: 'Nanofiber Internal Structure II', categoryID: 7 },
+  5973: { name: '5MN Y-T8 Compact Microwarpdrive', categoryID: 7 },
+  2977: { name: '200mm AutoCannon II', categoryID: 7 },
+  21896: { name: 'Republic Fleet EMP S', categoryID: 8 },
+  31153: { name: 'Small Projectile Burst Aerator II', categoryID: 7 },
+  2488: { name: 'Warrior II', categoryID: 18 },
+  28668: { name: 'Nanite Repair Paste', categoryID: 4 },
+}
+
+test('toEft writes the blocks in the importer’s order', () => {
+  const eft = toEft(
+    {
+      name: 'Shield Rifter',
+      ship_type_id: 587,
+      items: [
+        { type_id: 2977, flag: 'HiSlot0', quantity: 1 },
+        // A charge shares its module's flag — EFT joins the two on one line.
+        { type_id: 21896, flag: 'HiSlot0', quantity: 100 },
+        { type_id: 5973, flag: 'MedSlot0', quantity: 1 },
+        { type_id: 2873, flag: 'LoSlot0', quantity: 1 },
+        { type_id: 31153, flag: 'RigSlot0', quantity: 1 },
+        { type_id: 2488, flag: 'DroneBay', quantity: 2 },
+        { type_id: 28668, flag: 'Cargo', quantity: 50 },
+      ],
+    },
+    types
+  )
+
+  assert.equal(
+    eft,
+    [
+      '[Rifter, Shield Rifter]',
+      '',
+      'Nanofiber Internal Structure II',
+      '',
+      '5MN Y-T8 Compact Microwarpdrive',
+      '',
+      '200mm AutoCannon II, Republic Fleet EMP S',
+      '',
+      'Small Projectile Burst Aerator II',
+      '',
+      'Warrior II x2',
+      '',
+      'Nanite Repair Paste x50',
+    ].join('\n')
+  )
+})
+
+test('a gap below the highest fitted slot becomes an empty-slot placeholder', () => {
+  // LoSlot1 is unfitted between two fitted lows: the importer counts lines, so
+  // the hole has to be written out or the third module lands in slot two.
+  const eft = toEft(
+    {
+      name: null,
+      ship_type_id: 587,
+      items: [
+        { type_id: 2873, flag: 'LoSlot0', quantity: 1 },
+        { type_id: 2873, flag: 'LoSlot2', quantity: 1 },
+      ],
+    },
+    types
+  )
+
+  // No fit name falls back to the hull, the way an unnamed fit exports.
+  assert.equal(
+    eft,
+    [
+      '[Rifter, Rifter]',
+      '',
+      'Nanofiber Internal Structure II',
+      '[Empty Low slot]',
+      'Nanofiber Internal Structure II',
+    ].join('\n')
+  )
+})
+
+test('identical bay stacks fold into one quantity line', () => {
+  const eft = toEft(
+    {
+      name: 'Drones',
+      ship_type_id: 587,
+      items: [
+        { type_id: 2488, flag: 'DroneBay', quantity: 2 },
+        { type_id: 2488, flag: 'DroneBay', quantity: 3 },
+      ],
+    },
+    types
+  )
+  assert.equal(eft, ['[Rifter, Drones]', '', 'Warrior II x5'].join('\n'))
+})
+
+test('an unmirrored type still exports, rather than dropping a slot', () => {
+  const eft = toEft(
+    { name: 'Mystery', ship_type_id: 587, items: [{ type_id: 999999, flag: 'HiSlot0', quantity: 1 }] },
+    types
+  )
+  assert.equal(eft, ['[Rifter, Mystery]', '', '[Unknown type 999999]'].join('\n'))
+})


### PR DESCRIPTION
The fitting page rendered a fit in the wheel and itemized it as text, but there was no way to get it back into the game. This adds an EFT block at the foot of `/fitting/[characterId]/[fittingId]`: a read-only textarea carrying the fit in the plain-text notation the in-game fitting window reads from the clipboard. Clicking it selects the whole export and copies it (a manual ⌘A/⌘C still works if the clipboard API is denied — insecure context, permission refused — since the selection is already made).

```
[Rifter, Shield Rifter]

Nanofiber Internal Structure II
[Empty Low slot]

5MN Y-T8 Compact Microwarpdrive

200mm AutoCannon II, Republic Fleet EMP S

Small Projectile Burst Aerator II

Warrior II x2

Nanite Repair Paste x50
```

## The format is a contract, so it's a pure seam

The importer has no slot labels to go on — it counts blank-line-separated blocks, in the order low → mid → high → rig → subsystem → service → drone bay → fighter bay → cargo. `src/app/fitting/eft.ts` is therefore pure and tested (`test/fittingEft.test.ts`), with two details it has to get right:

- **A charge shares its module's slot flag** in an ESI fitting — that's how ESI says "loaded into" — so the two are only separable by SDE category (8 = Charge), and EFT joins them on one line: `200mm AutoCannon II, Republic Fleet EMP S`.
- **An unfitted slot below the highest occupied one is a real hole** and must be written out as `[Empty Low slot]`, or every module after it shifts up a slot on import. Slots *above* the highest occupied one are unknowable from a fitting alone (ESI never says how many the hull has), so the block simply ends and the importer fills the rest.

Identical bay stacks fold into one `Name xN` line, and a type the SDE mirror doesn't know renders as `[Unknown type 12345]` rather than silently dropping a slot and shifting everything after it.

## Type lookup

The page now resolves types through `getSdeTypes` rather than `fetchTypeNames`, since the exporter needs the categories; the names the page already used ride along from the same lookup, so this is not an extra round trip.

## Testing

- `pnpm test` — 564 pass (4 new)
- `pnpm run lint`, `pnpm run build` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdiAWfVCU4meC4hLyN2xtS)_