### PR TITLE
feat(registration): the grant matrix — jobs, grants and refresh in one grid

### DIFF
--- a/docs/registrations-page/03-jobs-parity.md
+++ b/docs/registrations-page/03-jobs-parity.md
@@ -1,5 +1,13 @@
 # Phase 3 — jobs sections at parity
 
+> **Shipped** (with phase 4, one PR). The jobs side landed as the design's
+> grant matrix rather than the /jobs tables: one cell per (character, job)
+> fusing grant state and last run, columns derived from
+> `jobsInSection('character')` (nine, not the mockup's five), corporations as
+> a second matrix with per-cell runs-as, and the shared-universe + recent
+> activity tables below. The checklist held; deviations and deferrals are
+> recorded at the end of 04-integration.md.
+
 Adds the extract-jobs half of `/registration`, over `fetchJobsOverview` from
 phase 1, presented per the phase-0 extraction. Whatever the mockup's visual
 treatment, the information and actions are exactly `/jobs`'s.

--- a/docs/registrations-page/04-integration.md
+++ b/docs/registrations-page/04-integration.md
@@ -1,5 +1,34 @@
 # Phase 4 — the actually-combined parts
 
+> **Shipped** (with phase 3, one PR). The fusion went further than the
+> candidates below — the design's whole point turned out to be the grant
+> matrix: per-(character, job) cells carrying grant state (on / missing /
+> extra / off), the editable request-template row, re-auth detection
+> ("grants trail the template"), and the four refresh granularities (cell,
+> column sweep, row tail, refresh-all). New seams: `registration/matrix.ts`
+> (pure, tested), `matrixData.ts` (token scopes via a service client scoped
+> to the caller's own registration ids — token grants stop at service_role
+> by design), `registration/actions.ts` (row/full dispatch through
+> `dispatchRefresh`, template toggling into `user_settings.enabled_scopes`),
+> `matrixButtons.tsx`. Registry entries now carry their jobs' ESI scopes.
+>
+> **Deliberate deviations & deferrals** (the user rules on each):
+>
+> - **remove** (per-row, in the mockup): not implemented. `registration`
+>   grants authenticated only select + update(is_main) — deleting a
+>   registration means a service-role action or a migration, and the cascade
+>   wipes the character's extract history. Needs a product ruling first.
+> - The mobile **bottom sheet** for scope sweeps is a plain `<details>`
+>   disclosure shown at narrow widths, not a modal sheet.
+> - The mockup's lowercase-heading voice was not adopted (extraction §4 —
+>   house case conventions kept).
+> - Freshness dots became the same scale as text colour on cell timestamps
+>   (extraction gap 7): quiet when fresh, warn when aging, danger when stale.
+> - The `/character` state fields (ISK, location, ship, clones, implants)
+>   live in a per-row `details` disclosure — the extraction's "expandable
+>   row" resolution; slot bubbles stay visible.
+> - Nav stays untouched — phase 5 as planned.
+
 Phases 2–3 could, at worst, ship two pages stacked under one URL. This phase
 delivers the reason for merging: the connections between a character and the
 jobs that feed their data. Exact scope comes from the phase-0 extraction —

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -36,6 +36,10 @@
   --ok: #15803d;
   --warn: #a16207;
   --danger: #b3261e;
+  /* Informational-but-fine, distinct from ok/warn/danger — added for the
+     /registration grant matrix's "granted but not requested" ring
+     (docs/registrations-page/00a-design-extraction.md §4). */
+  --info: #1d4ed8;
 
   --radius: 10px;
   --radius-sm: 7px;
@@ -70,6 +74,7 @@
     --ok: #4ade80;
     --warn: #fcd34d;
     --danger: #fca5a5;
+    --info: #93c5fd;
   }
 }
 

--- a/src/app/jobs/jobsData.ts
+++ b/src/app/jobs/jobsData.ts
@@ -30,7 +30,7 @@ export type OpenBeat = { job: string; registration_id: string | null; corporatio
 
 export type Task = ActivityTask & { registration_id: string | null }
 
-export type Registration = { id: string; name: string; corporation_id: number | null }
+export type Registration = { id: string; name: string; corporation_id: number | null; is_main: boolean }
 
 export type JobsOverview = {
   registrations: Registration[]
@@ -41,6 +41,10 @@ export type JobsOverview = {
   activity: ReturnType<typeof activityRows>
   // Whether any corporation rows exist at all — the section is hidden without.
   corporationCount: number
+  // Resolved corp names (universe_name) for the caller's corporations, for
+  // callers that label registrations by corp rather than rendering the corp
+  // entity rows (which carry their own resolved name already).
+  corporationNames: Map<number, string>
   anyActive: boolean
   chancellor: boolean
   now: number
@@ -59,7 +63,10 @@ export const fetchJobsOverview = async (supabase: SupabaseClient, userId: string
 
   const [{ data: registrationsData }, { data: beatsData }, { data: openData }, { data: tasksData }] = await Promise.all(
     [
-      supabase.from('registration').select('id, name, corporation_id').order('created_at', { ascending: true }),
+      supabase
+        .from('registration')
+        .select('id, name, corporation_id, is_main')
+        .order('created_at', { ascending: true }),
       supabase.rpc('latest_heartbeats'),
       // Open runs — started, not yet ended. This is what makes a *scheduled* run
       // visible as running; latest_heartbeats() returns completed rows only. The
@@ -212,6 +219,7 @@ export const fetchJobsOverview = async (supabase: SupabaseClient, userId: string
     runFor,
     activity: activityRows(tasks),
     corporationCount: corporations.size,
+    corporationNames: corpName,
     anyActive,
     chancellor,
     now,

--- a/src/app/jobs/registry.ts
+++ b/src/app/jobs/registry.ts
@@ -32,46 +32,157 @@ export type JobEntry = {
   label: string
   section: JobSection
   kickable: Kickable
+  // The ESI OAuth scopes gating this job's pull, matching the SCOPE/SCOPES
+  // constant of the job module under src/jobs/ (which can't be imported here —
+  // the job modules drag in the cron-side ESI/DB plumbing). One entry for
+  // every job but character-status, whose six live-state endpoints each have
+  // their own (forEachCharacterAnyScope runs whichever the token carries), and
+  // the shared-universe jobs, which pull public data under no grant at all.
+  // /registration reads these to fuse grant state into each job cell.
+  scopes: readonly string[]
 }
 
 export const JOBS: readonly JobEntry[] = [
-  { job: 'character-assets', label: 'assets', section: 'character', kickable: 'always' },
-  { job: 'character-blueprints', label: 'blueprints', section: 'character', kickable: 'always' },
-  { job: 'character-orders', label: 'orders', section: 'character', kickable: 'always' },
-  { job: 'character-wallet-transactions', label: 'transactions', section: 'character', kickable: 'always' },
-  { job: 'character-contracts', label: 'contracts', section: 'character', kickable: 'always' },
-  { job: 'character-industry-jobs', label: 'industry', section: 'character', kickable: 'always' },
-  { job: 'character-mercenary-dens', label: 'dens', section: 'character', kickable: 'always' },
-  { job: 'character-fittings', label: 'fittings', section: 'character', kickable: 'always' },
+  {
+    job: 'character-assets',
+    label: 'assets',
+    section: 'character',
+    kickable: 'always',
+    scopes: ['esi-assets.read_assets.v1'],
+  },
+  {
+    job: 'character-blueprints',
+    label: 'blueprints',
+    section: 'character',
+    kickable: 'always',
+    scopes: ['esi-characters.read_blueprints.v1'],
+  },
+  {
+    job: 'character-orders',
+    label: 'orders',
+    section: 'character',
+    kickable: 'always',
+    scopes: ['esi-markets.read_character_orders.v1'],
+  },
+  {
+    job: 'character-wallet-transactions',
+    label: 'transactions',
+    section: 'character',
+    kickable: 'always',
+    scopes: ['esi-wallet.read_character_wallet.v1'],
+  },
+  {
+    job: 'character-contracts',
+    label: 'contracts',
+    section: 'character',
+    kickable: 'always',
+    scopes: ['esi-contracts.read_character_contracts.v1'],
+  },
+  {
+    job: 'character-industry-jobs',
+    label: 'industry',
+    section: 'character',
+    kickable: 'always',
+    scopes: ['esi-industry.read_character_jobs.v1'],
+  },
+  {
+    job: 'character-mercenary-dens',
+    label: 'dens',
+    section: 'character',
+    kickable: 'always',
+    scopes: ['esi-structures.read_character.v1'],
+  },
+  {
+    job: 'character-fittings',
+    label: 'fittings',
+    section: 'character',
+    kickable: 'always',
+    scopes: ['esi-fittings.read_fittings.v1'],
+  },
   // Combined live-state pull: wallet, location, implants, clones, ship, skills
   // in one invocation (src/jobs/characterStatus.js).
-  { job: 'character-status', label: 'status', section: 'character', kickable: 'always' },
+  {
+    job: 'character-status',
+    label: 'status',
+    section: 'character',
+    kickable: 'always',
+    scopes: [
+      'esi-wallet.read_character_wallet.v1',
+      'esi-location.read_location.v1',
+      'esi-clones.read_implants.v1',
+      'esi-clones.read_clones.v1',
+      'esi-location.read_ship_type.v1',
+      'esi-skills.read_skills.v1',
+    ],
+  },
 
-  { job: 'corp-assets', label: 'assets', section: 'corporation', kickable: 'always' },
-  { job: 'corp-industry-jobs', label: 'industry', section: 'corporation', kickable: 'always' },
-  { job: 'corp-wallet-transactions', label: 'transactions', section: 'corporation', kickable: 'always' },
-  { job: 'corp-contracts', label: 'contracts', section: 'corporation', kickable: 'always' },
+  {
+    job: 'corp-assets',
+    label: 'assets',
+    section: 'corporation',
+    kickable: 'always',
+    scopes: ['esi-assets.read_corporation_assets.v1'],
+  },
+  {
+    job: 'corp-industry-jobs',
+    label: 'industry',
+    section: 'corporation',
+    kickable: 'always',
+    scopes: ['esi-industry.read_corporation_jobs.v1'],
+  },
+  {
+    job: 'corp-wallet-transactions',
+    label: 'transactions',
+    section: 'corporation',
+    kickable: 'always',
+    scopes: ['esi-wallet.read_corporation_wallets.v1'],
+  },
+  {
+    job: 'corp-contracts',
+    label: 'contracts',
+    section: 'corporation',
+    kickable: 'always',
+    scopes: ['esi-contracts.read_corporation_contracts.v1'],
+  },
   // Kickable since the structure-universe work: "refresh my structures" is the
   // lever the /structure page hangs off, and it dispatches this per corporation
   // alongside corp-assets, which carries the rigs (docs/structure-universe/design.md).
-  { job: 'corp-structures', label: 'structures', section: 'corporation', kickable: 'always' },
+  {
+    job: 'corp-structures',
+    label: 'structures',
+    section: 'corporation',
+    kickable: 'always',
+    scopes: ['esi-corporations.read_structures.v1'],
+  },
   // The two remaining daily whole-corp pulls a per-character fan-out would only
   // ever redo once per character, so they're scheduled-only (see dispatchRefresh.ts).
-  { job: 'corp-blueprints', label: 'blueprints', section: 'corporation', kickable: 'never' },
-  { job: 'corp-wallet-journal', label: 'wallet journal', section: 'corporation', kickable: 'never' },
+  {
+    job: 'corp-blueprints',
+    label: 'blueprints',
+    section: 'corporation',
+    kickable: 'never',
+    scopes: ['esi-corporations.read_blueprints.v1'],
+  },
+  {
+    job: 'corp-wallet-journal',
+    label: 'wallet journal',
+    section: 'corporation',
+    kickable: 'never',
+    scopes: ['esi-wallet.read_corporation_wallets.v1'],
+  },
 
-  { job: 'sde-mirror', label: 'SDE mirror', section: 'universe', kickable: 'never' },
-  { job: 'universe-names', label: 'names', section: 'universe', kickable: 'chancellor' },
-  { job: 'universe-structures', label: 'structures', section: 'universe', kickable: 'never' },
+  { job: 'sde-mirror', label: 'SDE mirror', section: 'universe', kickable: 'never', scopes: [] },
+  { job: 'universe-names', label: 'names', section: 'universe', kickable: 'chancellor', scopes: [] },
+  { job: 'universe-structures', label: 'structures', section: 'universe', kickable: 'never', scopes: [] },
   // Daily public-feed pull (ESI's public structure list + EVE Ref). Names
   // structures no token of ours can reach; see docs/structure-universe/design.md.
-  { job: 'structure-directory', label: 'structure directory', section: 'universe', kickable: 'chancellor' },
-  { job: 'character-directory', label: 'character directory', section: 'universe', kickable: 'chancellor' },
-  { job: 'industry-systems', label: 'industry indexes', section: 'universe', kickable: 'chancellor' },
+  { job: 'structure-directory', label: 'structure directory', section: 'universe', kickable: 'chancellor', scopes: [] },
+  { job: 'character-directory', label: 'character directory', section: 'universe', kickable: 'chancellor', scopes: [] },
+  { job: 'industry-systems', label: 'industry indexes', section: 'universe', kickable: 'chancellor', scopes: [] },
   // Hourly third-party price feed (appraise.gnf.lt), not ESI. Chancellor-kickable
   // like the other shared-universe pulls: one account's button spends everyone's
   // goodwill with someone else's bandwidth.
-  { job: 'market-prices', label: 'market prices', section: 'universe', kickable: 'chancellor' },
+  { job: 'market-prices', label: 'market prices', section: 'universe', kickable: 'chancellor', scopes: [] },
 ]
 
 export const jobsInSection = (section: JobSection) => JOBS.filter((entry) => entry.section === section)

--- a/src/app/registration/actions.ts
+++ b/src/app/registration/actions.ts
@@ -1,0 +1,99 @@
+'use server'
+
+// The /registration matrix's own dispatch levers, completing the design's four
+// refresh granularities (docs/registrations-page/00a-design-extraction.md §1,
+// "the axes rule"): the row-tail ↻ (every job for one character) and the page
+// header's ↻ (everything). The other two axes reuse /jobs's actions directly —
+// refreshCell for one cell, refreshAllCharacters for a column sweep — so there
+// is exactly one dispatch path per shape.
+//
+// Both go through dispatchRefresh, the same fan-out adding a character runs:
+// every on-demand per-character job, the corp jobs for the characters' corps,
+// and the account-wide jobs, one batch so Recent activity groups it.
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+
+import { createClient } from '@/utils/supabase/server'
+
+import { establishedUser } from '../account/lib/establishedUser'
+import { dispatchRefresh } from '../character/dispatchRefresh'
+import { defaultScopes, optionalScopes, requiredScopes } from '../character/scopes'
+
+// Kick every on-demand job for one character of the caller's.
+export const refreshCharacter = async (characterId: string) => {
+  const supabase = await createClient()
+
+  const user = await establishedUser(supabase)
+  if (!user) {
+    redirect('/account/login')
+  }
+
+  // RLS scopes the read to the caller's own registrations, so a foreign id
+  // matches nothing and can't be refreshed on someone else's behalf.
+  const { data: character } = await supabase.from('registration').select('id, name').eq('id', characterId).maybeSingle()
+  if (!character) throw new Error('unknown character')
+
+  await dispatchRefresh(user.id, [character])
+  revalidatePath('/registration')
+}
+
+// Kick every on-demand job for every character — the header's "refresh all".
+export const refreshEverything = async () => {
+  const supabase = await createClient()
+
+  const user = await establishedUser(supabase)
+  if (!user) {
+    redirect('/account/login')
+  }
+
+  const { data: characters } = await supabase
+    .from('registration')
+    .select('id, name')
+    .order('created_at', { ascending: true })
+  if (!characters?.length) return
+
+  await dispatchRefresh(user.id, characters)
+  revalidatePath('/registration')
+}
+
+// Toggle a set of optional scopes in the account's request template — the
+// matrix's template-row checkboxes. One checkbox governs one job column, which
+// for character-status is six scopes at once; a mixed column completes to the
+// full set first (matrix.ts templateCheck), so this takes the target state
+// rather than flipping each scope independently.
+//
+// Same storage as /settings/grants (user_settings.enabled_scopes, required
+// scopes always kept), without that page's redirect — the caller stays on the
+// matrix and the row re-renders.
+export const setTemplateScopes = async (scopes: string[], on: boolean) => {
+  const supabase = await createClient()
+
+  const user = await establishedUser(supabase)
+  if (!user) {
+    redirect('/account/login')
+  }
+
+  // Only real optional scopes can be toggled; anything else in the payload
+  // (a required scope, a typo, a scope we never ask for) is dropped.
+  const toggled = scopes.filter((scope) => optionalScopes.includes(scope))
+  if (toggled.length === 0) return
+
+  const { data: settings } = await supabase
+    .from('user_settings')
+    .select('enabled_scopes')
+    .eq('user_id', user.id)
+    .maybeSingle()
+  // No saved row means the default template (every non-opt-in scope) — see
+  // userScopes.ts. Materialize that before editing, or the first toggle-off
+  // would save a template of nothing but the toggled scopes.
+  const current: string[] = settings?.enabled_scopes ?? defaultScopes
+  const kept = current.filter((scope) => !toggled.includes(scope))
+  const enabled_scopes = [...new Set([...requiredScopes, ...kept, ...(on ? toggled : [])])]
+
+  const { error } = await supabase
+    .from('user_settings')
+    .upsert({ user_id: user.id, enabled_scopes, updated_at: new Date().toISOString() }, { onConflict: 'user_id' })
+  if (error) throw new Error(error.message)
+
+  revalidatePath('/registration')
+}

--- a/src/app/registration/matrix.ts
+++ b/src/app/registration/matrix.ts
@@ -1,0 +1,70 @@
+// The pure rules behind the /registration grant matrix: how a job column's
+// scopes, one character's granted token scopes and the account's request
+// template collapse into the four cell states of the design (grant and job in
+// one cell — docs/registrations-page/00a-design-extraction.md §1), plus the
+// derived headlines the page puts around the grid. No I/O and no React, so the
+// arithmetic that decides "why does this job never run" is testable on its own
+// (test/registrationMatrix.test.ts).
+
+// The four base states of a cell's grant icon:
+//   on      — requested by the template and granted: the job runs
+//   missing — requested but not granted: the job NEVER runs, and the red ✕ is
+//             why ("never — no grant")
+//   extra   — granted but no longer in the template: still refreshes; a later
+//             re-auth would drop it
+//   off     — neither requested nor granted: nothing to run, nothing to ask
+export type GrantState = 'on' | 'missing' | 'extra' | 'off'
+
+// A multi-scope column (character-status fronts six live-state endpoints) is
+// granted when ANY of its scopes is — forEachCharacterAnyScope runs whichever
+// endpoints the token carries, so one grant is enough for the job to exist.
+// Requested follows the same rule: a template asking for any of the six is
+// asking for a status pull.
+export const columnGrant = (
+  scopes: readonly string[],
+  granted: ReadonlySet<string>,
+  template: ReadonlySet<string>
+): GrantState => {
+  const has = scopes.some((scope) => granted.has(scope))
+  const wants = scopes.some((scope) => template.has(scope))
+  if (has) return wants ? 'on' : 'extra'
+  return wants ? 'missing' : 'off'
+}
+
+// A cell in one of these states has a job that can actually run; the refresh
+// triggers only render where this is true (a cell without a grant has nothing
+// to kick — the design's "no refresh trigger" rule).
+export const grantAllowsRun = (state: GrantState): boolean => state === 'on' || state === 'extra'
+
+// The template row's checkbox for one column. 'some' is a template that asks
+// for part of a multi-scope column — rendered as a mixed mark; toggling from
+// there completes the set rather than clearing it.
+export type TemplateCheck = 'all' | 'some' | 'none'
+
+export const templateCheck = (scopes: readonly string[], template: ReadonlySet<string>): TemplateCheck => {
+  const wanted = scopes.filter((scope) => template.has(scope)).length
+  if (wanted === 0) return 'none'
+  return wanted === scopes.length ? 'all' : 'some'
+}
+
+// Scopes the template asks for that this character's token doesn't carry —
+// non-empty means the character's grants trail the template and a re-auth
+// round trip through EVE SSO would catch them up. Compared over the whole
+// template, not only the scopes the matrix draws columns for: a re-auth
+// re-requests everything, so everything missing counts.
+export const trailingScopes = (template: ReadonlySet<string>, granted: ReadonlySet<string>): string[] =>
+  [...template].filter((scope) => !granted.has(scope))
+
+// The legend's warn summary: how many cells across the whole matrix sit in the
+// 'missing' state — jobs that will never run for want of a grant.
+export const blockedCellCount = (cells: readonly GrantState[]): number =>
+  cells.filter((state) => state === 'missing').length
+
+// The header's "next scheduled sweep" is the soonest next fire across the
+// given jobs' crons — one countdown for the page, where /jobs had one per row.
+// (The per-column next runs still live in each column header's title.)
+export const soonestNextRun = (nexts: readonly (Date | null)[]): Date | null =>
+  nexts.reduce<Date | null>(
+    (soonest, next) => (next !== null && (soonest === null || next < soonest) ? next : soonest),
+    null
+  )

--- a/src/app/registration/matrixButtons.tsx
+++ b/src/app/registration/matrixButtons.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+// The matrix's interactive pieces: the ↻ buttons at the design's four
+// granularities (cell / column / row / everything), the failed cell's retry
+// link, and the template row's checkboxes. Each wraps a server action in a
+// transition and then router.refresh()es, the same shape as /jobs's
+// refreshButton.tsx — the re-rendered page has a pending refresh_task for the
+// cell and the poller takes over until it settles.
+import { useRouter } from 'next/navigation'
+import { useTransition } from 'react'
+
+import { refreshAllCharacters, refreshCell } from '../jobs/actions'
+import { refreshCharacter, refreshEverything, setTemplateScopes } from './actions'
+import type { TemplateCheck } from './matrix'
+import styles from './registration.module.css'
+
+// One ↻ glyph button. Every trigger on the page is this, differing only in the
+// action behind it and the title explaining its blast radius.
+const Kick = ({ act, title, className }: { act: () => Promise<void>; title: string; className?: string }) => {
+  const router = useRouter()
+  const [pending, startTransition] = useTransition()
+  return (
+    <button
+      type="button"
+      className={className ?? styles.kick}
+      title={title}
+      aria-label={title}
+      disabled={pending}
+      onClick={() =>
+        startTransition(async () => {
+          await act()
+          router.refresh()
+        })
+      }
+    >
+      ↻
+    </button>
+  )
+}
+
+// One cell: one job for one character (or one corporation, via its
+// representative registration).
+export const CellKick = ({ job, characterId, title }: { job: string; characterId: string; title: string }) => (
+  <Kick act={() => refreshCell(job, characterId)} title={title} />
+)
+
+// Column header: this job for every character that has it.
+export const ColumnKick = ({ job, label }: { job: string; label: string }) => (
+  <Kick act={() => refreshAllCharacters(job)} title={`Refresh ${label} for every character`} />
+)
+
+// Row tail: every job for this character.
+export const RowKick = ({ characterId, name }: { characterId: string; name: string }) => (
+  <Kick act={() => refreshCharacter(characterId)} title={`Refresh every job for ${name}`} className={styles.rowKick} />
+)
+
+// Page header: everything. A real button with a label, not a glyph.
+export const RefreshAll = () => {
+  const router = useRouter()
+  const [pending, startTransition] = useTransition()
+  return (
+    <button
+      type="button"
+      disabled={pending}
+      onClick={() =>
+        startTransition(async () => {
+          await refreshEverything()
+          router.refresh()
+        })
+      }
+    >
+      {pending ? 'refreshing…' : '↻ Refresh all'}
+    </button>
+  )
+}
+
+// A shared-universe kick, Chancellor-gated server-side (jobs/actions.ts
+// re-checks; this only renders where the page already knows it may).
+export const UniverseKick = ({ job, label }: { job: string; label: string }) => (
+  <Kick act={() => refreshCell(job, null)} title={`Refresh ${label} for every account`} />
+)
+
+// A failed cell's retry link — the same dispatch as the cell ↻, worded as the
+// design words it.
+export const Retry = ({ job, characterId }: { job: string; characterId: string }) => {
+  const router = useRouter()
+  const [pending, startTransition] = useTransition()
+  return (
+    <button
+      type="button"
+      className={styles.retry}
+      disabled={pending}
+      onClick={() =>
+        startTransition(async () => {
+          await refreshCell(job, characterId)
+          router.refresh()
+        })
+      }
+    >
+      {pending ? 'retrying…' : 'retry'}
+    </button>
+  )
+}
+
+// One template-row checkbox: whether the next SSO request asks for this
+// column's scopes. A mixed column (some of character-status's six scopes)
+// completes to the full set on first click rather than clearing it.
+export const TemplateToggle = ({
+  scopes,
+  check,
+  label,
+}: {
+  scopes: readonly string[]
+  check: TemplateCheck
+  label: string
+}) => {
+  const router = useRouter()
+  const [pending, startTransition] = useTransition()
+  const on = check !== 'none'
+  const next = check !== 'all'
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={check === 'all' ? true : check === 'none' ? false : 'mixed'}
+      className={styles.templateBox}
+      data-check={check}
+      title={`${on ? (check === 'all' ? 'Requested' : 'Partly requested') : 'Not requested'} — the next character you register ${on ? 'will' : 'will not'} be asked for ${label}`}
+      disabled={pending}
+      onClick={() =>
+        startTransition(async () => {
+          await setTemplateScopes([...scopes], next)
+          router.refresh()
+        })
+      }
+    >
+      {check === 'all' ? '✓' : check === 'some' ? '~' : ''}
+    </button>
+  )
+}

--- a/src/app/registration/matrixData.ts
+++ b/src/app/registration/matrixData.ts
@@ -1,0 +1,48 @@
+// The grant side of the /registration matrix: which ESI scopes each of the
+// caller's characters has actually granted, and which ones the account's
+// request template will ask for next time. The job side comes from
+// fetchJobsOverview; matrix.ts fuses the two per cell.
+//
+// token.scope is readable only by the service role — the table's grants stop
+// at service_role on purpose (a browser that can read its own refresh_token is
+// an XSS-to-EVE-account bridge; see schema.sql). The scope ARRAY is not the
+// secret, so this reads it the way /bpos and /corpses read their tables:
+// service client, scoped to registration ids the caller's own RLS-limited
+// session already proved it owns, selecting only the columns needed.
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { forEach } from 'ramda'
+
+import { createServiceClient } from '@/utils/supabase/service'
+
+import { getEnabledScopes } from '../character/userScopes'
+
+export type GrantOverview = {
+  // Per registration uuid: the scopes its token actually carries. A
+  // registration with no token row (or an empty grant) maps to an empty set.
+  grantedByRegistration: Map<string, Set<string>>
+  // The scopes the next SSO request will ask for — required plus whatever
+  // optional ones the template has on (userScopes.ts).
+  template: Set<string>
+}
+
+export const fetchGrantOverview = async (
+  supabase: SupabaseClient,
+  userId: string,
+  registrationIds: readonly string[]
+): Promise<GrantOverview> => {
+  const template = new Set(await getEnabledScopes(supabase, userId))
+
+  const grantedByRegistration = new Map<string, Set<string>>(registrationIds.map((id) => [id, new Set<string>()]))
+  if (registrationIds.length > 0) {
+    const { data } = await createServiceClient()
+      .from('token')
+      .select('registration_id, scope')
+      .in('registration_id', [...registrationIds])
+    forEach(
+      (row) => grantedByRegistration.set(row.registration_id as string, new Set((row.scope ?? []) as string[])),
+      data ?? []
+    )
+  }
+
+  return { grantedByRegistration, template }
+}

--- a/src/app/registration/page.tsx
+++ b/src/app/registration/page.tsx
@@ -1,14 +1,17 @@
 // /registration — one page for the linked characters and the extract jobs that
 // keep their data fresh (docs/registrations-page). Laid out per the phase-0
-// design extraction: a page header over one bordered matrix, one row per
-// registration.
+// design extraction: a page header over one bordered matrix whose cells fuse
+// grant and job — one cell answers both "may we pull this" and "when did we".
 //
-// Phase 2 ships the shell and the character rows at parity with /character;
-// the per-scope job columns, the axis refresh triggers and the poller land in
-// phase 3. /character and /jobs stay live and unchanged until a separate
-// sunset decision.
+// Phase 3+4: the per-scope job columns with the four grant states, the axis
+// refresh triggers (cell / column / row / everything), the template row, the
+// corporation matrix, and the /jobs sections parity keeps below the fold
+// (shared universe, recent activity, poller). /character and /jobs stay live
+// and unchanged until a separate sunset decision.
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
+import type { CSSProperties } from 'react'
+import { reduce } from 'ramda'
 
 import { createClient } from '@/utils/supabase/server'
 
@@ -16,12 +19,147 @@ import { establishedUser } from '../account/lib/establishedUser'
 import { register } from '../character/actions'
 import { fetchCharacterOverviews, hasNoOptionalScopes } from '../character/characterData'
 import { JobSlots } from '../character/jobSlotBubbles'
+import { freshnessLevel, relativeTime } from '../freshness'
 import { formatBisk } from '../isk'
+import { type Registration, fetchJobsOverview } from '../jobs/jobsData'
+import { NextRun } from '../jobs/nextRun'
+import { RefreshPoller } from '../jobs/poller'
+import { type JobEntry, isOverdue, jobsInSection, nextRunFor } from '../jobs/registry'
+import { type EntityRun, isAbandoned, newestRun } from '../jobs/rows'
+import { Name } from '../names'
+import {
+  type GrantState,
+  blockedCellCount,
+  columnGrant,
+  grantAllowsRun,
+  soonestNextRun,
+  templateCheck,
+  trailingScopes,
+} from './matrix'
+import { CellKick, ColumnKick, RefreshAll, Retry, RowKick, TemplateToggle, UniverseKick } from './matrixButtons'
+import { fetchGrantOverview } from './matrixData'
 import styles from './registration.module.css'
 
-// The phase-3 poller re-requests this server component while a kicked job is
-// in flight, so never serve it from the router cache.
+// The poller re-requests this server component while a kicked job is in
+// flight, so never serve it from the router cache.
 export const dynamic = 'force-dynamic'
+
+const iso = (at: Date | null) => (at === null ? null : at.toISOString())
+
+const STATUS_LABEL: Record<string, string> = {
+  running: '● running',
+  queued: '· queued',
+  failed: '✗ failed',
+  skipped: '— not a director',
+  idle: 'idle',
+  pending: '· pending',
+  done: '✓ done',
+  error: '✗ error',
+  abandoned: '✗ abandoned',
+}
+
+const GRANT_GLYPH: Record<GrantState, string> = { on: '✓', missing: '✕', extra: '✓', off: '·' }
+
+const GRANT_TITLE: Record<GrantState, string> = {
+  on: 'Requested and granted — this job runs',
+  missing: 'Requested but not granted — this job never runs; re-auth to grant it',
+  extra: 'Granted but not in the request template — still refreshes',
+  off: 'Neither requested nor granted',
+}
+
+// One matrix cell: the grant icon over the job's last-run state. The four base
+// states come from the grant; running/failed overlay them (failure is
+// orthogonal to grant state — a granted pull can still die on a dead token).
+const MatrixCell = ({
+  job,
+  label,
+  entity,
+  grant,
+  kickable,
+  now,
+  runsAs,
+}: {
+  job: string
+  label: string
+  entity: EntityRun
+  grant: GrantState
+  kickable: boolean
+  now: number
+  // Corp cells: whose token the last pull ran under (or null when a corpmate's).
+  runsAs?: { name: string | null; corpmate: boolean }
+}) => {
+  const inFlight = entity.status === 'running' || entity.status === 'queued'
+  const runnable = grantAllowsRun(grant)
+  // Same offer rule as /jobs's Cell: kickable, nothing in flight, nothing
+  // skipped, and only once the data is off green or the last run failed.
+  const offerKick =
+    kickable &&
+    runnable &&
+    !inFlight &&
+    entity.status !== 'skipped' &&
+    (entity.status === 'failed' || freshnessLevel(entity.lastRunAt, now) !== 'fresh')
+  return (
+    <span className={styles.cell} data-grant={grant}>
+      <span className={styles.cellLabel}>{label}</span>
+      <span className={styles.grantIcon} data-grant={grant} title={GRANT_TITLE[grant]}>
+        {GRANT_GLYPH[grant]}
+      </span>
+      <span className={styles.cellBody}>
+        {entity.status === 'skipped' ? (
+          <span className={styles.cellNote} title={entity.error ?? undefined}>
+            — not a director
+          </span>
+        ) : inFlight ? (
+          <span className={styles.cellRunning}>{entity.status === 'queued' ? 'queued…' : 'running…'}</span>
+        ) : entity.status === 'failed' ? (
+          <span className={styles.cellFailed} title={entity.error ?? undefined}>
+            failed{entity.lastRunAt !== null && ` ${relativeTime(entity.lastRunAt, now)}`}
+            {kickable && runnable && (
+              <>
+                {' · '}
+                <Retry job={job} characterId={entity.id} />
+              </>
+            )}
+          </span>
+        ) : !runnable ? (
+          <span className={grant === 'missing' ? styles.cellBlocked : styles.cellOff}>
+            {grant === 'missing' ? 'never — no grant' : '—'}
+          </span>
+        ) : (
+          <span className={styles.cellTime} data-fresh={freshnessLevel(entity.lastRunAt, now)}>
+            {entity.lastRunAt === null ? 'never' : relativeTime(entity.lastRunAt, now)}
+          </span>
+        )}
+        {runsAs && entity.status !== 'skipped' && (
+          <span className={styles.cellRunsAs}>
+            {runsAs.corpmate ? 'a corpmate’s token' : runsAs.name === null ? '' : `as ${runsAs.name}`}
+          </span>
+        )}
+      </span>
+      {offerKick && <CellKick job={job} characterId={entity.id} title={`Refresh ${label} now`} />}
+    </span>
+  )
+}
+
+// A column's header: the job label over its sweep button and its next
+// scheduled fire (or the overdue flag when the previous one didn't happen).
+const ColumnHead = ({ entry, entities, sweep }: { entry: JobEntry; entities: EntityRun[]; sweep: boolean }) => (
+  <span className={styles.columnHead}>
+    <span className={styles.columnLabel} title={entry.job}>
+      {entry.label}
+    </span>
+    {sweep && <ColumnKick job={entry.job} label={entry.label} />}
+    {isOverdue(entry.job, newestRun(entities)) ? (
+      <span className={styles.overdue} title="The previous scheduled fire didn't produce a run">
+        overdue
+      </span>
+    ) : (
+      <span className={styles.columnNext}>
+        <NextRun at={iso(nextRunFor(entry.job))} />
+      </span>
+    )}
+  </span>
+)
 
 const RegistrationPage = async () => {
   const supabase = await createClient()
@@ -31,8 +169,85 @@ const RegistrationPage = async () => {
     redirect('/')
   }
 
-  const { characters, status, statusText, error } = await fetchCharacterOverviews(supabase)
-  const noOptionalScopes = await hasNoOptionalScopes(supabase, user.id)
+  const [{ characters, status, statusText, error }, noOptionalScopes, jobs] = await Promise.all([
+    fetchCharacterOverviews(supabase),
+    hasNoOptionalScopes(supabase, user.id),
+    fetchJobsOverview(supabase, user.id),
+  ])
+  const { grantedByRegistration, template } = await fetchGrantOverview(
+    supabase,
+    user.id,
+    jobs.registrations.map((r) => r.id)
+  )
+
+  const characterJobs = jobsInSection('character')
+  const corporationJobs = jobsInSection('corporation')
+  const overviewById = new Map(characters.map((c) => [c.id, c]))
+  const entityById = (job: string) => new Map((jobs.characterEntities[job] ?? []).map((e) => [e.id, e]))
+  const cellsByJob = new Map(characterJobs.map((entry) => [entry.job, entityById(entry.job)]))
+
+  const granted = (id: string) => grantedByRegistration.get(id) ?? new Set<string>()
+  // Everything a re-auth would catch up, per registration; non-empty = the
+  // character's grants trail the template.
+  const trailing = new Map(jobs.registrations.map((r) => [r.id, trailingScopes(template, granted(r.id))]))
+  const reauthCount = jobs.registrations.filter((r) => (trailing.get(r.id)?.length ?? 0) > 0).length
+
+  // The legend's warn summary counts every requested-but-ungranted cell.
+  const blocked = blockedCellCount(
+    jobs.registrations.flatMap((r) => characterJobs.map((entry) => columnGrant(entry.scopes, granted(r.id), template)))
+  )
+
+  // One countdown for the page: the soonest next fire across the per-character
+  // jobs (each column's own sits in its header).
+  const nextSweep = soonestNextRun(characterJobs.map((entry) => nextRunFor(entry.job)))
+
+  const requestedColumns = characterJobs.filter((entry) => templateCheck(entry.scopes, template) === 'all').length
+
+  const columnStyle = { '--cols': characterJobs.length } as CSSProperties
+  const corpColumnStyle = { '--cols': corporationJobs.length } as CSSProperties
+
+  // The caller's corporations with their registered members, in registration
+  // order — the same grouping and order jobsData builds corporationEntities
+  // from, so the row at index i here is the entity at index i there.
+  const corpList = [
+    ...reduce(
+      (acc, r: Registration) => {
+        if (r.corporation_id == null) return acc
+        const group = acc.get(r.corporation_id)
+        if (group) group.push(r)
+        else acc.set(r.corporation_id, [r])
+        return acc
+      },
+      new Map<number, Registration[]>(),
+      jobs.registrations
+    ).entries(),
+  ]
+
+  // The template row is live even before the first character — the empty state
+  // is the matrix, ghosted, with the request template already editable.
+  const templateRow = (
+    <div className={`${styles.row} ${styles.templateRow}`} style={columnStyle}>
+      <div className={styles.templateLabel}>
+        <span className={styles.templateTitle}>
+          {characters.length === 0 ? 'Your first request will ask for' : 'Next request asks for'}
+        </span>
+        <span className={styles.templateSub}>
+          {characters.length === 0
+            ? 'adjust before you register — you grant only what’s checked'
+            : 'what you grant when you register'}
+        </span>
+      </div>
+      {characterJobs.map((entry) => (
+        <span key={entry.job} className={styles.cell}>
+          <span className={styles.cellLabel}>{entry.label}</span>
+          <TemplateToggle scopes={entry.scopes} check={templateCheck(entry.scopes, template)} label={entry.label} />
+        </span>
+      ))}
+      <span className={styles.templateCount}>
+        {requestedColumns} of {characterJobs.length}
+      </span>
+    </div>
+  )
 
   return (
     <>
@@ -42,11 +257,28 @@ const RegistrationPage = async () => {
           <div className={styles.status}>
             <span className={styles.statusCount}>{characters.length}</span>{' '}
             {characters.length === 1 ? 'character' : 'characters'}
+            {reauthCount > 0 && (
+              <>
+                {' · '}
+                <span className={styles.statusWarn}>
+                  {reauthCount} need{reauthCount === 1 ? 's' : ''} re-auth
+                </span>
+              </>
+            )}
+            {nextSweep !== null && (
+              <>
+                {' · next scheduled sweep '}
+                <NextRun at={iso(nextSweep)} />
+              </>
+            )}
           </div>
         </div>
-        <form className={styles.headerActions}>
-          <button formAction={register}>+ Register a character</button>
-        </form>
+        <div className={styles.headerActions}>
+          {characters.length > 0 && <RefreshAll />}
+          <form className={styles.registerForm}>
+            <button formAction={register}>+ Register a character</button>
+          </form>
+        </div>
       </div>
 
       {noOptionalScopes && (
@@ -60,97 +292,373 @@ const RegistrationPage = async () => {
         </div>
       )}
 
-      <div className={styles.matrix}>
-        <div className={styles.headerRow}>
-          <span className={styles.columnLabel}>Character</span>
-          <span className={styles.columnLabel}>State</span>
-        </div>
+      <div className={styles.matrixScroll}>
+        <div className={styles.matrix}>
+          <div className={`${styles.headerRow} ${styles.row}`} style={columnStyle}>
+            <span className={styles.columnLabel}>Character</span>
+            {characterJobs.map((entry) => (
+              <ColumnHead
+                key={entry.job}
+                entry={entry}
+                entities={jobs.characterEntities[entry.job] ?? []}
+                sweep={characters.length > 1 && entry.kickable === 'always'}
+              />
+            ))}
+            <span className={styles.columnLabel}>All jobs</span>
+          </div>
 
-        {characters.length === 0 ? (
-          <>
-            {/* The empty state is the matrix, ghosted: one dashed row where the
-                first character will appear, so the CTA doesn't have to explain
-                what registering unlocks — the grid already does. */}
-            <div className={styles.ghostRow} aria-hidden="true">
-              <div className={styles.identity}>
-                <div className={styles.ghostAvatar} />
-                <div className={styles.ghostBar} />
+          {templateRow}
+
+          {characters.length === 0 ? (
+            <>
+              {/* The empty state is the matrix, ghosted: one dashed row where
+                  the first character will appear, so the CTA doesn't have to
+                  explain what registering unlocks — the grid already does. */}
+              <div className={`${styles.row} ${styles.ghostRow}`} style={columnStyle} aria-hidden="true">
+                <div className={styles.identity}>
+                  <div className={styles.ghostAvatar} />
+                  <div className={styles.ghostBar} />
+                </div>
+                {characterJobs.map((entry) => (
+                  <span key={entry.job} className={styles.cell}>
+                    <span className={styles.ghostCell} />
+                  </span>
+                ))}
+                <span />
               </div>
-            </div>
-            <div className={styles.empty}>
-              <div className={styles.emptyTitle}>No characters registered yet</div>
-              <p className={styles.emptyBody}>
-                Register one through EVE&apos;s SSO and this row fills in — refresh jobs start within a minute of the
-                grant.
-              </p>
-              <form className={styles.emptyActions}>
-                <button formAction={register}>Register your first character</button>
-              </form>
-              <div className={styles.reassurance}>
-                Uses CCP&apos;s official login — we never see your password.{' '}
-                <Link href="/settings/grants">What each scope unlocks</Link>
-              </div>
-            </div>
-          </>
-        ) : (
-          characters.map((c) => (
-            <div key={c.id} className={styles.row}>
-              <div className={styles.identity}>
-                {c.characterId ? (
-                  <img
-                    className={styles.avatar}
-                    src={`https://images.evetech.net/characters/${c.characterId}/portrait?size=128`}
-                    alt={c.name}
-                  />
-                ) : (
-                  <div className={styles.avatar} aria-hidden="true" />
-                )}
-                <div className={styles.identityText}>
-                  <div className={styles.name}>{c.name}</div>
-                  {/* Only for characters who have shared their skills — slots is
-                      null unless character_skill rows exist, so without the scope
-                      we don't guess a capacity, we show nothing. */}
-                  {c.slots && <JobSlots counts={c.slots.counts} max={c.slots.max} />}
+              <div className={styles.empty}>
+                <div className={styles.emptyTitle}>No characters registered yet</div>
+                <p className={styles.emptyBody}>
+                  Register one through EVE&apos;s SSO and this row fills in — refresh jobs start within a minute of the
+                  grant.
+                </p>
+                <form className={styles.emptyActions}>
+                  <button formAction={register}>Register your first character</button>
+                </form>
+                <div className={styles.reassurance}>
+                  Uses CCP&apos;s official login — we never see your password.{' '}
+                  <Link href="/settings/grants">What each scope unlocks</Link>
                 </div>
               </div>
-              <div className={styles.state}>
-                <div className={styles.field}>
-                  <span className={styles.fieldLabel}>ISK:</span>
-                  {c.balance === null ? '—' : formatBisk(c.balance)}
-                </div>
-                <div className={styles.field}>
-                  <span className={styles.fieldLabel}>Location:</span>
-                  {c.locationSystem ?? '—'}
-                </div>
-                <div className={styles.field}>
-                  <span className={styles.fieldLabel}>Ship:</span>
-                  {c.ship ? <Link href={`/ship/${c.ship.itemId}`}>{c.ship.label}</Link> : '—'}
-                </div>
-                {c.cloneSystems.length > 0 && (
-                  <div className={styles.field}>
-                    <span className={styles.fieldLabel}>Clone systems:</span>
-                    <ul className={`${styles.list} ${styles.cloneList}`}>
-                      {c.cloneSystems.map((system) => (
-                        <li key={system}>{system}</li>
-                      ))}
-                    </ul>
+            </>
+          ) : (
+            jobs.registrations.map((r) => {
+              const overview = overviewById.get(r.id)
+              const scopes = granted(r.id)
+              const trails = (trailing.get(r.id)?.length ?? 0) > 0
+              return (
+                <div key={r.id} className={styles.row} style={columnStyle}>
+                  <div className={styles.identity}>
+                    {overview?.characterId ? (
+                      <img
+                        className={styles.avatar}
+                        src={`https://images.evetech.net/characters/${overview.characterId}/portrait?size=128`}
+                        alt={r.name}
+                      />
+                    ) : (
+                      <div className={styles.avatar} aria-hidden="true" />
+                    )}
+                    <div className={styles.identityText}>
+                      <div className={styles.name}>{r.name}</div>
+                      {trails ? (
+                        <div className={styles.subline}>
+                          <span className={styles.sublineWarn}>grants trail the template</span>
+                          {' · '}
+                          <form className={styles.reauthForm}>
+                            <button formAction={register} className={styles.reauth}>
+                              re-auth
+                            </button>
+                          </form>
+                        </div>
+                      ) : (
+                        <div className={styles.subline}>
+                          {r.corporation_id !== null &&
+                            (jobs.corporationNames.get(r.corporation_id) ?? `#${r.corporation_id}`)}
+                          {r.corporation_id !== null && r.is_main && ' · '}
+                          {r.is_main && 'main'}
+                        </div>
+                      )}
+                      {overview?.slots && <JobSlots counts={overview.slots.counts} max={overview.slots.max} />}
+                      {overview && (
+                        <details className={styles.stateDetails}>
+                          <summary>details</summary>
+                          <div className={styles.state}>
+                            <div className={styles.field}>
+                              <span className={styles.fieldLabel}>ISK:</span>
+                              {overview.balance === null ? '—' : formatBisk(overview.balance)}
+                            </div>
+                            <div className={styles.field}>
+                              <span className={styles.fieldLabel}>Location:</span>
+                              {overview.locationSystem ?? '—'}
+                            </div>
+                            <div className={styles.field}>
+                              <span className={styles.fieldLabel}>Ship:</span>
+                              {overview.ship ? (
+                                <Link href={`/ship/${overview.ship.itemId}`}>{overview.ship.label}</Link>
+                              ) : (
+                                '—'
+                              )}
+                            </div>
+                            {overview.cloneSystems.length > 0 && (
+                              <div className={styles.field}>
+                                <span className={styles.fieldLabel}>Clone systems:</span>
+                                <ul className={`${styles.list} ${styles.cloneList}`}>
+                                  {overview.cloneSystems.map((system) => (
+                                    <li key={system}>{system}</li>
+                                  ))}
+                                </ul>
+                              </div>
+                            )}
+                            {overview.implants.length > 0 && (
+                              <div className={styles.field}>
+                                <span className={styles.fieldLabel}>Implants:</span>
+                                <ul className={styles.list}>
+                                  {overview.implants.map((name: string, i: number) => (
+                                    <li key={i}>{name}</li>
+                                  ))}
+                                </ul>
+                              </div>
+                            )}
+                          </div>
+                        </details>
+                      )}
+                    </div>
                   </div>
-                )}
-                {c.implants.length > 0 && (
-                  <div className={styles.field}>
-                    <span className={styles.fieldLabel}>Implants:</span>
-                    <ul className={styles.list}>
-                      {c.implants.map((name: string, i: number) => (
-                        <li key={i}>{name}</li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-              </div>
-            </div>
-          ))
+                  {characterJobs.map((entry) => (
+                    <MatrixCell
+                      key={entry.job}
+                      job={entry.job}
+                      label={entry.label}
+                      entity={
+                        cellsByJob.get(entry.job)?.get(r.id) ?? {
+                          id: r.id,
+                          name: r.name,
+                          lastRunAt: null,
+                          status: 'idle',
+                          error: null,
+                        }
+                      }
+                      grant={columnGrant(entry.scopes, scopes, template)}
+                      kickable={entry.kickable === 'always'}
+                      now={jobs.now}
+                    />
+                  ))}
+                  <span className={styles.rowTail}>
+                    <RowKick characterId={r.id} name={r.name} />
+                  </span>
+                </div>
+              )
+            })
+          )}
+        </div>
+      </div>
+
+      <div className={styles.legend}>
+        <span>
+          <span className={styles.grantIcon} data-grant="on">
+            ✓
+          </span>{' '}
+          requested + granted
+        </span>
+        <span>
+          <span className={styles.grantIcon} data-grant="missing">
+            ✕
+          </span>{' '}
+          requested, missing — job never runs
+        </span>
+        <span>
+          <span className={styles.grantIcon} data-grant="extra">
+            ✓
+          </span>{' '}
+          granted, not requested — still refreshes
+        </span>
+        <span>
+          <span className={styles.grantIcon} data-grant="off">
+            ·
+          </span>{' '}
+          neither
+        </span>
+        {blocked > 0 && (
+          <span className={styles.legendBlocked}>
+            {blocked} job{blocked === 1 ? '' : 's'} blocked by missing grants
+          </span>
         )}
       </div>
+
+      {/* Narrow widths lose the column headers, so the scope sweeps move into
+          this disclosure (the mockup's bottom sheet, as a plain details). */}
+      {characters.length > 1 && (
+        <details className={styles.sweepSheet}>
+          <summary>Refresh a scope everywhere</summary>
+          <ul className={styles.sweepList}>
+            {characterJobs
+              .filter((entry) => entry.kickable === 'always')
+              .map((entry) => (
+                <li key={entry.job}>
+                  <span>{entry.label}</span>
+                  <span className={styles.sweepCount}>×{characters.length}</span>
+                  <ColumnKick job={entry.job} label={entry.label} />
+                </li>
+              ))}
+          </ul>
+        </details>
+      )}
+
+      {jobs.corporationCount > 0 && (
+        <>
+          <h2>Corporations</h2>
+          <p className={styles.sectionIntro}>
+            Corp extracts run once per corporation, under the token of a character holding the in-game role — director,
+            accountant — that the endpoint requires. Each cell names whose token the last pull actually used, so a corp
+            going stale because its only director token stopped working is visible as such. A cell reading{' '}
+            <em>not a director</em> pulled nothing, but failed nothing either — there is nothing to retry.
+          </p>
+          <div className={styles.matrixScroll}>
+            <div className={styles.matrix}>
+              <div className={`${styles.headerRow} ${styles.row}`} style={corpColumnStyle}>
+                <span className={styles.columnLabel}>Corporation</span>
+                {corporationJobs.map((entry) => (
+                  <ColumnHead
+                    key={entry.job}
+                    entry={entry}
+                    entities={jobs.corporationEntities[entry.job] ?? []}
+                    sweep={false}
+                  />
+                ))}
+                <span />
+              </div>
+              {corpList.map(([corporationId, members], corpIndex) => {
+                // The corp's granted set is the union of its member tokens —
+                // any member's grant makes the pull possible (the in-game role
+                // check is EVE's, visible here as the skipped state).
+                const memberGranted = new Set(members.flatMap((m) => [...granted(m.id)]))
+                return (
+                  <div key={corporationId} className={styles.row} style={corpColumnStyle}>
+                    <div className={styles.identity}>
+                      <div className={styles.identityText}>
+                        <div className={styles.name}>
+                          <Name name={jobs.corporationNames.get(corporationId)} id={corporationId} />
+                        </div>
+                        <div className={styles.subline}>
+                          {members.length} of your character{members.length === 1 ? '' : 's'}
+                        </div>
+                      </div>
+                    </div>
+                    {corporationJobs.map((entry) => {
+                      const entity = (jobs.corporationEntities[entry.job] ?? [])[corpIndex]
+                      if (!entity) return <span key={entry.job} />
+                      return (
+                        <MatrixCell
+                          key={entry.job}
+                          job={entry.job}
+                          label={entry.label}
+                          entity={entity}
+                          grant={columnGrant(entry.scopes, memberGranted, template)}
+                          kickable={entry.kickable === 'always'}
+                          now={jobs.now}
+                          runsAs={{ name: entity.runsAs ?? null, corpmate: entity.runsAsCorpmate === true }}
+                        />
+                      )
+                    })}
+                    <span />
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        </>
+      )}
+
+      <h2>Shared universe</h2>
+      <p className={styles.sectionIntro}>
+        Game-wide data every account shares — the SDE mirror, structure and name resolution, industry cost indices.
+        These run once for everyone, so a run someone else kicked shows here as running for you too. Relative times
+        only: a nightly job would sit permanently red against the six-hourly freshness scale. Kicking one of these is a
+        Chancellor&apos;s call — the pull is game-wide, not yours.
+      </p>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>Job</th>
+            <th>Last run</th>
+            <th>Status</th>
+            <th>Next run</th>
+          </tr>
+        </thead>
+        <tbody>
+          {jobsInSection('universe').map((entry) => {
+            const beat = jobs.accountBeats.get(entry.job)
+            const entity: EntityRun = { id: '', name: entry.label, ...jobs.runFor(entry.job, '', beat) }
+            const inFlight = entity.status === 'running' || entity.status === 'queued'
+            const kick = entry.kickable === 'chancellor' && jobs.chancellor && !inFlight
+            return (
+              <tr key={entry.job}>
+                <td>
+                  {entry.label}
+                  <code className={styles.jobName}>{entry.job}</code>
+                </td>
+                <td>
+                  {entity.lastRunAt === null ? '—' : relativeTime(entity.lastRunAt, jobs.now)}
+                  {kick && <UniverseKick job={entry.job} label={entry.label} />}
+                </td>
+                <td>
+                  <span className={styles.statusCell} data-status={entity.status} title={entity.error ?? undefined}>
+                    {STATUS_LABEL[entity.status] ?? entity.status}
+                  </span>
+                </td>
+                <td>
+                  {isOverdue(entry.job, entity.lastRunAt) ? (
+                    <span className={styles.overdue} title="The previous scheduled fire didn't produce a run">
+                      overdue
+                    </span>
+                  ) : (
+                    <NextRun at={iso(nextRunFor(entry.job))} />
+                  )}
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+
+      <h2>Recent activity</h2>
+      <p className={styles.sectionIntro}>
+        Refreshes you kicked in the last 24 hours, newest first, grouped by the batch that dispatched them. This is the
+        only place an on-demand run that failed while you were away is visible.
+      </p>
+      {jobs.activity.length === 0 ? (
+        <p className={styles.sectionIntro}>Nothing kicked in the last 24 hours.</p>
+      ) : (
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>Enqueued</th>
+              <th>Job</th>
+              <th>For</th>
+              <th>Status</th>
+              <th>Took</th>
+            </tr>
+          </thead>
+          <tbody>
+            {jobs.activity.map((task) => (
+              <tr key={task.id}>
+                <td>{task.firstOfBatch ? relativeTime(task.created_at, jobs.now) : ''}</td>
+                <td>
+                  <code className={styles.jobName}>{task.job}</code>
+                </td>
+                <td>{task.character_name === null ? '—' : <Name name={task.character_name} />}</td>
+                <td>
+                  <span className={styles.statusCell} data-status={task.status} title={task.error ?? undefined}>
+                    {STATUS_LABEL[isAbandoned(task, jobs.now) ? 'abandoned' : task.status] ?? task.status}
+                  </span>
+                  {task.error !== null && <div className={styles.errorText}>{task.error}</div>}
+                </td>
+                <td>{task.durationSeconds === null ? '—' : `${task.durationSeconds}s`}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
 
       {error && (
         <>
@@ -164,6 +672,8 @@ const RegistrationPage = async () => {
           <pre>{JSON.stringify(error, undefined, 2)}</pre>
         </>
       )}
+
+      <RefreshPoller done={!jobs.anyActive} />
     </>
   )
 }

--- a/src/app/registration/registration.module.css
+++ b/src/app/registration/registration.module.css
@@ -1,14 +1,16 @@
 /* /registration — the registrations matrix from the phase-0 design extraction
-   (docs/registrations-page/00a-design-extraction.md §1, §4). Design tokens map
-   onto the app's own: bg-surface/canvas → --paper, bg-elevated → --paper-raised,
+   (docs/registrations-page/00a-design-extraction.md). Design tokens map onto
+   the app's own: bg-surface/canvas → --paper, bg-elevated → --paper-raised,
    border-subtle → --line-soft, border-strong → --line, text-secondary/tertiary
-   → --ink-soft/--ink-faint.
+   → --ink-soft/--ink-faint, status-info → --info (added in globals.css).
 
-   Phase 2 builds the shell and the character rows; the per-scope job columns
-   land in phase 3, which widens .row's grid template rather than replacing it. */
+   The matrix is a CSS grid per row: identity column, one column per job in the
+   registry's section (var(--cols), set inline — the column set is derived, not
+   hardcoded), and a row-tail column. Narrow widths collapse each row into a
+   per-character card (§6, the responsive intent). */
 
-/* Page header: title + status line on the left, actions right, baseline-ish
-   aligned per the mockup's flex-end row. */
+/* ── Page header ─────────────────────────────────────────────────────── */
+
 .header {
   display: flex;
   align-items: flex-end;
@@ -37,33 +39,53 @@
   color: var(--ink);
 }
 
+.statusWarn {
+  color: var(--warn);
+}
+
 .headerActions {
   display: flex;
+  align-items: center;
   gap: 8pt;
+}
+
+.registerForm {
   margin: 0;
 }
 
-/* The matrix: one bordered, rounded container, rows separated by hairlines and
-   clipped to the radius. */
-.matrix {
+/* ── The matrix ──────────────────────────────────────────────────────── */
+
+/* The bordered container scrolls sideways on middling widths rather than the
+   page — nine job columns have a real minimum. Mobile switches to cards and
+   needs no scroll. */
+.matrixScroll {
   border: 1px solid var(--line-soft);
   border-radius: var(--radius);
-  overflow: hidden;
+  overflow-x: auto;
+  margin-bottom: 8pt;
 }
 
-.columns {
+.matrix {
+  min-width: min-content;
+}
+
+.row {
   display: grid;
-  /* Phase 3 inserts `repeat(N, 1fr)` for the scope columns between these two. */
-  grid-template-columns: 230px 1fr;
-  gap: 14px;
-  align-items: start;
+  grid-template-columns: 220px repeat(var(--cols), minmax(72px, 1fr)) 74px;
+  gap: 10px;
+  align-items: center;
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.matrix > .row:last-child,
+.matrix > *:last-child .row:last-child {
+  border-bottom: none;
 }
 
 .headerRow {
-  composes: columns;
-  padding: 10px 14px;
-  border-bottom: 1px solid var(--line-soft);
   background: var(--paper-raised);
+  align-items: start;
 }
 
 .columnLabel {
@@ -73,18 +95,92 @@
   color: var(--ink-faint);
 }
 
-.row {
-  composes: columns;
-  padding: 11px 14px;
-  border-bottom: 1px solid var(--line-soft);
+.columnHead {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
+  min-width: 0;
+}
+
+.columnNext {
+  font-family: var(--mono);
+  font-size: 7.5pt;
+  color: var(--ink-faint);
+  white-space: nowrap;
+}
+
+.overdue {
+  color: var(--danger);
+  font-size: 8pt;
+  white-space: nowrap;
+}
+
+/* ── Template row ────────────────────────────────────────────────────── */
+
+/* Row zero: elevated, strongly separated — editable state, not data. */
+.templateRow {
+  background: var(--paper-raised);
+  border-bottom: 2px solid var(--line);
+}
+
+.templateLabel {
+  min-width: 0;
+}
+
+.templateTitle {
+  display: block;
+  color: var(--accent);
+  font-weight: bold;
+  font-size: 9.5pt;
+}
+
+.templateSub {
+  display: block;
+  font-size: 8pt;
+  color: var(--ink-faint);
+}
+
+.templateCount {
+  font-family: var(--mono);
+  font-size: 9pt;
+  color: var(--ink-soft);
+  white-space: nowrap;
+}
+
+/* The checkbox: filled accent ✓ when the column's scopes are requested,
+   hollow when not, a mixed ~ when the template asks for only part of a
+   multi-scope column. */
+.templateBox {
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  display: inline-flex;
   align-items: center;
+  justify-content: center;
+  font: inherit;
+  font-size: 11px;
+  line-height: 1;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: transparent;
+  cursor: pointer;
 }
 
-.row:last-child {
-  border-bottom: none;
+.templateBox[data-check='all'] {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--paper-raised);
 }
 
-/* Identity cell: portrait, name, and the job-slot bubbles beneath it. */
+.templateBox[data-check='some'] {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* ── Identity column ─────────────────────────────────────────────────── */
+
 .identity {
   display: flex;
   align-items: flex-start;
@@ -114,14 +210,58 @@
   white-space: nowrap;
 }
 
-/* Character state — the fields the mockup's row omits and parity keeps
-   (docs/registrations-page/00a-design-extraction.md §2). Phase 4 rules on
-   where these finally live. */
+/* Corp name + main for a healthy character; the re-auth warning when the
+   token's grants trail the template. Mono per the mockup's `[DSWB] · main`. */
+.subline {
+  font-family: var(--mono);
+  font-size: 8pt;
+  color: var(--ink-faint);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sublineWarn {
+  color: var(--warn);
+  font-family: var(--sans);
+}
+
+.reauthForm {
+  display: inline;
+  margin: 0;
+}
+
+/* The re-auth control is a server-action submit styled as the design's link. */
+.reauth {
+  font: inherit;
+  font-family: var(--sans);
+  font-weight: bold;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--warn);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+/* Character-state fields (ISK, location, ship, clones, implants) — parity from
+   /character, one disclosure away so the matrix row stays scannable (the
+   extraction's "expandable row" resolution for §2's gap list). */
+.stateDetails {
+  margin-top: 2px;
+  font-size: 8.5pt;
+}
+
+.stateDetails summary {
+  cursor: pointer;
+  color: var(--ink-faint);
+}
+
 .state {
   display: flex;
-  flex-wrap: wrap;
-  gap: 4px 24px;
-  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+  padding: 4px 0 2px;
   font-size: 9pt;
   color: var(--ink-soft);
 }
@@ -140,21 +280,291 @@
   padding-left: 16pt;
 }
 
-.list li {
-  white-space: nowrap;
-}
-
 .cloneList {
   list-style: none;
   padding-left: 0;
 }
 
-/* First run: the matrix, ghosted — one dashed row where the first character
-   will appear, then the invitation (design extraction, "First-run empty
-   state"). */
+/* ── Cells ───────────────────────────────────────────────────────────── */
+
+/* A cell stacks the grant icon over the last-run line; the label span only
+   shows once the row collapses into a card. */
+.cell {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  min-width: 0;
+}
+
+.cellLabel {
+  display: none;
+}
+
+.cellBody {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.grantIcon {
+  width: 16px;
+  height: 16px;
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  line-height: 1;
+  border-radius: 50%;
+  border: 1.5px solid currentColor;
+}
+
+.grantIcon[data-grant='on'] {
+  color: var(--ok);
+}
+
+.grantIcon[data-grant='missing'] {
+  color: var(--danger);
+}
+
+.grantIcon[data-grant='extra'] {
+  color: var(--info);
+}
+
+.grantIcon[data-grant='off'] {
+  color: var(--warn);
+  border-style: dotted;
+}
+
+.cellTime,
+.cellNote,
+.cellOff,
+.cellRunsAs {
+  font-family: var(--mono);
+  font-size: 7.5pt;
+  color: var(--ink-faint);
+  white-space: nowrap;
+}
+
+/* Freshness carries over from /jobs as text colour rather than the dot: green
+   is quiet, aging warns, stale alarms — same scale (freshness.ts). */
+.cellTime[data-fresh='aging'] {
+  color: var(--warn);
+}
+
+.cellTime[data-fresh='stale'] {
+  color: var(--danger);
+}
+
+.cellRunning {
+  font-family: var(--mono);
+  font-size: 7.5pt;
+  color: var(--accent);
+  white-space: nowrap;
+}
+
+.cellFailed {
+  font-family: var(--mono);
+  font-size: 7.5pt;
+  color: var(--danger);
+  white-space: nowrap;
+}
+
+/* "never — no grant": the ✕ explains why the job never runs. */
+.cellBlocked {
+  font-family: var(--mono);
+  font-size: 7.5pt;
+  color: var(--danger);
+  white-space: nowrap;
+}
+
+.cellNote {
+  font-style: italic;
+}
+
+.retry {
+  font: inherit;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--danger);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+/* ── Refresh triggers ────────────────────────────────────────────────── */
+
+.kick,
+.rowKick {
+  font: inherit;
+  font-size: 11px;
+  line-height: 1;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--ink-soft);
+  cursor: pointer;
+}
+
+.kick:hover,
+.rowKick:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.rowKick {
+  width: 26px;
+  height: 26px;
+  font-size: 13px;
+}
+
+.rowTail {
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* ── Legend ──────────────────────────────────────────────────────────── */
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 18px;
+  margin: 0 2px 16pt;
+  font-size: 8.5pt;
+  color: var(--ink-faint);
+}
+
+.legend .grantIcon {
+  width: 13px;
+  height: 13px;
+  font-size: 8px;
+  vertical-align: -2px;
+}
+
+.legendBlocked {
+  margin-left: auto;
+  color: var(--warn);
+}
+
+/* ── Scope sweeps as a sheet (narrow widths only) ────────────────────── */
+
+.sweepSheet {
+  display: none;
+  margin: 0 0 16pt;
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius);
+  padding: 8pt 12pt;
+  font-size: 9pt;
+}
+
+.sweepSheet summary {
+  cursor: pointer;
+  color: var(--ink-soft);
+}
+
+.sweepList {
+  list-style: none;
+  margin: 6pt 0 0;
+  padding: 0;
+}
+
+.sweepList li {
+  display: flex;
+  align-items: center;
+  gap: 8pt;
+  padding: 4pt 0;
+  border-top: 1px solid var(--line-soft);
+}
+
+.sweepCount {
+  margin-left: auto;
+  font-family: var(--mono);
+  color: var(--ink-faint);
+}
+
+/* ── Sections below the matrix ───────────────────────────────────────── */
+
+.sectionIntro {
+  font-size: 9.5pt;
+  color: var(--ink-soft);
+  max-width: 72em;
+}
+
+.table {
+  border-collapse: collapse;
+  margin-bottom: 16pt;
+}
+
+.table th {
+  text-align: left;
+  font-size: 8pt;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  font-weight: normal;
+  padding: 4pt 14pt 4pt 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.table td {
+  padding: 5pt 14pt 5pt 0;
+  border-bottom: 1px solid var(--line-soft);
+  font-size: 9.5pt;
+  vertical-align: top;
+}
+
+.jobName {
+  display: block;
+  font-family: var(--mono);
+  font-size: 0.75em;
+  color: var(--ink-faint);
+}
+
+.statusCell {
+  white-space: nowrap;
+}
+
+.statusCell[data-status='running'] {
+  color: var(--accent);
+}
+
+.statusCell[data-status='queued'],
+.statusCell[data-status='pending'],
+.statusCell[data-status='idle'] {
+  color: var(--ink-faint);
+}
+
+.statusCell[data-status='failed'],
+.statusCell[data-status='error'],
+.statusCell[data-status='abandoned'] {
+  color: var(--danger);
+}
+
+.statusCell[data-status='skipped'] {
+  color: var(--ink-faint);
+  font-style: italic;
+}
+
+.statusCell[data-status='done'] {
+  color: var(--ok);
+}
+
+.errorText {
+  color: var(--danger);
+  font-size: 0.85em;
+}
+
+/* ── Empty state ─────────────────────────────────────────────────────── */
+
 .ghostRow {
-  composes: columns;
-  padding: 11px 14px;
   opacity: 0.45;
 }
 
@@ -172,6 +582,13 @@
   margin-top: 8px;
   border: 1px dashed var(--line);
   border-radius: var(--radius-sm);
+}
+
+.ghostCell {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1px dashed var(--line);
 }
 
 .empty {
@@ -203,8 +620,8 @@
   color: var(--ink-faint);
 }
 
-/* Same treatment as /character's: an account that shares nothing optional gets
-   almost no data, so say so where characters are added. */
+/* ── The no-optional-scopes warning (parity from /character) ─────────── */
+
 .warning {
   margin: 12pt 0;
   padding: 10pt 12pt;
@@ -226,20 +643,63 @@
   color: var(--ink-soft);
 }
 
-/* Narrow widths: the matrix becomes per-character cards (design extraction §6
-   — the responsive intent). The grid collapses to one column and the identity
-   block sits above the state fields. */
-@media (max-width: 720px) {
-  .columns {
-    grid-template-columns: 1fr;
-    gap: 8px;
+/* ── Narrow widths: rows become cards (§6) ───────────────────────────── */
+
+@media (max-width: 760px) {
+  .row {
+    grid-template-columns: 1fr 1fr;
+    gap: 6px 10px;
+    align-items: start;
   }
 
   .headerRow {
     display: none;
   }
 
-  .row {
-    align-items: flex-start;
+  /* Identity spans the card's top; the row ↻ sits beside it. */
+  .identity {
+    grid-column: 1 / -1;
+  }
+
+  .rowTail {
+    grid-column: 1 / -1;
+    justify-content: flex-start;
+  }
+
+  /* Cells become labelled lines: icon · scope name · time. */
+  .cell {
+    flex-direction: row;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .cellLabel {
+    display: inline;
+    order: 1;
+    font-size: 8.5pt;
+    color: var(--ink-soft);
+    min-width: 5.5em;
+  }
+
+  .grantIcon {
+    order: 0;
+  }
+
+  .cellBody {
+    order: 2;
+  }
+
+  .cell > :global(button) {
+    order: 3;
+  }
+
+  .templateLabel,
+  .templateCount {
+    grid-column: 1 / -1;
+  }
+
+  /* The column sweeps live in the sheet on narrow screens. */
+  .sweepSheet {
+    display: block;
   }
 }

--- a/test/registrationMatrix.test.ts
+++ b/test/registrationMatrix.test.ts
@@ -1,0 +1,75 @@
+// Unit coverage for the /registration grant-matrix rules: the four cell
+// states fusing grant and job, the any-scope rule for multi-scope columns
+// (character-status), the mixed template checkbox, the re-auth trailing set,
+// and the two page headlines (blocked count, soonest sweep).
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  blockedCellCount,
+  columnGrant,
+  grantAllowsRun,
+  soonestNextRun,
+  templateCheck,
+  trailingScopes,
+} from '../src/app/registration/matrix.ts'
+
+const ASSETS = ['esi-assets.read_assets.v1']
+const STATUS = ['esi-wallet.read_character_wallet.v1', 'esi-location.read_location.v1']
+
+test('columnGrant: requested and granted is on', () => {
+  assert.equal(columnGrant(ASSETS, new Set(ASSETS), new Set(ASSETS)), 'on')
+})
+
+test('columnGrant: requested but not granted is missing — the job never runs', () => {
+  assert.equal(columnGrant(ASSETS, new Set(), new Set(ASSETS)), 'missing')
+})
+
+test('columnGrant: granted but not in the template still runs, as extra', () => {
+  assert.equal(columnGrant(ASSETS, new Set(ASSETS), new Set()), 'extra')
+})
+
+test('columnGrant: neither requested nor granted is off', () => {
+  assert.equal(columnGrant(ASSETS, new Set(), new Set()), 'off')
+})
+
+test('columnGrant: a multi-scope column is granted by ANY of its scopes', () => {
+  // character-status runs whichever endpoints the token carries, so one grant
+  // out of six is a runnable job, not a missing one.
+  assert.equal(columnGrant(STATUS, new Set([STATUS[1]]), new Set(STATUS)), 'on')
+})
+
+test('grantAllowsRun: only on and extra cells have anything to kick', () => {
+  assert.equal(grantAllowsRun('on'), true)
+  assert.equal(grantAllowsRun('extra'), true)
+  assert.equal(grantAllowsRun('missing'), false)
+  assert.equal(grantAllowsRun('off'), false)
+})
+
+test('templateCheck: all, some and none of a column’s scopes', () => {
+  assert.equal(templateCheck(STATUS, new Set(STATUS)), 'all')
+  assert.equal(templateCheck(STATUS, new Set([STATUS[0]])), 'some')
+  assert.equal(templateCheck(STATUS, new Set()), 'none')
+})
+
+test('trailingScopes: what a re-auth would catch up, over the whole template', () => {
+  const template = new Set(['a', 'b', 'c'])
+  assert.deepEqual(trailingScopes(template, new Set(['a'])), ['b', 'c'])
+  // A token can carry more than the template asks; extras never count against it.
+  assert.deepEqual(trailingScopes(template, new Set(['a', 'b', 'c', 'd'])), [])
+  // No token at all trails by the entire template.
+  assert.deepEqual(trailingScopes(template, new Set()), ['a', 'b', 'c'])
+})
+
+test('blockedCellCount counts only missing cells', () => {
+  assert.equal(blockedCellCount(['on', 'missing', 'extra', 'off', 'missing']), 2)
+  assert.equal(blockedCellCount([]), 0)
+})
+
+test('soonestNextRun picks the earliest fire and ignores manual-only jobs', () => {
+  const early = new Date('2026-08-26T01:00:00Z')
+  const late = new Date('2026-08-26T09:00:00Z')
+  assert.equal(soonestNextRun([late, null, early]), early)
+  assert.equal(soonestNextRun([null, null]), null)
+  assert.equal(soonestNextRun([]), null)
+})


### PR DESCRIPTION
Phases 3+4 of `docs/registrations-page` — the Registrations v2 design's core idea lands on `/registration`: **grant and job in one cell**. Continues #956/#957/#958; `/character` and `/jobs` stay live and untouched.

## The matrix

- One column per job in `jobsInSection('character')` (nine, derived — not the mockup's hardcoded five). Each cell stacks a grant icon over the job's last run:
  - **green ✓** requested + granted → runs; timestamp on the freshness scale (quiet / warn / danger = fresh / aging / stale)
  - **red ✕** requested, missing → `never — no grant` (the ✕ is *why* the job never runs)
  - **blue ✓** granted, not in the template → still refreshes (new `--info` token, both themes)
  - **amber ·** neither
  - running/failed overlay the base state; failed cells carry an inline **retry**
- **Template row** (elevated, row zero): editable checkboxes driving `user_settings.enabled_scopes` — same storage as `/settings/grants`, no redirect. Multi-scope columns (`character-status` fronts six scopes) render a mixed `~` and complete-then-clear.
- **Re-auth**: a character whose token scopes trail the template shows *grants trail the template · re-auth* (straight into the existing SSO round trip).
- **Refresh at all four granularities** (the design's axes rule): in-cell ↻, column-header sweep (`refreshAllCharacters`), row tail ↻ (every job for one character), and header *Refresh all* — the last two through the same `dispatchRefresh` fan-out adding a character runs, so Recent activity groups them as one batch.
- Legend row + "N jobs blocked by missing grants" summary; per-column next-run/overdue in the headers; one "next scheduled sweep" countdown in the page status line.
- **Corporations** as a second matrix: per-cell runs-as ("as Sir Cuddles" / "a corpmate's token"), *not a director* skip state, grant = union of member tokens.
- **Shared universe** and **Recent activity** keep their tables; `RefreshPoller` carries over; empty state gains the ghosted columns and a live template row.
- Mobile: rows collapse to per-character cards (labelled scope lines, ≥44px row ↻); column sweeps move into a "Refresh a scope everywhere" disclosure.

## Plumbing

- `registry.ts` entries now carry their jobs' ESI scopes (matching the `SCOPE` constants of the job modules, which can't be imported into the page graph).
- `registration/matrix.ts` — pure cell/template/re-auth/blocked rules, tested (`test/registrationMatrix.test.ts`, 9 cases).
- `matrixData.ts` — token scopes read with a **service client scoped to the caller's own registration ids** (the `token` table's grants stop at `service_role` by design; only `registration_id, scope` is selected, following the `/bpos`–`/corpses` pattern).
- `registration/actions.ts` — row/full dispatch + template toggling; cell and column reuse `/jobs`'s existing actions, so each dispatch shape has exactly one path.
- `jobsData.ts` additively returns `corporationNames` and selects `is_main` (no `/jobs` render change).

## Deliberate deferrals (recorded in `04-integration.md`, user to rule)

- **remove** per row: `registration` grants authenticated only select+update(is_main); deletion needs a product ruling (cascade wipes extract history) and a service-role action or migration.
- Mockup's modal bottom sheet → plain `<details>`; lowercase-heading voice not adopted (house typography kept).

Validated: `pnpm lint` clean, `pnpm test` 589 pass, `pnpm build` green with `/registration` in the manifest.

Note: the Claude Design MCP remained unreachable from this remote session (`/design-login` needs an interactive terminal) — this implements from the committed design files and `00a-design-extraction.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNLt3QGWHjLNLoPcQek8mV)_