### PR TITLE
feat(link): filter assets by the hangar they sit in

### DIFF
--- a/docs/sharing-layer/10-hangar-filter.md
+++ b/docs/sharing-layer/10-hangar-filter.md
@@ -1,0 +1,62 @@
+# Hangar filter: `hangar:` / `hangars:` on the GraphQL lists
+
+**Status: ✅ done** — `hangar`/`hangars` ship on `assets`, `restock` and
+`blueprints` in `schema.graphql.ts`/`resolvers.ts` over the pure seam
+`src/app/api/graphql/hangarFlags.ts`, with `test/graphqlHangar.test.ts` and the
+`test/graphqlSchema.test.ts` drift guard covering them.
+
+## Context
+
+A Link could already ask "what do I have **at** TK-DLH" (`location:`), but not
+"what is sitting **in** the Deliveries hangar" — the compartment a stack sits
+in, which is what tells you a courier dropped something off and nobody has
+unpacked it. The column was always in the response (`Asset.locationFlag`,
+`Blueprint.locationFlag`); there was simply no way to filter on it, and a Link
+viewer cannot post-filter — a Link renders whatever its stored query returns.
+
+`location_flag` is ESI's raw token, stored verbatim by the extract jobs
+(`Deliveries`, `CorpDeliveries`, `CorpSAG1`…`CorpSAG7`, `DroneBay`, …). Two
+things make it unlike every other filter dimension:
+
+- **There is no directory to resolve a name against.** Types have the SDE,
+  locations have the structure caches, owners have the caller's registrations.
+  Flags have nothing — no table, no view, no ESI endpoint.
+- **A character's Deliveries hangar and a corporation's are different
+  tokens.** `Deliveries` vs `CorpDeliveries`. Someone asking for "deliveries"
+  means both, and can't be expected to know either token exists.
+
+## Design
+
+`hangarFlags.ts` carries the catalog — flag token, the label the site would use,
+and the aliases people type — and **the catalog is the directory**. It follows
+the schema's singular/plural stance unchanged (`filters.ts`):
+
+- `hangar:` — case-insensitive **substring** over token, label and aliases,
+  keeping every flag it matched. `"deliveries"` → `Deliveries` **and**
+  `CorpDeliveries`; `"corp hangar"` → all seven divisions.
+- `hangars:` — an **exact** list of whole tokens, labels or aliases, mixed. One
+  entry may still resolve to several flags (the `Deliveries` alias sits on both
+  delivery hangars), the way an exact location name can name two stations.
+- The two are mutually exclusive, and an entry matching nothing is an **error**
+  listing the catalog — never a silently empty hangar, which is what a typo
+  would otherwise look like.
+
+That last rule makes the catalog load-bearing: a flag missing from it cannot be
+filtered by, so a bay worth filtering gets an entry there and a line in the
+test. The alternative — passing an arbitrary string straight to
+`.in('location_flag', …)` — accepts anything and returns nothing for a typo,
+which for a link nobody re-reads for a year is the worse failure.
+
+The resolvers push it down as one more `.in()` on the same builder the type and
+location filters use, on both owner sides, on the head-count and the row pages
+alike. It is on the three lists whose rows carry a flag — `assets`, the
+`restock` sum over them, and `blueprints`; an order, a job or a transaction
+names a place, not a compartment.
+
+## Surfaces
+
+- `assets(hangar: "Deliveries")` — the **Deliveries hangars** link template
+  (`src/app/link/templates.ts`), offered by the `/link` picker, the `/graphql`
+  examples and the MCP `link_schema` examples, since all three read that list.
+- `restock(hangar: …)` — narrows which hangars count as "on hand", so a buffer
+  can be measured over a staging division rather than everything you own.

--- a/src/app/api/graphql/hangarFlags.ts
+++ b/src/app/api/graphql/hangarFlags.ts
@@ -1,0 +1,145 @@
+// The HANGAR dimension of the GraphQL filters: which hangar (ESI's
+// `location_flag`) a stack sits in — a personal hangar, a Deliveries hangar,
+// one of a corporation's seven hangar divisions, or a bay inside a ship.
+// Pure, like filters.ts and restock.ts, so test/graphqlHangar.test.ts can
+// exercise it under the node test runner.
+//
+// This is the one filter dimension with NO id form and NO directory behind it:
+// `location_flag` is a raw ESI token stored verbatim by the extract jobs
+// (`Deliveries`, `CorpSAG3`, `DroneBay`), and there is no table of them to
+// resolve a name against. So the catalog below IS the directory — it maps the
+// tokens people actually mean to the tokens ESI writes, which is what lets a
+// caller say `hangar: "deliveries"` and reach BOTH `Deliveries` (a character's)
+// and `CorpDeliveries` (a corporation's) without knowing either token exists.
+//
+// It follows the schema's singular/plural stance (see filters.ts):
+//
+//   - `hangar:` is a case-insensitive SUBSTRING search over each flag's token,
+//     its label and its aliases, keeping every flag it matched — "deliveries"
+//     is both delivery hangars, "corp hangar" is all seven divisions.
+//   - `hangars:` is an EXACT list whose entries are whole tokens, labels or
+//     aliases, mixed. One entry may still resolve to several flags (the
+//     "Deliveries" alias sits on both), the way an exact location name can
+//     name two stations.
+//
+// An entry matching nothing is an ERROR rather than a silently empty result —
+// the same reason the other dimensions refuse one. That makes the catalog
+// load-bearing: a flag missing from it cannot be filtered by, so a new bay
+// worth filtering gets an entry here (and a line in the test).
+import { parseRefFilter } from './filters.ts'
+
+export type HangarFlag = {
+  // The token as ESI writes it and the extract jobs store it.
+  flag: string
+  // How the site says it — the /asset Hangar column shows the raw token, but
+  // this is what a person filtering means.
+  label: string
+  // Other whole names that reach this flag. The plural matches these whole,
+  // the singular as substrings.
+  aliases: readonly string[]
+}
+
+// The seven corporation hangar divisions, which are one flag per division
+// rather than a division argument. A corp renames them in game; we can't see
+// those names, so the number is the handle.
+const corpDivisions: HangarFlag[] = [1, 2, 3, 4, 5, 6, 7].map((n) => ({
+  flag: `CorpSAG${n}`,
+  label: `Corporation hangar division ${n}`,
+  aliases: [`corp hangar ${n}`, `corp division ${n}`, `division ${n}`, `sag${n}`],
+}))
+
+export const HANGAR_FLAGS: readonly HangarFlag[] = [
+  // Station and structure hangars — what a filter almost always means.
+  { flag: 'Hangar', label: 'Personal hangar', aliases: ['item hangar', 'personal hangar'] },
+  {
+    flag: 'Deliveries',
+    label: 'Deliveries',
+    aliases: ['deliveries', 'delivery hangar', 'personal deliveries', 'character deliveries'],
+  },
+  {
+    flag: 'CorpDeliveries',
+    label: 'Corporation deliveries',
+    aliases: ['deliveries', 'delivery hangar', 'corp deliveries', 'corporation deliveries'],
+  },
+  ...corpDivisions,
+  { flag: 'AssetSafety', label: 'Asset safety', aliases: ['asset safety wrap'] },
+  { flag: 'Impounded', label: 'Impounded', aliases: [] },
+  { flag: 'Locked', label: 'Locked (office container)', aliases: [] },
+  { flag: 'Unlocked', label: 'Unlocked (office container)', aliases: [] },
+  { flag: 'AutoFit', label: 'Auto-fit (inside a container or ship)', aliases: ['container'] },
+
+  // Bays inside a ship or structure. A stack nested in a ship carries these,
+  // so they are filterable for the same reason the ship page groups by them.
+  { flag: 'Cargo', label: 'Cargo hold', aliases: ['cargo hold', 'cargohold'] },
+  { flag: 'DroneBay', label: 'Drone bay', aliases: ['drone bay'] },
+  { flag: 'FighterBay', label: 'Fighter bay', aliases: ['fighter bay'] },
+  { flag: 'FleetHangar', label: 'Fleet hangar', aliases: ['fleet hangar'] },
+  { flag: 'ShipHangar', label: 'Ship maintenance bay', aliases: ['ship hangar', 'ship maintenance bay'] },
+  { flag: 'StructureFuel', label: 'Structure fuel bay', aliases: ['fuel bay'] },
+  { flag: 'SpecializedFuelBay', label: 'Fuel bay', aliases: ['fuel bay'] },
+  { flag: 'SpecializedOreHold', label: 'Ore hold', aliases: ['ore hold'] },
+  { flag: 'SpecializedGasHold', label: 'Gas hold', aliases: ['gas hold'] },
+  { flag: 'SpecializedMineralHold', label: 'Mineral hold', aliases: ['mineral hold'] },
+  { flag: 'SpecializedSalvageHold', label: 'Salvage hold', aliases: ['salvage hold'] },
+  { flag: 'SpecializedAmmoHold', label: 'Ammo hold', aliases: ['ammo hold'] },
+  { flag: 'SpecializedMaterialBay', label: 'Material bay', aliases: ['material bay'] },
+  { flag: 'SpecializedAsteroidHold', label: 'Asteroid hold', aliases: ['asteroid hold'] },
+  { flag: 'SpecializedIceHold', label: 'Ice hold', aliases: ['ice hold'] },
+  { flag: 'SpecializedCommandCenterHold', label: 'Command center hold', aliases: ['command center hold'] },
+  {
+    flag: 'SpecializedPlanetaryCommoditiesHold',
+    label: 'Planetary commodities hold',
+    aliases: ['planetary commodities hold', 'pi hold'],
+  },
+  { flag: 'SpecializedShipHold', label: 'Ship hold', aliases: ['ship hold'] },
+  { flag: 'SpecializedIndustrialShipHold', label: 'Industrial ship hold', aliases: ['industrial ship hold'] },
+  { flag: 'SubSystemBay', label: 'Subsystem bay', aliases: ['subsystem bay'] },
+  { flag: 'BoosterBay', label: 'Booster bay', aliases: ['booster bay'] },
+  { flag: 'QuantumCoreRoom', label: 'Quantum core room', aliases: ['quantum core room', 'core room'] },
+  { flag: 'InfrastructureHangar', label: 'Infrastructure hangar', aliases: ['infrastructure hangar'] },
+  { flag: 'Wardrobe', label: 'Wardrobe', aliases: [] },
+]
+
+// Everything one entry may be typed as, lowercased once.
+const termsOf = (entry: HangarFlag): string[] => [entry.flag, entry.label, ...entry.aliases].map((t) => t.toLowerCase())
+
+const available = (): string => HANGAR_FLAGS.map((e) => `${e.flag} (${e.label})`).join(', ')
+
+export type HangarMatch = { ok: true; flags: string[] | null } | { ok: false; message: string }
+
+// The hangar dimension → `location_flag` values to filter on, or null for no
+// filter at all. Mirrors matchOwnerFilter's shape so the resolvers treat every
+// dimension the same way.
+export const matchHangarFilter = (
+  hangar: string | null | undefined,
+  hangars: readonly string[] | null | undefined
+): HangarMatch => {
+  const parsed = parseRefFilter(hangar, hangars, 'hangar')
+  if (!parsed.ok) return { ok: false, message: parsed.message }
+  const query = parsed.query
+  if (query.kind === 'none') return { ok: true, flags: null }
+
+  if (query.kind === 'search') {
+    const wanted = query.term.toLowerCase()
+    const flags = HANGAR_FLAGS.filter((e) => termsOf(e).some((t) => t.includes(wanted))).map((e) => e.flag)
+    if (flags.length === 0) {
+      return { ok: false, message: `No hangar matched "${query.term}". Available: ${available()}.` }
+    }
+    return { ok: true, flags }
+  }
+
+  // Exact: a whole token, label or alias. One entry may still reach several
+  // flags — "Deliveries" is both a character's and a corporation's.
+  const matched = query.entries.map((entry) => {
+    const wanted = entry.toLowerCase()
+    return { entry, flags: HANGAR_FLAGS.filter((e) => termsOf(e).includes(wanted)).map((e) => e.flag) }
+  })
+  const unmatched = matched.filter((m) => m.flags.length === 0)
+  if (unmatched.length > 0) {
+    return {
+      ok: false,
+      message: `No hangar matched ${unmatched.map((m) => `"${m.entry}"`).join(', ')}. Available: ${available()}.`,
+    }
+  }
+  return { ok: true, flags: [...new Set(matched.flatMap((m) => m.flags))] }
+}

--- a/src/app/api/graphql/resolvers.ts
+++ b/src/app/api/graphql/resolvers.ts
@@ -21,6 +21,7 @@ import { guessLocationRef, resolveTypeFilter } from '@/app/api/mcp/lib'
 import { resolveLocations, type LocationRef, type ResolvedLocations } from '@/app/resolveLocations'
 import { getSdeTypes, searchSdeTypesAll, type SdeType } from '@/sdeTypes'
 import { clampLimit, matchExactNames, matchOwnerFilter, parseRefFilter, parseSince, splitRefEntries } from './filters'
+import { matchHangarFilter } from './hangarFlags'
 import { resolveLocationByTokens, searchLocationCandidates } from './locationSearch'
 import { resolveTargets, restockLines, type Stack } from './restock'
 import type { NamedRef, OwnerScopes } from './filters'
@@ -107,6 +108,15 @@ const locationIdsFor = async (
     return badRequest(`No location matched ${stillUnmatched.map((u) => `"${u}"`).join(', ')}.`)
   }
   return [...new Set([...ids, ...matched.ids, ...guessed.map(([, ref]) => (ref as NamedRef).id)])]
+}
+
+// The hangar dimension → `location_flag` values, or null for no filter. No
+// I/O: unlike the other dimensions there is no directory to resolve against,
+// so the catalog in hangarFlags.ts is the directory (and the refusal list).
+const hangarFlagsFor = (args: { hangar?: string | null; hangars?: readonly string[] | null }): string[] | null => {
+  const matched = matchHangarFilter(args.hangar, args.hangars)
+  if (!matched.ok) return badRequest(matched.message)
+  return matched.flags
 }
 
 // Page a filtered select up to `cap` rows — PostgREST caps a single request at
@@ -402,6 +412,8 @@ export const resolvers = {
         types?: readonly string[] | null
         location?: string | null
         locations?: readonly string[] | null
+        hangar?: string | null
+        hangars?: readonly string[] | null
         owner?: string | null
         owners?: readonly string[] | null
         limit?: number | null
@@ -422,6 +434,7 @@ export const resolvers = {
       const scopedIds = [...scopes.registrationIds, ...sharedIds]
       const typeIds = await typeIdsFor(args)
       const locationIds = await locationIdsFor(ctx, args)
+      const hangarFlags = hangarFlagsFor(args)
       const cap = clampLimit(args.limit, ctx.caps.asset)
 
       // The same filter set applies to the head-only count and the row pages,
@@ -431,6 +444,7 @@ export const resolvers = {
         let q = query.in(ownerColumn, ownerIds)
         if (typeIds !== null) q = q.in('type_id', typeIds)
         if (locationIds !== null) q = q.in('location_id', locationIds)
+        if (hangarFlags !== null) q = q.in('location_flag', hangarFlags)
         return q
       }
 
@@ -517,6 +531,8 @@ export const resolvers = {
         targets: ReadonlyArray<{ type: string; quantity: number }>
         location?: string | null
         locations?: readonly string[] | null
+        hangar?: string | null
+        hangars?: readonly string[] | null
         owner?: string | null
         owners?: readonly string[] | null
         onlyBelowTarget?: boolean | null
@@ -545,6 +561,7 @@ export const resolvers = {
 
       const scopes = await ownerScopesFor(ctx, args)
       const locationIds = await locationIdsFor(ctx, args)
+      const hangarFlags = hangarFlagsFor(args)
 
       // A TARGETED read: only the target types, only the two columns the sum
       // needs. Filtering by type keeps this far below the cap that paging the
@@ -553,6 +570,7 @@ export const resolvers = {
       const filtered = (query: any, ownerColumn: string, ownerIds: string[]): any => {
         let q = query.in(ownerColumn, ownerIds).in('type_id', targetTypeIds)
         if (locationIds !== null) q = q.in('location_id', locationIds)
+        if (hangarFlags !== null) q = q.in('location_flag', hangarFlags)
         return q
       }
 
@@ -655,6 +673,8 @@ export const resolvers = {
       args: {
         type?: string | null
         types?: readonly string[] | null
+        hangar?: string | null
+        hangars?: readonly string[] | null
         owner?: string | null
         owners?: readonly string[] | null
         limit?: number | null
@@ -663,6 +683,7 @@ export const resolvers = {
     ) => {
       const scopes = await ownerScopesFor(ctx, args)
       const typeIds = await typeIdsFor(args)
+      const hangarFlags = hangarFlagsFor(args)
       const cap = clampLimit(args.limit, ctx.caps.list)
 
       type BlueprintRow = {
@@ -679,8 +700,10 @@ export const resolvers = {
       }
 
       const filtered = (query: any, ownerColumn: string, ownerIds: string[]): any => {
-        const q = query.in(ownerColumn, ownerIds)
-        return typeIds !== null ? q.in('type_id', typeIds) : q
+        let q = query.in(ownerColumn, ownerIds)
+        if (typeIds !== null) q = q.in('type_id', typeIds)
+        if (hangarFlags !== null) q = q.in('location_flag', hangarFlags)
+        return q
       }
 
       const read = async (

--- a/src/app/api/graphql/schema.graphql.ts
+++ b/src/app/api/graphql/schema.graphql.ts
@@ -35,9 +35,11 @@
 // each filled only on their own side, and ownerId/ownerName coalesce the two.
 //
 // FILTERS COME IN SINGULAR/PLURAL PAIRS: owner/owners, location/locations,
-// type/types. An OWNER is a character or a corporation — one dimension, since
-// a row is owned by one or the other and asking "what do these own" shouldn't
-// care which. The singular is a
+// type/types, hangar/hangars. An OWNER is a character or a corporation — one
+// dimension, since a row is owned by one or the other and asking "what do
+// these own" shouldn't care which. A HANGAR is the compartment a stack sits in
+// (ESI's location_flag) rather than the place it sits at, so "in a Deliveries
+// hangar" is a hangar filter and "at Jita" a location one. The singular is a
 // case-insensitive substring SEARCH over names; the plural is an EXACT list
 // whose entries are ids or whole names, mixed freely. The two are mutually
 // exclusive, an entry matching nothing is an error, and each entity type's
@@ -53,9 +55,12 @@ export const typeDefs = /* GraphQL */ `
     """
     Current asset rows (live inventory) across your characters AND the
     corporations they belong to. Filters are the schema's singular/plural pairs
-    — type/types, location/locations, owner/owners, where an owner is a
-    character OR a corporation (see Owner and Corporation). includeShared
-    additionally
+    — type/types, location/locations, hangar/hangars, owner/owners, where an
+    owner is a character OR a corporation (see Owner and Corporation).
+    hangar/hangars narrow to the HANGAR a stack sits in rather than the place
+    it sits at, so \`hangar: "Deliveries"\` is everything waiting in a delivery
+    hangar — a character's and a corporation's alike (see locationFlag on
+    Asset). includeShared additionally
     returns rows other users have shared with you (session auth only — the
     api_token path is own-data only; a Link is the way to hand shared data to
     external tools).
@@ -65,6 +70,8 @@ export const typeDefs = /* GraphQL */ `
       types: [String!]
       location: String
       locations: [String!]
+      hangar: String
+      hangars: [String!]
       owner: String
       owners: [String!]
       limit: Int
@@ -75,9 +82,10 @@ export const typeDefs = /* GraphQL */ `
     A restock (shopping) list. You give TARGETS — an item type and the quantity
     you want on hand — and each line sums your current stacks of that type
     (across your characters AND their corporations, like assets) and reports
-    what you're missing. location/locations and owner/owners narrow which
-    hangars count as "on hand", exactly as they do on assets; the types come
-    from the targets, so there is no type filter here.
+    what you're missing. location/locations, hangar/hangars and owner/owners
+    narrow which hangars count as "on hand", exactly as they do on assets; the
+    types come from the targets, so there is no type filter here. Counting only
+    what is sitting in a delivery hangar is \`hangar: "Deliveries"\`.
 
     By default only lines below target come back; onlyBelowTarget: false keeps
     every target, including the covered ones.
@@ -86,6 +94,8 @@ export const typeDefs = /* GraphQL */ `
       targets: [RestockTarget!]!
       location: String
       locations: [String!]
+      hangar: String
+      hangars: [String!]
       owner: String
       owners: [String!]
       onlyBelowTarget: Boolean = true
@@ -94,8 +104,16 @@ export const typeDefs = /* GraphQL */ `
     "Asset shares other users have aimed at you (corporation/alliance/public). Session auth only."
     sharedWithMe: [ShareGrant!]!
 
-    "Current blueprint rows (BPOs and BPCs) across your characters and their corporations, filtered by item type and owner."
-    blueprints(type: String, types: [String!], owner: String, owners: [String!], limit: Int): BlueprintPage!
+    "Current blueprint rows (BPOs and BPCs) across your characters and their corporations, filtered by item type, hangar and owner."
+    blueprints(
+      type: String
+      types: [String!]
+      hangar: String
+      hangars: [String!]
+      owner: String
+      owners: [String!]
+      limit: Int
+    ): BlueprintPage!
 
     "Open market orders. Character-owned only: corp market orders are not extracted yet, so an owner filter naming only corporations is refused here rather than silently returning nothing."
     marketOrders(owner: String, owners: [String!]): [MarketOrder!]!
@@ -261,6 +279,7 @@ export const typeDefs = /* GraphQL */ `
     typeName: String
     quantity: String!
     locationId: String
+    "Which hangar or bay the stack sits in, as ESI names it: Hangar, Deliveries, CorpDeliveries, CorpSAG1…7, DroneBay… What the hangar:/hangars: filter selects on."
     locationFlag: String
     locationType: String
     locationName: String

--- a/src/app/link/templates.ts
+++ b/src/app/link/templates.ts
@@ -393,6 +393,38 @@ export const LINK_TEMPLATES: LinkTemplate[] = [
     variables: { container: ['1046809423988'], types: ['16273', '17887'] },
   },
   {
+    // The hangar dimension on its own: WHERE IN a place a stack sits, rather
+    // than which place. Deliveries is the courier drop, so "what just landed"
+    // is a hangar filter with nothing else on it.
+    id: 'deliveries',
+    label: 'Deliveries hangars',
+    description:
+      'Everything sitting in a Deliveries hangar — a character’s and a corporation’s alike — i.e. what couriers have dropped off and nobody has unpacked.',
+    query: `query Deliveries($hangar: String, $owners: [String!]) {
+  assets(hangar: $hangar, owners: $owners, limit: 500) {
+    totalCount
+    truncated
+    rows {
+      typeName
+      quantity
+      locationName
+      locationFlag
+      ownerName
+    }
+  }
+}`,
+    variables: { hangar: 'Deliveries' },
+    variableFields: [
+      {
+        name: 'hangar',
+        label: 'Hangar',
+        kind: 'text',
+        hint: 'A hangar name search — "Deliveries" catches both delivery hangars, "corp hangar 3" one division.',
+      },
+      OWNERS_FIELD,
+    ],
+  },
+  {
     id: 'restock',
     label: 'Restock list',
     description:

--- a/test/graphqlHangar.test.ts
+++ b/test/graphqlHangar.test.ts
@@ -1,0 +1,101 @@
+// Unit coverage for the GraphQL hangar filter
+// (src/app/api/graphql/hangarFlags.ts). The catalog IS the directory for this
+// dimension — there is no table of ESI location_flags to resolve against — so
+// what matters here is that the words people actually type reach the tokens
+// ESI writes, and that a word that reaches nothing is refused rather than
+// quietly returning an empty hangar.
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { HANGAR_FLAGS, matchHangarFilter } from '../src/app/api/graphql/hangarFlags.ts'
+
+const flagsOf = (result: ReturnType<typeof matchHangarFilter>): string[] => {
+  assert.ok(result.ok, `expected a match, got: ${result.ok ? '' : result.message}`)
+  assert.notEqual(result.flags, null)
+  return [...(result.flags as string[])].sort()
+}
+
+test('no hangar argument means no filter at all', () => {
+  const result = matchHangarFilter(null, null)
+  assert.ok(result.ok)
+  assert.equal(result.flags, null)
+  // Blank strings and empty lists read the same way as absent.
+  const blank = matchHangarFilter('  ', [])
+  assert.ok(blank.ok)
+  assert.equal(blank.flags, null)
+})
+
+test('"Deliveries" reaches BOTH delivery hangars, singular or plural', () => {
+  assert.deepEqual(flagsOf(matchHangarFilter('Deliveries', null)), ['CorpDeliveries', 'Deliveries'])
+  assert.deepEqual(flagsOf(matchHangarFilter(null, ['Deliveries'])), ['CorpDeliveries', 'Deliveries'])
+  // The point of the alias: a caller need not know either token exists.
+  assert.deepEqual(flagsOf(matchHangarFilter('delivery hangar', null)), ['CorpDeliveries', 'Deliveries'])
+})
+
+test('the singular is a case-insensitive substring, keeping everything it matched', () => {
+  assert.deepEqual(flagsOf(matchHangarFilter('deLIVeries', null)), ['CorpDeliveries', 'Deliveries'])
+  assert.deepEqual(flagsOf(matchHangarFilter('corp hangar', null)), [
+    'CorpSAG1',
+    'CorpSAG2',
+    'CorpSAG3',
+    'CorpSAG4',
+    'CorpSAG5',
+    'CorpSAG6',
+    'CorpSAG7',
+  ])
+})
+
+test('a corporation division is reachable by number, token or label', () => {
+  for (const entry of ['CorpSAG3', 'corp hangar 3', 'division 3', 'Corporation hangar division 3']) {
+    assert.deepEqual(flagsOf(matchHangarFilter(null, [entry])), ['CorpSAG3'], entry)
+  }
+})
+
+test('the plural is exact: a whole token, label or alias, mixed freely', () => {
+  assert.deepEqual(flagsOf(matchHangarFilter(null, ['Deliveries', 'CorpSAG1', 'drone bay'])), [
+    'CorpDeliveries',
+    'CorpSAG1',
+    'Deliveries',
+    'DroneBay',
+  ])
+  // Exact means whole: a substring that the singular would match is refused.
+  const partial = matchHangarFilter(null, ['deliv'])
+  assert.equal(partial.ok, false)
+})
+
+test('duplicate entries collapse rather than repeating a flag', () => {
+  assert.deepEqual(flagsOf(matchHangarFilter(null, ['Deliveries', 'CorpDeliveries', 'corp deliveries'])), [
+    'CorpDeliveries',
+    'Deliveries',
+  ])
+})
+
+test('a hangar that matches nothing is an error naming what is available', () => {
+  const typo = matchHangarFilter('delivries', null)
+  assert.equal(typo.ok, false)
+  assert.ok(!typo.ok && typo.message.includes('delivries'))
+  assert.ok(!typo.ok && typo.message.includes('CorpDeliveries'))
+
+  const list = matchHangarFilter(null, ['Deliveries', 'Nowhere'])
+  assert.equal(list.ok, false)
+  assert.ok(!list.ok && list.message.includes('"Nowhere"'))
+})
+
+test('the singular and the plural are mutually exclusive', () => {
+  const both = matchHangarFilter('Deliveries', ['CorpSAG1'])
+  assert.equal(both.ok, false)
+  assert.ok(!both.ok && both.message.includes('hangar'))
+})
+
+test('every catalog entry is a distinct ESI token with a label', () => {
+  const flags = HANGAR_FLAGS.map((e) => e.flag)
+  assert.equal(new Set(flags).size, flags.length, 'flags are unique')
+  for (const entry of HANGAR_FLAGS) {
+    assert.match(entry.flag, /^[A-Za-z][A-Za-z0-9]*$/, `${entry.flag} is a bare ESI token`)
+    assert.ok(entry.label.length > 0, `${entry.flag} has a label`)
+  }
+  // The four hangars a station-level filter is actually about.
+  for (const flag of ['Hangar', 'Deliveries', 'CorpDeliveries', 'CorpSAG1']) {
+    assert.ok(flags.includes(flag), `${flag} is in the catalog`)
+  }
+})

--- a/test/graphqlSchema.test.ts
+++ b/test/graphqlSchema.test.ts
@@ -59,6 +59,31 @@ test('the owner filter is on every list, including the character-only ones', () 
   }
 })
 
+// The hangar dimension (ESI's location_flag) is on the three lists whose rows
+// carry one — assets, the restock sum over them, and blueprints. Nothing else
+// has a hangar to sit in: an order, a job or a transaction names a place, not
+// a compartment.
+test('the hangar filter is on every list whose rows carry a location flag', () => {
+  const schema = buildSchema(typeDefs)
+  const fields = (schema.getQueryType() as GraphQLObjectType).getFields()
+  for (const name of ['assets', 'blueprints', 'restock']) {
+    const args = new Map(fields[name].args.map((a) => [a.name, String(a.type)]))
+    assert.equal(args.get('hangar'), 'String', `${name}.hangar`)
+    assert.equal(args.get('hangars'), '[String!]', `${name}.hangars`)
+  }
+  for (const name of ['industryJobs', 'marketOrders', 'walletTransactions']) {
+    const args = fields[name].args.map((a) => a.name)
+    assert.ok(!args.includes('hangar'), `${name} has no hangar filter`)
+  }
+})
+
+test('the rows a hangar filter selects on expose the flag they filtered by', () => {
+  const schema = buildSchema(typeDefs)
+  for (const name of ['Asset', 'Blueprint']) {
+    assert.ok(objectType(schema, name).getFields().locationFlag, `${name}.locationFlag`)
+  }
+})
+
 test('the SDL parses and exposes the expected query fields', () => {
   const schema = buildSchema(typeDefs)
   const query = schema.getQueryType() as GraphQLObjectType


### PR DESCRIPTION
A Link could already ask "what do I have **at** TK-DLH" (`location:`), but not "what is sitting **in** the Deliveries hangar" — the compartment a stack sits in, which is how you see what a courier dropped off and nobody unpacked. The column was always in the response (`Asset.locationFlag`); there was simply no way to filter on it, and a Link viewer cannot post-filter — a Link renders whatever its stored query returns.

## The filter

`hangar:` / `hangars:` on `assets`, `restock` and `blueprints` — the three lists whose rows carry a `location_flag`; an order, a job or a transaction names a place, not a compartment. It follows the schema's existing singular/plural stance unchanged: the singular is a case-insensitive substring search keeping everything it matched, the plural is an exact list of whole names, the two are mutually exclusive, and an entry matching nothing is an error rather than a silently empty hangar.

```graphql
{ assets(hangar: "Deliveries") { rows { typeName quantity locationName ownerName } } }
```

## Why a catalog

`location_flag` is ESI's raw token, stored verbatim by the extract jobs. Two things make it unlike every other filter dimension:

- **There is no directory to resolve a name against.** Types have the SDE, locations the structure caches, owners the caller's registrations. Flags have nothing — no table, no view, no ESI endpoint.
- **A character's Deliveries hangar and a corporation's are different tokens** (`Deliveries` vs `CorpDeliveries`), and someone asking for "deliveries" means both without being expected to know either token exists.

So `src/app/api/graphql/hangarFlags.ts` carries the tokens, the labels the site would use, and the aliases people type — and **that catalog is the directory**. `hangar: "deliveries"` reaches both delivery hangars; `"corp hangar"` reaches all seven divisions; `hangars: ["CorpSAG3"]` / `["division 3"]` reach the one. That also makes the catalog load-bearing: a flag missing from it cannot be filtered by, which is deliberate — passing an arbitrary string straight to `.in('location_flag', …)` accepts anything and returns nothing for a typo, the worse failure for a link nobody re-reads for a year.

The resolvers push it down as one more `.in()` on the same builder the type and location filters use, on both owner sides, on the head-count and the row pages alike.

## Also

- A **Deliveries hangars** link template, which the `/link` picker, the `/graphql` examples and the MCP `link_schema` examples all pick up from the one list.
- `test/graphqlHangar.test.ts` over the pure seam, plus two drift guards in `test/graphqlSchema.test.ts` pinning which lists carry the pair.
- `docs/sharing-layer/10-hangar-filter.md`.

`pnpm test` (571 pass), `pnpm run lint` and `pnpm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dy7BPQvZuGWj46xvUvanQU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dy7BPQvZuGWj46xvUvanQU)_