### PR TITLE
Bucket cost-index history in the database, and rework the structure tiles

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -83,6 +83,7 @@ drop view  if exists public.character_industry_job              cascade;
 drop table if exists public.character_industry_job_over_time    cascade;
 drop table if exists public.character_affiliation         cascade;
 drop table if exists public.character_directory   cascade;
+drop materialized view if exists public.industry_system_index_bucket cascade;
 drop table if exists public.industry_system_index cascade;
 drop table if exists public.market_adjusted_price cascade;
 drop view  if exists public.market_price               cascade;
@@ -156,6 +157,7 @@ drop table if exists public.registration         cascade;
 -- The mirror tables are minted dynamically at ingest time (sde_<stem>, one
 -- per JSONL file in CCP's export), so sweep them by prefix instead of by name.
 drop function if exists public.ensure_sde_mirror_table(text, text) cascade;
+drop function if exists public.refresh_industry_index_buckets()    cascade;
 drop function if exists public.sde_refresh_views()                 cascade;
 drop function if exists public.sde_search_type(text, int)          cascade;
 drop function if exists public.sde_search_system(text, int)        cascade;
@@ -3450,6 +3452,68 @@ create policy "Everyone reads industry indexes"
 
 grant select on public.industry_system_index to anon, authenticated;
 grant all    on public.industry_system_index to service_role;
+
+-- ── industry_system_index_bucket ──────────────────────────────────────────
+-- Pre-bucketed cost-index history for the /structure and /structure/[id]
+-- sparklines. The page used to read every raw industry_system_index row in
+-- the window and average them in JS; at hourly collection that is 150 rows an
+-- hour, so a 90-day window meant ~324k rows over ~324 sequential PostgREST
+-- pages and the render blew its function budget ("destination stream closed
+-- early"). The sparkline never draws more than ~180 points, so the averaging
+-- belongs here, next to the data.
+--
+-- One row per (granularity, system, activity, bucket). Three granularities are
+-- kept, each only as far back as the widest window that uses it: 1h backs the
+-- 1/3/7-day windows, 6h the 14/30-day ones, 24h the 90-day one (see
+-- src/app/structure/windows.ts, which picks the granularity by the same rule).
+-- That caps the whole view at ~60k rows no matter how long the source table
+-- accumulates, so a page load is a bounded handful of pages forever.
+--
+-- Buckets are epoch-aligned rather than date_trunc'd so they land exactly
+-- where the client's Math.floor(epochMs / bucketMs) puts them, and stay
+-- independent of the server's TimeZone setting. cost_index is the mean of the
+-- readings in the bucket; recorded_at is the newest reading in it, which is
+-- what the sparkline tooltip reports as "last updated".
+create materialized view public.industry_system_index_bucket as
+select
+  g.bucket_hours::smallint as bucket_hours,
+  i.system_id,
+  i.activity,
+  to_timestamp(floor(extract(epoch from i.recorded_at) / (g.bucket_hours * 3600)) * (g.bucket_hours * 3600)) as bucket_at,
+  avg(i.cost_index)::real as cost_index,
+  max(i.recorded_at) as recorded_at
+from public.industry_system_index i
+cross join (values (1, 8), (6, 31), (24, 91)) as g (bucket_hours, retention_days)
+where i.recorded_at >= now() - make_interval(days => g.retention_days)
+group by 1, 2, 3, 4;
+
+-- Unique index required by REFRESH MATERIALIZED VIEW CONCURRENTLY; also the
+-- access path for the page's query (granularity, then the system ids it asks
+-- for, then the window's lower bound).
+create unique index industry_system_index_bucket_uq
+  on public.industry_system_index_bucket (bucket_hours, system_id, activity, bucket_at);
+
+-- Materialized views can't carry RLS; a SELECT-only grant gives the same
+-- world-readable, nobody-writes access as industry_system_index itself, whose
+-- contents this only summarizes.
+grant select on public.industry_system_index_bucket to anon, authenticated, service_role;
+
+-- Refreshed at the end of every industry-systems run, right after the run's
+-- rows land. Concurrent so the page keeps reading the previous contents while
+-- the refresh runs.
+create or replace function public.refresh_industry_index_buckets()
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  refresh materialized view concurrently public.industry_system_index_bucket;
+end
+$$;
+
+revoke execute on function public.refresh_industry_index_buckets() from public, anon, authenticated;
+grant execute on function public.refresh_industry_index_buckets() to service_role;
 
 -- ── market_adjusted_price ───────────────────────────────────────────────
 -- CCP's adjusted prices, from public ESI GET /markets/prices/ — the price base

--- a/src/app/structure/[structureId]/page.tsx
+++ b/src/app/structure/[structureId]/page.tsx
@@ -382,7 +382,7 @@ const StructurePage = async ({ params, searchParams }: StructureParams) => {
               {s.fuel_expires &&
                 (() => {
                   const relative = formatRelativeFuture(s.fuel_expires, new Date())
-                  return relative ? <span className={structureStyles.subValue}> {relative}</span> : null
+                  return relative ? <span className={structureStyles.subLine}>{relative}</span> : null
                 })()}
             </td>
           </tr>

--- a/src/app/structure/industryIndex.ts
+++ b/src/app/structure/industryIndex.ts
@@ -1,5 +1,6 @@
 import { chain, collectBy, last, map, pipe, pluck, sum, uniq } from 'ramda'
 import type { createClient } from '@/utils/supabase/server'
+import { INDEX_BUCKET_HOURS } from './windows'
 
 // Per-structure industry cost indices. EVE's /industry/systems/ endpoint reports
 // a cost index per solar system for each industry activity; the structures job
@@ -120,7 +121,9 @@ export const fetchLatestSystemIndexes = async (
   return result
 }
 
-type HistoryRow = IndexRow & { recorded_at: string }
+// A row of the pre-bucketed view: cost_index is already the mean of the readings
+// in the bucket, and recorded_at the newest reading in it.
+type HistoryRow = IndexRow & { bucket_at: string; recorded_at: string }
 
 export type IndexSeries = {
   values: number[]
@@ -169,18 +172,23 @@ type Reading = {
 }
 
 // One row → zero or one readings (rows with an unusable cost or timestamp are
-// dropped). Returning a list lets `chain` map-and-filter in a single pass.
+// dropped). Returning a list lets `chain` map-and-filter in a single pass. The
+// view buckets on the same epoch grid this divides by, so bucket_at lands
+// exactly on a bucket boundary and the index round-trips without drift.
 const toReadings = (r: HistoryRow, bucketMs: number): Reading[] => {
   const cost = r.cost_index == null ? null : Number(r.cost_index)
   if (cost == null || !Number.isFinite(cost)) return []
-  const bucket = Math.floor(Date.parse(r.recorded_at) / bucketMs)
+  const bucket = Math.floor(Date.parse(r.bucket_at) / bucketMs)
   if (!Number.isFinite(bucket)) return []
   return [{ system: Number(r.system_id), activity: r.activity as Activity, bucket, cost, recordedAt: r.recorded_at }]
 }
 
-// Collapse one activity's readings into time buckets — averaging readings that
-// share a bucket — then densify into an evenly-spaced series. Readings arrive in
-// ascending recorded_at, so the last one carries the exact `updatedAt`.
+// Collapse one activity's readings into time buckets, then densify into an
+// evenly-spaced series. The view already averaged within a bucket and returns
+// one row per bucket, so the sum/count here is arithmetically a passthrough —
+// it stays because it costs nothing and keeps this fold correct if a caller
+// ever hands it more than one reading per bucket. Readings arrive in ascending
+// bucket order, so the last one carries the exact `updatedAt`.
 const seriesFrom = (nowBucket: number, readings: Reading[]): IndexSeries => {
   const buckets = new Map<number, Bucket>(
     collectBy((r: Reading) => r.bucket, readings).map((forBucket: Reading[]): [number, Bucket] => [
@@ -192,8 +200,10 @@ const seriesFrom = (nowBucket: number, readings: Reading[]): IndexSeries => {
   return { values, liveCount, updatedAt: last(readings)!.recordedAt }
 }
 
-// PostgREST caps a single select; page through industry_system_index so a busy
-// week of readings doesn't get silently truncated.
+// PostgREST caps a single select; page through the view so a wide window doesn't
+// get silently truncated. Bucketing bounds this at ~180 points per system per
+// activity, so the page count is a fixed handful however long the source table
+// accumulates.
 const HISTORY_PAGE = 1000
 
 export type HistoryOptions = {
@@ -201,16 +211,20 @@ export type HistoryOptions = {
   days?: number
   // Width of each averaged bucket, in hours — 1 gives an hourly series (the
   // pull job runs hourly); wider buckets keep long windows to a sane number of
-  // sparkline points.
+  // sparkline points. Must be one of INDEX_BUCKET_HOURS, the widths the view
+  // actually materializes; anything else is snapped up to the next one that
+  // exists, since asking for an unmaterialized width would match no rows and
+  // draw an empty sparkline rather than an obviously wrong one.
   bucketHours?: number
 }
 
 // Cost-index history per system per activity, in chronological order. Used to
-// draw sparklines next to each index. The pull job runs on GitHub Actions and
-// fires irregularly — sometimes several times an hour, sometimes with
-// multi-hour gaps — so raw points would space unevenly across the sparkline's
-// time axis. We bucket readings into fixed UTC intervals (averaging any that
-// share a bucket) and carry the previous bucket's value across empty ones,
+// draw sparklines next to each index. The pull job fires irregularly —
+// sometimes several times an hour, sometimes with multi-hour gaps — so raw
+// points would space unevenly across the sparkline's time axis. Readings are
+// bucketed into fixed UTC intervals (averaging any that share a bucket) by the
+// industry_system_index_bucket materialized view, which the pull job refreshes;
+// here we carry the previous bucket's value across empty ones,
 // giving one evenly-spaced point per bucket from the first reading to the
 // last. Returning `updatedAt` alongside the values lets the sparkline surface
 // "last updated" in a tooltip without a second lookup.
@@ -222,15 +236,18 @@ export const fetchSystemIndexHistory = async (
   const ids = uniq([...systemIds].filter((n) => Number.isFinite(n)))
   if (ids.length === 0) return new Map<number, Map<Activity, IndexSeries>>()
 
+  const width = INDEX_BUCKET_HOURS.find((h) => h >= bucketHours) ?? INDEX_BUCKET_HOURS[INDEX_BUCKET_HOURS.length - 1]
+
   const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString()
   const rows: HistoryRow[] = []
   for (let from = 0; ; from += HISTORY_PAGE) {
     const { data: page } = await supabase
-      .from('industry_system_index')
-      .select('system_id, activity, cost_index, recorded_at')
-      .gte('recorded_at', since)
+      .from('industry_system_index_bucket')
+      .select('system_id, activity, cost_index, bucket_at, recorded_at')
+      .eq('bucket_hours', width)
+      .gte('bucket_at', since)
       .in('system_id', ids)
-      .order('recorded_at', { ascending: true })
+      .order('bucket_at', { ascending: true })
       .range(from, from + HISTORY_PAGE - 1)
     if (!page || page.length === 0) break
     rows.push(...(page as HistoryRow[]))
@@ -240,7 +257,7 @@ export const fetchSystemIndexHistory = async (
   // Group the readings system → activity, then collapse each activity's readings
   // into its bucketed series. `collectBy` keeps the rows' ascending order within
   // each group, so a group's first row identifies it and its last row is latest.
-  const bucketMs = bucketHours * 3_600_000
+  const bucketMs = width * 3_600_000
   const nowBucket = Math.floor(Date.now() / bucketMs)
   const readings = chain((r: HistoryRow) => toReadings(r, bucketMs), rows)
 

--- a/src/app/structure/page.tsx
+++ b/src/app/structure/page.tsx
@@ -873,24 +873,35 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
                     const indexActivities = structureIndexActivities(s.services)
                     const systemIndexes = indexesBySystem.get(Number(s.system_id))
                     const systemHistory = indexHistoryBySystem.get(Number(s.system_id))
+                    // The render backs the title rather than sitting above it, so the
+                    // head carries the over-image treatment only when there is an image
+                    // to sit on — the silhouette fallback keeps the plain tile colours.
+                    const head = (
+                      <div className={s.type_id != null ? `${styles.head} ${styles.heroHead}` : styles.head}>
+                        <div>
+                          <Link href={`/structure/${s.structure_id}`} className={styles.name}>
+                            {s.name ?? `Structure #${s.structure_id}`}
+                            <LinkSpinner />
+                          </Link>
+                          {/* Upwell structures share their structure_id with the station/facility id industry jobs run at. */}
+                          <span className={styles.subId}>#{s.structure_id}</span>
+                        </div>
+                        <FavoriteStar structureId={String(s.structure_id)} favorite={isFavorite(s)} />
+                      </div>
+                    )
                     return (
                       <li key={`structure-${s.structure_id}`} className={styles.tile}>
                         {s.type_id != null ? (
-                          <TypeIcon id={s.type_id} size={256} prefer="render" className={styles.tileArt} />
-                        ) : (
-                          <StructureSilhouette typeId={0} className={styles.silhouette} />
-                        )}
-                        <div className={styles.head}>
-                          <div>
-                            <Link href={`/structure/${s.structure_id}`} className={styles.name}>
-                              {s.name ?? `Structure #${s.structure_id}`}
-                              <LinkSpinner />
-                            </Link>
-                            {/* Upwell structures share their structure_id with the station/facility id industry jobs run at. */}
-                            <span className={styles.subId}>#{s.structure_id}</span>
+                          <div className={styles.hero}>
+                            <TypeIcon id={s.type_id} size={256} prefer="render" className={styles.heroArt} />
+                            {head}
                           </div>
-                          <FavoriteStar structureId={String(s.structure_id)} favorite={isFavorite(s)} />
-                        </div>
+                        ) : (
+                          <>
+                            <StructureSilhouette typeId={0} className={styles.silhouette} />
+                            {head}
+                          </>
+                        )}
 
                         <div className={styles.fields}>
                           {totalByStructure.get(String(s.structure_id)) && (
@@ -973,7 +984,7 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
                                 <DateTime value={s.fuel_expires} />
                                 {(() => {
                                   const relative = formatRelativeFuture(s.fuel_expires, now)
-                                  return relative ? <span className={styles.subValue}> {relative}</span> : null
+                                  return relative ? <span className={styles.subLine}>{relative}</span> : null
                                 })()}
                               </span>
                             </>
@@ -988,7 +999,7 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
                                 {services.map((svc, i) => (
                                   <li key={`svc-${s.structure_id}-${i}`} className={styles.chip}>
                                     {serviceIcons.has(svc) && (
-                                      <TypeIcon id={serviceIcons.get(svc)!} size={16} className={styles.chipIcon} />
+                                      <TypeIcon id={serviceIcons.get(svc)!} size={64} className={styles.chipIcon} />
                                     )}
                                     {svc}
                                   </li>
@@ -1004,7 +1015,7 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
                             <ul className={styles.chips}>
                               {rigs.map((rig, i) => (
                                 <li key={`rig-${s.structure_id}-${i}`} className={styles.chip}>
-                                  <TypeIcon id={rig.typeID} size={16} className={styles.chipIcon} />
+                                  <TypeIcon id={rig.typeID} size={64} className={styles.chipIcon} />
                                   {rig.name}
                                 </li>
                               ))}

--- a/src/app/structure/page.tsx
+++ b/src/app/structure/page.tsx
@@ -47,7 +47,7 @@ import { StructureSilhouette } from './silhouette'
 import { TypeIcon } from '../typeIcon'
 import { Sparkline } from './sparkline'
 import { WindowSelect } from './windowSelect'
-import { structureWindowDays } from './windows'
+import { indexBucketHours, structureWindowDays } from './windows'
 import styles from './structures.module.css'
 
 const PAGE_SIZE = 1000
@@ -454,15 +454,13 @@ const StructuresPage = async ({ searchParams }: StructuresParams) => {
     ids((s) => s.system_id)
   )
   // The same window that drives the revenue footer also scopes the index
-  // sparklines. Widen the bucket for longer windows so the point count stays
-  // sane on a 100px sparkline (~180 points max: 24h/day ÷ bucketHours).
+  // sparklines. indexBucketHours widens the bucket for longer windows so the
+  // point count stays sane on a 100px sparkline, and names one of the widths
+  // the bucketed view materializes.
   const indexHistoryBySystem = await fetchSystemIndexHistory(
     supabase,
     ids((s) => s.system_id),
-    {
-      days: windowDays,
-      bucketHours: Math.max(1, Math.ceil((windowDays * 24) / 180)),
-    }
+    { days: windowDays, bucketHours: indexBucketHours(windowDays) }
   )
 
   // Both signs, sorted out by foldTaxLedger below rather than here. industry_job_tax cuts both ways

--- a/src/app/structure/structures.module.css
+++ b/src/app/structure/structures.module.css
@@ -142,10 +142,11 @@
 }
 
 /* Rigs/services rendered as tiles-within-the-tile. An equal-column grid keeps
- * every chip the same width as they wrap, instead of flex's ragged widths. */
+ * every chip the same width as they wrap, instead of flex's ragged widths. The
+ * columns are wide enough for the 64px icon each chip stacks above its name. */
 .chips {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
   gap: 6px;
   list-style: none;
   padding: 0;
@@ -153,9 +154,15 @@
 }
 
 .chip {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 5px;
   font-family: var(--serif);
   font-size: 12px;
-  padding: 3px 9px;
+  text-align: center;
+  padding: 8px 6px;
   border: 1px solid var(--line);
   border-radius: var(--radius-sm);
   background: var(--paper);
@@ -459,28 +466,90 @@
   font-size: 12px;
 }
 
-/* The structure's in-game render, replacing the line-art silhouette wherever
- * the type is known. CCP's renders are square on a space background, so the
- * tile crops a letterboxed band out of the middle rather than stacking a big
- * black square above the name. */
-.tileArt {
-  display: block;
+/* The structure's in-game render, now the backdrop for its name rather than a
+ * band above it. CCP serves these at 512px around a small subject, so scaled to
+ * tile width they read as pixelated; blurring hard turns that liability into a
+ * soft field of the structure's own colours, which is all a backdrop needs to
+ * be. Only used where the type is known — otherwise the line-art silhouette
+ * above still stands in. */
+.hero {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  min-height: 96px;
+  padding: 14px;
+  overflow: hidden;
+  border-radius: calc(var(--radius) - 4px);
+  /* Keeps the negative z-indexes below from escaping behind the tile itself. */
+  isolation: isolate;
+}
+
+.heroArt {
+  position: absolute;
+  inset: 0;
   width: 100%;
-  height: 96px;
+  height: 100%;
   object-fit: cover;
   object-position: center 38%;
-  border-radius: calc(var(--radius) - 4px);
-  margin-bottom: 4px;
+  filter: blur(10px);
+  /* A blur samples past the element's edges, so without an overscan the corners
+   * fade to transparent and the tile shows through them. */
+  transform: scale(1.25);
+  z-index: -2;
 }
 
-/* Item icon leading a service/rig chip. */
+/* A scrim between render and letters. The text-shadow below is what makes the
+ * title stand off the image, but the renders run from near-black to bright hull
+ * plating and a shadow alone can't carry light letters over the bright ones. */
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to right, rgb(8 10 14 / 70%), rgb(8 10 14 / 44%));
+  z-index: -1;
+}
+
+/* Light letters over the render — the backdrop is dark in both themes, so these
+ * are literal colours rather than theme tokens, which would flip to dark-on-dark
+ * in one of them. */
+.heroHead .name {
+  color: #f2f5f9 !important;
+  text-shadow: 0 1px 3px rgb(0 0 0 / 70%);
+}
+
+.heroHead .name:hover {
+  color: #ffffff !important;
+}
+
+.heroHead .subId {
+  color: rgb(236 241 247 / 90%);
+  text-shadow: 0 1px 3px rgb(0 0 0 / 75%);
+}
+
+/* An unpinned star only; a pinned one keeps its accent colour, which reads fine
+ * over the scrim. */
+.heroHead .favorite:not([aria-pressed='true']) {
+  color: rgb(233 238 245 / 82%);
+  text-shadow: 0 1px 3px rgb(0 0 0 / 70%);
+}
+
+/* Item icon stacked above a service/rig chip's name. */
 .chipIcon {
-  vertical-align: -3px;
-  margin-right: 5px;
+  display: block;
+  flex: none;
 }
 
-/* Muted qualifier after a value: the relative fuel countdown, the recovered
- * tax rate. */
+/* The fuel countdown, dropped below the timestamp rather than trailing it. The
+ * two are one fact read two ways, and inline they ran together into a single
+ * long string that wrapped mid-phrase at tile width. */
+.subLine {
+  display: block;
+  color: var(--ink-faint);
+  font-size: 11px;
+}
+
+/* Muted qualifier after a value, inline: the recovered tax rate. */
 .subValue {
   color: var(--ink-faint);
   font-size: 11px;

--- a/src/app/structure/windows.ts
+++ b/src/app/structure/windows.ts
@@ -29,3 +29,20 @@ export const structureWindowDays = (raw: string | undefined): number => {
   const n = Number(raw)
   return STRUCTURE_WINDOW_OPTIONS.some((o) => o.days === n) ? n : fallback.days
 }
+
+// A sparkline is ~100px wide, so past roughly 180 points the extra readings are
+// invisible — and fetching them is what made the 90-day window time out. The
+// bucketed history (industry_system_index_bucket) is materialized at these three
+// granularities only, so this both sizes the series and names the rows to read.
+// Keep in step with the retention cuts in the materialized view: each width must
+// be kept back at least as far as the widest window that selects it.
+export const INDEX_BUCKET_HOURS = [1, 6, 24]
+
+const MAX_SPARKLINE_POINTS = 180
+
+// The coarsest-to-finest first fit: the narrowest bucket whose point count over
+// `days` still fits the sparkline. 7 days → hourly (168 points), 30 days → 6h
+// (120), 90 days → daily (90).
+export const indexBucketHours = (days: number): number =>
+  INDEX_BUCKET_HOURS.find((h) => (days * 24) / h <= MAX_SPARKLINE_POINTS) ??
+  INDEX_BUCKET_HOURS[INDEX_BUCKET_HOURS.length - 1]

--- a/src/jobs/industrySystems.js
+++ b/src/jobs/industrySystems.js
@@ -120,6 +120,16 @@ export const runIndustrySystems = async () => {
     throw insertErr
   }
   console.log(`[${TAG}] recorded ${rows.length} industry index row(s)`)
+
+  // Roll the fresh readings into industry_system_index_bucket, the pre-averaged
+  // history the /structure and /indexes sparklines read. Refreshing here is what
+  // keeps that view within an hour of the source table. Best-effort: the rows
+  // above are already committed, and failing the run over a stale sparkline
+  // would cost us the next hour's readings too — the following run refreshes
+  // again and catches up.
+  const { error: refreshErr } = await sudoSupabase.rpc('refresh_industry_index_buckets')
+  if (refreshErr) console.error(`[${TAG}] bucket refresh FAILED (sparklines will lag): ${refreshErr.message}`)
+  else console.log(`[${TAG}] refreshed industry index buckets`)
 }
 
 cli(import.meta.url, TAG, runIndustrySystems)

--- a/supabase/migrations/20260826230750_industry_index_buckets.sql
+++ b/supabase/migrations/20260826230750_industry_index_buckets.sql
@@ -1,0 +1,61 @@
+-- ── industry_system_index_bucket ──────────────────────────────────────────
+-- Pre-bucketed cost-index history for the /structure and /structure/[id]
+-- sparklines. The page used to read every raw industry_system_index row in
+-- the window and average them in JS; at hourly collection that is 150 rows an
+-- hour, so a 90-day window meant ~324k rows over ~324 sequential PostgREST
+-- pages and the render blew its function budget ("destination stream closed
+-- early"). The sparkline never draws more than ~180 points, so the averaging
+-- belongs here, next to the data.
+--
+-- One row per (granularity, system, activity, bucket). Three granularities are
+-- kept, each only as far back as the widest window that uses it: 1h backs the
+-- 1/3/7-day windows, 6h the 14/30-day ones, 24h the 90-day one (see
+-- src/app/structure/windows.ts, which picks the granularity by the same rule).
+-- That caps the whole view at ~60k rows no matter how long the source table
+-- accumulates, so a page load is a bounded handful of pages forever.
+--
+-- Buckets are epoch-aligned rather than date_trunc'd so they land exactly
+-- where the client's Math.floor(epochMs / bucketMs) puts them, and stay
+-- independent of the server's TimeZone setting. cost_index is the mean of the
+-- readings in the bucket; recorded_at is the newest reading in it, which is
+-- what the sparkline tooltip reports as "last updated".
+create materialized view public.industry_system_index_bucket as
+select
+  g.bucket_hours::smallint as bucket_hours,
+  i.system_id,
+  i.activity,
+  to_timestamp(floor(extract(epoch from i.recorded_at) / (g.bucket_hours * 3600)) * (g.bucket_hours * 3600)) as bucket_at,
+  avg(i.cost_index)::real as cost_index,
+  max(i.recorded_at) as recorded_at
+from public.industry_system_index i
+cross join (values (1, 8), (6, 31), (24, 91)) as g (bucket_hours, retention_days)
+where i.recorded_at >= now() - make_interval(days => g.retention_days)
+group by 1, 2, 3, 4;
+
+-- Unique index required by REFRESH MATERIALIZED VIEW CONCURRENTLY; also the
+-- access path for the page's query (granularity, then the system ids it asks
+-- for, then the window's lower bound).
+create unique index industry_system_index_bucket_uq
+  on public.industry_system_index_bucket (bucket_hours, system_id, activity, bucket_at);
+
+-- Materialized views can't carry RLS; a SELECT-only grant gives the same
+-- world-readable, nobody-writes access as industry_system_index itself, whose
+-- contents this only summarizes.
+grant select on public.industry_system_index_bucket to anon, authenticated, service_role;
+
+-- Refreshed at the end of every industry-systems run, right after the run's
+-- rows land. Concurrent so the page keeps reading the previous contents while
+-- the refresh runs.
+create or replace function public.refresh_industry_index_buckets()
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  refresh materialized view concurrently public.industry_system_index_bucket;
+end
+$$;
+
+revoke execute on function public.refresh_industry_index_buckets() from public, anon, authenticated;
+grant execute on function public.refresh_industry_index_buckets() to service_role;

--- a/test/sql/industry_index_bucket.sql
+++ b/test/sql/industry_index_bucket.sql
@@ -1,0 +1,136 @@
+-- SQL-level coverage for industry_system_index_bucket, the pre-averaged
+-- cost-index history behind the /structure and /indexes sparklines.
+--
+-- This is in SQL rather than node:test because the whole point of the view is
+-- that the averaging happens in the database: the application no longer sees a
+-- raw reading, so there is nothing left in JS to assert against. Two properties
+-- carry the design, and both live here.
+--
+--   1. Bucket boundaries land on the same epoch grid the client divides by
+--      (src/app/structure/industryIndex.ts's Math.floor(epochMs / bucketMs)).
+--      Off-grid boundaries would still render — as a series silently shifted
+--      by part of a bucket — so nothing downstream would catch this.
+--   2. Each bucket's cost_index is the mean of the readings in it, and its
+--      recorded_at the newest of them. That is exactly what the JS fold this
+--      view replaced computed, and the sparkline tooltip reports recorded_at
+--      as "last updated".
+--
+-- Run against a THROWAWAY database (it creates a stand-in table named after the
+-- real one in `public`) from the repo root:
+--
+--   initdb -D /tmp/pg && pg_ctl -D /tmp/pg -o '-k /tmp -p 55432' start
+--   createdb -h /tmp -p 55432 iib
+--   DATABASE_URL='postgresql://…/iib' pnpm run test:sql
+--
+-- Everything runs in one transaction and rolls back, so nothing is left behind.
+begin;
+
+-- A stand-in with the columns the view reads. The real table (schema.sql) adds
+-- only its identity primary key, which the view never touches.
+create table public.industry_system_index (
+  id bigint generated always as identity primary key,
+  system_id bigint not null,
+  activity text not null,
+  cost_index real not null,
+  recorded_at timestamptz not null default now()
+);
+
+-- The view under test, verbatim from the migration.
+create materialized view public.industry_system_index_bucket as
+select
+  g.bucket_hours::smallint as bucket_hours,
+  i.system_id,
+  i.activity,
+  to_timestamp(floor(extract(epoch from i.recorded_at) / (g.bucket_hours * 3600)) * (g.bucket_hours * 3600)) as bucket_at,
+  avg(i.cost_index)::real as cost_index,
+  max(i.recorded_at) as recorded_at
+from public.industry_system_index i
+cross join (values (1, 8), (6, 31), (24, 91)) as g (bucket_hours, retention_days)
+where i.recorded_at >= now() - make_interval(days => g.retention_days)
+group by 1, 2, 3, 4;
+
+-- ── Bucket boundaries sit on the client's epoch grid ──────────────────────
+-- Readings every 20 minutes for two days, so every width has several readings
+-- per bucket and the 1h width has exactly three.
+insert into public.industry_system_index (system_id, activity, cost_index, recorded_at)
+select 30000142, 'manufacturing', 0.05, now() - make_interval(mins => m)
+from generate_series(0, 2 * 24 * 3) g(m3), lateral (select g.m3 * 20 as m) x;
+
+refresh materialized view public.industry_system_index_bucket;
+
+do $$
+declare
+  off_grid int;
+begin
+  -- A bucket_at is on the grid when its epoch is an exact multiple of the
+  -- bucket width in seconds — the condition under which the client's
+  -- floor(epochMs / bucketMs) reproduces this bucket's own index.
+  select count(*) into off_grid
+    from public.industry_system_index_bucket
+   where (extract(epoch from bucket_at)::bigint % (bucket_hours * 3600)) <> 0;
+  assert off_grid = 0, format('expected every bucket on the epoch grid, %s were off', off_grid);
+end $$;
+
+-- ── A bucket averages its readings, and carries the newest timestamp ──────
+-- Three readings in one known hour, with a mean that is not any of them.
+delete from public.industry_system_index;
+insert into public.industry_system_index (system_id, activity, cost_index, recorded_at)
+values
+  (30000142, 'reaction', 0.02, timestamptz '2026-08-20 04:05:00+00'),
+  (30000142, 'reaction', 0.04, timestamptz '2026-08-20 04:35:00+00'),
+  (30000142, 'reaction', 0.06, timestamptz '2026-08-20 04:55:00+00'),
+  -- The next hour, to prove the boundary actually separates them.
+  (30000142, 'reaction', 0.99, timestamptz '2026-08-20 05:05:00+00');
+
+refresh materialized view public.industry_system_index_bucket;
+
+do $$
+declare
+  b record;
+begin
+  select * into b
+    from public.industry_system_index_bucket
+   where bucket_hours = 1
+     and activity = 'reaction'
+     and bucket_at = timestamptz '2026-08-20 04:00:00+00';
+
+  assert b is not null, 'expected an hourly bucket at 04:00';
+  -- (0.02 + 0.04 + 0.06) / 3 = 0.04, and none of the three readings is 0.04
+  -- by itself, so a "take one row" bug cannot pass this.
+  assert abs(b.cost_index - 0.04) < 1e-6, format('expected mean 0.04, got %s', b.cost_index);
+  assert b.recorded_at = timestamptz '2026-08-20 04:55:00+00',
+    format('expected the newest reading in the bucket, got %s', b.recorded_at);
+end $$;
+
+-- The 05:05 reading must not have leaked into the 04:00 bucket.
+do $$
+declare
+  n int;
+begin
+  select count(*) into n
+    from public.industry_system_index_bucket
+   where bucket_hours = 1 and activity = 'reaction';
+  assert n = 2, format('expected 2 hourly buckets, got %s', n);
+end $$;
+
+-- ── Each width is retained at least as far as the window that selects it ──
+-- src/app/structure/windows.ts routes 7 days to the 1h width, 30 to 6h and 90
+-- to 24h; a retention cut shorter than that would silently truncate the left
+-- edge of the sparkline rather than fail.
+do $$
+declare
+  cut record;
+begin
+  for cut in
+    select * from (values (1, 7), (6, 30), (24, 90)) as w (bucket_hours, widest_window_days)
+  loop
+    perform 1
+       from (values (1, 8), (6, 31), (24, 91)) as g (bucket_hours, retention_days)
+      where g.bucket_hours = cut.bucket_hours
+        and g.retention_days > cut.widest_window_days;
+    assert found, format('the %sh width is not retained past its %s-day window',
+                         cut.bucket_hours, cut.widest_window_days);
+  end loop;
+end $$;
+
+rollback;


### PR DESCRIPTION
## Why

`/structure?days=90` died mid-render. Production recorded one error, on a 200 whose stream had already started:

```
22:18:23 GET /structure 200 [error/serverless-middleware]
    Error: The destination stream closed early.   digest: '725576948'
```

The sparklines read every raw `industry_system_index` row in the window and averaged them in JS. The pull job writes 150 rows an hour (25 systems × 6 activities), so:

| window | rows | sequential PostgREST pages |
|---|---|---|
| 7 days | ~25,000 | 25 |
| 30 days (the default) | ~108,000 | 108 |
| 90 days | ~324,000 | **324** |

The paging loop awaits inside a `for`, so that is 324 serial round trips before the 90-day journal fetch and the SDE lookups. `/structure/page.tsx` sets no `maxDuration`. `/indexes` ran the same query and had the same failure at its own 90-day window.

Not a regression from any deploy — the query has always been unaggregated, and the 90-day option just crossed the line as the table accumulated.

## Bucketing

A sparkline is ~100px wide and never draws more than ~180 points, so the averaging moves next to the data. `industry_system_index_bucket` materializes the mean per `(width, system, activity, bucket)` at the three widths the pages select, each retained only as far back as the widest window using it (1h/8d, 6h/31d, 24h/91d).

That pins the view at ~61k rows however long the source table grows, so a page load is a bounded handful of pages forever:

| window | width | rows fetched | query time |
|---|---|---|---|
| 90 days | 24h | 13,500 | 6.6ms |
| 30 days | 6h | 18,000 | 5.8ms |

Buckets are epoch-aligned rather than `date_trunc`'d, so they land exactly where the client's `floor(epochMs / bucketMs)` puts them and stay independent of the server's `TimeZone`.

`indexBucketHours` in `windows.ts` picks the width, and `fetchSystemIndexHistory` snaps anything else up to a width that exists — asking for an unmaterialized width would match no rows and draw an empty sparkline rather than an obviously wrong one. `/indexes` already declared exactly `{1, 6, 24}` in its own window table, so it needed no change and is fixed by the same view.

The `industry-systems` job refreshes the view concurrently after its insert, best-effort: the readings are already committed, and failing the run over a stale sparkline would cost the next hour's readings too.

## Verification

Ran against a throwaway Postgres 16 seeded to production's shape (25 systems × 6 activities × 100 days = 360,150 rows):

- The view reproduces the JS fold it replaces on **every** bucket (full outer join on cost_index and recorded_at, zero rows differ).
- Every `bucket_at` sits exactly on the JS epoch grid.
- Concurrent refresh takes ~1.1s, against an hourly job.

`test/sql/industry_index_bucket.sql` covers grid alignment, the mean and its newest timestamp, and the retention cuts. Mutation-checked — all three mutants caught:

| mutant | caught by |
|---|---|
| `min()` instead of `avg()` | `expected mean 0.04, got 0.02` |
| timezone-dependent `date_trunc` | `88 buckets off the epoch grid` |
| 24h retention cut to 45 days | `the 24h width is not retained past its 90-day window` |

## Tile changes

Separate commit, on `/structure`:

- The fuel countdown moves onto its own line under the timestamp — inline, the two ran together into one long string that wrapped mid-phrase. The detail page's Fuel Expires row gets the same treatment.
- Service and rig chips take the 64px icon, stacked above a centred name. The 16px icons were the smallest artwork CCP serves and read as mush; at 64 they are legible, which only works with the chip centred around them.
- The structure's render becomes the backdrop for its title rather than a band above it. CCP serves these at 512px around a small subject, so at tile width they looked pixelated; a 10px blur turns that into a soft field of the structure's own colours. The title sits on it in light letters with a shadow, over a scrim — the renders run from near-black to bright hull plating, and a shadow alone cannot carry light letters over the bright ones. Checked at both extremes in both themes. Tiles with no known type keep the line-art silhouette and plain colours.

## Notes for review

- Migration `20260826230750_industry_index_buckets.sql`, timestamp taken from the clock. `schema.sql` updated alongside it.
- The materialized view carries no RLS (they can't); a SELECT-only grant gives the same world-readable access as `industry_system_index`, which it only summarizes.
- `refresh_industry_index_buckets()` is `security definer` with execute revoked from everyone but `service_role`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AcGQtVm2QXKoJxBRRbdJVL)_